### PR TITLE
Add DragHandle, Slider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ nightly = []
 internal_doc = []
 
 [dependencies]
+conv = "0.3"
 log = "0.4"
 rusttype = "0.8"
 smallvec = "1.1"

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -29,6 +29,8 @@ pub struct DimensionsParams {
     pub button_frame: f32,
     /// Scrollbar minimum handle size
     pub scrollbar_size: Vec2,
+    /// Slider minimum handle size
+    pub slider_size: Vec2,
 }
 
 /// Dimensions available within [`DimensionsWindow`]
@@ -44,6 +46,7 @@ pub struct Dimensions {
     pub button_frame: u32,
     pub checkbox: u32,
     pub scrollbar: Size,
+    pub slider: Size,
 }
 
 impl Dimensions {
@@ -63,6 +66,7 @@ impl Dimensions {
             button_frame: (params.button_frame * dpi_factor).round() as u32,
             checkbox: (font_scale * 0.7).round() as u32 + 2 * (margin + frame),
             scrollbar: Size::from(params.scrollbar_size * dpi_factor),
+            slider: Size::from(params.slider_size * dpi_factor),
         }
     }
 }
@@ -192,6 +196,11 @@ impl<'a, Draw: DrawText> draw::SizeHandle for SizeHandle<'a, Draw> {
 
     fn scrollbar(&self) -> (Size, u32) {
         let size = self.dims.scrollbar;
+        (size, 2 * size.0)
+    }
+
+    fn slider(&self) -> (Size, u32) {
+        let size = self.dims.slider;
         (size, 2 * size.0)
     }
 }

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -11,7 +11,7 @@ use std::any::Any;
 use std::f32;
 
 use kas::draw::{self, DrawText, FontId, TextClass};
-use kas::geom::Size;
+use kas::geom::{Size, Vec2};
 use kas::layout::{AxisInfo, SizeRules, StretchPolicy};
 use kas::Direction::{Horizontal, Vertical};
 
@@ -27,8 +27,8 @@ pub struct DimensionsParams {
     pub frame_size: f32,
     /// Button frame size (non-flat outer region)
     pub button_frame: f32,
-    /// Scrollbar width & min length
-    pub scrollbar_size: f32,
+    /// Scrollbar minimum handle size
+    pub scrollbar_size: Vec2,
 }
 
 /// Dimensions available within [`DimensionsWindow`]
@@ -43,7 +43,7 @@ pub struct Dimensions {
     pub frame: u32,
     pub button_frame: u32,
     pub checkbox: u32,
-    pub scrollbar: u32,
+    pub scrollbar: Size,
 }
 
 impl Dimensions {
@@ -62,7 +62,7 @@ impl Dimensions {
             frame,
             button_frame: (params.button_frame * dpi_factor).round() as u32,
             checkbox: (font_scale * 0.7).round() as u32 + 2 * (margin + frame),
-            scrollbar: (params.scrollbar_size * dpi_factor).round() as u32,
+            scrollbar: Size::from(params.scrollbar_size * dpi_factor),
         }
     }
 }
@@ -190,8 +190,8 @@ impl<'a, Draw: DrawText> draw::SizeHandle for SizeHandle<'a, Draw> {
         self.checkbox()
     }
 
-    fn scrollbar(&self) -> (u32, u32, u32) {
-        let s = self.dims.scrollbar as u32;
-        (s, s, 2 * s)
+    fn scrollbar(&self) -> (Size, u32) {
+        let size = self.dims.scrollbar;
+        (size, 2 * size.0)
     }
 }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -42,6 +42,7 @@ const DIMS: DimensionsParams = DimensionsParams {
     frame_size: 4.0,
     button_frame: 6.0,
     scrollbar_size: Vec2::splat(8.0),
+    slider_size: Vec2(10.0, 25.0),
 };
 
 pub struct DrawHandle<'a, D: Draw> {
@@ -281,5 +282,30 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         let col = self.cols.scrollbar_state(highlights);
         self.draw.rounded_frame(self.pass, outer, inner, 0.0, col);
         self.draw.rect(self.pass, inner, col);
+    }
+
+    fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
+        // track
+        let mut outer = rect + self.offset;
+        // TODO: draw with floats; ints are too inaccurate!
+        let half;
+        match dir {
+            Direction::Horizontal => {
+                half = outer.size.1 / 8;
+                outer.pos.1 += 3 * half as i32;
+                outer.size.1 -= 6 * half;
+            }
+            Direction::Vertical => {
+                half = outer.size.0 / 8;
+                outer.pos.0 += 3 * half as i32;
+                outer.size.0 -= 6 * half;
+            }
+        };
+        let inner = outer.shrink(half);
+        let col = self.cols.frame;
+        self.draw.rounded_frame(self.pass, outer, inner, 0.0, col);
+
+        // handle
+        self.scrollbar(rect, h_rect, dir, highlights);
     }
 }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -15,7 +15,7 @@ use kas::draw::{
     TextClass, TextProperties,
 };
 use kas::event::HighlightState;
-use kas::geom::{Coord, Rect};
+use kas::geom::{Coord, Rect, Vec2};
 use kas::{Align, Direction, ThemeAction, ThemeApi};
 
 /// A theme with flat (unshaded) rendering
@@ -41,7 +41,7 @@ const DIMS: DimensionsParams = DimensionsParams {
     margin: 2.0,
     frame_size: 4.0,
     button_frame: 6.0,
-    scrollbar_size: 8.0,
+    scrollbar_size: Vec2::splat(8.0),
 };
 
 pub struct DrawHandle<'a, D: Draw> {
@@ -249,7 +249,6 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         }
     }
 
-    #[inline]
     fn radiobox(&mut self, rect: Rect, checked: bool, highlights: HighlightState) {
         let nav_col = self.cols.nav_region(highlights).or_else(|| {
             if checked {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -13,7 +13,7 @@ use kas::draw::{
     Region, TextClass, TextProperties,
 };
 use kas::event::HighlightState;
-use kas::geom::{Coord, Rect};
+use kas::geom::{Coord, Rect, Vec2};
 use kas::{Align, Direction, ThemeAction, ThemeApi};
 
 /// A theme using simple shading to give apparent depth to elements
@@ -39,7 +39,7 @@ const DIMS: DimensionsParams = DimensionsParams {
     margin: 2.0,
     frame_size: 5.0,
     button_frame: 5.0,
-    scrollbar_size: 8.0,
+    scrollbar_size: Vec2::splat(8.0),
 };
 
 pub struct DrawHandle<'a, D: Draw> {
@@ -241,7 +241,6 @@ where
         }
     }
 
-    #[inline]
     fn radiobox(&mut self, rect: Rect, checked: bool, highlights: HighlightState) {
         let nav_col = self.cols.nav_region(highlights).or_else(|| {
             if checked {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -40,6 +40,7 @@ const DIMS: DimensionsParams = DimensionsParams {
     frame_size: 5.0,
     button_frame: 5.0,
     scrollbar_size: Vec2::splat(8.0),
+    slider_size: Vec2(10.0, 25.0),
 };
 
 pub struct DrawHandle<'a, D: Draw> {
@@ -273,5 +274,30 @@ where
         self.draw
             .shaded_round_frame(self.pass, outer, inner, (0.0, 0.6), col);
         self.draw.rect(self.pass, inner, col);
+    }
+
+    fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
+        // track
+        let mut outer = rect + self.offset;
+        let half;
+        match dir {
+            Direction::Horizontal => {
+                half = outer.size.1 / 8;
+                outer.pos.1 += 3 * half as i32;
+                outer.size.1 -= 6 * half;
+            }
+            Direction::Vertical => {
+                half = outer.size.0 / 8;
+                outer.pos.0 += 3 * half as i32;
+                outer.size.0 -= 6 * half;
+            }
+        };
+        let inner = outer.shrink(half);
+        let col = self.cols.background;
+        self.draw
+            .shaded_round_frame(self.pass, outer, inner, (0.0, -0.8), col);
+
+        // handle
+        self.scrollbar(rect, h_rect, dir, highlights);
     }
 }

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -17,6 +17,7 @@ enum Item {
     Check(bool),
     Radio(WidgetId),
     Edit(String),
+    Slider(i32),
     Scroll(u32),
     Popup,
 }
@@ -46,13 +47,19 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[widget(row=5, col=0)] _ = Label::from("RadioBox"),
             #[widget(row=5, col=1)] _ = RadioBox::new(radio, "radio box 2").state(true)
                 .on_activate(|id| Item::Radio(id)),
-            #[widget(row=6, col=0)] _ = Label::from("ScrollBar"),
-            #[widget(row=6, col=1, handler = handle_scroll)] _ =
+            #[widget(row=6, col=0)] _ = Label::from("Slider"),
+            #[widget(row=6, col=1, handler = handle_slider)] _ =
+                Slider::<i32, Horizontal>::new(-2, 2).with_value(0),
+            #[widget(row=7, col=0)] _ = Label::from("ScrollBar"),
+            #[widget(row=7, col=1, handler = handle_scroll)] _ =
                 ScrollBar::<Horizontal>::new().with_limits(5, 2),
             #[widget(row=8)] _ = Label::from("Child window"),
             #[widget(row=8, col = 1)] _ = TextButton::new("Open", Item::Popup),
         }
         impl {
+            fn handle_slider(&mut self, _: &mut Manager, msg: i32) -> Response<Item> {
+                Response::Msg(Item::Slider(msg))
+            }
             fn handle_scroll(&mut self, _: &mut Manager, msg: u32) -> Response<Item> {
                 Response::Msg(Item::Scroll(msg))
             }
@@ -123,6 +130,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                         Item::Check(b) => println!("Checkbox: {}", b),
                         Item::Radio(id) => println!("Radiobox: {}", id),
                         Item::Edit(s) => println!("Edited: {}", s),
+                        Item::Slider(p) => println!("Slider: {}", p),
                         Item::Scroll(p) => println!("ScrollBar: {}", p),
                         Item::Popup => {
                             let window = MessageBox::new("Popup", "Hello!");

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -523,7 +523,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         #[handler(msg = event::VoidMsg)]
         struct {
             #[widget(cspan=2)] label: Label = Label::new(mbrot.loc()),
-            #[widget(row=2)] iters: Label = Label::new("064"),
+            #[widget(row=2, halign=centre)] iters: Label = Label::new("64").reserve("000"),
             #[widget(row=1, handler = iter)] _: Slider<i32, Vertical> = slider,
             #[widget(col=1, row=1, rspan=2, handler = mbrot)] mbrot: Mandlebrot = mbrot,
         }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -18,8 +18,8 @@ use kas::event::{self, Event, Manager, Response, VoidResponse};
 use kas::geom::{Coord, DVec2, Rect, Size, Vec2};
 use kas::layout::{AxisInfo, SizeRules, StretchPolicy};
 use kas::macros::make_widget;
-use kas::widget::{Label, ScrollBar, Window};
-use kas::{AlignHints, Horizontal, Layout, WidgetCore, WidgetId};
+use kas::widget::{Label, Slider, Window};
+use kas::{AlignHints, Layout, ThemeApi, Vertical, WidgetCore, WidgetId};
 use kas_wgpu::draw::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom, DrawWindow};
 use kas_wgpu::Options;
 
@@ -501,12 +501,11 @@ impl Mandlebrot {
     fn loc(&self) -> String {
         let op = if self.delta.1 < 0.0 { "−" } else { "+" };
         format!(
-            "Location: {} {} {}i; scale: {}; iters: {}",
+            "Location: {} {} {}i; scale: {}",
             self.delta.0,
             op,
             self.delta.1.abs(),
-            self.alpha.sum_square().sqrt(),
-            self.iter
+            self.alpha.sum_square().sqrt()
         )
     }
 }
@@ -515,23 +514,24 @@ fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
     let mbrot = Mandlebrot::new();
-
-    // We use a scrollbar as a slider because we don't have that yet!
-    let slider = ScrollBar::new().with_limits(256, 8).with_value(64);
+    // TODO: move slider below iters — but currently grids with cell-spans can't handle this correctly!
+    let slider = Slider::new(0, 256).with_value(64);
 
     let window = make_widget! {
         #[widget]
-        #[layout(vertical)]
+        #[layout(grid)]
         #[handler(msg = event::VoidMsg)]
         struct {
-            #[widget] label: Label = Label::new(mbrot.loc()),
-            #[widget(handler = iter)] iters: ScrollBar<Horizontal> = slider,
-            #[widget(handler = mbrot)] mbrot: Mandlebrot = mbrot,
+            #[widget(cspan=2)] label: Label = Label::new(mbrot.loc()),
+            #[widget(row=2)] iters: Label = Label::new("064"),
+            #[widget(row=1, handler = iter)] _: Slider<i32, Vertical> = slider,
+            #[widget(col=1, row=1, rspan=2, handler = mbrot)] mbrot: Mandlebrot = mbrot,
         }
         impl {
-            fn iter(&mut self, mgr: &mut Manager, iter: u32) -> VoidResponse {
-                self.mbrot.iter = iter as i32;
+            fn iter(&mut self, mgr: &mut Manager, iter: i32) -> VoidResponse {
+                self.mbrot.iter = iter;
                 self.label.set_string(mgr, self.mbrot.loc());
+                self.iters.set_string(mgr, format!("{}", iter));
                 Response::None
             }
             fn mbrot(&mut self, mgr: &mut Manager, _: ()) -> VoidResponse {
@@ -542,7 +542,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
     };
     let window = Window::new("Mandlebrot", window);
 
-    let theme = kas_theme::FlatTheme::new();
+    let mut theme = kas_theme::FlatTheme::new();
+    theme.set_colours("dark");
     let mut toolkit = kas_wgpu::Toolkit::new_custom(PipeBuilder, theme, Options::from_env())?;
     toolkit.add(window)?;
     toolkit.run()

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[layout(vertical)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget] display: Label = Label::from("0"),
+                #[widget(halign=centre)] display: Label = Label::from("0"),
                 #[widget(handler = handle_button)] buttons -> Message = buttons,
                 handle: UpdateHandle = handle,
             }

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -88,6 +88,17 @@ pub trait SizeHandle {
     ///
     /// Required bound: `min_len >= size.0`.
     fn scrollbar(&self) -> (Size, u32);
+
+    /// Dimensions for a slider
+    ///
+    /// Returns:
+    ///
+    /// -   `size`: minimum size of handle in horizontal orientation;
+    ///     `size.1` is also the dimension of the slider
+    /// -   `min_len`: minimum length for the whole bar
+    ///
+    /// Required bound: `min_len >= size.0`.
+    fn slider(&self) -> (Size, u32);
 }
 
 /// Handle passed to objects during draw and sizing operations
@@ -165,6 +176,14 @@ pub trait DrawHandle {
     /// -   `dir`: direction of bar
     /// -   `highlights`: highlighting information
     fn scrollbar(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState);
+
+    /// Draw UI element: slider
+    ///
+    /// -   `rect`: area of whole widget (slider track)
+    /// -   `h_rect`: area of slider handle
+    /// -   `dir`: direction of slider (currently only LTR or TTB)
+    /// -   `highlights`: highlighting information
+    fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState);
 }
 
 impl<S: SizeHandle> SizeHandle for Box<S> {
@@ -200,6 +219,9 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
     }
     fn scrollbar(&self) -> (Size, u32) {
         self.deref().scrollbar()
+    }
+    fn slider(&self) -> (Size, u32) {
+        self.deref().slider()
     }
 }
 
@@ -241,6 +263,9 @@ where
     fn scrollbar(&self) -> (Size, u32) {
         self.deref().scrollbar()
     }
+    fn slider(&self) -> (Size, u32) {
+        self.deref().slider()
+    }
 }
 
 impl<H: DrawHandle> DrawHandle for Box<H> {
@@ -273,6 +298,9 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     }
     fn scrollbar(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
         self.deref_mut().scrollbar(rect, h_rect, dir, highlights)
+    }
+    fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
+        self.deref_mut().slider(rect, h_rect, dir, highlights)
     }
 }
 
@@ -310,5 +338,8 @@ where
     }
     fn scrollbar(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
         self.deref_mut().scrollbar(rect, h_rect, dir, highlights)
+    }
+    fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
+        self.deref_mut().slider(rect, h_rect, dir, highlights)
     }
 }

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -80,16 +80,14 @@ pub trait SizeHandle {
 
     /// Dimensions for a scrollbar
     ///
-    /// Returns three components:
+    /// Returns:
     ///
-    /// -   `thickness`: scroll-bar width (for vertical scroll bars)
-    /// -   `min_handle_len`: minimum length for the handle
+    /// -   `size`: minimum size of handle in horizontal orientation;
+    ///     `size.1` is also the dimension of the scrollbar
     /// -   `min_len`: minimum length for the whole bar
     ///
-    /// Generally, one expects `min_len` is significantly greater than
-    /// `min_handle_len` (so that some movement is always possible).
-    /// It is required that `min_len >= min_handle_len`.
-    fn scrollbar(&self) -> (u32, u32, u32);
+    /// Required bound: `min_len >= size.0`.
+    fn scrollbar(&self) -> (Size, u32);
 }
 
 /// Handle passed to objects during draw and sizing operations
@@ -200,7 +198,7 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
     fn radiobox(&self) -> Size {
         self.deref().radiobox()
     }
-    fn scrollbar(&self) -> (u32, u32, u32) {
+    fn scrollbar(&self) -> (Size, u32) {
         self.deref().scrollbar()
     }
 }
@@ -240,7 +238,7 @@ where
     fn radiobox(&self) -> Size {
         self.deref().radiobox()
     }
-    fn scrollbar(&self) -> (u32, u32, u32) {
+    fn scrollbar(&self) -> (Size, u32) {
         self.deref().scrollbar()
     }
 }

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -45,6 +45,12 @@ impl Coord {
         self.min(max).max(min)
     }
 
+    /// Return the transpose (swap width and height)
+    #[inline]
+    pub fn transpose(self) -> Self {
+        Coord(self.1, self.0)
+    }
+
     /// Convert from a logical position
     #[cfg(feature = "winit")]
     pub fn from_logical<X: Pixel>(logical: LogicalPosition<X>, dpi_factor: f64) -> Self {
@@ -145,6 +151,12 @@ impl Size {
     #[inline]
     pub fn max(self, other: Self) -> Self {
         Size(self.0.max(other.0), self.1.max(other.1))
+    }
+
+    /// Return the transpose (swap width and height)
+    #[inline]
+    pub fn transpose(self) -> Self {
+        Size(self.1, self.0)
     }
 }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -37,6 +37,14 @@ impl Coord {
         Coord(self.0.max(other.0), self.1.max(other.1))
     }
 
+    /// Return the value clamped to the given `min` and `max`
+    ///
+    /// In the case that `min > max`, the `min` value is returned.
+    #[inline]
+    pub fn clamped(self, min: Self, max: Self) -> Self {
+        self.min(max).max(min)
+    }
+
     /// Convert from a logical position
     #[cfg(feature = "winit")]
     pub fn from_logical<X: Pixel>(logical: LogicalPosition<X>, dpi_factor: f64) -> Self {
@@ -211,6 +219,15 @@ impl std::ops::Mul<f32> for Size {
     #[inline]
     fn mul(self, x: f32) -> Self {
         Size((self.0 as f32 * x) as u32, (self.1 as f32 * x) as u32)
+    }
+}
+
+impl std::ops::Div<u32> for Size {
+    type Output = Self;
+
+    #[inline]
+    fn div(self, x: u32) -> Self {
+        Size(self.0 / x, self.1 / x)
     }
 }
 

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -226,6 +226,13 @@ impl From<Vec2> for Coord {
     }
 }
 
+impl From<Vec2> for Size {
+    #[inline]
+    fn from(arg: Vec2) -> Self {
+        Size(arg.0.round() as u32, arg.1.round() as u32)
+    }
+}
+
 /// 2D vector (double precision)
 ///
 /// Usually used as either a coordinate or a difference of coordinates, but

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -67,6 +67,8 @@ pub enum StretchPolicy {
     Filler,
     /// Extra space has low utility
     LowUtility,
+    /// Extra space has high utility
+    HighUtility,
     /// Greedily consume as much space as possible
     Maximise,
 }

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -1,0 +1,181 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! `DragHandle` control
+
+use std::fmt::Debug;
+
+use crate::draw::{DrawHandle, SizeHandle};
+use crate::event::{self, Event, Manager, PressSource, Response};
+use crate::geom::*;
+use crate::layout::{AxisInfo, SizeRules};
+use crate::macros::Widget;
+use crate::{AlignHints, CoreData, Layout, WidgetCore, WidgetId};
+
+/// Draggable Handle
+///
+/// A `DragHandle` is a draggable object with a given size which is restricted
+/// to a *track* and has an *offset* relative to the start of that track.
+///
+/// This widget is unusual in several ways:
+///
+/// 1.  [`Layout::size_rules`] does not request any size; the parent is expected
+///     to do this.
+/// 2.  [`Layout::set_rect`] sets the *track* within which this handle may move;
+///     the parent should always call [`DragHandle::set_size_and_offset`]
+///     afterwards.
+/// 3.  [`Layout::draw`] does nothing. The parent should handle all drawing.
+/// 4.  Optionally, this widget can handle clicks on the track area via
+///     [`DragHandle::handle_press_on_track`].
+#[widget]
+#[derive(Clone, Debug, Default, Widget)]
+pub struct DragHandle {
+    #[core]
+    core: CoreData,
+    // The track is the area within which this DragHandle may move
+    track: Rect,
+    press_source: Option<event::PressSource>,
+    press_offset: Coord,
+}
+
+impl DragHandle {
+    /// Construct
+    pub fn new() -> Self {
+        DragHandle {
+            core: Default::default(),
+            track: Default::default(),
+            press_source: None,
+            press_offset: Coord::ZERO,
+        }
+    }
+
+    /// Set a new handle size and offset
+    ///
+    /// Returns true if a redraw is required.
+    pub fn set_size_and_offset(&mut self, size: Size, offset: Coord) -> bool {
+        self.core.rect.size = size;
+        self.set_offset(offset).1
+    }
+
+    /// Get the current handle offset
+    #[inline]
+    pub fn offset(&self) -> Coord {
+        self.core.rect.pos - self.track.pos
+    }
+
+    /// Get the maximum allowed offset
+    ///
+    /// This depends on size of the handle and the track.
+    #[inline]
+    pub fn max_offset(&self) -> Coord {
+        Coord::from(self.track.size) - Coord::from(self.core.rect.size)
+    }
+
+    /// Set a new handle offset
+    ///
+    /// Returns the new offset (after clamping input), and a boolean which
+    /// is true if the offset is different from the previous offset.
+    pub fn set_offset(&mut self, offset: Coord) -> (Coord, bool) {
+        let offset = offset.clamped(Coord::ZERO, self.max_offset());
+        let handle_pos = self.track.pos + offset;
+        if handle_pos != self.core.rect.pos {
+            self.core.rect.pos = handle_pos;
+            (offset, true)
+        } else {
+            (offset, false)
+        }
+    }
+
+    /// Handle an event on the track itself
+    ///
+    /// If it is desired to make the handle move when the track area is clicked,
+    /// then the parent widget should call this method when receiving
+    /// [`Event::PressStart`].
+    ///
+    /// This method moves the handle immediately and returns the new offset.
+    pub fn handle_press_on_track(
+        &mut self,
+        mgr: &mut Manager,
+        source: PressSource,
+        coord: Coord,
+    ) -> Coord {
+        if !self.grab_press(mgr, source, coord) {
+            return self.offset();
+        }
+
+        self.press_offset = Coord::from(self.core.rect.size / 2) + self.track.pos;
+
+        // Since the press is not on the handle, we move the bar immediately.
+        let (offset, moved) = self.set_offset(coord - self.press_offset);
+        debug_assert!(moved);
+        mgr.redraw(self.id());
+        offset
+    }
+
+    fn grab_press(&mut self, mgr: &mut Manager, source: PressSource, coord: Coord) -> bool {
+        let cur = Some(event::CursorIcon::Grabbing);
+        if mgr.request_grab(self.id(), source, coord, event::GrabMode::Grab, cur) {
+            // Interacting with a scrollbar with multiple presses
+            // does not make sense. Any other gets aborted.
+            self.press_source = Some(source);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// This implementation is unusual in that:
+///
+/// 1.  `size_rules` always returns [`SizeRules::EMPTY`]
+/// 2.  `set_rect` sets the *track* within which this handle may move; the
+///     parent should call [`DragHandle::set_size_and_offset`] after
+///     `set_rect` (otherwise the handle's offset will not be updated)
+/// 3.  `draw` does nothing: the parent is expected to do all drawing
+impl Layout for DragHandle {
+    fn size_rules(&mut self, _: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
+        SizeRules::EMPTY
+    }
+
+    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, _: AlignHints) {
+        self.track = rect;
+    }
+
+    fn draw(&self, _: &mut dyn DrawHandle, _: &event::ManagerState) {}
+}
+
+impl event::Handler for DragHandle {
+    /// Offset from first possible position (should be non-negative).
+    type Msg = Coord;
+
+    fn handle(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
+        match event {
+            Event::PressStart { source, coord, .. } => {
+                if !self.grab_press(mgr, source, coord) {
+                    return Response::None;
+                }
+
+                // Event delivery implies coord is over the handle.
+                self.press_offset = coord - self.offset();
+                Response::None
+            }
+            Event::PressMove { source, coord, .. } if Some(source) == self.press_source => {
+                let offset = coord - self.press_offset;
+                let (offset, moved) = self.set_offset(offset);
+                if moved {
+                    mgr.redraw(self.id());
+                    Response::Msg(offset)
+                } else {
+                    Response::None
+                }
+            }
+            Event::PressEnd { source, .. } if Some(source) == self.press_source => {
+                self.press_source = None;
+                Response::None
+            }
+            e @ _ => Manager::handle_generic(self, mgr, e),
+        }
+    }
+}

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -21,12 +21,14 @@ pub struct Label {
     #[core]
     core: CoreData,
     align: (Align, Align),
+    reserve: Option<&'static str>,
     text: String,
 }
 
 impl Layout for Label {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let rules = size_handle.text_bound(&self.text, TextClass::Label, axis);
+        let text = self.reserve.unwrap_or(&self.text);
+        let rules = size_handle.text_bound(text, TextClass::Label, axis);
         if axis.is_horizontal() {
             self.core_data_mut().rect.size.0 = rules.ideal_size();
         } else {
@@ -54,8 +56,18 @@ impl Label {
         Label {
             core: Default::default(),
             align: Default::default(),
+            reserve: None,
             text: text.to_string(),
         }
+    }
+
+    /// Reserve sufficient room for the given text
+    ///
+    /// If this option is used, the label will be sized to fit this text, not
+    /// the actual text.
+    pub fn reserve(mut self, text: &'static str) -> Self {
+        self.reserve = Some(text);
+        self
     }
 }
 
@@ -67,6 +79,7 @@ where
         Label {
             core: Default::default(),
             align: Default::default(),
+            reserve: None,
             text: String::from(text),
         }
     }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -19,6 +19,7 @@ mod list;
 mod radiobox;
 mod scroll;
 mod scrollbar;
+mod slider;
 mod window;
 
 pub use button::TextButton;
@@ -32,4 +33,5 @@ pub use list::{BoxColumn, BoxList, BoxRow, Column, List, Row};
 pub use radiobox::{RadioBox, RadioBoxBare};
 pub use scroll::ScrollRegion;
 pub use scrollbar::ScrollBar;
+pub use slider::Slider;
 pub use window::Window;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -11,6 +11,7 @@
 mod button;
 mod checkbox;
 mod dialog;
+mod drag;
 mod editbox;
 mod filler;
 mod label;
@@ -23,6 +24,7 @@ mod window;
 pub use button::TextButton;
 pub use checkbox::{CheckBox, CheckBoxBare};
 pub use dialog::MessageBox;
+pub use drag::DragHandle;
 pub use editbox::{EditBox, EditGuard};
 pub use filler::Filler;
 pub use label::Label;

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -155,7 +155,8 @@ impl<W: Widget> Layout for ScrollRegion<W> {
         // We use simplified layout code here
         let pos = rect.pos;
         self.inner_size = rect.size;
-        let width = size_handle.scrollbar().0;
+        // using vertical-mode notation:
+        let width = (size_handle.scrollbar().0).1;
 
         if self.auto_bars {
             self.show_bars = (

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -179,7 +179,7 @@ impl<W: Widget> Layout for ScrollRegion<W> {
 
         if self.show_bars.0 {
             let pos = Coord(pos.0, pos.1 + self.inner_size.1 as i32);
-            let size = Size(self.core.rect.size.0, width);
+            let size = Size(self.inner_size.0, width);
             self.horiz_bar
                 .set_rect(size_handle, Rect { pos, size }, AlignHints::NONE);
             self.horiz_bar

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -186,7 +186,7 @@ impl<D: Directional> Layout for ScrollBar<D> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let (size, min_len) = size_handle.scrollbar();
         if self.direction.is_vertical() == axis.is_vertical() {
-            SizeRules::new(min_len, min_len, StretchPolicy::LowUtility)
+            SizeRules::new(min_len, min_len, StretchPolicy::HighUtility)
         } else {
             SizeRules::fixed(size.1)
         }

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -184,17 +184,17 @@ impl<D: Directional> ScrollBar<D> {
 
 impl<D: Directional> Layout for ScrollBar<D> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let (width, _, min_len) = size_handle.scrollbar();
+        let (size, min_len) = size_handle.scrollbar();
         if self.direction.is_vertical() == axis.is_vertical() {
             SizeRules::new(min_len, min_len, StretchPolicy::LowUtility)
         } else {
-            SizeRules::fixed(width)
+            SizeRules::fixed(size.1)
         }
     }
 
     fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
-        let (_, min_handle_len, _) = size_handle.scrollbar();
-        self.min_handle_len = min_handle_len;
+        let (size, _) = size_handle.scrollbar();
+        self.min_handle_len = size.0;
         self.core.rect = rect;
         self.handle.set_rect(size_handle, rect, align);
         self.update_handle();

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -1,0 +1,224 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! `Slider` control
+
+use conv::{ApproxFrom, ApproxInto, RoundToNearest};
+use std::fmt::Debug;
+use std::ops::{Add, Sub};
+
+use super::DragHandle;
+use crate::draw::{DrawHandle, SizeHandle};
+use crate::event::{self, Event, Manager, Response};
+use crate::geom::*;
+use crate::layout::{AxisInfo, SizeRules, StretchPolicy};
+use crate::macros::Widget;
+use crate::{AlignHints, CoreData, Directional, Layout, WidgetCore, WidgetId};
+
+pub trait SliderType:
+    Copy
+    + Debug
+    + PartialOrd
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + ApproxInto<f64>
+    + ApproxFrom<f64, RoundToNearest>
+{
+}
+
+impl<
+        T: Copy
+            + Debug
+            + PartialOrd
+            + Add<Output = Self>
+            + Sub<Output = T>
+            + ApproxInto<f64>
+            + ApproxFrom<f64, RoundToNearest>,
+    > SliderType for T
+{
+}
+
+/// A slider
+///
+/// Sliders allow user input of a value from a fixed range.
+#[widget]
+#[derive(Clone, Debug, Default, Widget)]
+pub struct Slider<T, D: Directional>
+where
+    T: SliderType,
+{
+    #[core]
+    core: CoreData,
+    direction: D, // TODO: also reversed direction
+    // Terminology assumes vertical orientation:
+    range: (T, T),
+    value: T,
+    #[widget]
+    handle: DragHandle,
+}
+
+impl<T, D: Directional + Default> Slider<T, D>
+where
+    T: SliderType,
+{
+    /// Construct a slider
+    ///
+    /// The range must be specified; the initial value defaults to the range's
+    /// lower bound but may be specified via [`Slider::with_value`].
+    pub fn new(min: T, max: T) -> Self {
+        Slider::new_with_direction(min, max, D::default())
+    }
+}
+
+impl<T, D: Directional> Slider<T, D>
+where
+    T: SliderType,
+{
+    /// Construct a slider with the given `direction`
+    ///
+    /// The range must be specified; the initial value defaults to the range's
+    /// lower bound but may be specified via [`Slider::with_value`].
+    #[inline]
+    pub fn new_with_direction(min: T, max: T, direction: D) -> Self {
+        assert!(min <= max);
+        let value = min;
+        Slider {
+            core: Default::default(),
+            direction,
+            range: (min, max),
+            value,
+            handle: DragHandle::new(),
+        }
+    }
+
+    /// Set the initial value
+    #[inline]
+    pub fn with_value(mut self, value: T) -> Self {
+        self.value = value;
+        self
+    }
+
+    /// Get the current value
+    #[inline]
+    pub fn value(&self) -> T {
+        self.value
+    }
+
+    /// Set the value
+    pub fn set_value(&mut self, mgr: &mut Manager, mut value: T) {
+        if value < self.range.0 {
+            value = self.range.0;
+        } else if value > self.range.1 {
+            value = self.range.1;
+        }
+        if value != self.value {
+            self.value = value;
+            if self.handle.set_offset(self.offset()).1 {
+                mgr.redraw(self.handle.id());
+            }
+        }
+    }
+
+    // translate value to offset in local coordinates
+    fn offset(&self) -> Coord {
+        let a: f64 = (self.value - self.range.0).approx_into().unwrap();
+        let b: f64 = (self.range.1 - self.range.0).approx_into().unwrap();
+        let max_offset = self.handle.max_offset();
+        match self.direction.is_vertical() {
+            false => Coord((max_offset.0 as f64 * a / b) as i32, 0),
+            true => Coord(0, (max_offset.1 as f64 * a / b) as i32),
+        }
+    }
+
+    // true if not equal to old value
+    fn set_offset(&mut self, offset: Coord) -> bool {
+        let b: f64 = (self.range.1 - self.range.0).approx_into().unwrap();
+        let max_offset = self.handle.max_offset();
+        let a = match self.direction.is_vertical() {
+            false => b * offset.0 as f64 / max_offset.0 as f64,
+            true => b * offset.1 as f64 / max_offset.1 as f64,
+        };
+        let value = T::approx_from(a).unwrap() + self.range.0;
+        let value = if !(value >= self.range.0) {
+            self.range.0
+        } else if !(value <= self.range.1) {
+            self.range.1
+        } else {
+            value
+        };
+        if value != self.value {
+            self.value = value;
+            return true;
+        }
+        false
+    }
+}
+
+impl<T, D: Directional> Layout for Slider<T, D>
+where
+    T: SliderType,
+{
+    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        let (size, min_len) = size_handle.slider();
+        if self.direction.is_vertical() == axis.is_vertical() {
+            SizeRules::new(min_len, min_len, StretchPolicy::LowUtility)
+        } else {
+            SizeRules::fixed(size.1)
+        }
+    }
+
+    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+        let (size, _) = size_handle.slider();
+        let size = size.min(rect.size);
+        self.core.rect = rect;
+        self.handle.set_rect(size_handle, rect, align);
+        self.handle.set_size_and_offset(size, self.offset());
+    }
+
+    fn find_id(&self, coord: Coord) -> Option<WidgetId> {
+        if self.handle.rect().contains(coord) {
+            Some(self.handle.id())
+        } else {
+            Some(self.id())
+        }
+    }
+
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState) {
+        let dir = self.direction.as_direction();
+        let hl = mgr.highlight_state(self.handle.id());
+        draw_handle.slider(self.core.rect, self.handle.rect(), dir, hl);
+    }
+}
+
+impl<T, D: Directional> event::Handler for Slider<T, D>
+where
+    T: SliderType,
+{
+    type Msg = T;
+
+    fn handle(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
+        let offset = if id <= self.handle.id() {
+            match self.handle.handle(mgr, id, event).try_into() {
+                Ok(res) => return res,
+                Err(offset) => offset,
+            }
+        } else {
+            match event {
+                Event::PressStart { source, coord, .. } => {
+                    self.handle.handle_press_on_track(mgr, source, coord)
+                }
+                ev @ _ => return Response::Unhandled(ev),
+            }
+        };
+
+        let r = if self.set_offset(offset) {
+            Response::Msg(self.value)
+        } else {
+            Response::None
+        };
+        self.handle.set_offset(self.offset());
+        r
+    }
+}


### PR DESCRIPTION
- add `DragHandle` abstraction
- add `Slider` widget
- use `Slider` in Mandlebrot example
- allow a label to calculate space via a reservation