### PR TITLE
Input fixes

### DIFF
--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -950,25 +950,25 @@ impl<'a> Manager<'a> {
                         }
                         _ => Response::None,
                     },
-                    (scancode, ElementState::Pressed, Some(vkey)) if !char_focus && !is_synthetic => match vkey {
-                        VirtualKeyCode::Tab => {
+                    (scancode, ElementState::Pressed, Some(vkey)) if !char_focus && !is_synthetic => match (vkey, self.mgr.nav_focus) {
+                        (VirtualKeyCode::Tab, _) => {
                             self.next_nav_focus(widget.as_widget_mut());
                             Response::None
                         }
-                        VirtualKeyCode::Space | VirtualKeyCode::Return | VirtualKeyCode::NumpadEnter => {
-                            if let Some(id) = self.mgr.nav_focus {
-                                // Add to key_events for visual feedback
-                                self.add_key_event(scancode, id);
+                        (VirtualKeyCode::Space, Some(nav_id)) |
+                        (VirtualKeyCode::Return, Some(nav_id)) |
+                        (VirtualKeyCode::NumpadEnter, Some(nav_id)) => {
+                            // Add to key_events for visual feedback
+                            self.add_key_event(scancode, nav_id);
 
-                                let ev = Event::Action(Action::Activate);
-                                widget.handle(self, id, ev)
-                            } else { Response::None }
+                            let ev = Event::Action(Action::Activate);
+                            widget.handle(self, nav_id, ev)
                         }
-                        VirtualKeyCode::Escape => {
+                        (VirtualKeyCode::Escape, Some(_)) => {
                             self.unset_nav_focus();
                             Response::None
                         }
-                        vkey @ _ => {
+                        (vkey @ _, _) => {
                             if let Some(id) = self.mgr.accel_keys.get(&vkey).cloned() {
                                 // Add to key_events for visual feedback
                                 self.add_key_event(scancode, id);

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -387,10 +387,10 @@ impl ManagerState {
         self.nav_focus == Some(w_id)
     }
 
-    /// Get whether the widget is under the mouse or finger
+    /// Get whether the widget is under the mouse cursor
     #[inline]
     pub fn is_hovered(&self, w_id: WidgetId) -> bool {
-        self.hover == Some(w_id)
+        self.mouse_grab.is_none() && self.hover == Some(w_id)
     }
 
     /// Check whether the given widget is visually depressed

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -1009,9 +1009,12 @@ impl<'a> Manager<'a> {
             }
             // CursorEntered { .. },
             CursorLeft { .. } => {
-                // Set a fake coordinate off the window
-                self.mgr.last_mouse_coord = Coord(-1, -1);
-                self.set_hover(widget, None);
+                if self.mouse_grab().is_none() {
+                    // If there's a mouse grab, we will continue to receive
+                    // coordinates; if not, set a fake coordinate off the window
+                    self.mgr.last_mouse_coord = Coord(-1, -1);
+                    self.set_hover(widget, None);
+                }
             }
             MouseWheel { delta, .. } => {
                 let action = Action::Scroll(match delta {


### PR DESCRIPTION
Fixes a few little things:

- Enter/Space key presses were consumed by the keyboard-navigation code even when keyboard-navigation was not active
- There was a glitch in the drag offset when moving the cursor off the window
- Highlighting buttons under the cursor during a mouse-grab makes little sense (but currently we still highlight if the mouse button was pressed on a widget which did not initiate a grab, and still process left-clicks normally while the right-button is held down — this may need tweaking)
- Do not bother tracking `Response` values within `handle_winit` since we have no use for them anyway