### PR TITLE
Fixes: new repo URL, shared draw state, initial window size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "GUI Toolkit Abstraction System"
 keywords = ["gui"]
 categories = ["gui"]
-repository = "https://github.com/dhardy/kas"
+repository = "https://github.com/kas-gui/kas"
 
 [features]
 # Enables usage of unstable Rust features

--- a/README.md
+++ b/README.md
@@ -53,14 +53,23 @@ For details, see the [Examples README](kas-wgpu/examples/README.md).
 ![Mandlebrot](screenshots/mandlebrot.png)
 
 
-Installation and Testing
-------------------------
+Installation and dependencies
+----------------
 
-For the most part, Cargo should take care of dependencies, but note:
+Currently, KAS's only drawing method is [WebGPU](https://github.com/gfx-rs/wgpu-rs),
+which requires DirectX 11/12, Vulkan or Metal.
+In the future, there may be support for OpenGL and software rendering.
 
--   [shaderc may require some setup](https://github.com/google/shaderc-rs#setup)
--   [wgpu](https://github.com/gfx-rs/wgpu-rs) requires DirectX 11/12, Vulkan or
-    Metal (in the future it may support OpenGL)
+If you haven't already, install [Rust](https://www.rust-lang.org/), including
+the *nightly* channel (`rustup toolchain install nightly`). Either make nightly
+the default (`rustup default nightly`) or use `cargo +nightly ...` below.
+
+A few other dependencies may require installation, depending on the system.
+On Ubuntu:
+
+```sh
+sudo apt-get install build-essential git python3 cmake libxcb-shape0-dev libxcb-xfixes0-dev
+```
 
 Next, clone the repository and run the examples as follows:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 KAS GUI
 ==========
 
-[![home](https://img.shields.io/badge/GitHub-home-blue)](https://github.com/dhardy/kas)
+[![home](https://img.shields.io/badge/GitHub-home-blue)](https://github.com/kas-gui/kas)
 [![old-home](https://img.shields.io/badge/GitLab-old--home-blueviolet)](https://gitlab.com/dhardy/kas)
-[![Build Status](https://travis-ci.com/dhardy/kas.svg?branch=master)](https://travis-ci.com/dhardy/kas)
+[![Build Status](https://travis-ci.com/kas-gui/kas.svg?branch=master)](https://travis-ci.com/kas-gui/kas)
 [![Docs](https://docs.rs/kas/badge.svg)](https://docs.rs/kas)
 ![Minimum rustc version](https://img.shields.io/badge/rustc-nightly-lightgray.svg)
 
@@ -65,7 +65,7 @@ For the most part, Cargo should take care of dependencies, but note:
 Next, clone the repository and run the examples as follows:
 
 ```
-git clone https://github.com/dhardy/kas.git
+git clone https://github.com/kas-gui/kas.git
 cd kas
 cargo test
 cd kas-wgpu

--- a/kas-macros/Cargo.toml
+++ b/kas-macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "GUI Toolkit Abstraction System (macros)"
 keywords = ["gui", "proc-macro"]
 categories = ["gui"]
-repository = "https://github.com/dhardy/kas"
+repository = "https://github.com/kas-gui/kas"
 
 [lib]
 proc-macro = true

--- a/kas-theme/Cargo.toml
+++ b/kas-theme/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "KAS toolkit — theme support"
 keywords = ["gui"]
 categories = ["gui"]
-repository = "https://github.com/dhardy/kas"
+repository = "https://github.com/kas-gui/kas"
 
 [features]
 default = ["font-kit", "stack_dst"]

--- a/kas-theme/src/font.rs
+++ b/kas-theme/src/font.rs
@@ -17,7 +17,7 @@ use lazy_static::lazy_static;
 use std::sync::Once;
 // use wgpu_glyph::rusttype::FontCollection;
 
-use kas::draw::{DrawText, Font, FontId};
+use kas::draw::{DrawTextShared, Font, FontId};
 
 #[cfg(feature = "font-kit")]
 use std::{fs::File, io::Read, sync::Arc};
@@ -74,7 +74,7 @@ lazy_static! {
 }
 
 /// Load fonts
-pub(crate) fn load_fonts<D: DrawText>(draw: &mut D) -> FontId {
+pub(crate) fn load_fonts<D: DrawTextShared>(draw: &mut D) -> FontId {
     static LOAD_FONTS: Once = Once::new();
     LOAD_FONTS.call_once(|| {
         let font_id = draw.load_font(FONT.clone());

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -109,7 +109,7 @@ where
 }
 
 #[cfg(feature = "gat")]
-impl<'a, D: DrawShared, T: Theme<D>> ThemeDst<D> for T {
+impl<'a, D: DrawShared + 'static, T: Theme<D>> ThemeDst<D> for T {
     fn init(&mut self, draw: &mut D) {
         self.init(draw);
     }

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "Native KAS toolkit using wgpu"
 keywords = ["gui"]
 categories = ["gui"]
-repository = "https://github.com/dhardy/kas"
+repository = "https://github.com/kas-gui/kas"
 
 [features]
 default = ["clipboard", "stack_dst"]

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -18,7 +18,7 @@ use kas::geom::{Coord, Rect, Size};
 use kas::layout::{AxisInfo, SizeRules};
 use kas::widget::Window;
 use kas::{Align, AlignHints, Direction, Layout, Widget, WidgetCore};
-use kas_wgpu::draw::DrawPipe;
+use kas_wgpu::draw::DrawWindow;
 
 #[handler]
 #[derive(Clone, Debug, kas :: macros :: Widget)]
@@ -67,7 +67,7 @@ impl Layout for Clock {
         // Note: offset is used for scroll-regions, and should be zero here;
         // we add it anyway as is recommended.
         let (region, offset, draw) = draw_handle.draw_device();
-        let draw = draw.as_any_mut().downcast_mut::<DrawPipe<()>>().unwrap();
+        let draw = draw.as_any_mut().downcast_mut::<DrawWindow<()>>().unwrap();
 
         draw.circle(region, self.core.rect + offset, 0.95, col_face);
 

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[layout(vertical)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget] display: Label = Label::from("0"),
+                #[widget(halign=centre)] display: Label = Label::from("0"),
                 #[widget(handler = handle_button)] buttons -> Message = buttons,
                 counter: usize = 0,
             }

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -49,43 +49,46 @@ thread_local! {
     static BACKGROUND: Cell<Colour> = Cell::new(Colour::grey(1.0));
 }
 
-impl<Draw: DrawRounded + DrawText> Theme<Draw> for CustomTheme {
-    type Window = <FlatTheme as Theme<Draw>>::Window;
+impl<D: DrawShared + DrawTextShared + 'static> Theme<D> for CustomTheme
+where
+    D::Draw: DrawRounded + DrawText,
+{
+    type Window = <FlatTheme as Theme<D>>::Window;
 
     #[cfg(not(feature = "gat"))]
-    type DrawHandle = <FlatTheme as Theme<Draw>>::DrawHandle;
+    type DrawHandle = <FlatTheme as Theme<D>>::DrawHandle;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a> = <FlatTheme as Theme<Draw>>::DrawHandle<'a>;
+    type DrawHandle<'a> = <FlatTheme as Theme<D>>::DrawHandle<'a>;
 
-    fn init(&mut self, draw: &mut Draw) {
+    fn init(&mut self, draw: &mut D) {
         self.inner.init(draw);
     }
 
-    fn new_window(&self, draw: &mut Draw, dpi_factor: f32) -> Self::Window {
-        Theme::<Draw>::new_window(&self.inner, draw, dpi_factor)
+    fn new_window(&self, draw: &mut D::Draw, dpi_factor: f32) -> Self::Window {
+        Theme::<D>::new_window(&self.inner, draw, dpi_factor)
     }
 
     fn update_window(&self, window: &mut Self::Window, dpi_factor: f32) {
-        Theme::<Draw>::update_window(&self.inner, window, dpi_factor);
+        Theme::<D>::update_window(&self.inner, window, dpi_factor);
     }
 
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        draw: &mut Draw,
+        draw: &mut D::Draw,
         window: &mut Self::Window,
         rect: Rect,
     ) -> Self::DrawHandle {
-        self.inner.draw_handle(draw, window, rect)
+        Theme::<D>::draw_handle(&self.inner, draw, window, rect)
     }
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        draw: &'a mut Draw,
+        draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
         rect: Rect,
     ) -> Self::DrawHandle<'a> {
-        self.inner.draw_handle(draw, window, rect)
+        Theme::<D>::draw_handle(&self.inner, draw, window, rect)
     }
 
     fn clear_colour(&self) -> Colour {

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -307,7 +307,7 @@ struct Mandlebrot {
 
 impl Layout for Mandlebrot {
     fn size_rules(&mut self, _: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
-        SizeRules::new(100, 100, StretchPolicy::Maximise)
+        SizeRules::new(500, 500, StretchPolicy::Maximise)
     }
 
     #[inline]

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -22,7 +22,7 @@ use kas::layout::{AxisInfo, SizeRules, StretchPolicy};
 use kas::macros::make_widget;
 use kas::widget::{Label, Window};
 use kas::{AlignHints, Layout, WidgetCore, WidgetId};
-use kas_wgpu::draw::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom, DrawPipe, Vec2};
+use kas_wgpu::draw::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom, DrawWindow, Vec2};
 use kas_wgpu::Options;
 
 const VERTEX: &'static str = "
@@ -111,7 +111,7 @@ struct PipeBuilder;
 impl CustomPipeBuilder for PipeBuilder {
     type Pipe = Pipe;
 
-    fn build(&mut self, device: &wgpu::Device) -> Self::Pipe {
+    fn build(&mut self, device: &wgpu::Device, _: wgpu::TextureFormat) -> Self::Pipe {
         // Note: real apps should compile shaders once and share between windows
         let shaders = Shaders::compile(device);
 
@@ -319,7 +319,10 @@ impl Layout for Mandlebrot {
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState) {
         let (region, offset, draw) = draw_handle.draw_device();
-        let draw = draw.as_any_mut().downcast_mut::<DrawPipe<Pipe>>().unwrap();
+        let draw = draw
+            .as_any_mut()
+            .downcast_mut::<DrawWindow<PipeWindow>>()
+            .unwrap();
         let p = (self.centre, self.scalar);
         draw.custom(region, self.core.rect + offset, p);
     }

--- a/kas-wgpu/src/draw/custom.rs
+++ b/kas-wgpu/src/draw/custom.rs
@@ -40,7 +40,7 @@ pub trait CustomPipeBuilder {
 /// enum for the `Param` type).
 pub trait CustomPipe {
     /// Type for per-window data
-    type Window: CustomWindow;
+    type Window: CustomWindow + 'static;
 
     /// Construct a window associated with this pipeline
     fn new_window(&self, device: &wgpu::Device, size: Size) -> Self::Window;

--- a/kas-wgpu/src/draw/custom.rs
+++ b/kas-wgpu/src/draw/custom.rs
@@ -50,7 +50,7 @@ pub trait CustomPipe {
     /// Rendering uses one pass per region, where each region has its own
     /// scissor rect. This method may be called multiple times per frame.
     /// Each widget invoking this pipe will give the correct `pass` number for
-    /// the widget in [`CustomPipe::invoke`]; multiple widgets may use the same
+    /// the widget in [`CustomWindow::invoke`]; multiple widgets may use the same
     /// `pass`.
     fn render(
         &self,

--- a/kas-wgpu/src/draw/custom.rs
+++ b/kas-wgpu/src/draw/custom.rs
@@ -15,7 +15,7 @@ use kas::geom::{Rect, Size};
 /// corresponding [`CustomPipeBuilder`] to [`crate::Toolkit::new_custom`].
 pub trait DrawCustom<C: CustomPipe> {
     /// Call a custom draw pipe
-    fn custom(&mut self, region: Region, rect: Rect, param: C::Param);
+    fn custom(&mut self, region: Region, rect: Rect, param: <C::Window as CustomWindow>::Param);
 }
 
 /// Builder for a [`CustomPipe`]
@@ -23,7 +23,7 @@ pub trait CustomPipeBuilder {
     type Pipe: CustomPipe;
 
     /// Build a pipe
-    fn build(&mut self, device: &wgpu::Device, size: Size) -> Self::Pipe;
+    fn build(&mut self, device: &wgpu::Device) -> Self::Pipe;
 }
 
 /// A custom draw pipe
@@ -39,6 +39,29 @@ pub trait CustomPipeBuilder {
 /// one, you will have to implement your own multiplexer (presumably using an
 /// enum for the `Param` type).
 pub trait CustomPipe {
+    /// Type for per-window data
+    type Window: CustomWindow;
+
+    /// Construct a window associated with this pipeline
+    fn new_window(&self, device: &wgpu::Device, size: Size) -> Self::Window;
+
+    /// Do a render pass.
+    ///
+    /// Rendering uses one pass per region, where each region has its own
+    /// scissor rect. This method may be called multiple times per frame.
+    /// Each widget invoking this pipe will give the correct `pass` number for
+    /// the widget in [`CustomPipe::invoke`]; multiple widgets may use the same
+    /// `pass`.
+    fn render(
+        &self,
+        window: &mut Self::Window,
+        device: &wgpu::Device,
+        pass: usize,
+        rpass: &mut wgpu::RenderPass,
+    );
+}
+
+pub trait CustomWindow {
     /// User parameter type
     type Param;
 
@@ -50,21 +73,12 @@ pub trait CustomPipe {
     /// Custom add-primitives / update function called from user code by
     /// [`DrawCustom::custom`].
     fn invoke(&mut self, pass: usize, rect: Rect, param: Self::Param);
-
-    /// Do a render pass.
-    ///
-    /// Rendering uses one pass per region, where each region has its own
-    /// scissor rect. This method may be called multiple times per frame.
-    /// Each widget invoking this pipe will give the correct `pass` number for
-    /// the widget in [`CustomPipe::invoke`]; multiple widgets may use the same
-    /// `pass`.
-    fn render(&mut self, device: &wgpu::Device, pass: usize, rpass: &mut wgpu::RenderPass);
 }
 
 /// A dummy implementation (does nothing)
 impl CustomPipeBuilder for () {
     type Pipe = ();
-    fn build(&mut self, _: &wgpu::Device, _: Size) -> Self::Pipe {
+    fn build(&mut self, _: &wgpu::Device) -> Self::Pipe {
         ()
     }
 }
@@ -73,14 +87,22 @@ pub enum Void {}
 
 /// A dummy implementation (does nothing)
 impl CustomPipe for () {
+    type Window = ();
+    fn new_window(&self, _: &wgpu::Device, _: Size) -> Self::Window {
+        ()
+    }
+    fn render(&self, _: &mut Self::Window, _: &wgpu::Device, _: usize, _: &mut wgpu::RenderPass) {}
+}
+
+/// A dummy implementation (does nothing)
+impl CustomWindow for () {
     type Param = Void;
     fn resize(&mut self, _: &wgpu::Device, _: &mut wgpu::CommandEncoder, _: Size) {}
     fn invoke(&mut self, _: usize, _: Rect, _: Self::Param) {}
-    fn render(&mut self, _: &wgpu::Device, _: usize, _: &mut wgpu::RenderPass) {}
 }
 
 impl<C: CustomPipe> DrawCustom<C> for DrawPipe<C> {
-    fn custom(&mut self, region: Region, rect: Rect, param: C::Param) {
+    fn custom(&mut self, region: Region, rect: Rect, param: <C::Window as CustomWindow>::Param) {
         self.custom.invoke(region.0, rect, param);
     }
 }

--- a/kas-wgpu/src/draw/custom.rs
+++ b/kas-wgpu/src/draw/custom.rs
@@ -5,7 +5,7 @@
 
 //! Custom draw pipes
 
-use super::DrawPipe;
+use super::DrawWindow;
 use kas::draw::Region;
 use kas::geom::{Rect, Size};
 
@@ -13,9 +13,9 @@ use kas::geom::{Rect, Size};
 ///
 /// To use this, write an implementation of [`CustomPipe`], then pass the
 /// corresponding [`CustomPipeBuilder`] to [`crate::Toolkit::new_custom`].
-pub trait DrawCustom<C: CustomPipe> {
+pub trait DrawCustom<CW: CustomWindow> {
     /// Call a custom draw pipe
-    fn custom(&mut self, region: Region, rect: Rect, param: <C::Window as CustomWindow>::Param);
+    fn custom(&mut self, region: Region, rect: Rect, param: CW::Param);
 }
 
 /// Builder for a [`CustomPipe`]
@@ -23,7 +23,7 @@ pub trait CustomPipeBuilder {
     type Pipe: CustomPipe;
 
     /// Build a pipe
-    fn build(&mut self, device: &wgpu::Device) -> Self::Pipe;
+    fn build(&mut self, device: &wgpu::Device, tex_format: wgpu::TextureFormat) -> Self::Pipe;
 }
 
 /// A custom draw pipe
@@ -78,7 +78,7 @@ pub trait CustomWindow {
 /// A dummy implementation (does nothing)
 impl CustomPipeBuilder for () {
     type Pipe = ();
-    fn build(&mut self, _: &wgpu::Device) -> Self::Pipe {
+    fn build(&mut self, _: &wgpu::Device, _: wgpu::TextureFormat) -> Self::Pipe {
         ()
     }
 }
@@ -101,8 +101,8 @@ impl CustomWindow for () {
     fn invoke(&mut self, _: usize, _: Rect, _: Self::Param) {}
 }
 
-impl<C: CustomPipe> DrawCustom<C> for DrawPipe<C> {
-    fn custom(&mut self, region: Region, rect: Rect, param: <C::Window as CustomWindow>::Param) {
+impl<CW: CustomWindow> DrawCustom<CW> for DrawWindow<CW> {
+    fn custom(&mut self, region: Region, rect: Rect, param: CW::Param) {
         self.custom.invoke(region.0, rect, param);
     }
 }

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -13,7 +13,7 @@ use super::{
     flat_round, shaded_round, shaded_square, CustomPipe, CustomPipeBuilder, CustomWindow, DrawPipe,
     DrawWindow, ShaderManager, Vec2, TEX_FORMAT,
 };
-use kas::draw::{Colour, Draw, DrawRounded, DrawShaded, Region};
+use kas::draw::{Colour, Draw, DrawRounded, DrawShaded, DrawShared, Region};
 use kas::geom::{Coord, Rect, Size};
 
 impl<C: CustomPipe> DrawPipe<C> {
@@ -29,6 +29,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         let custom = custom.build(&device, TEX_FORMAT);
 
         DrawPipe {
+            fonts: vec![],
             shaded_square,
             shaded_round,
             flat_round,
@@ -60,7 +61,8 @@ impl<C: CustomPipe> DrawPipe<C> {
         let flat_round = self.flat_round.new_window(device, size);
         let custom = self.custom.new_window(device, size);
 
-        let glyph_brush = GlyphBrushBuilder::using_fonts(vec![]).build(device, TEX_FORMAT);
+        let glyph_brush =
+            GlyphBrushBuilder::using_fonts(self.fonts.clone()).build(device, TEX_FORMAT);
 
         DrawWindow {
             clip_regions: vec![region],
@@ -142,6 +144,10 @@ impl<CW: CustomWindow> DrawWindow<CW> {
         self.flat_round.resize(device, &mut encoder, size);
         encoder.finish()
     }
+}
+
+impl<C: CustomPipe> DrawShared for DrawPipe<C> {
+    type Draw = DrawWindow<C::Window>;
 }
 
 impl<CW: CustomWindow + 'static> Draw for DrawWindow<CW> {

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -12,7 +12,7 @@ use std::f32::consts::FRAC_PI_2;
 use wgpu_glyph::GlyphBrushBuilder;
 
 use super::{flat_round, shaded_round, shaded_square};
-use super::{CustomPipe, CustomPipeBuilder, DrawPipe, Vec2};
+use super::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawPipe, Vec2};
 use crate::shared::SharedState;
 use kas::draw::{Colour, Draw, DrawRounded, DrawShaded, Region};
 use kas::geom::{Coord, Rect, Size};
@@ -38,7 +38,8 @@ impl<C: CustomPipe> DrawPipe<C> {
         let f = a.0 / a.1;
         let norm = [dir.1.sin() * f, -dir.1.cos() * f, 1.0];
 
-        let custom = shared.custom.build(&shared.device, size);
+        let pipe_custom = shared.custom.build(&shared.device);
+        let custom = pipe_custom.new_window(&shared.device, size);
 
         let glyph_brush =
             GlyphBrushBuilder::using_fonts(vec![]).build(&mut shared.device, tex_format);
@@ -62,6 +63,7 @@ impl<C: CustomPipe> DrawPipe<C> {
             pipe_shaded_square,
             pipe_shaded_round,
             pipe_flat_round,
+            pipe_custom,
             shaded_square,
             shaded_round,
             flat_round,
@@ -118,7 +120,8 @@ impl<C: CustomPipe> DrawPipe<C> {
                 .render(&mut self.shaded_round, device, pass, &mut rpass);
             self.pipe_flat_round
                 .render(&mut self.flat_round, device, pass, &mut rpass);
-            self.custom.render(device, pass, &mut rpass);
+            self.pipe_custom
+                .render(&mut self.custom, device, pass, &mut rpass);
             drop(rpass);
 
             load_op = wgpu::LoadOp::Load;

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -4,29 +4,41 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 //! Drawing API for `kas_wgpu`
-//!
-//! TODO: move traits up to kas?
 
 use std::any::Any;
 use std::f32::consts::FRAC_PI_2;
 use wgpu_glyph::GlyphBrushBuilder;
 
-use super::{flat_round, shaded_round, shaded_square};
-use super::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawPipe, Vec2};
-use crate::shared::SharedState;
+use super::{
+    flat_round, shaded_round, shaded_square, CustomPipe, CustomPipeBuilder, CustomWindow, DrawPipe,
+    DrawWindow, ShaderManager, Vec2, TEX_FORMAT,
+};
 use kas::draw::{Colour, Draw, DrawRounded, DrawShaded, Region};
 use kas::geom::{Coord, Rect, Size};
-use kas_theme::Theme;
 
 impl<C: CustomPipe> DrawPipe<C> {
     /// Construct
-    // TODO: do we want to share state across windows? With glyph_brush this is
-    // not trivial but with our "pipes" it shouldn't be difficult.
-    pub fn new<CB: CustomPipeBuilder<Pipe = C>, T: Theme<Self>>(
-        shared: &mut SharedState<CB, T>,
-        tex_format: wgpu::TextureFormat,
-        size: Size,
+    pub fn new<CB: CustomPipeBuilder<Pipe = C>>(
+        mut custom: CB,
+        device: &wgpu::Device,
+        shaders: &ShaderManager,
     ) -> Self {
+        let shaded_square = shaded_square::Pipeline::new(device, shaders);
+        let shaded_round = shaded_round::Pipeline::new(device, shaders);
+        let flat_round = flat_round::Pipeline::new(device, shaders);
+        let custom = custom.build(&device, TEX_FORMAT);
+
+        DrawPipe {
+            shaded_square,
+            shaded_round,
+            flat_round,
+            custom,
+        }
+    }
+
+    /// Construct per-window state
+    // TODO: device should be &, not &mut (but for glyph_brush)
+    pub fn new_window(&self, device: &mut wgpu::Device, size: Size) -> DrawWindow<C::Window> {
         // Light dir: `(a, b)` where `0 ≤ a < pi/2` is the angle to the screen
         // normal (i.e. `a = 0` is straight at the screen) and `b` is the bearing
         // (from UP, clockwise), both in radians.
@@ -38,32 +50,20 @@ impl<C: CustomPipe> DrawPipe<C> {
         let f = a.0 / a.1;
         let norm = [dir.1.sin() * f, -dir.1.cos() * f, 1.0];
 
-        let pipe_custom = shared.custom.build(&shared.device);
-        let custom = pipe_custom.new_window(&shared.device, size);
-
-        let glyph_brush =
-            GlyphBrushBuilder::using_fonts(vec![]).build(&mut shared.device, tex_format);
-
         let region = Rect {
             pos: Coord::ZERO,
             size,
         };
 
-        let pipe_shaded_square = shaded_square::Pipeline::new(shared);
-        let shaded_square = pipe_shaded_square.new_window(&shared.device, size, norm);
+        let shaded_square = self.shaded_square.new_window(device, size, norm);
+        let shaded_round = self.shaded_round.new_window(device, size, norm);
+        let flat_round = self.flat_round.new_window(device, size);
+        let custom = self.custom.new_window(device, size);
 
-        let pipe_shaded_round = shaded_round::Pipeline::new(shared);
-        let shaded_round = pipe_shaded_round.new_window(&shared.device, size, norm);
+        let glyph_brush = GlyphBrushBuilder::using_fonts(vec![]).build(device, TEX_FORMAT);
 
-        let pipe_flat_round = flat_round::Pipeline::new(shared);
-        let flat_round = pipe_flat_round.new_window(&shared.device, size);
-
-        DrawPipe {
+        DrawWindow {
             clip_regions: vec![region],
-            pipe_shaded_square,
-            pipe_shaded_round,
-            pipe_flat_round,
-            pipe_custom,
             shaded_square,
             shaded_round,
             flat_round,
@@ -72,21 +72,10 @@ impl<C: CustomPipe> DrawPipe<C> {
         }
     }
 
-    /// Process window resize
-    pub fn resize(&mut self, device: &wgpu::Device, size: Size) -> wgpu::CommandBuffer {
-        self.clip_regions[0].size = size;
-        let mut encoder =
-            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
-        self.shaded_square.resize(device, &mut encoder, size);
-        self.shaded_round.resize(device, &mut encoder, size);
-        self.custom.resize(device, &mut encoder, size);
-        self.flat_round.resize(device, &mut encoder, size);
-        encoder.finish()
-    }
-
     /// Render batched draw instructions via `rpass`
     pub fn render(
-        &mut self,
+        &self,
+        window: &mut DrawWindow<C::Window>,
         device: &mut wgpu::Device,
         frame_view: &wgpu::TextureView,
         clear_color: wgpu::Color,
@@ -96,7 +85,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         let mut load_op = wgpu::LoadOp::Clear;
 
         // We use a separate render pass for each clipped region.
-        for (pass, region) in self.clip_regions.iter().enumerate() {
+        for (pass, region) in window.clip_regions.iter().enumerate() {
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: frame_view,
@@ -114,33 +103,48 @@ impl<C: CustomPipe> DrawPipe<C> {
                 region.size.1,
             );
 
-            self.pipe_shaded_square
-                .render(&mut self.shaded_square, device, pass, &mut rpass);
-            self.pipe_shaded_round
-                .render(&mut self.shaded_round, device, pass, &mut rpass);
-            self.pipe_flat_round
-                .render(&mut self.flat_round, device, pass, &mut rpass);
-            self.pipe_custom
-                .render(&mut self.custom, device, pass, &mut rpass);
+            self.shaded_square
+                .render(&mut window.shaded_square, device, pass, &mut rpass);
+            self.shaded_round
+                .render(&mut window.shaded_round, device, pass, &mut rpass);
+            self.flat_round
+                .render(&mut window.flat_round, device, pass, &mut rpass);
+            self.custom
+                .render(&mut window.custom, device, pass, &mut rpass);
             drop(rpass);
 
             load_op = wgpu::LoadOp::Load;
         }
 
         // Fonts use their own render pass(es).
-        let size = self.clip_regions[0].size;
-        self.glyph_brush
+        let size = window.clip_regions[0].size;
+        window
+            .glyph_brush
             .draw_queued(device, &mut encoder, frame_view, size.0, size.1)
             .expect("glyph_brush.draw_queued");
 
         // Keep only first clip region (which is the entire window)
-        self.clip_regions.truncate(1);
+        window.clip_regions.truncate(1);
 
         encoder.finish()
     }
 }
 
-impl<C: CustomPipe + 'static> Draw for DrawPipe<C> {
+impl<CW: CustomWindow> DrawWindow<CW> {
+    /// Process window resize
+    pub fn resize(&mut self, device: &wgpu::Device, size: Size) -> wgpu::CommandBuffer {
+        self.clip_regions[0].size = size;
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
+        self.shaded_square.resize(device, &mut encoder, size);
+        self.shaded_round.resize(device, &mut encoder, size);
+        self.custom.resize(device, &mut encoder, size);
+        self.flat_round.resize(device, &mut encoder, size);
+        encoder.finish()
+    }
+}
+
+impl<CW: CustomWindow + 'static> Draw for DrawWindow<CW> {
     #[inline]
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
@@ -163,7 +167,7 @@ impl<C: CustomPipe + 'static> Draw for DrawPipe<C> {
     }
 }
 
-impl<C: CustomPipe + 'static> DrawRounded for DrawPipe<C> {
+impl<CW: CustomWindow + 'static> DrawRounded for DrawWindow<CW> {
     #[inline]
     fn rounded_line(&mut self, pass: Region, p1: Coord, p2: Coord, radius: f32, col: Colour) {
         self.flat_round.line(pass.0, p1, p2, radius, col);
@@ -188,7 +192,7 @@ impl<C: CustomPipe + 'static> DrawRounded for DrawPipe<C> {
     }
 }
 
-impl<C: CustomPipe + 'static> DrawShaded for DrawPipe<C> {
+impl<CW: CustomWindow + 'static> DrawShaded for DrawWindow<CW> {
     #[inline]
     fn shaded_square(&mut self, pass: Region, rect: Rect, norm: (f32, f32), col: Colour) {
         self.shaded_square

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -8,12 +8,12 @@
 use std::f32;
 use wgpu_glyph::{GlyphCruncher, HorizontalAlign, Layout, Scale, Section, VerticalAlign};
 
-use crate::draw::{CustomPipe, DrawPipe, Vec2};
+use super::{CustomWindow, DrawWindow, Vec2};
 use kas::draw::{DrawText, Font, FontId, TextProperties};
 use kas::geom::{Coord, Rect};
 use kas::Align;
 
-impl<C: CustomPipe + 'static> DrawText for DrawPipe<C> {
+impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
     fn load_font(&mut self, font: Font<'static>) -> FontId {
         FontId(self.glyph_brush.add_font(font).0)
     }

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -8,16 +8,20 @@
 use std::f32;
 use wgpu_glyph::{GlyphCruncher, HorizontalAlign, Layout, Scale, Section, VerticalAlign};
 
-use super::{CustomWindow, DrawWindow, Vec2};
-use kas::draw::{DrawText, Font, FontId, TextProperties};
+use super::{CustomPipe, CustomWindow, DrawPipe, DrawWindow, Vec2};
+use kas::draw::{DrawText, DrawTextShared, Font, FontId, TextProperties};
 use kas::geom::{Coord, Rect};
 use kas::Align;
 
-impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
+impl<C: CustomPipe + 'static> DrawTextShared for DrawPipe<C> {
     fn load_font(&mut self, font: Font<'static>) -> FontId {
-        FontId(self.glyph_brush.add_font(font).0)
+        let id = FontId(self.fonts.len());
+        self.fonts.push(font);
+        id
     }
+}
 
+impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
     fn text(&mut self, rect: Rect, text: &str, props: TextProperties) {
         let bounds = Coord::from(rect.size);
 

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -21,26 +21,22 @@ const OFFSET: f32 = 0.125;
 struct Vertex(Vec2, Rgb, f32, Vec2, Vec2);
 
 /// A pipeline for rendering rounded shapes
-pub struct FlatRound {
+pub struct Pipeline {
+    bind_group_layout: wgpu::BindGroupLayout,
+    render_pipeline: wgpu::RenderPipeline,
+}
+
+/// Per-window state
+pub struct Window {
     bind_group: wgpu::BindGroup,
     scale_buf: wgpu::Buffer,
-    render_pipeline: wgpu::RenderPipeline,
     passes: Vec<Vec<Vertex>>,
 }
 
-impl FlatRound {
+impl Pipeline {
     /// Construct
-    pub fn new<C, T>(shared: &SharedState<C, T>, size: Size) -> Self {
+    pub fn new<C, T>(shared: &SharedState<C, T>) -> Self {
         let device = &shared.device;
-
-        type Scale = [f32; 2];
-        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
-        let scale_buf = device
-            .create_buffer_mapped(
-                scale_factor.len(),
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
-            .fill_from_slice(&scale_factor);
 
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[wgpu::BindGroupLayoutBinding {
@@ -49,16 +45,7 @@ impl FlatRound {
                 ty: wgpu::BindingType::UniformBuffer { dynamic: false },
             }],
         });
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &bind_group_layout,
-            bindings: &[wgpu::Binding {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer {
-                    buffer: &scale_buf,
-                    range: 0..(size_of::<Scale>() as u64),
-                },
-            }],
-        });
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             bind_group_layouts: &[&bind_group_layout],
         });
@@ -134,14 +121,68 @@ impl FlatRound {
             alpha_to_coverage_enabled: false,
         });
 
-        FlatRound {
+        Pipeline {
+            bind_group_layout,
+            render_pipeline,
+        }
+    }
+
+    /// Construct per-window state
+    pub fn new_window(&self, device: &wgpu::Device, size: Size) -> Window {
+        type Scale = [f32; 2];
+        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
+        let scale_buf = device
+            .create_buffer_mapped(
+                scale_factor.len(),
+                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            )
+            .fill_from_slice(&scale_factor);
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &self.bind_group_layout,
+            bindings: &[wgpu::Binding {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer {
+                    buffer: &scale_buf,
+                    range: 0..(size_of::<Scale>() as u64),
+                },
+            }],
+        });
+
+        Window {
             bind_group,
             scale_buf,
-            render_pipeline,
             passes: vec![],
         }
     }
 
+    /// Render queued triangles and clear the queue
+    pub fn render(
+        &mut self,
+        window: &mut Window,
+        device: &wgpu::Device,
+        pass: usize,
+        rpass: &mut wgpu::RenderPass,
+    ) {
+        if pass >= window.passes.len() {
+            return;
+        }
+        let v = &mut window.passes[pass];
+        let buffer = device
+            .create_buffer_mapped(v.len(), wgpu::BufferUsage::VERTEX)
+            .fill_from_slice(&v);
+        let count = v.len() as u32;
+
+        rpass.set_pipeline(&self.render_pipeline);
+        rpass.set_bind_group(0, &window.bind_group, &[]);
+        rpass.set_vertex_buffers(0, &[(&buffer, 0)]);
+        rpass.draw(0..count, 0..1);
+
+        v.clear();
+    }
+}
+
+impl Window {
     pub fn resize(
         &mut self,
         device: &wgpu::Device,
@@ -156,25 +197,6 @@ impl FlatRound {
         let byte_len = size_of::<Scale>() as u64;
 
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &self.scale_buf, 0, byte_len);
-    }
-
-    /// Render queued triangles and clear the queue
-    pub fn render(&mut self, device: &wgpu::Device, pass: usize, rpass: &mut wgpu::RenderPass) {
-        if pass >= self.passes.len() {
-            return;
-        }
-        let v = &mut self.passes[pass];
-        let buffer = device
-            .create_buffer_mapped(v.len(), wgpu::BufferUsage::VERTEX)
-            .fill_from_slice(&v);
-        let count = v.len() as u32;
-
-        rpass.set_pipeline(&self.render_pipeline);
-        rpass.set_bind_group(0, &self.bind_group, &[]);
-        rpass.set_vertex_buffers(0, &[(&buffer, 0)]);
-        rpass.draw(0..count, 0..1);
-
-        v.clear();
     }
 
     pub fn line(&mut self, pass: usize, p1: Coord, p2: Coord, radius: f32, col: Colour) {

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -7,8 +7,7 @@
 
 use std::mem::size_of;
 
-use crate::draw::{Rgb, Vec2};
-use crate::shared::SharedState;
+use crate::draw::{Rgb, ShaderManager, Vec2};
 use kas::draw::Colour;
 use kas::geom::{Coord, Rect, Size};
 
@@ -35,9 +34,7 @@ pub struct Window {
 
 impl Pipeline {
     /// Construct
-    pub fn new<C, T>(shared: &SharedState<C, T>) -> Self {
-        let device = &shared.device;
-
+    pub fn new(device: &wgpu::Device, shaders: &ShaderManager) -> Self {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[wgpu::BindGroupLayoutBinding {
                 binding: 0,
@@ -53,11 +50,11 @@ impl Pipeline {
         let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             layout: &pipeline_layout,
             vertex_stage: wgpu::ProgrammableStageDescriptor {
-                module: &shared.shaders.vert_3122,
+                module: &shaders.vert_3122,
                 entry_point: "main",
             },
             fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
-                module: &shared.shaders.frag_flat_round,
+                module: &shaders.frag_flat_round,
                 entry_point: "main",
             }),
             rasterization_state: Some(wgpu::RasterizationStateDescriptor {
@@ -158,7 +155,7 @@ impl Pipeline {
 
     /// Render queued triangles and clear the queue
     pub fn render(
-        &mut self,
+        &self,
         window: &mut Window,
         device: &wgpu::Device,
         pass: usize,

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -24,6 +24,8 @@ pub(crate) use shaders::ShaderManager;
 pub use custom::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom};
 pub use vector::{Quad, Vec2};
 
+pub(crate) const TEX_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8UnormSrgb;
+
 /// 3-part colour data
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -43,16 +45,20 @@ impl From<kas::draw::Colour> for Rgb {
     }
 }
 
-/// `kas-wgpu`'s implemention of [`kas::draw::Draw`] and friends
-pub struct DrawPipe<C: CustomPipe> {
+/// Shared pipeline data
+pub struct DrawPipe<C> {
+    shaded_square: shaded_square::Pipeline,
+    shaded_round: shaded_round::Pipeline,
+    flat_round: flat_round::Pipeline,
+    custom: C,
+}
+
+/// Per-window pipeline data
+pub struct DrawWindow<CW: CustomWindow> {
     clip_regions: Vec<Rect>,
-    pipe_shaded_square: shaded_square::Pipeline,
-    pipe_shaded_round: shaded_round::Pipeline,
-    pipe_flat_round: flat_round::Pipeline,
-    pipe_custom: C,
     shaded_square: shaded_square::Window,
     shaded_round: shaded_round::Window,
     flat_round: flat_round::Window,
-    custom: C::Window,
-    glyph_brush: GlyphBrush<'static, ()>,
+    custom: CW,
+    glyph_brush: GlyphBrush<'static, ()>, // TODO: should be in DrawPipe
 }

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -19,9 +19,6 @@ mod vector;
 use kas::geom::Rect;
 use wgpu_glyph::GlyphBrush;
 
-pub(crate) use flat_round::FlatRound;
-pub(crate) use shaded_round::ShadedRound;
-pub(crate) use shaded_square::ShadedSquare;
 pub(crate) use shaders::ShaderManager;
 
 pub use custom::{CustomPipe, CustomPipeBuilder, DrawCustom};
@@ -49,9 +46,12 @@ impl From<kas::draw::Colour> for Rgb {
 /// `kas-wgpu`'s implemention of [`kas::draw::Draw`] and friends
 pub struct DrawPipe<C> {
     clip_regions: Vec<Rect>,
-    shaded_round: ShadedRound,
-    shaded_square: ShadedSquare,
+    pipe_shaded_square: shaded_square::Pipeline,
+    pipe_shaded_round: shaded_round::Pipeline,
+    pipe_flat_round: flat_round::Pipeline,
+    shaded_square: shaded_square::Window,
+    shaded_round: shaded_round::Window,
+    flat_round: flat_round::Window,
     custom: C,
-    flat_round: FlatRound,
     glyph_brush: GlyphBrush<'static, ()>,
 }

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -21,7 +21,7 @@ use wgpu_glyph::GlyphBrush;
 
 pub(crate) use shaders::ShaderManager;
 
-pub use custom::{CustomPipe, CustomPipeBuilder, DrawCustom};
+pub use custom::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom};
 pub use vector::{Quad, Vec2};
 
 /// 3-part colour data
@@ -44,14 +44,15 @@ impl From<kas::draw::Colour> for Rgb {
 }
 
 /// `kas-wgpu`'s implemention of [`kas::draw::Draw`] and friends
-pub struct DrawPipe<C> {
+pub struct DrawPipe<C: CustomPipe> {
     clip_regions: Vec<Rect>,
     pipe_shaded_square: shaded_square::Pipeline,
     pipe_shaded_round: shaded_round::Pipeline,
     pipe_flat_round: flat_round::Pipeline,
+    pipe_custom: C,
     shaded_square: shaded_square::Window,
     shaded_round: shaded_round::Window,
     flat_round: flat_round::Window,
-    custom: C,
+    custom: C::Window,
     glyph_brush: GlyphBrush<'static, ()>,
 }

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -16,6 +16,7 @@ mod shaded_square;
 mod shaders;
 mod vector;
 
+use kas::draw::Font;
 use kas::geom::Rect;
 use wgpu_glyph::GlyphBrush;
 
@@ -47,6 +48,7 @@ impl From<kas::draw::Colour> for Rgb {
 
 /// Shared pipeline data
 pub struct DrawPipe<C> {
+    fonts: Vec<Font<'static>>,
     shaded_square: shaded_square::Pipeline,
     shaded_round: shaded_round::Pipeline,
     flat_round: flat_round::Pipeline,

--- a/kas-wgpu/src/draw/shaded_round.rs
+++ b/kas-wgpu/src/draw/shaded_round.rs
@@ -22,33 +22,22 @@ const OFFSET: f32 = 0.125;
 struct Vertex(Vec2, Rgb, Vec2, Vec2, Vec2);
 
 /// A pipeline for rendering rounded shapes
-pub struct ShadedRound {
+pub struct Pipeline {
+    bind_group_layout: wgpu::BindGroupLayout,
+    render_pipeline: wgpu::RenderPipeline,
+}
+
+/// Per-window state
+pub struct Window {
     bind_group: wgpu::BindGroup,
     scale_buf: wgpu::Buffer,
-    render_pipeline: wgpu::RenderPipeline,
     passes: Vec<Vec<Vertex>>,
 }
 
-impl ShadedRound {
+impl Pipeline {
     /// Construct
-    pub fn new<C, T>(shared: &SharedState<C, T>, size: Size, light_norm: [f32; 3]) -> Self {
+    pub fn new<C, T>(shared: &SharedState<C, T>) -> Self {
         let device = &shared.device;
-
-        type Scale = [f32; 2];
-        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
-        let scale_buf = device
-            .create_buffer_mapped(
-                scale_factor.len(),
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
-            .fill_from_slice(&scale_factor);
-
-        let light_norm_buf = device
-            .create_buffer_mapped(
-                light_norm.len(),
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
-            .fill_from_slice(&light_norm);
 
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[
@@ -61,25 +50,6 @@ impl ShadedRound {
                     binding: 1,
                     visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                },
-            ],
-        });
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &bind_group_layout,
-            bindings: &[
-                wgpu::Binding {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Buffer {
-                        buffer: &scale_buf,
-                        range: 0..(size_of::<Scale>() as u64),
-                    },
-                },
-                wgpu::Binding {
-                    binding: 1,
-                    resource: wgpu::BindingResource::Buffer {
-                        buffer: &light_norm_buf,
-                        range: 0..(size_of::<[f32; 3]>() as u64),
-                    },
                 },
             ],
         });
@@ -157,14 +127,84 @@ impl ShadedRound {
             alpha_to_coverage_enabled: false,
         });
 
-        ShadedRound {
+        Pipeline {
+            bind_group_layout,
+            render_pipeline,
+        }
+    }
+
+    /// Construct per-window state
+    pub fn new_window(&self, device: &wgpu::Device, size: Size, light_norm: [f32; 3]) -> Window {
+        type Scale = [f32; 2];
+        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
+        let scale_buf = device
+            .create_buffer_mapped(
+                scale_factor.len(),
+                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            )
+            .fill_from_slice(&scale_factor);
+
+        let light_norm_buf = device
+            .create_buffer_mapped(
+                light_norm.len(),
+                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            )
+            .fill_from_slice(&light_norm);
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &self.bind_group_layout,
+            bindings: &[
+                wgpu::Binding {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer {
+                        buffer: &scale_buf,
+                        range: 0..(size_of::<Scale>() as u64),
+                    },
+                },
+                wgpu::Binding {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Buffer {
+                        buffer: &light_norm_buf,
+                        range: 0..(size_of::<[f32; 3]>() as u64),
+                    },
+                },
+            ],
+        });
+
+        Window {
             bind_group,
             scale_buf,
-            render_pipeline,
             passes: vec![],
         }
     }
 
+    /// Render queued triangles and clear the queue
+    pub fn render(
+        &mut self,
+        window: &mut Window,
+        device: &wgpu::Device,
+        pass: usize,
+        rpass: &mut wgpu::RenderPass,
+    ) {
+        if pass >= window.passes.len() {
+            return;
+        }
+        let v = &mut window.passes[pass];
+        let buffer = device
+            .create_buffer_mapped(v.len(), wgpu::BufferUsage::VERTEX)
+            .fill_from_slice(&v);
+        let count = v.len() as u32;
+
+        rpass.set_pipeline(&self.render_pipeline);
+        rpass.set_bind_group(0, &window.bind_group, &[]);
+        rpass.set_vertex_buffers(0, &[(&buffer, 0)]);
+        rpass.draw(0..count, 0..1);
+
+        v.clear();
+    }
+}
+
+impl Window {
     pub fn resize(
         &mut self,
         device: &wgpu::Device,
@@ -179,25 +219,6 @@ impl ShadedRound {
         let byte_len = size_of::<Scale>() as u64;
 
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &self.scale_buf, 0, byte_len);
-    }
-
-    /// Render queued triangles and clear the queue
-    pub fn render(&mut self, device: &wgpu::Device, pass: usize, rpass: &mut wgpu::RenderPass) {
-        if pass >= self.passes.len() {
-            return;
-        }
-        let v = &mut self.passes[pass];
-        let buffer = device
-            .create_buffer_mapped(v.len(), wgpu::BufferUsage::VERTEX)
-            .fill_from_slice(&v);
-        let count = v.len() as u32;
-
-        rpass.set_pipeline(&self.render_pipeline);
-        rpass.set_bind_group(0, &self.bind_group, &[]);
-        rpass.set_vertex_buffers(0, &[(&buffer, 0)]);
-        rpass.draw(0..count, 0..1);
-
-        v.clear();
     }
 
     /// Bounds on input: `0 ≤ inner_radius ≤ 1`.

--- a/kas-wgpu/src/draw/shaded_round.rs
+++ b/kas-wgpu/src/draw/shaded_round.rs
@@ -8,8 +8,7 @@
 use std::f32::consts::FRAC_PI_2;
 use std::mem::size_of;
 
-use crate::draw::{Rgb, Vec2};
-use crate::shared::SharedState;
+use crate::draw::{Rgb, ShaderManager, Vec2};
 use kas::draw::Colour;
 use kas::geom::{Rect, Size};
 
@@ -36,9 +35,7 @@ pub struct Window {
 
 impl Pipeline {
     /// Construct
-    pub fn new<C, T>(shared: &SharedState<C, T>) -> Self {
-        let device = &shared.device;
-
+    pub fn new(device: &wgpu::Device, shaders: &ShaderManager) -> Self {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[
                 wgpu::BindGroupLayoutBinding {
@@ -60,11 +57,11 @@ impl Pipeline {
         let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             layout: &pipeline_layout,
             vertex_stage: wgpu::ProgrammableStageDescriptor {
-                module: &shared.shaders.vert_3222,
+                module: &shaders.vert_3222,
                 entry_point: "main",
             },
             fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
-                module: &shared.shaders.frag_shaded_round,
+                module: &shaders.frag_shaded_round,
                 entry_point: "main",
             }),
             rasterization_state: Some(wgpu::RasterizationStateDescriptor {
@@ -180,7 +177,7 @@ impl Pipeline {
 
     /// Render queued triangles and clear the queue
     pub fn render(
-        &mut self,
+        &self,
         window: &mut Window,
         device: &wgpu::Device,
         pass: usize,

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -8,8 +8,7 @@
 use std::f32;
 use std::mem::size_of;
 
-use crate::draw::{Rgb, Vec2};
-use crate::shared::SharedState;
+use crate::draw::{Rgb, ShaderManager, Vec2};
 use kas::draw::Colour;
 use kas::geom::{Rect, Size};
 
@@ -32,9 +31,7 @@ pub struct Window {
 
 impl Pipeline {
     /// Construct
-    pub fn new<C, T>(shared: &SharedState<C, T>) -> Self {
-        let device = &shared.device;
-
+    pub fn new(device: &wgpu::Device, shaders: &ShaderManager) -> Self {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[
                 wgpu::BindGroupLayoutBinding {
@@ -57,11 +54,11 @@ impl Pipeline {
         let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             layout: &pipeline_layout,
             vertex_stage: wgpu::ProgrammableStageDescriptor {
-                module: &shared.shaders.vert_32,
+                module: &shaders.vert_32,
                 entry_point: "main",
             },
             fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
-                module: &shared.shaders.frag_shaded_square,
+                module: &shaders.frag_shaded_square,
                 entry_point: "main",
             }),
             rasterization_state: Some(wgpu::RasterizationStateDescriptor {
@@ -159,7 +156,7 @@ impl Pipeline {
 
     /// Render queued triangles and clear the queue
     pub fn render(
-        &mut self,
+        &self,
         window: &mut Window,
         device: &wgpu::Device,
         pass: usize,

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -18,32 +18,22 @@ use kas::geom::{Rect, Size};
 struct Vertex(Vec2, Rgb, Vec2);
 
 /// A pipeline for rendering with flat and square-corner shading
-pub struct ShadedSquare {
+pub struct Pipeline {
+    bind_group_layout: wgpu::BindGroupLayout,
+    render_pipeline: wgpu::RenderPipeline,
+}
+
+/// Per-window state
+pub struct Window {
     bind_group: wgpu::BindGroup,
     scale_buf: wgpu::Buffer,
-    render_pipeline: wgpu::RenderPipeline,
     passes: Vec<Vec<Vertex>>,
 }
 
-impl ShadedSquare {
+impl Pipeline {
     /// Construct
-    pub fn new<C, T>(shared: &SharedState<C, T>, size: Size, light_norm: [f32; 3]) -> Self {
+    pub fn new<C, T>(shared: &SharedState<C, T>) -> Self {
         let device = &shared.device;
-        type Scale = [f32; 2];
-        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
-        let scale_buf = device
-            .create_buffer_mapped(
-                scale_factor.len(),
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
-            .fill_from_slice(&scale_factor);
-
-        let light_norm_buf = device
-            .create_buffer_mapped(
-                light_norm.len(),
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
-            .fill_from_slice(&light_norm);
 
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[
@@ -59,25 +49,7 @@ impl ShadedSquare {
                 },
             ],
         });
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &bind_group_layout,
-            bindings: &[
-                wgpu::Binding {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Buffer {
-                        buffer: &scale_buf,
-                        range: 0..(size_of::<Scale>() as u64),
-                    },
-                },
-                wgpu::Binding {
-                    binding: 1,
-                    resource: wgpu::BindingResource::Buffer {
-                        buffer: &light_norm_buf,
-                        range: 0..(size_of::<[f32; 3]>() as u64),
-                    },
-                },
-            ],
-        });
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             bind_group_layouts: &[&bind_group_layout],
         });
@@ -134,14 +106,84 @@ impl ShadedSquare {
             alpha_to_coverage_enabled: false,
         });
 
-        ShadedSquare {
+        Pipeline {
+            bind_group_layout,
+            render_pipeline,
+        }
+    }
+
+    /// Construct per-window state
+    pub fn new_window(&self, device: &wgpu::Device, size: Size, light_norm: [f32; 3]) -> Window {
+        type Scale = [f32; 2];
+        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
+        let scale_buf = device
+            .create_buffer_mapped(
+                scale_factor.len(),
+                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            )
+            .fill_from_slice(&scale_factor);
+
+        let light_norm_buf = device
+            .create_buffer_mapped(
+                light_norm.len(),
+                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            )
+            .fill_from_slice(&light_norm);
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &self.bind_group_layout,
+            bindings: &[
+                wgpu::Binding {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer {
+                        buffer: &scale_buf,
+                        range: 0..(size_of::<Scale>() as u64),
+                    },
+                },
+                wgpu::Binding {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Buffer {
+                        buffer: &light_norm_buf,
+                        range: 0..(size_of::<[f32; 3]>() as u64),
+                    },
+                },
+            ],
+        });
+
+        Window {
             bind_group,
             scale_buf,
-            render_pipeline,
             passes: vec![],
         }
     }
 
+    /// Render queued triangles and clear the queue
+    pub fn render(
+        &mut self,
+        window: &mut Window,
+        device: &wgpu::Device,
+        pass: usize,
+        rpass: &mut wgpu::RenderPass,
+    ) {
+        if pass >= window.passes.len() {
+            return;
+        }
+        let v = &mut window.passes[pass];
+        let buffer = device
+            .create_buffer_mapped(v.len(), wgpu::BufferUsage::VERTEX)
+            .fill_from_slice(&v);
+        let count = v.len() as u32;
+
+        rpass.set_pipeline(&self.render_pipeline);
+        rpass.set_bind_group(0, &window.bind_group, &[]);
+        rpass.set_vertex_buffers(0, &[(&buffer, 0)]);
+        rpass.draw(0..count, 0..1);
+
+        v.clear();
+    }
+}
+
+impl Window {
     pub fn resize(
         &mut self,
         device: &wgpu::Device,
@@ -156,25 +198,6 @@ impl ShadedSquare {
         let byte_len = size_of::<Scale>() as u64;
 
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &self.scale_buf, 0, byte_len);
-    }
-
-    /// Render queued triangles and clear the queue
-    pub fn render(&mut self, device: &wgpu::Device, pass: usize, rpass: &mut wgpu::RenderPass) {
-        if pass >= self.passes.len() {
-            return;
-        }
-        let v = &mut self.passes[pass];
-        let buffer = device
-            .create_buffer_mapped(v.len(), wgpu::BufferUsage::VERTEX)
-            .fill_from_slice(&v);
-        let count = v.len() as u32;
-
-        rpass.set_pipeline(&self.render_pipeline);
-        rpass.set_bind_group(0, &self.bind_group, &[]);
-        rpass.set_vertex_buffers(0, &[(&buffer, 0)]);
-        rpass.draw(0..count, 0..1);
-
-        v.clear();
     }
 
     /// Add a rectangle to the buffer

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -17,26 +17,26 @@ use winit::window as ww;
 use kas::TkAction;
 use kas_theme::Theme;
 
-use crate::draw::{CustomPipeBuilder, DrawPipe};
+use crate::draw::{CustomPipe, DrawWindow};
 use crate::shared::{PendingAction, SharedState};
 use crate::{ProxyAction, Window, WindowId};
 
 /// Event-loop data structure (i.e. all run-time state)
-pub(crate) struct Loop<CB: CustomPipeBuilder, T: Theme<DrawPipe<CB::Pipe>>> {
+pub(crate) struct Loop<C: CustomPipe, T: Theme<DrawWindow<C::Window>>> {
     /// Window states
-    windows: HashMap<ww::WindowId, Window<CB::Pipe, T::Window>>,
+    windows: HashMap<ww::WindowId, Window<C::Window, T::Window>>,
     /// Translates our WindowId to winit's
     id_map: HashMap<WindowId, ww::WindowId>,
     /// Shared data passed from Toolkit
-    shared: SharedState<CB, T>,
+    shared: SharedState<C, T>,
     /// Timer resumes: (time, window index)
     resumes: Vec<(Instant, ww::WindowId)>,
 }
 
-impl<CB: CustomPipeBuilder, T: Theme<DrawPipe<CB::Pipe>>> Loop<CB, T> {
+impl<C: CustomPipe, T: Theme<DrawWindow<C::Window>>> Loop<C, T> {
     pub(crate) fn new(
-        mut windows: Vec<(WindowId, Window<CB::Pipe, T::Window>)>,
-        shared: SharedState<CB, T>,
+        mut windows: Vec<(WindowId, Window<C::Window, T::Window>)>,
+        shared: SharedState<C, T>,
     ) -> Self {
         let id_map = windows.iter().map(|(id, w)| (*id, w.window.id())).collect();
         Loop {

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -17,12 +17,15 @@ use winit::window as ww;
 use kas::TkAction;
 use kas_theme::Theme;
 
-use crate::draw::{CustomPipe, DrawWindow};
+use crate::draw::{CustomPipe, DrawPipe, DrawWindow};
 use crate::shared::{PendingAction, SharedState};
 use crate::{ProxyAction, Window, WindowId};
 
 /// Event-loop data structure (i.e. all run-time state)
-pub(crate) struct Loop<C: CustomPipe, T: Theme<DrawWindow<C::Window>>> {
+pub(crate) struct Loop<C: CustomPipe + 'static, T: Theme<DrawPipe<C>>>
+where
+    T::Window: kas_theme::Window<DrawWindow<C::Window>>,
+{
     /// Window states
     windows: HashMap<ww::WindowId, Window<C::Window, T::Window>>,
     /// Translates our WindowId to winit's
@@ -33,7 +36,10 @@ pub(crate) struct Loop<C: CustomPipe, T: Theme<DrawWindow<C::Window>>> {
     resumes: Vec<(Instant, ww::WindowId)>,
 }
 
-impl<C: CustomPipe, T: Theme<DrawWindow<C::Window>>> Loop<C, T> {
+impl<C: CustomPipe + 'static, T: Theme<DrawPipe<C>>> Loop<C, T>
+where
+    T::Window: kas_theme::Window<DrawWindow<C::Window>>,
+{
     pub(crate) fn new(
         mut windows: Vec<(WindowId, Window<C::Window, T::Window>)>,
         shared: SharedState<C, T>,

--- a/kas-wgpu/src/lib.rs
+++ b/kas-wgpu/src/lib.rs
@@ -28,7 +28,7 @@ use kas_theme::Theme;
 use winit::error::OsError;
 use winit::event_loop::{EventLoop, EventLoopProxy};
 
-use crate::draw::{CustomPipe, CustomPipeBuilder, DrawWindow};
+use crate::draw::{CustomPipe, CustomPipeBuilder, DrawPipe, DrawWindow};
 use crate::shared::SharedState;
 use window::Window;
 
@@ -83,13 +83,21 @@ impl From<shaderc::Error> for Error {
 }
 
 /// Builds a toolkit over a `winit::event_loop::EventLoop`.
-pub struct Toolkit<C: CustomPipe, T: Theme<DrawWindow<C::Window>>> {
+pub struct Toolkit<C: CustomPipe, T: Theme<DrawPipe<C>>>
+where
+    // TODO: investigate why this bound is required (in many places)!
+    // It simply restates the bound on Theme::Window. Compiler bug?
+    T::Window: kas_theme::Window<DrawWindow<C::Window>>,
+{
     el: EventLoop<ProxyAction>,
     windows: Vec<(WindowId, Window<C::Window, T::Window>)>,
     shared: SharedState<C, T>,
 }
 
-impl<T: Theme<DrawWindow<()>> + 'static> Toolkit<(), T> {
+impl<T: Theme<DrawPipe<()>> + 'static> Toolkit<(), T>
+where
+    T::Window: kas_theme::Window<DrawWindow<()>>,
+{
     /// Construct a new instance with default options.
     ///
     /// Environment variables may affect option selection; see documentation
@@ -99,7 +107,10 @@ impl<T: Theme<DrawWindow<()>> + 'static> Toolkit<(), T> {
     }
 }
 
-impl<C: CustomPipe + 'static, T: Theme<DrawWindow<C::Window>> + 'static> Toolkit<C, T> {
+impl<C: CustomPipe + 'static, T: Theme<DrawPipe<C>> + 'static> Toolkit<C, T>
+where
+    T::Window: kas_theme::Window<DrawWindow<C::Window>>,
+{
     /// Construct an instance with custom options
     ///
     /// The `custom` parameter accepts a custom draw pipe (see [`CustomPipeBuilder`]).

--- a/kas-wgpu/src/lib.rs
+++ b/kas-wgpu/src/lib.rs
@@ -123,10 +123,12 @@ where
         theme: T,
         options: Options,
     ) -> Result<Self, Error> {
+        let el = EventLoop::with_user_event();
+        let scale_factor = el.primary_monitor().scale_factor();
         Ok(Toolkit {
-            el: EventLoop::with_user_event(),
+            el,
             windows: vec![],
-            shared: SharedState::new(custom, theme, options)?,
+            shared: SharedState::new(custom, theme, options, scale_factor)?,
         })
     }
 

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -26,6 +26,9 @@ pub struct SharedState<C: CustomPipe, T> {
     pub draw: DrawPipe<C>,
     pub theme: T,
     pub pending: Vec<PendingAction>,
+    /// Newly created windows need to know the scale_factor *before* they are
+    /// created. This is used to estimate ideal window size.
+    pub scale_factor: f64,
     window_id: u32,
 }
 
@@ -38,6 +41,7 @@ where
         custom: CB,
         mut theme: T,
         options: Options,
+        scale_factor: f64,
     ) -> Result<Self, Error> {
         #[cfg(feature = "clipboard")]
         let clipboard = match ClipboardContext::new() {
@@ -77,6 +81,7 @@ where
             draw,
             theme,
             pending: vec![],
+            scale_factor,
             window_id: 0,
         })
     }

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -6,7 +6,6 @@
 //! `Window` and `WindowList` types
 
 use log::{debug, info, trace};
-use std::marker::PhantomData;
 use std::time::Instant;
 
 use kas::event::{Callback, CursorIcon, ManagerState, UpdateHandle};
@@ -18,12 +17,12 @@ use winit::error::OsError;
 use winit::event::WindowEvent;
 use winit::event_loop::EventLoopWindowTarget;
 
-use crate::draw::{CustomPipe, CustomPipeBuilder, DrawPipe};
+use crate::draw::{CustomPipe, CustomWindow, DrawWindow, TEX_FORMAT};
 use crate::shared::{PendingAction, SharedState};
 use crate::ProxyAction;
 
 /// Per-window data
-pub(crate) struct Window<C: CustomPipe, TW> {
+pub(crate) struct Window<CW: CustomWindow, TW> {
     widget: Box<dyn kas::Window>,
     mgr: ManagerState,
     /// The winit window
@@ -31,15 +30,15 @@ pub(crate) struct Window<C: CustomPipe, TW> {
     surface: wgpu::Surface,
     sc_desc: wgpu::SwapChainDescriptor,
     swap_chain: wgpu::SwapChain,
-    draw_pipe: DrawPipe<C>,
+    draw: DrawWindow<CW>,
     theme_window: TW,
 }
 
 // Public functions, for use by the toolkit
-impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> {
+impl<CW: CustomWindow, TW: kas_theme::Window<DrawWindow<CW>> + 'static> Window<CW, TW> {
     /// Construct a window
-    pub fn new<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>, Window = TW>>(
-        shared: &mut SharedState<CB, T>,
+    pub fn new<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>, Window = TW>>(
+        shared: &mut SharedState<C, T>,
         elwt: &EventLoopWindowTarget<ProxyAction>,
         widget: Box<dyn kas::Window>,
     ) -> Result<Self, OsError> {
@@ -54,16 +53,16 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
 
         let sc_desc = wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
-            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            format: TEX_FORMAT,
             width: size.0,
             height: size.1,
             present_mode: wgpu::PresentMode::Vsync,
         };
         let swap_chain = shared.device.create_swap_chain(&surface, &sc_desc);
 
-        let mut draw_pipe = DrawPipe::new(shared, sc_desc.format, size);
-        shared.theme.init(&mut draw_pipe);
-        let theme_window = shared.theme.new_window(&mut draw_pipe, dpi_factor as f32);
+        let mut draw = shared.draw.new_window(&mut shared.device, size);
+        shared.theme.init(&mut draw);
+        let theme_window = shared.theme.new_window(&mut draw, dpi_factor as f32);
 
         let mgr = ManagerState::new(dpi_factor);
 
@@ -74,7 +73,7 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
             surface,
             sc_desc,
             swap_chain,
-            draw_pipe,
+            draw,
             theme_window,
         })
     }
@@ -83,9 +82,9 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
     /// windows. Optionally returns a callback time.
     ///
     /// `init` should always return an action of at least `TkAction::Reconfigure`.
-    pub fn init<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>>>(
+    pub fn init<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>>>(
         &mut self,
-        shared: &mut SharedState<CB, T>,
+        shared: &mut SharedState<C, T>,
     ) -> TkAction {
         debug!("Window::init");
         let mut tkw = TkWindow::new(&self.window, shared);
@@ -105,14 +104,14 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
     }
 
     /// Recompute layout of widgets and redraw
-    pub fn reconfigure<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>>>(
+    pub fn reconfigure<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>>>(
         &mut self,
-        shared: &mut SharedState<CB, T>,
+        shared: &mut SharedState<C, T>,
     ) -> Option<Instant> {
         let size = Size(self.sc_desc.width, self.sc_desc.height);
         debug!("Reconfiguring window (size = {:?})", size);
 
-        let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw_pipe) };
+        let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw) };
         let (min, max) = self.widget.resize(&mut size_handle, size);
         self.window.set_min_inner_size(min);
         self.window.set_max_inner_size(max);
@@ -123,9 +122,9 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
         self.mgr.next_resume()
     }
 
-    pub fn theme_resize<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>, Window = TW>>(
+    pub fn theme_resize<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>, Window = TW>>(
         &mut self,
-        shared: &SharedState<CB, T>,
+        shared: &SharedState<C, T>,
     ) {
         debug!("Applying theme resize");
         let scale_factor = self.window.scale_factor() as f32;
@@ -133,7 +132,7 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
             .theme
             .update_window(&mut self.theme_window, scale_factor);
         let size = Size(self.sc_desc.width, self.sc_desc.height);
-        let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw_pipe) };
+        let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw) };
         let (min, max) = self.widget.resize(&mut size_handle, size);
         self.window.set_min_inner_size(min);
         self.window.set_max_inner_size(max);
@@ -143,9 +142,9 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
     /// Handle an event
     ///
     /// Return true to remove the window
-    pub fn handle_event<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>, Window = TW>>(
+    pub fn handle_event<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>, Window = TW>>(
         &mut self,
-        shared: &mut SharedState<CB, T>,
+        shared: &mut SharedState<C, T>,
         event: WindowEvent,
     ) -> (TkAction, Option<Instant>) {
         // Note: resize must be handled here to update self.swap_chain.
@@ -177,9 +176,9 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
         self.mgr.region_moved(&mut *self.widget);
     }
 
-    pub fn handle_closure<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>>>(
+    pub fn handle_closure<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>>>(
         mut self,
-        shared: &mut SharedState<CB, T>,
+        shared: &mut SharedState<C, T>,
     ) -> TkAction {
         let mut tkw = TkWindow::new(&self.window, shared);
         let mut mgr = self.mgr.manager(&mut tkw);
@@ -196,9 +195,9 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
         mgr.finish(&mut *self.widget)
     }
 
-    pub fn update_timer<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>>>(
+    pub fn update_timer<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>>>(
         &mut self,
-        shared: &mut SharedState<CB, T>,
+        shared: &mut SharedState<C, T>,
     ) -> (TkAction, Option<Instant>) {
         let mut tkw = TkWindow::new(&self.window, shared);
         let mut mgr = self.mgr.manager(&mut tkw);
@@ -208,9 +207,9 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
         (action, self.mgr.next_resume())
     }
 
-    pub fn update_handle<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>>>(
+    pub fn update_handle<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>>>(
         &mut self,
-        shared: &mut SharedState<CB, T>,
+        shared: &mut SharedState<C, T>,
         handle: UpdateHandle,
         payload: u64,
     ) -> TkAction {
@@ -222,10 +221,10 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
 }
 
 // Internal functions
-impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> {
-    fn do_resize<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>, Window = TW>>(
+impl<CW: CustomWindow, TW: kas_theme::Window<DrawWindow<CW>> + 'static> Window<CW, TW> {
+    fn do_resize<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>, Window = TW>>(
         &mut self,
-        shared: &mut SharedState<CB, T>,
+        shared: &mut SharedState<C, T>,
         size: PhysicalSize<u32>,
     ) -> TkAction {
         let size = size.into();
@@ -234,11 +233,11 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
         }
 
         debug!("Resizing window to size={:?}", size);
-        let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw_pipe) };
+        let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw) };
         self.widget.resize(&mut size_handle, size);
         drop(size_handle);
 
-        let buf = self.draw_pipe.resize(&shared.device, size);
+        let buf = self.draw.resize(&shared.device, size);
         shared.queue.submit(&[buf]);
 
         self.sc_desc.width = size.0;
@@ -250,9 +249,9 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
         TkAction::Redraw
     }
 
-    pub(crate) fn do_draw<CB: CustomPipeBuilder<Pipe = C>, T: Theme<DrawPipe<C>, Window = TW>>(
+    pub(crate) fn do_draw<C: CustomPipe<Window = CW>, T: Theme<DrawWindow<CW>, Window = TW>>(
         &mut self,
-        shared: &mut SharedState<CB, T>,
+        shared: &mut SharedState<C, T>,
     ) {
         trace!("Drawing window");
         let size = Size(self.sc_desc.width, self.sc_desc.height);
@@ -263,16 +262,14 @@ impl<C: CustomPipe, TW: kas_theme::Window<DrawPipe<C>> + 'static> Window<C, TW> 
         let mut draw_handle = unsafe {
             shared
                 .theme
-                .draw_handle(&mut self.draw_pipe, &mut self.theme_window, rect)
+                .draw_handle(&mut self.draw, &mut self.theme_window, rect)
         };
         self.widget.draw(&mut draw_handle, &self.mgr);
         drop(draw_handle);
 
         let frame = self.swap_chain.get_next_texture();
         let clear_color = to_wgpu_color(shared.theme.clear_colour());
-        let buf = self
-            .draw_pipe
-            .render(&mut shared.device, &frame.view, clear_color);
+        let buf = shared.render(&mut self.draw, &frame.view, clear_color);
         shared.queue.submit(&[buf]);
     }
 }
@@ -286,25 +283,18 @@ fn to_wgpu_color(c: kas::draw::Colour) -> wgpu::Color {
     }
 }
 
-struct TkWindow<'a, CB, T> {
+struct TkWindow<'a, C: CustomPipe, T> {
     window: &'a winit::window::Window,
-    shared: &'a mut SharedState<CB, T>,
-    _phantom: PhantomData<CB>,
+    shared: &'a mut SharedState<C, T>,
 }
 
-impl<'a, CB, T> TkWindow<'a, CB, T> {
-    fn new(window: &'a winit::window::Window, shared: &'a mut SharedState<CB, T>) -> Self {
-        TkWindow {
-            window,
-            shared,
-            _phantom: Default::default(),
-        }
+impl<'a, C: CustomPipe, T> TkWindow<'a, C, T> {
+    fn new(window: &'a winit::window::Window, shared: &'a mut SharedState<C, T>) -> Self {
+        TkWindow { window, shared }
     }
 }
 
-impl<'a, CB: CustomPipeBuilder, T: Theme<DrawPipe<CB::Pipe>>> kas::TkWindow
-    for TkWindow<'a, CB, T>
-{
+impl<'a, C: CustomPipe, T: Theme<DrawWindow<C::Window>>> kas::TkWindow for TkWindow<'a, C, T> {
     fn add_window(&mut self, widget: Box<dyn kas::Window>) -> WindowId {
         // By far the simplest way to implement this is to let our call
         // anscestor, event::Loop::handle, do the work.

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -50,6 +50,7 @@ impl<CW: CustomWindow + 'static, TW: kas_theme::Window<DrawWindow<CW>> + 'static
 
         let mut size_handle = unsafe { theme_window.size_handle(&mut draw) };
         let (min, ideal) = widget.find_size(&mut size_handle);
+        drop(size_handle);
 
         let mut builder = WindowBuilder::new().with_inner_size(ideal);
         if let Some(min) = min {

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -51,13 +51,18 @@ use crate::geom::{Coord, Rect};
 
 pub use colour::Colour;
 pub use handle::{DrawHandle, SizeHandle, TextClass};
-pub use text::{DrawText, Font, FontId, TextProperties};
+pub use text::{DrawText, DrawTextShared, Font, FontId, TextProperties};
 
 /// Type returned by [`Draw::add_clip_region`].
 ///
 /// Supports [`Default`], which may be used to target the root region.
 #[derive(Copy, Clone, Default)]
 pub struct Region(pub usize);
+
+/// Bounds on type shared across [`Draw`] implementations
+pub trait DrawShared {
+    type Draw: Draw;
+}
 
 /// Base abstraction over drawing
 ///

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -7,7 +7,7 @@
 
 pub use rusttype::Font;
 
-use super::{Colour, Draw};
+use super::{Colour, Draw, DrawShared};
 use crate::geom::Rect;
 use crate::Align;
 
@@ -17,7 +17,7 @@ use crate::Align;
 /// first font loaded by the (first) theme.
 ///
 /// Other than this, users should treat this type as an opaque handle.
-/// An instance may be obtained by [`DrawText::load_font`].
+/// An instance may be obtained by [`DrawTextShared::load_font`].
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct FontId(pub usize);
 
@@ -37,6 +37,12 @@ pub struct TextProperties {
     pub line_wrap: bool,
 }
 
+/// Abstraction over type shared by [`DrawText`] implementations
+pub trait DrawTextShared: DrawShared {
+    /// Load a font
+    fn load_font(&mut self, font: Font<'static>) -> FontId;
+}
+
 /// Abstraction over text rendering
 ///
 /// This trait is an extension over [`Draw`] providing basic text rendering.
@@ -46,9 +52,6 @@ pub struct TextProperties {
 /// Note: the current API is designed to meet only current requirements since
 /// changes are expected to support external font shaping libraries.
 pub trait DrawText: Draw {
-    /// Load a font
-    fn load_font(&mut self, font: Font<'static>) -> FontId;
-
     /// Simple text drawing
     ///
     /// This allows text to be drawn according to a high-level API, and should

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -21,7 +21,7 @@ pub use grid_solver::{GridChildInfo, GridSetter, GridSolver};
 pub use row_solver::{RowPositionSolver, RowSetter, RowSolver};
 pub use single_solver::{SingleSetter, SingleSolver};
 pub use size_rules::{Margins, SizeRules, StretchPolicy};
-pub use sizer::{solve, RulesSetter, RulesSolver};
+pub use sizer::{solve, solve_and_set, RulesSetter, RulesSolver};
 pub use storage::{
     DynGridStorage, DynRowStorage, FixedGridStorage, FixedRowStorage, GridStorage, RowStorage,
     RowTemp, Storage,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -311,7 +311,14 @@ pub trait Window: Widget + Handler<Msg = VoidMsg> {
     /// Get the window title
     fn title(&self) -> &str;
 
+    /// Calculate required size
+    ///
+    /// Returns optional minimum size, and ideal size.
+    fn find_size(&mut self, size_handle: &mut dyn SizeHandle) -> (Option<Size>, Size);
+
     /// Adjust the size of the window, repositioning widgets.
+    ///
+    /// Returns optional minimum size and optional maximum size.
     fn resize(
         &mut self,
         size_handle: &mut dyn SizeHandle,

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -62,13 +62,18 @@ impl Window for MessageBox {
         &self.title
     }
 
+    fn find_size(&mut self, size_handle: &mut dyn SizeHandle) -> (Option<Size>, Size) {
+        let (min, ideal) = layout::solve(self, size_handle);
+        (Some(min), ideal)
+    }
+
     fn resize(
         &mut self,
         size_handle: &mut dyn SizeHandle,
         size: Size,
     ) -> (Option<Size>, Option<Size>) {
-        let (min, max) = layout::solve(self, size_handle, size);
-        (Some(min), Some(max))
+        let (min, ideal) = layout::solve_and_set(self, size_handle, size);
+        (Some(min), Some(ideal))
     }
 
     // doesn't support callbacks, so doesn't need to do anything here

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -106,15 +106,21 @@ impl<W: Widget + Handler<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
         &self.title
     }
 
+    fn find_size(&mut self, size_handle: &mut dyn SizeHandle) -> (Option<Size>, Size) {
+        let (min, ideal) = layout::solve(self, size_handle);
+        let min = if self.enforce_min { Some(min) } else { None };
+        (min, ideal)
+    }
+
     fn resize(
         &mut self,
         size_handle: &mut dyn SizeHandle,
         size: Size,
     ) -> (Option<Size>, Option<Size>) {
-        let (min, max) = layout::solve(self, size_handle, size);
+        let (min, ideal) = layout::solve_and_set(self, size_handle, size);
         (
             if self.enforce_min { Some(min) } else { None },
-            if self.enforce_max { Some(max) } else { None },
+            if self.enforce_max { Some(ideal) } else { None },
         )
     }
 


### PR DESCRIPTION
Mostly this PR is about sharing draw state between windows. Unfortunately sharing the font texture cache between windows is well beyond the scope of this PR (touching `wgpu_glyph`, `glyph_brush` and even `rusttype`), but it's not really required either.

- fixes crash when opening child window from gallery example
- calculates window size before creation