### PR TITLE
Trait revision (Layout & Handler), CowString, update actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ script:
   - cargo test --all-features
   - cargo test --manifest-path kas-macros/Cargo.toml --all-features
   - cargo test --manifest-path kas-theme/Cargo.toml --all-features
-  - travis_wait cargo test --manifest-path kas-wgpu/Cargo.toml
-  - cargo test --manifest-path kas-wgpu/Cargo.toml --features stack_dst
+  - cargo test --manifest-path kas-wgpu/Cargo.toml
   - cargo test --manifest-path kas-wgpu/Cargo.toml --all-features
   - cargo doc --features winit,stack_dst --no-deps
   - cargo doc --manifest-path kas-theme/Cargo.toml --features stack_dst --no-deps
@@ -24,3 +23,10 @@ matrix:
 
     - name: "OSX nightly"
       os: osx
+      # Note: this has timeout issues testing kas-wgpu, so only use cargo check
+      script:
+        - cargo test --all-features
+        - cargo test --manifest-path kas-macros/Cargo.toml --all-features
+        - cargo check --manifest-path kas-theme/Cargo.toml
+        - cargo check --manifest-path kas-wgpu/Cargo.toml --examples
+        - cargo doc --features winit,stack_dst --no-deps

--- a/kas-macros/Cargo.toml
+++ b/kas-macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0"
-proc-macro2 = { version = "1.0", features = ["nightly"] }
+proc-macro2 = { version = "1.0" }
 
 [dependencies.syn]
 version = "1.0.14"

--- a/kas-macros/src/args.rs
+++ b/kas-macros/src/args.rs
@@ -23,7 +23,7 @@ pub struct Child {
 }
 
 pub struct Args {
-    pub core: Member,
+    pub core_data: Member,
     pub layout_data: Option<Member>,
     pub widget: Option<WidgetArgs>,
     pub layout: Option<LayoutArgs>,
@@ -54,19 +54,19 @@ pub fn read_attrs(ast: &mut DeriveInput) -> Result<Args> {
         Data::Union(data) => return not_struct_err(data.union_token.span()),
     };
 
-    let mut core = None;
+    let mut core_data = None;
     let mut layout_data = None;
     let mut children = vec![];
 
     for (i, field) in fields.iter_mut().enumerate() {
         for attr in field.attrs.drain(..) {
-            if attr.path == parse_quote! { core } {
-                if core.is_none() {
-                    core = Some(member(i, field.ident.clone()));
+            if attr.path == parse_quote! { widget_core } {
+                if core_data.is_none() {
+                    core_data = Some(member(i, field.ident.clone()));
                 } else {
                     attr.span()
                         .unwrap()
-                        .error("multiple fields marked with #[core]")
+                        .error("multiple fields marked with #[widget_core]")
                         .emit();
                 }
             } else if attr.path == parse_quote! { layout_data } {
@@ -124,9 +124,9 @@ pub fn read_attrs(ast: &mut DeriveInput) -> Result<Args> {
         }
     }
 
-    if let Some(core) = core {
+    if let Some(core_data) = core_data {
         Ok(Args {
-            core,
+            core_data,
             layout_data,
             widget,
             layout,
@@ -136,7 +136,7 @@ pub fn read_attrs(ast: &mut DeriveInput) -> Result<Args> {
     } else {
         Err(Error::new(
             *span,
-            "one field must be marked with #[core] when deriving Widget",
+            "one field must be marked with #[widget_core] when deriving Widget",
         ))
     }
 }

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -278,6 +278,10 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     for #name #ty_generics #where_clause
             {
                 type Msg = #msg;
+            }
+            impl #impl_generics kas::event::EvHandler
+                    for #name #ty_generics #where_clause
+            {
                 #handler
             }
         });
@@ -405,7 +409,7 @@ pub fn make_widget(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
                 if let Some(ref wattr) = attr {
                     if let Some(tyr) = gen_msg {
-                        handler_clauses.push(quote! { #ty: kas::event::Handler<Msg = #tyr> });
+                        handler_clauses.push(quote! { #ty: kas::event::EvHandler<Msg = #tyr> });
                     } else {
                         // No typing. If a handler is specified, then the child must implement
                         // Handler<Msg = X> where the handler takes type X; otherwise
@@ -413,7 +417,7 @@ pub fn make_widget(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                         if let Some(ref handler) = wattr.args.handler {
                             if let Some(ty_bound) = find_handler_ty(handler, &args.impls) {
                                 handler_clauses
-                                    .push(quote! { #ty: kas::event::Handler<Msg = #ty_bound> });
+                                    .push(quote! { #ty: kas::event::EvHandler<Msg = #ty_bound> });
                             } else {
                                 return quote! {}.into(); // exit after emitting error
                             }
@@ -421,7 +425,7 @@ pub fn make_widget(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                             name_buf.push_str("R");
                             let tyr = Ident::new(&name_buf, Span::call_site());
                             handler_extra.push(tyr.clone());
-                            handler_clauses.push(quote! { #ty: kas::event::Handler<Msg = #tyr> });
+                            handler_clauses.push(quote! { #ty: kas::event::EvHandler<Msg = #tyr> });
                             handler_clauses.push(quote! { #msg: From<#tyr> });
                         }
                     }

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -250,7 +250,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             };
             ev_to_num.append_all(quote! {
                 if id <= self.#ident.id() {
-                    let r = self.#ident.handle(mgr, id, event);
+                    let r = self.#ident.event(mgr, id, event);
                     #handler
                 } else
             });
@@ -261,12 +261,12 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             quote! {}
         } else {
             quote! {
-                fn handle(&mut self, mgr: &mut kas::event::Manager, id: kas::WidgetId, event: kas::event::Event)
+                fn event(&mut self, mgr: &mut kas::event::Manager, id: kas::WidgetId, event: kas::event::Event)
                 -> kas::event::Response<Self::Msg>
                 {
                     use kas::{WidgetCore, event::Response};
                     #ev_to_num {
-                        debug_assert!(id == self.id(), "Handler::handle: bad WidgetId");
+                        debug_assert!(id == self.id(), "Handler::event: bad WidgetId");
                         Response::Unhandled(event)
                     }
                 }

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -112,6 +112,9 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         walk_mut_rules.append_all(quote! { self.#ident.walk_mut(f); });
     }
 
+    let key_nav = args.widget_core.key_nav;
+    let cursor_icon = args.widget_core.cursor_icon;
+
     let mut toks = quote! {
         impl #impl_generics kas::WidgetCore
             for #name #ty_generics #where_clause
@@ -153,6 +156,13 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn kas::Widget)) {
                 #walk_mut_rules
                 f(self);
+            }
+
+            fn key_nav(&self) -> bool {
+                #key_nav
+            }
+            fn cursor_icon(&self) -> kas::event::CursorIcon {
+                #cursor_icon
             }
         }
     };

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -85,7 +85,7 @@ impl<'a> ToTokens for SubstTyGenerics<'a> {
 /// Macro to derive widget traits
 ///
 /// See the [`kas::macros`](../kas/macros/index.html) module documentation.
-#[proc_macro_derive(Widget, attributes(core, widget, layout, handler, layout_data))]
+#[proc_macro_derive(Widget, attributes(widget_core, widget, layout, handler, layout_data))]
 pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
 
@@ -97,7 +97,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let name = &ast.ident;
     let widget_name = name.to_string();
 
-    let core = args.core;
+    let core_data = args.core_data;
     let count = args.children.len();
 
     let mut get_rules = quote! {};
@@ -117,11 +117,11 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             for #name #ty_generics #where_clause
         {
             fn core_data(&self) -> &kas::CoreData {
-                &self.#core
+                &self.#core_data
             }
 
             fn core_data_mut(&mut self) -> &mut kas::CoreData {
-                &mut self.#core
+                &mut self.#core_data
             }
 
             fn widget_name(&self) -> &'static str {
@@ -354,7 +354,7 @@ pub fn make_widget(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     // fields of anonymous struct:
     let mut field_toks = quote! {
-        #[core] core: kas::CoreData,
+        #[widget_core] core: kas::CoreData,
         #[layout_data] layout_data: <Self as kas::LayoutData>::Data,
     };
     // initialisers for these fields:

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -260,7 +260,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                 {
                     use kas::{WidgetCore, event::Response};
                     #ev_to_num {
-                        debug_assert!(id == self.id(), "Handler::event: bad WidgetId");
+                        debug_assert!(id == self.id(), "Layout::event: bad WidgetId");
                         Response::Unhandled(event)
                     }
                 }
@@ -278,22 +278,13 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
 
         if let Some(ref layout) = args.layout {
-            // NOTE: we cannot always derive EvHandler; only doing so when
-            // deriving Layout is a temporary solution.
-            toks.append_all(quote! {
-                impl #impl_generics kas::event::EvHandler
-                        for #name #ty_generics #where_clause
-                {
-                    #event
-                }
-            });
-
             match layout::derive(&args.children, layout, &args.layout_data) {
                 Ok(fns) => toks.append_all(quote! {
                     impl #impl_generics kas::Layout
                             for #name #ty_generics #where_clause
                     {
                         #fns
+                        #event
                     }
                 }),
                 Err(err) => return err.to_compile_error().into(),

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -11,13 +11,13 @@ use std::marker::Unsize;
 use crate::{StackDst, Theme, ThemeDst, WindowDst};
 use kas::draw::{Colour, DrawHandle, DrawShared};
 use kas::geom::Rect;
-use kas::{ThemeAction, ThemeApi};
+use kas::{CowString, ThemeAction, ThemeApi};
 
 /// Wrapper around mutliple themes, supporting run-time switching
 ///
 /// **Feature gated**: this is only available with feature `stack_dst`.
 pub struct MultiTheme<Draw> {
-    names: HashMap<String, usize>,
+    names: HashMap<CowString, usize>,
     themes: Vec<StackDst<dyn ThemeDst<Draw>>>,
     active: usize,
 }
@@ -26,7 +26,7 @@ pub struct MultiTheme<Draw> {
 ///
 /// Construct via [`MultiTheme::builder`].
 pub struct MultiThemeBuilder<Draw> {
-    names: HashMap<String, usize>,
+    names: HashMap<CowString, usize>,
     themes: Vec<StackDst<dyn ThemeDst<Draw>>>,
 }
 
@@ -42,13 +42,13 @@ impl<Draw> MultiTheme<Draw> {
 
 impl<Draw> MultiThemeBuilder<Draw> {
     /// Add a theme
-    pub fn add<S: ToString, U>(mut self, name: S, theme: U) -> Self
+    pub fn add<S: Into<CowString>, U>(mut self, name: S, theme: U) -> Self
     where
         U: Unsize<dyn ThemeDst<Draw>>,
         Box<U>: Unsize<dyn ThemeDst<Draw>>,
     {
         let index = self.themes.len();
-        self.names.insert(name.to_string(), index);
+        self.names.insert(name.into(), index);
         self.themes.push(StackDst::new_or_boxed(theme));
         self
     }

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -13,7 +13,7 @@ use std::f32::consts::PI;
 use std::time::Duration;
 
 use kas::draw::{Colour, DrawHandle, DrawRounded, DrawText, SizeHandle, TextClass, TextProperties};
-use kas::event::{Manager, ManagerState};
+use kas::event::{self, Manager, ManagerState};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::{AxisInfo, SizeRules};
 use kas::widget::Window;
@@ -32,6 +32,8 @@ struct Clock {
     date: String,
     time: String,
 }
+
+impl event::EvHandler for Clock {}
 
 impl Layout for Clock {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -13,14 +13,13 @@ use std::f32::consts::PI;
 use std::time::Duration;
 
 use kas::draw::{Colour, DrawHandle, DrawRounded, DrawText, SizeHandle, TextClass, TextProperties};
-use kas::event::{Manager, ManagerState};
+use kas::event::{self, Action, Event, Handler, Response, Manager, ManagerState};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::{AxisInfo, SizeRules};
 use kas::widget::Window;
 use kas::{Align, AlignHints, Direction, Layout, Widget, WidgetCore};
 use kas_wgpu::draw::DrawWindow;
 
-#[handler]
 #[derive(Clone, Debug, kas :: macros :: Widget)]
 struct Clock {
     #[widget_core]
@@ -128,15 +127,26 @@ impl Widget for Clock {
     fn configure(&mut self, mgr: &mut Manager) {
         mgr.update_on_timer(Duration::new(0, 0), self.id());
     }
+}
 
-    fn update_timer(&mut self, mgr: &mut Manager) -> Option<Duration> {
-        self.now = Local::now();
-        mgr.redraw(self.id());
-        self.date = self.now.format("%Y-%m-%d").to_string();
-        self.time = self.now.format("%H:%M:%S").to_string();
-        let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
-        info!("Requesting update in {}ns", ns);
-        Some(Duration::new(0, ns))
+impl Handler for Clock {
+    type Msg = event::VoidMsg;
+
+    #[inline]
+    fn action(&mut self, mgr: &mut Manager, action: Action) -> Response<Self::Msg> {
+        match action {
+            Action::TimerUpdate => {
+                self.now = Local::now();
+                mgr.redraw(self.id());
+                self.date = self.now.format("%Y-%m-%d").to_string();
+                self.time = self.now.format("%H:%M:%S").to_string();
+                let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
+                info!("Requesting update in {}ns", ns);
+                mgr.update_on_timer(Duration::new(0, ns), self.id());
+                Response::None
+            }
+            a @ _ => Response::Unhandled(Event::Action(a)),
+        }
     }
 }
 

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -23,7 +23,7 @@ use kas_wgpu::draw::DrawWindow;
 #[handler]
 #[derive(Clone, Debug, kas :: macros :: Widget)]
 struct Clock {
-    #[core]
+    #[widget_core]
     core: kas::CoreData,
     date_rect: Rect,
     time_rect: Rect,

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -13,7 +13,7 @@ use std::f32::consts::PI;
 use std::time::Duration;
 
 use kas::draw::{Colour, DrawHandle, DrawRounded, DrawText, SizeHandle, TextClass, TextProperties};
-use kas::event::{self, Manager, ManagerState};
+use kas::event::{Manager, ManagerState};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::{AxisInfo, SizeRules};
 use kas::widget::Window;
@@ -32,8 +32,6 @@ struct Clock {
     date: String,
     time: String,
 }
-
-impl event::EvHandler for Clock {}
 
 impl Layout for Clock {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[layout(vertical)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget(halign=centre)] display: Label = Label::from("0"),
+                #[widget(halign=centre)] display: Label = Label::new("0"),
                 #[widget(handler = handle_button)] buttons -> Message = buttons,
                 counter: usize = 0,
             }

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -122,7 +122,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         #[layout(grid)]
         #[handler(msg = Item)]
         struct {
-            #[widget(row=1, col=1)] _ = Label::from("Custom theme demo\nChoose your colour!"),
+            #[widget(row=1, col=1)] _ = Label::new("Custom theme demo\nChoose your colour!"),
             #[widget(row=0, col=1)] _ = TextButton::new("White", Item::White),
             #[widget(row=1, col=2)] _ = TextButton::new("Red", Item::Red),
             #[widget(row=2, col=1)] _ = TextButton::new("Yellow", Item::Yellow),

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -9,7 +9,7 @@
 use kas::class::HasText;
 use kas::event::{Callback, Manager, Response, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
-use kas::widget::{Column, EditBox, Filler, Label, ScrollRegion, TextButton, Window};
+use kas::widget::{Column, EditBox, EditBoxVoid, Filler, Label, ScrollRegion, TextButton, Window};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Control {
@@ -60,7 +60,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             struct {
                 #[widget] _ = Label::new("Demonstration of dynamic widget creation / deletion"),
                 #[widget(handler = handler)] controls -> usize = controls,
-                #[widget] list: ScrollRegion<Column<EditBox<()>>> =
+                #[widget] list: ScrollRegion<Column<EditBoxVoid>> =
                     ScrollRegion::new(Column::new(vec![])).with_bars(false, true),
                 #[widget] _ = Filler::maximise(),
             }

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     Control::Incr => self.n.saturating_add(1),
                     Control::Set => self.n,
                 };
-                self.edit.set_string(mgr, n.to_string());
+                self.edit.set_text(mgr, n.to_string());
                 self.n = n;
                 n.into()
             }

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -31,29 +31,29 @@ fn main() -> Result<(), kas_wgpu::Error> {
         #[layout(grid)]
         #[handler(msg = Item)]
         struct {
-            #[widget(row=0, col=0)] _ = Label::from("Label"),
-            #[widget(row=0, col=1)] _ = Label::from("Hello world"),
-            #[widget(row=1, col=0)] _ = Label::from("EditBox"),
+            #[widget(row=0, col=0)] _ = Label::new("Label"),
+            #[widget(row=0, col=1)] _ = Label::new("Hello world"),
+            #[widget(row=1, col=0)] _ = Label::new("EditBox"),
             #[widget(row=1, col=1)] _ = EditBox::new("edit me")
                 .on_activate(|text| Some(Item::Edit(text.to_string()))),
-            #[widget(row=2, col=0)] _ = Label::from("TextButton"),
+            #[widget(row=2, col=0)] _ = Label::new("TextButton"),
             #[widget(row=2, col=1)] _ = TextButton::new("Press me", Item::Button),
-            #[widget(row=3, col=0)] _ = Label::from("CheckBox"),
+            #[widget(row=3, col=0)] _ = Label::new("CheckBox"),
             #[widget(row=3, col=1)] _ = CheckBox::new("Check me").state(true)
                 .on_toggle(|check| Item::Check(check)),
-            #[widget(row=4, col=0)] _ = Label::from("RadioBox"),
+            #[widget(row=4, col=0)] _ = Label::new("RadioBox"),
             #[widget(row=4, col=1)] _ = RadioBox::new(radio, "radio box 1").state(false)
                 .on_activate(|id| Item::Radio(id)),
-            #[widget(row=5, col=0)] _ = Label::from("RadioBox"),
+            #[widget(row=5, col=0)] _ = Label::new("RadioBox"),
             #[widget(row=5, col=1)] _ = RadioBox::new(radio, "radio box 2").state(true)
                 .on_activate(|id| Item::Radio(id)),
-            #[widget(row=6, col=0)] _ = Label::from("Slider"),
+            #[widget(row=6, col=0)] _ = Label::new("Slider"),
             #[widget(row=6, col=1, handler = handle_slider)] _ =
                 Slider::<i32, Horizontal>::new(-2, 2).with_value(0),
-            #[widget(row=7, col=0)] _ = Label::from("ScrollBar"),
+            #[widget(row=7, col=0)] _ = Label::new("ScrollBar"),
             #[widget(row=7, col=1, handler = handle_scroll)] _ =
                 ScrollBar::<Horizontal>::new().with_limits(5, 2),
-            #[widget(row=8)] _ = Label::from("Child window"),
+            #[widget(row=8)] _ = Label::new("Child window"),
             #[widget(row=8, col = 1)] _ = TextButton::new("Open", Item::Popup),
         }
         impl {
@@ -71,7 +71,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         #[layout(vertical)]
         #[handler(msg = VoidMsg)]
         struct {
-            #[widget(halign=centre)] _ = Label::from("Widget Gallery"),
+            #[widget(halign=centre)] _ = Label::new("Widget Gallery"),
             #[widget(handler=set_theme)] _ = make_widget! {
                 #[widget]
                 #[layout(horizontal)]

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -23,13 +23,13 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[layout(grid)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget(row=0, col=2)] _ = Label::from("Layout demo"),
-                #[widget(row=1, col=1, cspan=3)] _ = Label::from(lipsum),
+                #[widget(row=0, col=2)] _ = Label::new("Layout demo"),
+                #[widget(row=1, col=1, cspan=3)] _ = Label::new(lipsum),
                 #[widget(row=1, col=4)] _ = CheckBox::new(""),
-                #[widget(row=2, col=0)] _ = Label::from("Text"),
-                #[widget(row=2, col=2, cspan=2, rspan=2)] _ = Label::from(crasit),
+                #[widget(row=2, col=0)] _ = Label::new("Text"),
+                #[widget(row=2, col=2, cspan=2, rspan=2)] _ = Label::new(crasit),
                 #[widget(row=3, col=1)] _ = EditBox::new("edit"),
-                #[widget(row=0, col=3)] _ = Label::from("<->"),
+                #[widget(row=0, col=3)] _ = Label::new("<->"),
             }
         },
     );

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -530,12 +530,12 @@ fn main() -> Result<(), kas_wgpu::Error> {
         impl {
             fn iter(&mut self, mgr: &mut Manager, iter: i32) -> VoidResponse {
                 self.mbrot.iter = iter;
-                self.label.set_string(mgr, self.mbrot.loc());
-                self.iters.set_string(mgr, format!("{}", iter));
+                self.label.set_text(mgr, self.mbrot.loc());
+                self.iters.set_text(mgr, format!("{}", iter));
                 Response::None
             }
             fn mbrot(&mut self, mgr: &mut Manager, _: ()) -> VoidResponse {
-                self.label.set_string(mgr, self.mbrot.loc());
+                self.label.set_text(mgr, self.mbrot.loc());
                 Response::None
             }
         }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -404,6 +404,10 @@ struct Mandlebrot {
     iter: i32,
 }
 
+impl event::Handler for Mandlebrot {
+    type Msg = ();
+}
+
 impl Layout for Mandlebrot {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, a: AxisInfo) -> SizeRules {
         let size = (match a.is_horizontal() {
@@ -437,13 +441,7 @@ impl Layout for Mandlebrot {
         let p = (self.alpha, self.delta, self.rel_width, self.iter);
         draw.custom(region, self.core.rect + offset, p);
     }
-}
 
-impl event::Handler for Mandlebrot {
-    type Msg = ();
-}
-
-impl event::EvHandler for Mandlebrot {
     fn event(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
         match event {
             Event::Action(event::Action::Scroll(delta)) => {

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -441,7 +441,9 @@ impl Layout for Mandlebrot {
 
 impl event::Handler for Mandlebrot {
     type Msg = ();
+}
 
+impl event::EvHandler for Mandlebrot {
     fn event(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
         match event {
             Event::Action(event::Action::Scroll(delta)) => {

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -394,7 +394,7 @@ impl PipeWindow {
 #[widget]
 #[derive(Clone, Debug, kas :: macros :: Widget)]
 struct Mandlebrot {
-    #[core]
+    #[widget_core]
     core: kas::CoreData,
     alpha: DVec2,
     delta: DVec2,

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -442,7 +442,7 @@ impl Layout for Mandlebrot {
 impl event::Handler for Mandlebrot {
     type Msg = ();
 
-    fn handle(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
+    fn event(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
         match event {
             Event::Action(event::Action::Scroll(delta)) => {
                 let factor = match delta {

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -6,7 +6,6 @@
 //! Counter example (simple button)
 #![feature(proc_macro_hygiene)]
 
-use std::fmt::Write;
 use std::time::{Duration, Instant};
 
 use kas::class::HasText;
@@ -28,12 +27,11 @@ fn make_window() -> Box<dyn kas::Window> {
         #[layout(horizontal)]
         #[handler(msg = VoidMsg)]
         struct {
-            #[widget] display: impl HasText = Frame::new(Label::from("0.000")),
+            #[widget] display: impl HasText = Frame::new(Label::new("0.000")),
             #[widget(handler = handle_button)] b_reset = TextButton::new("reset", Control::Reset),
             #[widget(handler = handle_button)] b_start = TextButton::new("start / stop", Control::Start),
             saved: Duration = Duration::default(),
             start: Option<Instant> = None,
-            dur_buf: String = String::default(),
         }
         impl {
             fn handle_button(&mut self, mgr: &mut Manager, msg: Control) -> Response<VoidMsg> {
@@ -60,13 +58,11 @@ fn make_window() -> Box<dyn kas::Window> {
             fn update_timer(&mut self, mgr: &mut Manager) -> Option<Duration> {
                 if let Some(start) = self.start {
                     let dur = self.saved + (Instant::now() - start);
-                    self.dur_buf.clear();
-                    self.dur_buf.write_fmt(format_args!(
+                    self.display.set_text(mgr, format!(
                         "{}.{:03}",
                         dur.as_secs(),
                         dur.subsec_millis()
-                    )).unwrap();
-                    self.display.set_text(mgr, &self.dur_buf);
+                    ));
                     Some(Duration::new(0, 1))
                 } else {
                     None

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[layout(vertical)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget(halign=centre)] display: Label = Label::from("0"),
+                #[widget(halign=centre)] display: Label = Label::new("0"),
                 #[widget(handler = handle_button)] buttons -> Message = buttons,
                 handle: UpdateHandle = handle,
             }

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -105,16 +105,16 @@ where
 
     #[cfg(not(feature = "clipboard"))]
     #[inline]
-    pub fn get_clipboard(&mut self) -> Option<String> {
+    pub fn get_clipboard(&mut self) -> Option<kas::CowString> {
         None
     }
 
     #[cfg(feature = "clipboard")]
-    pub fn get_clipboard(&mut self) -> Option<String> {
+    pub fn get_clipboard(&mut self) -> Option<kas::CowString> {
         self.clipboard
             .as_mut()
             .and_then(|cb| match cb.get_contents() {
-                Ok(c) => Some(c),
+                Ok(c) => Some(c.into()),
                 Err(e) => {
                     warn!("Failed to get clipboard contents: {:?}", e);
                     None
@@ -124,12 +124,12 @@ where
 
     #[cfg(not(feature = "clipboard"))]
     #[inline]
-    pub fn set_clipboard(&mut self, _content: String) {}
+    pub fn set_clipboard<'c>(&mut self, content: kas::CowStringL<'c>) {}
 
     #[cfg(feature = "clipboard")]
-    pub fn set_clipboard(&mut self, content: String) {
+    pub fn set_clipboard<'c>(&mut self, content: kas::CowStringL<'c>) {
         self.clipboard.as_mut().map(|cb| {
-            cb.set_contents(content)
+            cb.set_contents(content.into())
                 .unwrap_or_else(|e| warn!("Failed to set clipboard contents: {:?}", e))
         });
     }

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -371,12 +371,12 @@ where
     }
 
     #[inline]
-    fn get_clipboard(&mut self) -> Option<String> {
+    fn get_clipboard(&mut self) -> Option<kas::CowString> {
         self.shared.get_clipboard()
     }
 
     #[inline]
-    fn set_clipboard(&mut self, content: String) {
+    fn set_clipboard<'c>(&mut self, content: kas::CowStringL<'c>) {
         self.shared.set_clipboard(content);
     }
 

--- a/src/class.rs
+++ b/src/class.rs
@@ -6,6 +6,7 @@
 //! Class-specific widget traits
 
 use crate::event::Manager;
+use crate::CowString;
 
 /// Functionality for widgets which can be toggled or selected: check boxes,
 /// radio buttons, toggle switches.
@@ -30,17 +31,18 @@ pub trait HasText {
     fn get_text(&self) -> &str;
 
     /// Set the widget's text.
-    fn set_text<T: ToString>(&mut self, mgr: &mut Manager, text: T)
+    fn set_text<T: Into<CowString>>(&mut self, mgr: &mut Manager, text: T)
     where
         Self: Sized,
     {
-        self.set_string(mgr, text.to_string());
+        self.set_cow_string(mgr, text.into());
     }
 
-    /// Set the widget's text (string only).
+    /// Set the widget's text ([`CowString`])
     ///
-    /// This method is for implementation.
-    fn set_string(&mut self, mgr: &mut Manager, text: String);
+    /// This method is for implementation. It is recommended to use
+    /// [`HasText::set_text`] instead.
+    fn set_cow_string(&mut self, mgr: &mut Manager, text: CowString);
 }
 
 /// Additional functionality required by the `EditBox` widget.

--- a/src/data.rs
+++ b/src/data.rs
@@ -72,7 +72,7 @@ impl fmt::Display for WidgetId {
 
 /// Common widget data
 ///
-/// All widgets should embed a `#[core] core: CoreData` field.
+/// All widgets should embed a `#[widget_core] core: CoreData` field.
 #[derive(Clone, Default, Debug)]
 pub struct CoreData {
     pub rect: Rect,

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -5,7 +5,7 @@
 
 //! Event handling: events
 
-use super::MouseButton;
+use super::{MouseButton, UpdateHandle};
 
 use crate::geom::{Coord, DVec2};
 use crate::WidgetId;
@@ -74,6 +74,19 @@ pub enum Action {
         /// Translation component
         delta: DVec2,
     },
+    /// Update from a timer
+    ///
+    /// This event is received after requesting timed wake-up(s)
+    /// (see [`Manager::update_on_timer`]).
+    TimerUpdate,
+    /// Update triggerred via an [`UpdateHandle`]
+    ///
+    /// This event may be received after registering an [`UpdateHandle`] via
+    /// [`Manager::update_on_handle`].
+    ///
+    /// A user-defined payload is passed. Interpretation of this payload is
+    /// user-defined and unfortunately not type safe.
+    HandleUpdate { handle: UpdateHandle, payload: u64 },
 }
 
 /// Low-level events addressed to a widget by [`WidgetId`] or coordinate.

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -94,10 +94,6 @@ impl<M> Widget for Box<dyn Handler<Msg = M>> {
     fn update_handle(&mut self, mgr: &mut Manager, handle: UpdateHandle, payload: u64) {
         self.as_mut().update_handle(mgr, handle, payload);
     }
-
-    fn allow_focus(&self) -> bool {
-        self.as_ref().allow_focus()
-    }
 }
 
 impl<M> Layout for Box<dyn Handler<Msg = M>> {
@@ -152,6 +148,13 @@ impl<M> WidgetCore for Box<dyn Handler<Msg = M>> {
     }
     fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn Widget)) {
         self.as_mut().walk_mut(f);
+    }
+
+    fn key_nav(&self) -> bool {
+        self.as_ref().key_nav()
+    }
+    fn cursor_icon(&self) -> event::CursorIcon {
+        self.as_ref().cursor_icon()
     }
 }
 

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -17,8 +17,6 @@ use crate::{AlignHints, CoreData, Layout, Widget, WidgetCore, WidgetId};
 ///
 /// This is a companion trait to [`Widget`]. It can (optionally) be implemented
 /// by the `derive(Widget)` macro, or can be implemented manually.
-///
-/// [`Widget`]: crate::Widget
 pub trait Handler: Widget {
     /// Type of message returned by this handler.
     ///
@@ -51,8 +49,6 @@ pub trait Handler: Widget {
 ///
 /// This is a companion trait to [`Widget`]. It can (optionally) be implemented
 /// by the `derive(Widget)` macro, or can be implemented manually.
-///
-/// [`Widget`]: crate::Widget
 pub trait EvHandler: Handler {
     /// Handle a low-level event.
     ///
@@ -74,7 +70,7 @@ pub trait EvHandler: Handler {
     }
 }
 
-impl<M> Handler for Box<dyn EvHandler<Msg = M>> {
+impl<M> Handler for Box<dyn Layout<Msg = M>> {
     type Msg = M;
 
     fn activation_via_press(&self) -> bool {
@@ -86,13 +82,13 @@ impl<M> Handler for Box<dyn EvHandler<Msg = M>> {
     }
 }
 
-impl<M> EvHandler for Box<dyn EvHandler<Msg = M>> {
+impl<M> EvHandler for Box<dyn Layout<Msg = M>> {
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         self.as_mut().event(mgr, id, event)
     }
 }
 
-impl<M> Widget for Box<dyn EvHandler<Msg = M>> {
+impl<M> Widget for Box<dyn Layout<Msg = M>> {
     fn configure(&mut self, mgr: &mut Manager) {
         self.as_mut().configure(mgr);
     }
@@ -106,7 +102,7 @@ impl<M> Widget for Box<dyn EvHandler<Msg = M>> {
     }
 }
 
-impl<M> Layout for Box<dyn EvHandler<Msg = M>> {
+impl<M> Layout for Box<dyn Layout<Msg = M>> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         self.as_mut().size_rules(size_handle, axis)
     }
@@ -124,7 +120,7 @@ impl<M> Layout for Box<dyn EvHandler<Msg = M>> {
     }
 }
 
-impl<M> WidgetCore for Box<dyn EvHandler<Msg = M>> {
+impl<M> WidgetCore for Box<dyn Layout<Msg = M>> {
     fn core_data(&self) -> &CoreData {
         self.as_ref().core_data()
     }
@@ -168,7 +164,7 @@ impl<M> WidgetCore for Box<dyn EvHandler<Msg = M>> {
     }
 }
 
-impl<M: 'static> Clone for Box<dyn Handler<Msg = M>> {
+impl<M: 'static> Clone for Box<dyn Layout<Msg = M>> {
     fn clone(&self) -> Self {
         #[cfg(feature = "nightly")]
         unsafe {

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -5,13 +5,8 @@
 
 //! Event handling - handler
 
-use std::time::Duration;
-
-use crate::draw::{DrawHandle, SizeHandle};
-use crate::event::{self, Action, Event, Manager, Response, UpdateHandle};
-use crate::geom::{Coord, Rect};
-use crate::layout::{AxisInfo, SizeRules};
-use crate::{AlignHints, CoreData, Layout, Widget, WidgetCore, WidgetId};
+use crate::event::{self, Action, Event, Manager, Response};
+use crate::Widget;
 
 /// High-level event handling for a [`Widget`]
 ///
@@ -42,143 +37,6 @@ pub trait Handler: Widget {
     #[inline]
     fn action(&mut self, _: &mut Manager, action: Action) -> Response<Self::Msg> {
         Response::Unhandled(Event::Action(action))
-    }
-}
-
-/// Low-level event handling for a [`Widget`]
-///
-/// This is a companion trait to [`Widget`]. It can (optionally) be implemented
-/// by the `derive(Widget)` macro, or can be implemented manually.
-pub trait EvHandler: Handler {
-    /// Handle a low-level event.
-    ///
-    /// Most non-parent widgets will not need to implement this method manually.
-    /// The default implementation (which wraps [`Manager::handle_generic`])
-    /// forwards high-level events via [`Handler::action`].
-    ///
-    /// Parent widgets should forward events to the appropriate child widget,
-    /// translating event coordinates where applicable. Unused events should be
-    /// handled (directly or through [`Manager::handle_generic`]) or returned
-    /// via [`Response::Unhandled`]. The return-value from child handlers may
-    /// be intercepted in order to handle as-yet-unhandled events.
-    ///
-    /// Additionally, this method allows lower-level interpretation of some
-    /// events, e.g. more direct access to mouse inputs.
-    #[inline]
-    fn event(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
-        Manager::handle_generic(self, mgr, event)
-    }
-}
-
-impl<M> Handler for Box<dyn Layout<Msg = M>> {
-    type Msg = M;
-
-    fn activation_via_press(&self) -> bool {
-        self.as_ref().activation_via_press()
-    }
-
-    fn action(&mut self, mgr: &mut Manager, action: Action) -> Response<Self::Msg> {
-        self.as_mut().action(mgr, action)
-    }
-}
-
-impl<M> EvHandler for Box<dyn Layout<Msg = M>> {
-    fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
-        self.as_mut().event(mgr, id, event)
-    }
-}
-
-impl<M> Widget for Box<dyn Layout<Msg = M>> {
-    fn configure(&mut self, mgr: &mut Manager) {
-        self.as_mut().configure(mgr);
-    }
-
-    fn update_timer(&mut self, mgr: &mut Manager) -> Option<Duration> {
-        self.as_mut().update_timer(mgr)
-    }
-
-    fn update_handle(&mut self, mgr: &mut Manager, handle: UpdateHandle, payload: u64) {
-        self.as_mut().update_handle(mgr, handle, payload);
-    }
-}
-
-impl<M> Layout for Box<dyn Layout<Msg = M>> {
-    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        self.as_mut().size_rules(size_handle, axis)
-    }
-
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
-        self.as_mut().set_rect(size_handle, rect, align);
-    }
-
-    fn find_id(&self, coord: Coord) -> Option<WidgetId> {
-        self.as_ref().find_id(coord)
-    }
-
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState) {
-        self.as_ref().draw(draw_handle, mgr);
-    }
-}
-
-impl<M> WidgetCore for Box<dyn Layout<Msg = M>> {
-    fn core_data(&self) -> &CoreData {
-        self.as_ref().core_data()
-    }
-    fn core_data_mut(&mut self) -> &mut CoreData {
-        self.as_mut().core_data_mut()
-    }
-
-    fn widget_name(&self) -> &'static str {
-        self.as_ref().widget_name()
-    }
-
-    fn as_widget(&self) -> &dyn Widget {
-        self.as_ref().as_widget()
-    }
-    fn as_widget_mut(&mut self) -> &mut dyn Widget {
-        self.as_mut().as_widget_mut()
-    }
-
-    fn len(&self) -> usize {
-        self.as_ref().len()
-    }
-    fn get(&self, index: usize) -> Option<&dyn Widget> {
-        self.as_ref().get(index)
-    }
-    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
-        self.as_mut().get_mut(index)
-    }
-
-    fn walk(&self, f: &mut dyn FnMut(&dyn Widget)) {
-        self.as_ref().walk(f);
-    }
-    fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn Widget)) {
-        self.as_mut().walk_mut(f);
-    }
-
-    fn key_nav(&self) -> bool {
-        self.as_ref().key_nav()
-    }
-    fn cursor_icon(&self) -> event::CursorIcon {
-        self.as_ref().cursor_icon()
-    }
-}
-
-impl<M: 'static> Clone for Box<dyn Layout<Msg = M>> {
-    fn clone(&self) -> Self {
-        #[cfg(feature = "nightly")]
-        unsafe {
-            use crate::CloneTo;
-            let mut x = Box::new_uninit();
-            self.clone_to(x.as_mut_ptr());
-            x.assume_init()
-        }
-
-        // Run-time failure is not ideal — but we would hit compile-issues which
-        // don't necessarily correspond to actual usage otherwise due to
-        // `derive(Clone)` on any widget produced by `make_widget!`.
-        #[cfg(not(feature = "nightly"))]
-        panic!("Clone for Box<dyn Widget> only supported on nightly");
     }
 }
 

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -751,7 +751,7 @@ impl<'a> Manager<'a> {
     }
 
     #[cfg(feature = "winit")]
-    fn next_nav_focus(&mut self, widget: &mut dyn Widget) {
+    fn next_nav_focus<W: Widget + ?Sized>(&mut self, widget: &mut W) {
         let mut id = self.mgr.nav_focus.unwrap_or(WidgetId::FIRST);
         let end = widget.id();
         loop {
@@ -953,7 +953,7 @@ impl<'a> Manager<'a> {
                         } else {
                             match (vkey, self.mgr.nav_focus) {
                                 (VirtualKeyCode::Tab, _) => {
-                                    self.next_nav_focus(widget.as_widget_mut());
+                                    self.next_nav_focus(widget);
                                 }
                                 (VirtualKeyCode::Space, Some(nav_id)) |
                                 (VirtualKeyCode::Return, Some(nav_id)) |

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -525,13 +525,13 @@ impl<'a> Manager<'a> {
     /// In case of failure, paste actions will simply fail. The implementation
     /// may wish to log an appropriate warning message.
     #[inline]
-    pub fn get_clipboard(&mut self) -> Option<String> {
+    pub fn get_clipboard(&mut self) -> Option<crate::CowString> {
         self.tkw.get_clipboard()
     }
 
     /// Attempt to set clipboard contents
     #[inline]
-    pub fn set_clipboard(&mut self, content: String) {
+    pub fn set_clipboard<'c>(&mut self, content: crate::CowStringL<'c>) {
         self.tkw.set_clipboard(content)
     }
 

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -761,7 +761,7 @@ impl<'a> Manager<'a> {
             }
 
             // TODO(opt): incorporate walk/find logic
-            if widget.find(id).map(|w| w.allow_focus()).unwrap_or(false) {
+            if widget.find(id).map(|w| w.key_nav()).unwrap_or(false) {
                 self.send_action(TkAction::Redraw);
                 self.mgr.nav_focus = Some(id);
                 return;

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -840,7 +840,7 @@ impl<'a> Manager<'a> {
             let id = grab.id;
             if alpha != DVec2(1.0, 0.0) || delta != DVec2::ZERO {
                 let ev = Event::Action(Action::Pan { alpha, delta });
-                let _ = widget.handle(&mut self, id, ev);
+                let _ = widget.event(&mut self, id, ev);
             }
         }
 
@@ -853,7 +853,7 @@ impl<'a> Manager<'a> {
             match item {
                 Pending::LostCharFocus(id) => {
                     let ev = Event::Action(Action::LostCharFocus);
-                    let _ = widget.handle(&mut self, id, ev);
+                    let _ = widget.event(&mut self, id, ev);
                 }
             }
         }
@@ -937,7 +937,7 @@ impl<'a> Manager<'a> {
             ReceivedCharacter(c) if c != '\u{1b}' /* escape */ => {
                 if let Some(id) = self.mgr.char_focus {
                     let ev = Event::Action(Action::ReceivedCharacter(c));
-                    let _ = widget.handle(self, id, ev);
+                    let _ = widget.event(self, id, ev);
                 }
             }
             // Focused(bool),
@@ -962,7 +962,7 @@ impl<'a> Manager<'a> {
                                     self.add_key_event(input.scancode, nav_id);
 
                                     let ev = Event::Action(Action::Activate);
-                                    let _ = widget.handle(self, nav_id, ev);
+                                    let _ = widget.event(self, nav_id, ev);
                                 }
                                 (VirtualKeyCode::Escape, _) => self.unset_nav_focus(),
                                 (vkey, _) => {
@@ -971,7 +971,7 @@ impl<'a> Manager<'a> {
                                         self.add_key_event(input.scancode, id);
 
                                         let ev = Event::Action(Action::Activate);
-                                        let _ = widget.handle(self, id, ev);
+                                        let _ = widget.event(self, id, ev);
                                     }
                                 }
                             }
@@ -995,7 +995,7 @@ impl<'a> Manager<'a> {
                     if grab.mode == GrabMode::Grab {
                         let source = PressSource::Mouse(grab.button);
                         let ev = Event::PressMove { source, coord, delta };
-                        let _ = widget.handle(self, grab.start_id, ev);
+                        let _ = widget.event(self, grab.start_id, ev);
                     } else {
                         if let Some(pan) = self.mgr.pan_grab.get_mut(grab.pan_grab.0 as usize) {
                             pan.coords[grab.pan_grab.1 as usize].1 = coord;
@@ -1023,7 +1023,7 @@ impl<'a> Manager<'a> {
                         ScrollDelta::PixelDelta(Coord::from_logical(pos, self.mgr.dpi_factor)),
                 });
                 if let Some(id) = self.mgr.hover {
-                    let _ = widget.handle(self, id, Event::Action(action));
+                    let _ = widget.event(self, id, Event::Action(action));
                 }
             }
             MouseInput {
@@ -1046,7 +1046,7 @@ impl<'a> Manager<'a> {
                                     coord,
                                 },
                             };
-                            let _ = widget.handle(self, grab.start_id, ev);
+                            let _ = widget.event(self, grab.start_id, ev);
                         }
                         // Pan events do not receive Start/End notifications
                         _ => (),
@@ -1059,7 +1059,7 @@ impl<'a> Manager<'a> {
                     // No mouse grab but have a hover target
                     if state == ElementState::Pressed {
                         let ev = Event::PressStart { source, coord };
-                        let _ = widget.handle(self, id, ev);
+                        let _ = widget.event(self, id, ev);
                     }
                 }
             }
@@ -1073,11 +1073,11 @@ impl<'a> Manager<'a> {
                     TouchPhase::Started => {
                         if let Some(id) = widget.find_id(coord) {
                             let ev = Event::PressStart { source, coord };
-                            let _ = widget.handle(self, id, ev);
+                            let _ = widget.event(self, id, ev);
                         }
                     }
                     TouchPhase::Moved => {
-                        // NOTE: calling widget.handle twice appears
+                        // NOTE: calling widget.event twice appears
                         // to be unavoidable (as with CursorMoved)
                         let cur_id = widget.find_id(coord);
 
@@ -1108,7 +1108,7 @@ impl<'a> Manager<'a> {
                             if redraw {
                                 self.send_action(TkAction::Redraw);
                             }
-                            let _ = widget.handle(self, id, action);
+                            let _ = widget.event(self, id, action);
                         } else if let Some(pan_grab) = pan_grab {
                             if (pan_grab.1 as usize) < MAX_PAN_GRABS {
                                 if let Some(pan) = self.mgr.pan_grab.get_mut(pan_grab.0 as usize) {
@@ -1128,7 +1128,7 @@ impl<'a> Manager<'a> {
                                 if let Some(cur_id) = grab.cur_id {
                                     self.redraw(cur_id);
                                 }
-                                let _ = widget.handle(self, grab.start_id, action);
+                                let _ = widget.event(self, grab.start_id, action);
                             } else {
                                 self.mgr.remove_pan_grab(grab.pan_grab);
                             }
@@ -1144,7 +1144,7 @@ impl<'a> Manager<'a> {
                             if let Some(cur_id) = grab.cur_id {
                                 self.redraw(cur_id);
                             }
-                            let _ = widget.handle(self, grab.start_id, action);
+                            let _ = widget.event(self, grab.start_id, action);
                         }
                     }
                 }

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -799,7 +799,7 @@ impl<'a> Manager<'a> {
     /// Update, after receiving all events
     pub fn finish<W>(mut self, widget: &mut W) -> TkAction
     where
-        W: Widget + Handler<Msg = VoidMsg> + ?Sized,
+        W: Widget + EvHandler<Msg = VoidMsg> + ?Sized,
     {
         for gi in 0..self.mgr.pan_grab.len() {
             let grab = &mut self.mgr.pan_grab[gi];
@@ -915,7 +915,7 @@ impl<'a> Manager<'a> {
     #[cfg(feature = "winit")]
     pub fn handle_winit<W>(&mut self, widget: &mut W, event: winit::event::WindowEvent)
     where
-        W: Widget + Handler<Msg = VoidMsg> + ?Sized,
+        W: Widget + EvHandler<Msg = VoidMsg> + ?Sized,
     {
         use winit::event::{ElementState, MouseScrollDelta, TouchPhase, WindowEvent::*};
         trace!("Event: {:?}", event);

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -13,7 +13,7 @@ use std::u16;
 
 use super::*;
 use crate::geom::{Coord, DVec2};
-use crate::{ThemeAction, ThemeApi, TkAction, TkWindow, Widget, WidgetId, WindowId};
+use crate::{Layout, ThemeAction, ThemeApi, TkAction, TkWindow, WidgetId, WindowId};
 
 /// Highlighting state of a widget
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
@@ -160,7 +160,7 @@ impl ManagerState {
     /// is created (before or after resizing).
     pub fn configure<W>(&mut self, tkw: &mut dyn TkWindow, widget: &mut W)
     where
-        W: Widget + Handler<Msg = VoidMsg> + ?Sized,
+        W: Layout<Msg = VoidMsg> + ?Sized,
     {
         // Re-assigning WidgetIds might invalidate state; to avoid this we map
         // existing ids to new ids
@@ -240,7 +240,7 @@ impl ManagerState {
             .map(|id| (elt.0, *id)));
     }
 
-    pub fn region_moved<W: Widget + ?Sized>(&mut self, widget: &mut W) {
+    pub fn region_moved<W: Layout + ?Sized>(&mut self, widget: &mut W) {
         // Note: redraw is already implied.
 
         // Update hovered widget
@@ -654,7 +654,7 @@ impl<'a> Manager<'a> {
 /// Internal methods
 impl<'a> Manager<'a> {
     #[cfg(feature = "winit")]
-    fn set_hover<W: Widget + ?Sized>(&mut self, widget: &mut W, w_id: Option<WidgetId>) {
+    fn set_hover<W: Layout + ?Sized>(&mut self, widget: &mut W, w_id: Option<WidgetId>) {
         if self.mgr.hover != w_id {
             self.mgr.hover = w_id;
             self.send_action(TkAction::Redraw);
@@ -751,7 +751,7 @@ impl<'a> Manager<'a> {
     }
 
     #[cfg(feature = "winit")]
-    fn next_nav_focus<W: Widget + ?Sized>(&mut self, widget: &mut W) {
+    fn next_nav_focus<W: Layout + ?Sized>(&mut self, widget: &mut W) {
         let mut id = self.mgr.nav_focus.unwrap_or(WidgetId::FIRST);
         let end = widget.id();
         loop {
@@ -799,7 +799,7 @@ impl<'a> Manager<'a> {
     /// Update, after receiving all events
     pub fn finish<W>(mut self, widget: &mut W) -> TkAction
     where
-        W: Widget + EvHandler<Msg = VoidMsg> + ?Sized,
+        W: Layout<Msg = VoidMsg> + ?Sized,
     {
         for gi in 0..self.mgr.pan_grab.len() {
             let grab = &mut self.mgr.pan_grab[gi];
@@ -864,7 +864,7 @@ impl<'a> Manager<'a> {
     }
 
     /// Update widgets due to timer
-    pub fn update_timer<W: Widget + ?Sized>(&mut self, widget: &mut W) {
+    pub fn update_timer<W: Layout + ?Sized>(&mut self, widget: &mut W) {
         let now = Instant::now();
 
         // assumption: time_updates are sorted
@@ -890,7 +890,7 @@ impl<'a> Manager<'a> {
     }
 
     /// Update widgets due to handle
-    pub fn update_handle<W: Widget + ?Sized>(
+    pub fn update_handle<W: Layout + ?Sized>(
         &mut self,
         widget: &mut W,
         handle: UpdateHandle,
@@ -915,7 +915,7 @@ impl<'a> Manager<'a> {
     #[cfg(feature = "winit")]
     pub fn handle_winit<W>(&mut self, widget: &mut W, event: winit::event::WindowEvent)
     where
-        W: Widget + EvHandler<Msg = VoidMsg> + ?Sized,
+        W: Layout<Msg = VoidMsg> + ?Sized,
     {
         use winit::event::{ElementState, MouseScrollDelta, TouchPhase, WindowEvent::*};
         trace!("Event: {:?}", event);

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -119,4 +119,4 @@ impl_void_msg!(bool, char,);
 impl_void_msg!(u8, u16, u32, u64, u128, usize,);
 impl_void_msg!(i8, i16, i32, i64, i128, isize,);
 impl_void_msg!(f32, f64,);
-impl_void_msg!(&'static str, String,);
+impl_void_msg!(&'static str, String, kas::CowString,);

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -75,7 +75,7 @@ pub use callback::Callback;
 #[cfg(not(feature = "winit"))]
 pub use enums::{CursorIcon, MouseButton, VirtualKeyCode};
 pub use events::*;
-pub use handler::Handler;
+pub use handler::{EvHandler, Handler};
 pub use manager::{GrabMode, HighlightState, Manager, ManagerState};
 pub use response::Response;
 pub use update::UpdateHandle;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -75,7 +75,7 @@ pub use callback::Callback;
 #[cfg(not(feature = "winit"))]
 pub use enums::{CursorIcon, MouseButton, VirtualKeyCode};
 pub use events::*;
-pub use handler::{EvHandler, Handler};
+pub use handler::Handler;
 pub use manager::{GrabMode, HighlightState, Manager, ManagerState};
 pub use response::Response;
 pub use update::UpdateHandle;

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -7,12 +7,12 @@
 
 use super::{Action, Event};
 
-/// Response type from [`Handler::handle`].
+/// Response type from [`Handler::action`].
 ///
 /// This type wraps [`Handler::Msg`] allowing both custom messages and toolkit
 /// messages.
 ///
-/// [`Handler::handle`]: super::Handler::handle
+/// [`Handler::action`]: super::Handler::action
 /// [`Handler::Msg`]: super::Handler::Msg
 #[derive(Clone, Debug)]
 #[must_use]

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -11,11 +11,8 @@ use std::fmt;
 use super::{AxisInfo, SizeRules};
 use crate::draw::SizeHandle;
 use crate::geom::{Coord, Rect, Size};
-use crate::{
-    AlignHints,
-    Direction::{Horizontal, Vertical},
-    Widget,
-};
+use crate::Direction::{Horizontal, Vertical};
+use crate::{AlignHints, Layout, Widget};
 
 /// A [`SizeRules`] solver for layouts
 ///
@@ -61,7 +58,7 @@ pub trait RulesSetter {
 /// Calculate required size of widget
 ///
 /// Return min and ideal sizes.
-pub fn solve<L: Widget>(widget: &mut L, size_handle: &mut dyn SizeHandle) -> (Size, Size) {
+pub fn solve<L: Layout>(widget: &mut L, size_handle: &mut dyn SizeHandle) -> (Size, Size) {
     // We call size_rules not because we want the result, but because our
     // spec requires that we do so before calling set_rect.
     let w = widget.size_rules(size_handle, AxisInfo::new(Horizontal, None));
@@ -76,7 +73,7 @@ pub fn solve<L: Widget>(widget: &mut L, size_handle: &mut dyn SizeHandle) -> (Si
 /// Solve and assign widget layout
 ///
 /// Return min and ideal sizes.
-pub fn solve_and_set<L: Widget>(
+pub fn solve_and_set<L: Layout>(
     widget: &mut L,
     size_handle: &mut dyn SizeHandle,
     size: Size,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,5 +45,8 @@ pub use crate::data::*;
 pub use crate::toolkit::*;
 pub use crate::traits::*;
 
-/// Convenience definition
-pub type CowString = std::borrow::Cow<'static, str>;
+/// Convenience definition: `Cow<'a, str>`
+pub type CowStringL<'a> = std::borrow::Cow<'a, str>;
+
+/// Convenience definition: `Cow<'static, str>`
+pub type CowString = CowStringL<'static>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,3 +44,6 @@ pub mod macros;
 pub use crate::data::*;
 pub use crate::toolkit::*;
 pub use crate::traits::*;
+
+/// Convenience definition
+pub type CowString = std::borrow::Cow<'static, str>;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -48,11 +48,11 @@
 //! ```
 //! use kas::macros::Widget;
 //! use kas::event::{EvHandler, VoidMsg};
-//! use kas::{CoreData, LayoutData, Widget};
+//! use kas::{CoreData, Layout, LayoutData, Widget};
 //!
 //! #[widget]
 //! #[layout(single)]
-//! #[handler(generics = <> where W: EvHandler<Msg = VoidMsg>)]
+//! #[handler(generics = <> where W: Layout<Msg = VoidMsg>)]
 //! #[derive(Clone, Debug, Widget)]
 //! struct WrapperWidget<W: Widget> {
 //!     #[widget_core] core: CoreData,
@@ -73,11 +73,13 @@
 //!
 //! #[widget]
 //! #[widget_core(key_nav = true)]
+//! #[handler]
 //! #[derive(Clone, Debug, Default, Widget)]
 //! struct MyWidget {
 //!     #[widget_core] core: CoreData,
 //! }
 //!
+//! impl event::EvHandler for MyWidget {}
 //! impl Layout for MyWidget {
 //!     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
 //!         todo!()
@@ -155,10 +157,10 @@
 //! `W: EvHandler`. This may be achieved as follows:
 //! ```
 //! # use kas::macros::Widget;
-//! # use kas::{CoreData, Widget, event::{Handler, EvHandler}};
+//! # use kas::{CoreData, Layout, Widget, event::{Handler, EvHandler}};
 //! #[layout(single)]
 //! #[widget]
-//! #[handler(generics = <> where W: EvHandler; msg = <W as Handler>::Msg)]
+//! #[handler(generics = <> where W: Layout; msg = <W as Handler>::Msg)]
 //! #[derive(Clone, Debug, Default, Widget)]
 //! pub struct Frame<W: Widget> {
 //!     #[widget_core]
@@ -224,14 +226,14 @@
 //! use kas::event::{EvHandler, Manager, VoidResponse, VoidMsg};
 //! use kas::macros::Widget;
 //! use kas::widget::Label;
-//! use kas::{CoreData, LayoutData, Widget};
+//! use kas::{CoreData, Layout, LayoutData, Widget};
 //!
 //! #[derive(Debug)]
 //! enum ChildMessage { A }
 //!
 //! #[widget]
 //! #[layout(vertical)]
-//! #[handler(generics = <> where W: EvHandler<Msg = ChildMessage>)]
+//! #[handler(generics = <> where W: Layout<Msg = ChildMessage>)]
 //! #[derive(Debug, Widget)]
 //! struct MyWidget<W: Widget> {
 //!     #[widget_core] core: CoreData,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -60,6 +60,42 @@
 //! }
 //! ```
 //!
+//! #### WidgetCore
+//!
+//! The [`WidgetCore`] trait is always implemented by this macro. The
+//! `#[widget_core]` attribute may be used to parameterise this implementation,
+//! for example:
+//! ```
+//! use kas::draw::{DrawHandle, SizeHandle};
+//! use kas::layout::{AxisInfo, SizeRules};
+//! use kas::macros::Widget;
+//! use kas::{event, CoreData, Layout};
+//!
+//! #[widget]
+//! #[widget_core(key_nav = true)]
+//! #[derive(Clone, Debug, Default, Widget)]
+//! struct MyWidget {
+//!     #[widget_core] core: CoreData,
+//! }
+//!
+//! impl Layout for MyWidget {
+//!     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+//!         todo!()
+//!     }
+//!     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState) {
+//!         todo!()
+//!     }
+//! }
+//! ```
+//!
+//! The `#[widget_core]` attribute supports the following parameters, each
+//! with the specified default value:
+//!
+//! -   `key_nav = false`: a boolean, describing whether the widget supports
+//!     keyboard navigation (see [`WidgetCore::key_nav`])
+//! -   `cursor_icon = kas::event::CursorIcon::Default`: the cursor icon to use
+//!     when the mouse hovers over this widget (see [`WidgetCore::cursor_icon`])
+//!
 //! #### Widget
 //!
 //! If the `#[widget]` attribute is present, the [`Widget`] trait is derived
@@ -346,14 +382,9 @@
 //! #[derive(VoidMsg)]
 //! enum MyMessage { A, B };
 //! ```
-//!
-//! [`CoreData`]: crate::CoreData
-//! [`WidgetCore`]: crate::WidgetCore
-//! [`Widget`]: crate::Widget
-//! [`Layout`]: crate::Layout
-//! [`Layout::set_rect`]: crate::Layout::set_rect
-//! [`LayoutData`]: crate::LayoutData
-//! [`Handler`]: crate::event::Handler
-//! [`Handler::Msg`]: crate::event::Handler::Msg
+
+// Imported for doc-links
+#[allow(unused)]
+use crate::{event::Handler, CoreData, Layout, LayoutData, Widget, WidgetCore};
 
 pub use kas_macros::{make_widget, VoidMsg, Widget};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -138,25 +138,39 @@
 //! and [`EvHandler`]
 //! traits are implemented (potentially multiple times with different
 //! substitutions of generic parameters).
-//! This attribute accepts the following arguments:
+//! This attribute accepts the following semi-colon separated arguments:
 //!
+//! -   (optional) `noderive` — do not derive [`Handler`] (but do still derive
+//!     [`EvHandler`])
 //! -   (optional) `msg = TYPE` — the [`Handler::Msg`] associated type; if not
 //!     specified, this type defaults to [`kas::event::VoidMsg`]
-//! -   (optional) `substitutions = TUPLE` — a tuple of subsitutions for type
-//!     generics, for example: `(T1 = MyType, T2 = some::other::Type)`
+//! -   (optional) `substitutions = LIST` — a list subsitutions for type
+//!     generics, for example: (T1 = MyType, T2 = some::other::Type`
 //! -   (optional): `generics = < X, Y, ... > where CONDS`
-//!     (`where CONDS` is optional, and if present must be the last argument)
+//!     (`where CONDS` is optional)
 //!
-//! Commonly the [`Handler`] implementation requires extra bounds on generic
-//! types, and sometimes also additional type parameters; the `generics`
-//! argument allows this. This argument is optional and if present must be the
-//! last argument. Note that the generic types and bounds given are *added to*
-//! the generics defined on the struct itself.
+//! Commonly, implementations of these traits require extra type bounds on the
+//! `impl` which do not appear on the struct, for example a struct may be
+//! parametrised with `W: Widget`, but the [`Handler`] impl may require
+//! `W: EvHandler`. This may be achieved as follows:
+//! ```
+//! # use kas::macros::Widget;
+//! # use kas::{CoreData, Widget, event::{Handler, EvHandler}};
+//! #[layout(single)]
+//! #[widget]
+//! #[handler(generics = <> where W: EvHandler; msg = <W as Handler>::Msg)]
+//! #[derive(Clone, Debug, Default, Widget)]
+//! pub struct Frame<W: Widget> {
+//!     #[widget_core]
+//!     core: CoreData,
+//!     #[widget]
+//!     child: W,
+//! }
+//! ```
+//! Unusually, the `#[handler]` attribute uses `;` as a parameter separator,
+//! since both the `substitutions` and `generics` parameters may contain
+//! comma-separated lists.
 //!
-//! If you need to substitute generic parameters on the struct with concrete
-//! types for the [`Handler`] implementation, use the `substitutions` argument.
-//! Be aware that this behaviour is a hack which only supports type generics
-//! on parameters without where clause constraints.
 //! (Note that ideally we would use equality constraints in `where` predicates
 //! instead of adding special parameter substitution support, but type equality
 //! constraints are not supported by Rust yet: #20041.)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,7 +55,7 @@
 //! #[handler(generics = <> where W: Handler<Msg = VoidMsg>)]
 //! #[derive(Clone, Debug, Widget)]
 //! struct WrapperWidget<W: Widget> {
-//!     #[core] core: CoreData,
+//!     #[widget_core] core: CoreData,
 //!     #[widget] child: W,
 //! }
 //! ```
@@ -126,7 +126,7 @@
 //!
 //! ### Fields
 //!
-//! One struct field with specification `#[core] core: CoreData` is required.
+//! One struct field with specification `#[widget_core] core: CoreData` is required.
 //! When deriving layouts a `#[layout_data]` field is also required (see above).
 //!
 //! Other fields may be child widgets or simply data fields. Those with a
@@ -183,7 +183,7 @@
 //! #[handler(generics = <> where W: Handler<Msg = ChildMessage>)]
 //! #[derive(Debug, Widget)]
 //! struct MyWidget<W: Widget> {
-//!     #[core] core: CoreData,
+//!     #[widget_core] core: CoreData,
 //!     #[layout_data] layout_data: <Self as LayoutData>::Data,
 //!     #[widget] label: Label,
 //!     #[widget(handler = handler)] child: W,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,12 +47,12 @@
 //!
 //! ```
 //! use kas::macros::Widget;
-//! use kas::event::{Handler, VoidMsg};
+//! use kas::event::{EvHandler, VoidMsg};
 //! use kas::{CoreData, LayoutData, Widget};
 //!
 //! #[widget]
 //! #[layout(single)]
-//! #[handler(generics = <> where W: Handler<Msg = VoidMsg>)]
+//! #[handler(generics = <> where W: EvHandler<Msg = VoidMsg>)]
 //! #[derive(Clone, Debug, Widget)]
 //! struct WrapperWidget<W: Widget> {
 //!     #[widget_core] core: CoreData,
@@ -135,7 +135,8 @@
 //! #### Handler
 //!
 //! If one or more `#[handler]` attributes are present, then the [`Handler`]
-//! trait is implemented (potentially multiple times with different
+//! and [`EvHandler`]
+//! traits are implemented (potentially multiple times with different
 //! substitutions of generic parameters).
 //! This attribute accepts the following arguments:
 //!
@@ -206,7 +207,7 @@
 //! The example below includes multiple children and custom event handling.
 //!
 //! ```
-//! use kas::event::{Handler, Manager, VoidResponse, VoidMsg};
+//! use kas::event::{EvHandler, Manager, VoidResponse, VoidMsg};
 //! use kas::macros::Widget;
 //! use kas::widget::Label;
 //! use kas::{CoreData, LayoutData, Widget};
@@ -216,7 +217,7 @@
 //!
 //! #[widget]
 //! #[layout(vertical)]
-//! #[handler(generics = <> where W: Handler<Msg = ChildMessage>)]
+//! #[handler(generics = <> where W: EvHandler<Msg = ChildMessage>)]
 //! #[derive(Debug, Widget)]
 //! struct MyWidget<W: Widget> {
 //!     #[widget_core] core: CoreData,
@@ -385,6 +386,6 @@
 
 // Imported for doc-links
 #[allow(unused)]
-use crate::{event::Handler, CoreData, Layout, LayoutData, Widget, WidgetCore};
+use crate::{event::EvHandler, event::Handler, CoreData, Layout, LayoutData, Widget, WidgetCore};
 
 pub use kas_macros::{make_widget, VoidMsg, Widget};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -226,7 +226,7 @@
 //!     #[layout(vertical)]
 //!     #[handler(msg = VoidMsg)]
 //!     struct {
-//!         #[widget] _ = Label::from("Widget Gallery"),
+//!         #[widget] _ = Label::new("Widget Gallery"),
 //!         #[widget(handler = activations)] _ = inner_widgets,
 //!         last_item: Item = Item::Button,
 //!     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,7 +47,7 @@
 //!
 //! ```
 //! use kas::macros::Widget;
-//! use kas::event::{EvHandler, VoidMsg};
+//! use kas::event::VoidMsg;
 //! use kas::{CoreData, Layout, LayoutData, Widget};
 //!
 //! #[widget]
@@ -79,7 +79,6 @@
 //!     #[widget_core] core: CoreData,
 //! }
 //!
-//! impl event::EvHandler for MyWidget {}
 //! impl Layout for MyWidget {
 //!     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
 //!         todo!()
@@ -137,13 +136,12 @@
 //! #### Handler
 //!
 //! If one or more `#[handler]` attributes are present, then the [`Handler`]
-//! and [`EvHandler`]
-//! traits are implemented (potentially multiple times with different
+//! trait is implemented (potentially multiple times with different
 //! substitutions of generic parameters).
 //! This attribute accepts the following semi-colon separated arguments:
 //!
-//! -   (optional) `noderive` — do not derive [`Handler`] (but do still derive
-//!     [`EvHandler`])
+//! -   (optional) `noderive` — do not derive [`Handler`] (but apply generics
+//!     to derivation of [`Layout`], if applicable)
 //! -   (optional) `msg = TYPE` — the [`Handler::Msg`] associated type; if not
 //!     specified, this type defaults to [`kas::event::VoidMsg`]
 //! -   (optional) `substitutions = LIST` — a list subsitutions for type
@@ -151,13 +149,14 @@
 //! -   (optional): `generics = < X, Y, ... > where CONDS`
 //!     (`where CONDS` is optional)
 //!
-//! Commonly, implementations of these traits require extra type bounds on the
+//! Commonly, implementations of the [`Handler`] and [`Layout`] traits require
+//! extra type bounds on the
 //! `impl` which do not appear on the struct, for example a struct may be
 //! parametrised with `W: Widget`, but the [`Handler`] impl may require
-//! `W: EvHandler`. This may be achieved as follows:
+//! `W: Layout`. This may be achieved as follows:
 //! ```
 //! # use kas::macros::Widget;
-//! # use kas::{CoreData, Layout, Widget, event::{Handler, EvHandler}};
+//! # use kas::{CoreData, Layout, Widget, event::Handler};
 //! #[layout(single)]
 //! #[widget]
 //! #[handler(generics = <> where W: Layout; msg = <W as Handler>::Msg)]
@@ -223,7 +222,7 @@
 //! The example below includes multiple children and custom event handling.
 //!
 //! ```
-//! use kas::event::{EvHandler, Manager, VoidResponse, VoidMsg};
+//! use kas::event::{Manager, VoidResponse, VoidMsg};
 //! use kas::macros::Widget;
 //! use kas::widget::Label;
 //! use kas::{CoreData, Layout, LayoutData, Widget};
@@ -402,6 +401,6 @@
 
 // Imported for doc-links
 #[allow(unused)]
-use crate::{event::EvHandler, event::Handler, CoreData, Layout, LayoutData, Widget, WidgetCore};
+use crate::{event::Handler, CoreData, Layout, LayoutData, Widget, WidgetCore};
 
 pub use kas_macros::{make_widget, VoidMsg, Widget};

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -97,10 +97,10 @@ pub trait TkWindow {
     ///
     /// In case of failure, paste actions will simply fail. The implementation
     /// may wish to log an appropriate warning message.
-    fn get_clipboard(&mut self) -> Option<String>;
+    fn get_clipboard(&mut self) -> Option<crate::CowString>;
 
     /// Attempt to set clipboard contents
-    fn set_clipboard(&mut self, content: String);
+    fn set_clipboard<'c>(&mut self, content: crate::CowStringL<'c>);
 
     /// Adjust the theme
     fn adjust_theme(&mut self, f: &mut dyn FnMut(&mut dyn ThemeApi) -> ThemeAction);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -139,6 +139,18 @@ pub trait WidgetCore: fmt::Debug {
     /// This walk is iterative (nonconcurrent), depth-first, and always calls
     /// `f` on self *after* walking through all children.
     fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn Widget));
+
+    /// Is this widget navigable via Tab key?
+    fn key_nav(&self) -> bool {
+        false
+    }
+
+    /// Which cursor icon should be used on hover?
+    ///
+    /// Where no specific icon should be used, return [`event::CursorIcon::Default`].
+    fn cursor_icon(&self) -> event::CursorIcon {
+        event::CursorIcon::Default
+    }
 }
 
 /// Positioning and drawing routines for widgets
@@ -250,18 +262,6 @@ pub trait Widget: Layout {
     ///
     /// This method being called does not imply a redraw.
     fn update_handle(&mut self, _mgr: &mut Manager, _handle: event::UpdateHandle, _payload: u64) {}
-
-    /// Is this widget navigable via Tab key?
-    fn allow_focus(&self) -> bool {
-        false
-    }
-
-    /// Which cursor icon should be used on hover?
-    ///
-    /// Where no specific icon should be used, return [`event::CursorIcon::Default`].
-    fn cursor_icon(&self) -> event::CursorIcon {
-        event::CursorIcon::Default
-    }
 }
 
 /// Trait to describe the type needed by the layout implementation.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -288,7 +288,7 @@ pub trait LayoutData {
 // Window should be a Widget. So alternatives are (1) use a struct instead of a
 // trait or (2) allow any Widget to derive Window (i.e. implement required
 // functionality with macros instead of the generic code below).
-pub trait Window: Widget + event::Handler<Msg = event::VoidMsg> {
+pub trait Window: Widget + event::EvHandler<Msg = event::VoidMsg> {
     /// Get the window title
     fn title(&self) -> &str;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,7 +7,6 @@
 
 use std::fmt;
 use std::ops::DerefMut;
-use std::time::Duration;
 
 use crate::draw::{DrawHandle, SizeHandle};
 use crate::event::{self, Event, Manager, ManagerState, Response};
@@ -172,32 +171,6 @@ pub trait Widget: WidgetCore {
     ///
     /// This method is called immediately after assigning `self.core_data().id`.
     fn configure(&mut self, _: &mut Manager) {}
-
-    /// Update the widget via a timer
-    ///
-    /// This method is called on scheduled updates
-    /// (see [`Manager::update_on_timer`]).
-    ///
-    /// When some [`Duration`] is returned, another timed update is scheduled
-    /// at approximately this duration from now (but without blocking redraws;
-    /// usage of 1ns effectively enables per-frame update with FPS limited via
-    /// VSync). Required: `duration > 0`.
-    ///
-    /// This method being called does not imply a redraw.
-    fn update_timer(&mut self, _: &mut Manager) -> Option<Duration> {
-        None
-    }
-
-    /// Update the widget via an update handle
-    ///
-    /// This method is called on triggered updates (see [`Manager::update_on_handle`]).
-    /// The source handle is specified via the [`event::UpdateHandle`] parameter.
-    ///
-    /// A user-defined payload is passed. Interpretation of this payload is
-    /// user-defined and unfortunately not type safe.
-    ///
-    /// This method being called does not imply a redraw.
-    fn update_handle(&mut self, _mgr: &mut Manager, _handle: event::UpdateHandle, _payload: u64) {}
 }
 
 /// Positioning and drawing routines for widgets
@@ -275,7 +248,7 @@ pub trait Layout: event::Handler {
     ///
     /// Parent widgets should forward events to the appropriate child widget,
     /// via logic like the following:
-    /// ```
+    /// ```norun
     /// if id <= self.child1.id() {
     ///     self.child1.event(mgr, id, event).into()
     /// } else if id <= self.child2.id() {

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -1,0 +1,125 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Trait impls
+
+use std::time::Duration;
+
+use super::*;
+use crate::draw::{DrawHandle, SizeHandle};
+use crate::event::{self, Action, Event, Manager, Response, UpdateHandle};
+use crate::geom::{Coord, Rect};
+use crate::layout::{AxisInfo, SizeRules};
+use crate::{AlignHints, CoreData, WidgetId};
+
+impl<M> WidgetCore for Box<dyn Layout<Msg = M>> {
+    fn core_data(&self) -> &CoreData {
+        self.as_ref().core_data()
+    }
+    fn core_data_mut(&mut self) -> &mut CoreData {
+        self.as_mut().core_data_mut()
+    }
+
+    fn widget_name(&self) -> &'static str {
+        self.as_ref().widget_name()
+    }
+
+    fn as_widget(&self) -> &dyn Widget {
+        self.as_ref().as_widget()
+    }
+    fn as_widget_mut(&mut self) -> &mut dyn Widget {
+        self.as_mut().as_widget_mut()
+    }
+
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+    fn get(&self, index: usize) -> Option<&dyn Widget> {
+        self.as_ref().get(index)
+    }
+    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
+        self.as_mut().get_mut(index)
+    }
+
+    fn walk(&self, f: &mut dyn FnMut(&dyn Widget)) {
+        self.as_ref().walk(f);
+    }
+    fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn Widget)) {
+        self.as_mut().walk_mut(f);
+    }
+
+    fn key_nav(&self) -> bool {
+        self.as_ref().key_nav()
+    }
+    fn cursor_icon(&self) -> event::CursorIcon {
+        self.as_ref().cursor_icon()
+    }
+}
+
+impl<M> Widget for Box<dyn Layout<Msg = M>> {
+    fn configure(&mut self, mgr: &mut Manager) {
+        self.as_mut().configure(mgr);
+    }
+
+    fn update_timer(&mut self, mgr: &mut Manager) -> Option<Duration> {
+        self.as_mut().update_timer(mgr)
+    }
+
+    fn update_handle(&mut self, mgr: &mut Manager, handle: UpdateHandle, payload: u64) {
+        self.as_mut().update_handle(mgr, handle, payload);
+    }
+}
+
+impl<M> event::Handler for Box<dyn Layout<Msg = M>> {
+    type Msg = M;
+
+    fn activation_via_press(&self) -> bool {
+        self.as_ref().activation_via_press()
+    }
+
+    fn action(&mut self, mgr: &mut Manager, action: Action) -> Response<Self::Msg> {
+        self.as_mut().action(mgr, action)
+    }
+}
+
+impl<M> Layout for Box<dyn Layout<Msg = M>> {
+    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        self.as_mut().size_rules(size_handle, axis)
+    }
+
+    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+        self.as_mut().set_rect(size_handle, rect, align);
+    }
+
+    fn find_id(&self, coord: Coord) -> Option<WidgetId> {
+        self.as_ref().find_id(coord)
+    }
+
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState) {
+        self.as_ref().draw(draw_handle, mgr);
+    }
+
+    fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
+        self.as_mut().event(mgr, id, event)
+    }
+}
+
+impl<M: 'static> Clone for Box<dyn Layout<Msg = M>> {
+    fn clone(&self) -> Self {
+        #[cfg(feature = "nightly")]
+        unsafe {
+            use crate::CloneTo;
+            let mut x = Box::new_uninit();
+            self.clone_to(x.as_mut_ptr());
+            x.assume_init()
+        }
+
+        // Run-time failure is not ideal — but we would hit compile-issues which
+        // don't necessarily correspond to actual usage otherwise due to
+        // `derive(Clone)` on any widget produced by `make_widget!`.
+        #[cfg(not(feature = "nightly"))]
+        panic!("Clone for Box<dyn Widget> only supported on nightly");
+    }
+}

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -5,11 +5,9 @@
 
 //! Trait impls
 
-use std::time::Duration;
-
 use super::*;
 use crate::draw::{DrawHandle, SizeHandle};
-use crate::event::{self, Action, Event, Manager, Response, UpdateHandle};
+use crate::event::{self, Action, Event, Manager, Response};
 use crate::geom::{Coord, Rect};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::{AlignHints, CoreData, WidgetId};
@@ -61,14 +59,6 @@ impl<M> WidgetCore for Box<dyn Layout<Msg = M>> {
 impl<M> Widget for Box<dyn Layout<Msg = M>> {
     fn configure(&mut self, mgr: &mut Manager) {
         self.as_mut().configure(mgr);
-    }
-
-    fn update_timer(&mut self, mgr: &mut Manager) -> Option<Duration> {
-        self.as_mut().update_timer(mgr)
-    }
-
-    fn update_handle(&mut self, mgr: &mut Manager, handle: UpdateHandle, payload: u64) {
-        self.as_mut().update_handle(mgr, handle, payload);
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -46,20 +46,10 @@ impl<M: Clone + Debug> Layout for TextButton<M> {
         let frame_rules = SizeRules::extract_fixed(axis.dir(), sides.0 + sides.1, margins);
 
         let content_rules = size_handle.text_bound(&self.label, TextClass::Button, axis);
-        let rules = content_rules.surrounded_by(frame_rules, true);
-
-        if axis.is_horizontal() {
-            self.core.rect.size.0 = rules.ideal_size();
-        } else {
-            self.core.rect.size.1 = rules.ideal_size();
-        }
-        rules
+        content_rules.surrounded_by(frame_rules, true)
     }
 
-    fn set_rect(&mut self, _size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
-        let rect = align
-            .complete(Align::Stretch, Align::Stretch, self.rect().size)
-            .apply(rect);
+    fn set_rect(&mut self, _size_handle: &mut dyn SizeHandle, rect: Rect, _align: AlignHints) {
         self.core.rect = rect;
 
         // In theory, text rendering should be restricted as in EditBox.

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -18,6 +18,7 @@ use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore};
 
 /// A push-button with a text label
 #[widget_core(key_nav = true)]
+#[handler(noderive)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct TextButton<M: Clone + Debug> {
     #[widget_core]
@@ -122,6 +123,3 @@ impl<M: Clone + Debug> event::Handler for TextButton<M> {
         }
     }
 }
-
-// TODO: derive
-impl<M: Clone + Debug> event::EvHandler for TextButton<M> {}

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -122,3 +122,6 @@ impl<M: Clone + Debug> event::Handler for TextButton<M> {
         }
     }
 }
+
+// TODO: derive
+impl<M: Clone + Debug> event::EvHandler for TextButton<M> {}

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -37,8 +37,6 @@ impl<M: Clone + Debug> Widget for TextButton<M> {
     }
 }
 
-impl<M: Clone + Debug> event::EvHandler for TextButton<M> {}
-
 impl<M: Clone + Debug> Layout for TextButton<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let sides = size_handle.button_surround();

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -17,6 +17,7 @@ use crate::macros::Widget;
 use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore};
 
 /// A push-button with a text label
+#[widget_core(key_nav = true)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct TextButton<M: Clone + Debug> {
     #[widget_core]
@@ -32,10 +33,6 @@ impl<M: Clone + Debug> Widget for TextButton<M> {
         for key in &self.keys {
             mgr.add_accel_key(*key, self.id());
         }
-    }
-
-    fn allow_focus(&self) -> bool {
-        true
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -19,7 +19,7 @@ use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore};
 /// A push-button with a text label
 #[derive(Clone, Debug, Default, Widget)]
 pub struct TextButton<M: Clone + Debug> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     keys: SmallVec<[VirtualKeyCode; 4]>,
     // text_rect: Rect,

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -14,7 +14,7 @@ use crate::event::{self, Action, Manager, Response, VirtualKeyCode};
 use crate::geom::Rect;
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
-use crate::{Align, AlignHints, CoreData, Layout, Widget, WidgetCore};
+use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore};
 
 /// A push-button with a text label
 #[derive(Clone, Debug, Default, Widget)]
@@ -23,7 +23,7 @@ pub struct TextButton<M: Clone + Debug> {
     core: CoreData,
     keys: SmallVec<[VirtualKeyCode; 4]>,
     // text_rect: Rect,
-    label: String,
+    label: CowString,
     msg: M,
 }
 
@@ -72,7 +72,7 @@ impl<M: Clone + Debug> TextButton<M> {
     /// type supporting `Clone` is valid, though it is recommended to use a
     /// simple `Copy` type (e.g. an enum). Click actions must be implemented on
     /// the parent (or other ancestor).
-    pub fn new<S: Into<String>>(label: S, msg: M) -> Self {
+    pub fn new<S: Into<CowString>>(label: S, msg: M) -> Self {
         TextButton {
             core: Default::default(),
             keys: SmallVec::new(),
@@ -104,7 +104,7 @@ impl<M: Clone + Debug> HasText for TextButton<M> {
         &self.label
     }
 
-    fn set_string(&mut self, mgr: &mut Manager, text: String) {
+    fn set_cow_string(&mut self, mgr: &mut Manager, text: CowString) {
         self.label = text;
         mgr.redraw(self.id());
     }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -37,6 +37,8 @@ impl<M: Clone + Debug> Widget for TextButton<M> {
     }
 }
 
+impl<M: Clone + Debug> event::EvHandler for TextButton<M> {}
+
 impl<M: Clone + Debug> Layout for TextButton<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let sides = size_handle.button_surround();

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -115,7 +115,7 @@ impl<M: Clone + Debug> event::Handler for TextButton<M> {
         true
     }
 
-    fn handle_action(&mut self, _: &mut Manager, action: Action) -> Response<M> {
+    fn action(&mut self, _: &mut Manager, action: Action) -> Response<M> {
         match action {
             Action::Activate => self.msg.clone().into(),
             a @ _ => Response::unhandled_action(a),

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -39,8 +39,6 @@ impl<M> Debug for CheckBoxBare<M> {
     }
 }
 
-impl<M> event::EvHandler for CheckBoxBare<M> {}
-
 impl<M> Layout for CheckBoxBare<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.checkbox();

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -20,6 +20,7 @@ use crate::{Align, AlignHints, CoreData, CowString, Layout, WidgetCore};
 /// A bare checkbox (no label)
 #[widget]
 #[widget_core(key_nav = true)]
+#[handler(noderive)]
 #[derive(Clone, Default, Widget)]
 pub struct CheckBoxBare<M> {
     #[widget_core]
@@ -148,14 +149,11 @@ impl<M> event::Handler for CheckBoxBare<M> {
     }
 }
 
-// TODO: derive
-impl<M> event::EvHandler for CheckBoxBare<M> {}
-
 /// A checkable box with optional label
 // TODO: use a generic wrapper for CheckBox and RadioBox?
 #[layout(horizontal, area=checkbox)]
 #[widget]
-#[handler(msg = M, generics = <> where M: From<VoidMsg>)]
+#[handler(msg = M; generics = <> where M: From<VoidMsg>)]
 #[derive(Clone, Default, Widget)]
 pub struct CheckBox<M> {
     #[widget_core]

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -6,6 +6,7 @@
 //! Toggle widgets
 
 use std::fmt::{self, Debug};
+use std::rc::Rc;
 
 use super::Label;
 use crate::class::HasBool;
@@ -20,14 +21,14 @@ use crate::{Align, AlignHints, CoreData, CowString, Layout, WidgetCore};
 #[widget]
 #[widget_core(key_nav = true)]
 #[derive(Clone, Default, Widget)]
-pub struct CheckBoxBare<OT: 'static> {
+pub struct CheckBoxBare<M> {
     #[widget_core]
     core: CoreData,
     state: bool,
-    on_toggle: OT,
+    on_toggle: Option<Rc<dyn Fn(bool) -> M>>,
 }
 
-impl<H> Debug for CheckBoxBare<H> {
+impl<M> Debug for CheckBoxBare<M> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -37,7 +38,7 @@ impl<H> Debug for CheckBoxBare<H> {
     }
 }
 
-impl<OT: 'static> Layout for CheckBoxBare<OT> {
+impl<M> Layout for CheckBoxBare<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.checkbox();
         self.core.rect.size = size;
@@ -58,7 +59,7 @@ impl<OT: 'static> Layout for CheckBoxBare<OT> {
     }
 }
 
-impl<M, OT: Fn(bool) -> M> CheckBoxBare<OT> {
+impl<M> CheckBoxBare<M> {
     /// Construct a checkbox which calls `f` when toggled
     ///
     /// This is a shortcut for `CheckBoxBare::new().on_toggle(f)`.
@@ -66,23 +67,23 @@ impl<M, OT: Fn(bool) -> M> CheckBoxBare<OT> {
     /// The closure `f` is called with the new state of the checkbox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn new_on(f: OT) -> Self {
+    pub fn new_on<F: Fn(bool) -> M + 'static>(f: F) -> Self {
         CheckBoxBare {
             core: Default::default(),
             state: false,
-            on_toggle: f,
+            on_toggle: Some(Rc::new(f)),
         }
     }
 }
 
-impl CheckBoxBare<()> {
+impl CheckBoxBare<VoidMsg> {
     /// Construct a checkbox
     #[inline]
     pub fn new() -> Self {
         CheckBoxBare {
             core: Default::default(),
             state: false,
-            on_toggle: (),
+            on_toggle: None,
         }
     }
 
@@ -91,16 +92,19 @@ impl CheckBoxBare<()> {
     /// The closure `f` is called with the new state of the checkbox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn on_toggle<M, OT: Fn(bool) -> M>(self, f: OT) -> CheckBoxBare<OT> {
+    pub fn on_toggle<M, F>(self, f: F) -> CheckBoxBare<M>
+    where
+        F: Fn(bool) -> M + 'static,
+    {
         CheckBoxBare {
             core: self.core,
             state: self.state,
-            on_toggle: f,
+            on_toggle: Some(Rc::new(f)),
         }
     }
 }
 
-impl<OT: 'static> CheckBoxBare<OT> {
+impl<M> CheckBoxBare<M> {
     /// Set the initial state of the checkbox.
     #[inline]
     pub fn state(mut self, state: bool) -> Self {
@@ -109,7 +113,7 @@ impl<OT: 'static> CheckBoxBare<OT> {
     }
 }
 
-impl<H> HasBool for CheckBoxBare<H> {
+impl<M> HasBool for CheckBoxBare<M> {
     fn get_bool(&self) -> bool {
         self.state
     }
@@ -120,27 +124,7 @@ impl<H> HasBool for CheckBoxBare<H> {
     }
 }
 
-impl event::Handler for CheckBoxBare<()> {
-    type Msg = VoidMsg;
-
-    #[inline]
-    fn activation_via_press(&self) -> bool {
-        true
-    }
-
-    fn handle_action(&mut self, mgr: &mut Manager, action: Action) -> Response<VoidMsg> {
-        match action {
-            Action::Activate => {
-                self.state = !self.state;
-                mgr.redraw(self.id());
-                Response::None
-            }
-            a @ _ => Response::unhandled_action(a),
-        }
-    }
-}
-
-impl<M, H: Fn(bool) -> M> event::Handler for CheckBoxBare<H> {
+impl<M> event::Handler for CheckBoxBare<M> {
     type Msg = M;
 
     #[inline]
@@ -153,7 +137,11 @@ impl<M, H: Fn(bool) -> M> event::Handler for CheckBoxBare<H> {
             Action::Activate => {
                 self.state = !self.state;
                 mgr.redraw(self.id());
-                ((self.on_toggle)(self.state)).into()
+                if let Some(ref f) = self.on_toggle {
+                    f(self.state).into()
+                } else {
+                    Response::None
+                }
             }
             a @ _ => Response::unhandled_action(a),
         }
@@ -164,21 +152,20 @@ impl<M, H: Fn(bool) -> M> event::Handler for CheckBoxBare<H> {
 // TODO: use a generic wrapper for CheckBox and RadioBox?
 #[layout(horizontal, area=checkbox)]
 #[widget]
-#[handler(substitutions = (OT = ()))]
-#[handler(msg = M, generics = <M: From<VoidMsg>> where OT: Fn(bool) -> M)]
+#[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[derive(Clone, Default, Widget)]
-pub struct CheckBox<OT: 'static> {
+pub struct CheckBox<M> {
     #[widget_core]
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,
     #[widget]
-    checkbox: CheckBoxBare<OT>,
+    checkbox: CheckBoxBare<M>,
     #[widget]
     label: Label,
 }
 
-impl<H> Debug for CheckBox<H> {
+impl<M> Debug for CheckBox<M> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -188,7 +175,7 @@ impl<H> Debug for CheckBox<H> {
     }
 }
 
-impl<M, OT: Fn(bool) -> M> CheckBox<OT> {
+impl<M> CheckBox<M> {
     /// Construct a checkbox with a given `label` which calls `f` when toggled.
     ///
     /// This is a shortcut for `CheckBox::new(label).on_toggle(f)`.
@@ -199,7 +186,10 @@ impl<M, OT: Fn(bool) -> M> CheckBox<OT> {
     /// The closure `f` is called with the new state of the checkbox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn new_on<T: Into<CowString>>(f: OT, label: T) -> Self {
+    pub fn new_on<T: Into<CowString>, F>(f: F, label: T) -> Self
+    where
+        F: Fn(bool) -> M + 'static,
+    {
         CheckBox {
             core: Default::default(),
             layout_data: Default::default(),
@@ -209,7 +199,7 @@ impl<M, OT: Fn(bool) -> M> CheckBox<OT> {
     }
 }
 
-impl CheckBox<()> {
+impl CheckBox<VoidMsg> {
     /// Construct a checkbox with a given `label`.
     ///
     /// CheckBox labels are optional; if no label is desired, use an empty
@@ -229,7 +219,10 @@ impl CheckBox<()> {
     /// The closure `f` is called with the new state of the checkbox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn on_toggle<M, OT: Fn(bool) -> M>(self, f: OT) -> CheckBox<OT> {
+    pub fn on_toggle<M, F>(self, f: F) -> CheckBox<M>
+    where
+        F: Fn(bool) -> M + 'static,
+    {
         CheckBox {
             core: self.core,
             layout_data: self.layout_data,
@@ -239,7 +232,7 @@ impl CheckBox<()> {
     }
 }
 
-impl<OT: 'static> CheckBox<OT> {
+impl<M> CheckBox<M> {
     /// Set the initial state of the checkbox.
     #[inline]
     pub fn state(mut self, state: bool) -> Self {
@@ -248,7 +241,7 @@ impl<OT: 'static> CheckBox<OT> {
     }
 }
 
-impl<H> HasBool for CheckBox<H> {
+impl<M> HasBool for CheckBox<M> {
     #[inline]
     fn get_bool(&self) -> bool {
         self.checkbox.get_bool()

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -39,6 +39,8 @@ impl<M> Debug for CheckBoxBare<M> {
     }
 }
 
+impl<M> event::EvHandler for CheckBoxBare<M> {}
+
 impl<M> Layout for CheckBoxBare<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.checkbox();

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -19,7 +19,7 @@ use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore};
 /// A bare checkbox (no label)
 #[derive(Clone, Default, Widget)]
 pub struct CheckBoxBare<OT: 'static> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     state: bool,
     on_toggle: OT,
@@ -172,7 +172,7 @@ impl<M, H: Fn(bool) -> M> event::Handler for CheckBoxBare<H> {
 #[handler(msg = M, generics = <M: From<VoidMsg>> where OT: Fn(bool) -> M)]
 #[derive(Clone, Default, Widget)]
 pub struct CheckBox<OT: 'static> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -14,7 +14,7 @@ use crate::event::{self, Action, Manager, Response, VoidMsg};
 use crate::geom::Rect;
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
-use crate::{Align, AlignHints, CoreData, Layout, Widget, WidgetCore};
+use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore};
 
 /// A bare checkbox (no label)
 #[derive(Clone, Default, Widget)]
@@ -203,7 +203,7 @@ impl<M, OT: Fn(bool) -> M> CheckBox<OT> {
     /// The closure `f` is called with the new state of the checkbox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn new_on<T: ToString>(f: OT, label: T) -> Self {
+    pub fn new_on<T: Into<CowString>>(f: OT, label: T) -> Self {
         CheckBox {
             core: Default::default(),
             layout_data: Default::default(),
@@ -219,7 +219,7 @@ impl CheckBox<()> {
     /// CheckBox labels are optional; if no label is desired, use an empty
     /// string.
     #[inline]
-    pub fn new<T: ToString>(label: T) -> Self {
+    pub fn new<T: Into<CowString>>(label: T) -> Self {
         CheckBox {
             core: Default::default(),
             layout_data: Default::default(),

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -148,6 +148,9 @@ impl<M> event::Handler for CheckBoxBare<M> {
     }
 }
 
+// TODO: derive
+impl<M> event::EvHandler for CheckBoxBare<M> {}
+
 /// A checkable box with optional label
 // TODO: use a generic wrapper for CheckBox and RadioBox?
 #[layout(horizontal, area=checkbox)]

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -14,9 +14,11 @@ use crate::event::{self, Action, Manager, Response, VoidMsg};
 use crate::geom::Rect;
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
-use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore};
+use crate::{Align, AlignHints, CoreData, CowString, Layout, WidgetCore};
 
 /// A bare checkbox (no label)
+#[widget]
+#[widget_core(key_nav = true)]
 #[derive(Clone, Default, Widget)]
 pub struct CheckBoxBare<OT: 'static> {
     #[widget_core]
@@ -32,12 +34,6 @@ impl<H> Debug for CheckBoxBare<H> {
             "CheckBoxBare {{ core: {:?}, state: {:?}, ... }}",
             self.core, self.state
         )
-    }
-}
-
-impl<OT: 'static> Widget for CheckBoxBare<OT> {
-    fn allow_focus(&self) -> bool {
-        true
     }
 }
 

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -132,7 +132,7 @@ impl<M> event::Handler for CheckBoxBare<M> {
         true
     }
 
-    fn handle_action(&mut self, mgr: &mut Manager, action: Action) -> Response<M> {
+    fn action(&mut self, mgr: &mut Manager, action: Action) -> Response<M> {
         match action {
             Action::Activate => {
                 self.state = !self.state;

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -27,7 +27,7 @@ enum DialogButton {
 #[handler]
 #[derive(Clone, Debug, Widget)]
 pub struct MessageBox {
-    #[core]
+    #[widget_core]
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -14,7 +14,7 @@ use crate::geom::Size;
 use crate::layout;
 use crate::macros::{VoidMsg, Widget};
 use crate::widget::{Label, TextButton};
-use crate::{CoreData, TkAction, Window};
+use crate::{CoreData, CowString, TkAction, Window};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum DialogButton {
@@ -31,7 +31,7 @@ pub struct MessageBox {
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,
-    title: String,
+    title: CowString,
     #[widget]
     label: Label,
     #[widget(handler = handle_button)]
@@ -39,11 +39,11 @@ pub struct MessageBox {
 }
 
 impl MessageBox {
-    pub fn new<T: ToString, M: ToString>(title: T, message: M) -> Self {
+    pub fn new<T: Into<CowString>, M: Into<CowString>>(title: T, message: M) -> Self {
         MessageBox {
             core: Default::default(),
             layout_data: Default::default(),
-            title: title.to_string(),
+            title: title.into(),
             label: Label::new(message),
             button: TextButton::new("Ok", DialogButton::Close),
         }

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -32,7 +32,7 @@ use crate::{AlignHints, CoreData, Layout, WidgetCore, WidgetId};
 #[widget]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct DragHandle {
-    #[core]
+    #[widget_core]
     core: CoreData,
     // The track is the area within which this DragHandle may move
     track: Rect,

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -149,7 +149,9 @@ impl Layout for DragHandle {
 impl event::Handler for DragHandle {
     /// Offset from first possible position (should be non-negative).
     type Msg = Coord;
+}
 
+impl event::EvHandler for DragHandle {
     fn event(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
         match event {
             Event::PressStart { source, coord, .. } => {

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -150,7 +150,7 @@ impl event::Handler for DragHandle {
     /// Offset from first possible position (should be non-negative).
     type Msg = Coord;
 
-    fn handle(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
+    fn event(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
         match event {
             Event::PressStart { source, coord, .. } => {
                 if !self.grab_press(mgr, source, coord) {

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -127,6 +127,11 @@ impl DragHandle {
     }
 }
 
+impl event::Handler for DragHandle {
+    /// Offset from first possible position (should be non-negative).
+    type Msg = Coord;
+}
+
 /// This implementation is unusual in that:
 ///
 /// 1.  `size_rules` always returns [`SizeRules::EMPTY`]
@@ -144,14 +149,7 @@ impl Layout for DragHandle {
     }
 
     fn draw(&self, _: &mut dyn DrawHandle, _: &event::ManagerState) {}
-}
 
-impl event::Handler for DragHandle {
-    /// Offset from first possible position (should be non-negative).
-    type Msg = Coord;
-}
-
-impl event::EvHandler for DragHandle {
     fn event(&mut self, mgr: &mut Manager, _: WidgetId, event: Event) -> Response<Self::Msg> {
         match event {
             Event::PressStart { source, coord, .. } => {

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Debug};
 
 use crate::class::{Editable, HasText};
 use crate::draw::{DrawHandle, SizeHandle, TextClass};
-use crate::event::{self, Action, Handler, Manager, Response, VoidMsg};
+use crate::event::{self, Action, Manager, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::{Align, AlignHints, CoreData, CowString, Layout, WidgetCore};
@@ -55,7 +55,7 @@ pub type EditBoxVoid = EditBox<EditVoid>;
 ///
 /// All methods have a default implementation which does nothing.
 pub trait EditGuard: Sized {
-    /// The [`Handler::Msg`] type
+    /// The [`event::Handler::Msg`] type
     type Msg;
 
     /// Activation guard
@@ -391,7 +391,7 @@ impl<G> Editable for EditBox<G> {
     }
 }
 
-impl<G: EditGuard + 'static> Handler for EditBox<G> {
+impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
     type Msg = G::Msg;
 
     #[inline]
@@ -421,3 +421,6 @@ impl<G: EditGuard + 'static> Handler for EditBox<G> {
         }
     }
 }
+
+// TODO: derive
+impl<G: EditGuard + 'static> event::EvHandler for EditBox<G> {}

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -12,7 +12,7 @@ use crate::draw::{DrawHandle, SizeHandle, TextClass};
 use crate::event::{self, Action, Handler, Manager, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
-use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore};
+use crate::{Align, AlignHints, CoreData, CowString, Layout, WidgetCore};
 use kas::geom::Rect;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -109,6 +109,8 @@ impl<F: Fn(&str) -> Option<M>, M> EditGuard for EditEdit<F, M> {
 }
 
 /// An editable, single-line text box.
+#[widget]
+#[widget_core(key_nav = true, cursor_icon = event::CursorIcon::Text)]
 #[derive(Clone, Default, Widget)]
 pub struct EditBox<G: 'static> {
     #[widget_core]
@@ -131,16 +133,6 @@ impl<G> Debug for EditBox<G> {
             "EditBox {{ core: {:?}, editable: {:?}, text: {:?}, ... }}",
             self.core, self.editable, self.text
         )
-    }
-}
-
-impl<G: 'static> Widget for EditBox<G> {
-    fn allow_focus(&self) -> bool {
-        true
-    }
-
-    fn cursor_icon(&self) -> event::CursorIcon {
-        event::CursorIcon::Text
     }
 }
 

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -303,7 +303,7 @@ impl<G> EditBox<G> {
             match c {
                 '\u{03}' /* copy */ => {
                     // we don't yet have selection support, so just copy everything
-                    mgr.set_clipboard(self.text.clone());
+                    mgr.set_clipboard((&self.text).into());
                 }
                 '\u{08}' /* backspace */  => {
                     if self.last_edit != LastEdit::Backspace {

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -149,7 +149,9 @@ impl<G> Debug for EditBox<G> {
     }
 }
 
-impl<G: 'static> Layout for EditBox<G> {
+impl<G: EditGuard + 'static> event::EvHandler for EditBox<G> {}
+
+impl<G: EditGuard + 'static> Layout for EditBox<G> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let frame_sides = size_handle.edit_surround();
         let inner = size_handle.inner_margin();

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -123,6 +123,7 @@ impl<F: Fn(&str) -> Option<M>, M> EditGuard for EditEdit<F, M> {
 /// An editable, single-line text box.
 #[widget]
 #[widget_core(key_nav = true, cursor_icon = event::CursorIcon::Text)]
+#[handler(noderive; generics = <> where G: EditGuard)]
 #[derive(Clone, Default, Widget)]
 pub struct EditBox<G: 'static> {
     #[widget_core]
@@ -421,6 +422,3 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
         }
     }
 }
-
-// TODO: derive
-impl<G: EditGuard + 'static> event::EvHandler for EditBox<G> {}

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -111,7 +111,7 @@ impl<F: Fn(&str) -> Option<M>, M> EditGuard for EditEdit<F, M> {
 /// An editable, single-line text box.
 #[derive(Clone, Default, Widget)]
 pub struct EditBox<G: 'static> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     // During sizing, text_rect is used for the frame+inner-margin dimensions
     text_rect: Rect,

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -399,7 +399,7 @@ impl<G: EditGuard + 'static> Handler for EditBox<G> {
         true
     }
 
-    fn handle_action(&mut self, mgr: &mut Manager, action: Action) -> Response<Self::Msg> {
+    fn action(&mut self, mgr: &mut Manager, action: Action) -> Response<Self::Msg> {
         match action {
             Action::Activate => {
                 mgr.request_char_focus(self.id());

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -12,7 +12,7 @@ use crate::draw::{DrawHandle, SizeHandle, TextClass};
 use crate::event::{self, Action, Handler, Manager, Response, VoidMsg};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
-use crate::{Align, AlignHints, CoreData, Layout, Widget, WidgetCore};
+use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore};
 use kas::geom::Rect;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -371,8 +371,8 @@ impl<G> HasText for EditBox<G> {
         &self.text
     }
 
-    fn set_string(&mut self, mgr: &mut Manager, text: String) {
-        self.text = text;
+    fn set_cow_string(&mut self, mgr: &mut Manager, text: CowString) {
+        self.text = text.to_string();
         mgr.redraw(self.id());
     }
 }

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -149,8 +149,6 @@ impl<G> Debug for EditBox<G> {
     }
 }
 
-impl<G: EditGuard + 'static> event::EvHandler for EditBox<G> {}
-
 impl<G: EditGuard + 'static> Layout for EditBox<G> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let frame_sides = size_handle.edit_surround();

--- a/src/widget/filler.rs
+++ b/src/widget/filler.rs
@@ -23,8 +23,6 @@ pub struct Filler {
     policy: StretchPolicy,
 }
 
-impl event::EvHandler for Filler {}
-
 impl Layout for Filler {
     fn size_rules(&mut self, _: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
         SizeRules::empty(self.policy)

--- a/src/widget/filler.rs
+++ b/src/widget/filler.rs
@@ -18,7 +18,7 @@ use crate::{event, CoreData, Layout};
 #[handler]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct Filler {
-    #[core]
+    #[widget_core]
     core: CoreData,
     policy: StretchPolicy,
 }

--- a/src/widget/filler.rs
+++ b/src/widget/filler.rs
@@ -23,6 +23,8 @@ pub struct Filler {
     policy: StretchPolicy,
 }
 
+impl event::EvHandler for Filler {}
+
 impl Layout for Filler {
     fn size_rules(&mut self, _: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
         SizeRules::empty(self.policy)

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -13,7 +13,7 @@ use crate::event::{self, Handler, Manager};
 use crate::geom::{Coord, Rect, Size};
 use crate::layout::{AxisInfo, Margins, SizeRules};
 use crate::macros::Widget;
-use crate::{AlignHints, CoreData, Layout, Widget, WidgetCore, WidgetId};
+use crate::{AlignHints, CoreData, CowString, Layout, Widget, WidgetCore, WidgetId};
 
 /// A frame around content
 ///
@@ -101,15 +101,8 @@ impl<W: HasText + Widget> HasText for Frame<W> {
         self.child.get_text()
     }
 
-    fn set_text<T: ToString>(&mut self, mgr: &mut Manager, text: T)
-    where
-        Self: Sized,
-    {
-        self.child.set_text(mgr, text);
-    }
-
-    fn set_string(&mut self, mgr: &mut Manager, text: String) {
-        self.child.set_string(mgr, text);
+    fn set_cow_string(&mut self, mgr: &mut Manager, text: CowString) {
+        self.child.set_cow_string(mgr, text);
     }
 }
 

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -23,7 +23,7 @@ use crate::{AlignHints, CoreData, CowString, Layout, Widget, WidgetCore, WidgetI
 #[handler(msg = <W as Handler>::Msg, generics = <> where W: Handler)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct Frame<W: Widget> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     #[widget]
     child: W,

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -44,7 +44,9 @@ impl<W: Widget> Frame<W> {
     }
 }
 
-impl<W: Widget> Layout for Frame<W> {
+impl<W: Layout> event::EvHandler for Frame<W> {}
+
+impl<W: Layout> Layout for Frame<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let sides = size_handle.outer_frame();
         let margins = Margins::ZERO;

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -20,7 +20,7 @@ use crate::{AlignHints, CoreData, CowString, Layout, Widget, WidgetCore, WidgetI
 /// This widget provides a simple abstraction: drawing a frame around its
 /// contents.
 #[widget]
-#[handler(msg = <W as Handler>::Msg, generics = <> where W: EvHandler)]
+#[handler(msg = <W as Handler>::Msg; generics = <> where W: EvHandler)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct Frame<W: Widget> {
     #[widget_core]

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 
 use crate::class::*;
 use crate::draw::{DrawHandle, SizeHandle};
-use crate::event::{self, Handler, Manager};
+use crate::event::{self, EvHandler, Handler, Manager};
 use crate::geom::{Coord, Rect, Size};
 use crate::layout::{AxisInfo, Margins, SizeRules};
 use crate::macros::Widget;
@@ -20,7 +20,7 @@ use crate::{AlignHints, CoreData, CowString, Layout, Widget, WidgetCore, WidgetI
 /// This widget provides a simple abstraction: drawing a frame around its
 /// contents.
 #[widget]
-#[handler(msg = <W as Handler>::Msg, generics = <> where W: Handler)]
+#[handler(msg = <W as Handler>::Msg, generics = <> where W: EvHandler)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct Frame<W: Widget> {
     #[widget_core]

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -7,7 +7,7 @@
 
 use crate::class::HasText;
 use crate::draw::{DrawHandle, SizeHandle, TextClass};
-use crate::event::{Manager, ManagerState};
+use crate::event::{self, Manager, ManagerState};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::{Align, AlignHints, CoreData, CowString, Layout, WidgetCore};
@@ -24,6 +24,8 @@ pub struct Label {
     reserve: Option<&'static str>,
     text: CowString,
 }
+
+impl event::EvHandler for Label {}
 
 impl Layout for Label {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -10,7 +10,7 @@ use crate::draw::{DrawHandle, SizeHandle, TextClass};
 use crate::event::{Manager, ManagerState};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
-use crate::{Align, AlignHints, CoreData, Layout, WidgetCore};
+use crate::{Align, AlignHints, CoreData, CowString, Layout, WidgetCore};
 use kas::geom::Rect;
 
 /// A simple text label
@@ -22,7 +22,7 @@ pub struct Label {
     core: CoreData,
     align: (Align, Align),
     reserve: Option<&'static str>,
-    text: String,
+    text: CowString,
 }
 
 impl Layout for Label {
@@ -52,12 +52,12 @@ impl Layout for Label {
 
 impl Label {
     /// Construct a new, empty instance
-    pub fn new<T: ToString>(text: T) -> Self {
+    pub fn new<T: Into<CowString>>(text: T) -> Self {
         Label {
             core: Default::default(),
             align: Default::default(),
             reserve: None,
-            text: text.to_string(),
+            text: text.into(),
         }
     }
 
@@ -71,27 +71,13 @@ impl Label {
     }
 }
 
-impl<T> From<T> for Label
-where
-    String: From<T>,
-{
-    fn from(text: T) -> Self {
-        Label {
-            core: Default::default(),
-            align: Default::default(),
-            reserve: None,
-            text: String::from(text),
-        }
-    }
-}
-
 impl HasText for Label {
     fn get_text(&self) -> &str {
         &self.text
     }
 
-    fn set_string(&mut self, mgr: &mut Manager, text: String) {
-        self.text = text;
+    fn set_cow_string(&mut self, mgr: &mut Manager, text: CowString) {
+        self.text = text.into();
         mgr.redraw(self.id());
     }
 }

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -18,7 +18,7 @@ use kas::geom::Rect;
 #[handler]
 #[derive(Clone, Default, Debug, Widget)]
 pub struct Label {
-    #[core]
+    #[widget_core]
     core: CoreData,
     align: (Align, Align),
     reserve: Option<&'static str>,

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -7,7 +7,7 @@
 
 use crate::class::HasText;
 use crate::draw::{DrawHandle, SizeHandle, TextClass};
-use crate::event::{self, Manager, ManagerState};
+use crate::event::{Manager, ManagerState};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::{Align, AlignHints, CoreData, CowString, Layout, WidgetCore};
@@ -24,8 +24,6 @@ pub struct Label {
     reserve: Option<&'static str>,
     text: CowString,
 }
-
-impl event::EvHandler for Label {}
 
 impl Layout for Label {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -6,7 +6,7 @@
 //! Dynamic widgets
 
 use crate::draw::{DrawHandle, SizeHandle};
-use crate::event::{self, Event, Handler, Manager, Response};
+use crate::event::{self, EvHandler, Event, Manager, Response};
 use crate::geom::Coord;
 use crate::layout::{self, AxisInfo, RulesSetter, RulesSolver, SizeRules};
 use crate::{AlignHints, Directional, Horizontal, Vertical};
@@ -42,7 +42,7 @@ pub type BoxColumn<M> = BoxList<Vertical, M>;
 /// This is parameterised over directionality and handler message type.
 ///
 /// See documentation of [`List`] type.
-pub type BoxList<D, M> = List<D, Box<dyn Handler<Msg = M>>>;
+pub type BoxList<D, M> = List<D, Box<dyn EvHandler<Msg = M>>>;
 
 /// A generic row/column widget
 ///
@@ -178,9 +178,11 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
     }
 }
 
-impl<D: Directional, W: Widget + Handler> Handler for List<D, W> {
-    type Msg = <W as Handler>::Msg;
+impl<D: Directional, W: Widget + EvHandler> event::Handler for List<D, W> {
+    type Msg = <W as event::Handler>::Msg;
+}
 
+impl<D: Directional, W: Widget + EvHandler> event::EvHandler for List<D, W> {
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         for child in &mut self.widgets {
             if id <= child.id() {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -6,7 +6,7 @@
 //! Dynamic widgets
 
 use crate::draw::{DrawHandle, SizeHandle};
-use crate::event::{self, EvHandler, Event, Manager, Response};
+use crate::event::{self, Event, Manager, Response};
 use crate::geom::Coord;
 use crate::layout::{self, AxisInfo, RulesSetter, RulesSolver, SizeRules};
 use crate::{AlignHints, Directional, Horizontal, Vertical};
@@ -42,7 +42,7 @@ pub type BoxColumn<M> = BoxList<Vertical, M>;
 /// This is parameterised over directionality and handler message type.
 ///
 /// See documentation of [`List`] type.
-pub type BoxList<D, M> = List<D, Box<dyn EvHandler<Msg = M>>>;
+pub type BoxList<D, M> = List<D, Box<dyn Layout<Msg = M>>>;
 
 /// A generic row/column widget
 ///
@@ -130,6 +130,10 @@ impl<D: Directional, W: Widget> WidgetCore for List<D, W> {
 
 impl<D: Directional, W: Widget> Widget for List<D, W> {}
 
+impl<D: Directional, W: Layout> event::Handler for List<D, W> {
+    type Msg = <W as event::Handler>::Msg;
+}
+
 impl<D: Directional, W: Layout> Layout for List<D, W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let mut solver = layout::RowSolver::<Vec<u32>, _>::new(
@@ -176,13 +180,7 @@ impl<D: Directional, W: Layout> Layout for List<D, W> {
             w.draw(draw_handle, mgr)
         });
     }
-}
 
-impl<D: Directional, W: Widget + EvHandler> event::Handler for List<D, W> {
-    type Msg = <W as event::Handler>::Msg;
-}
-
-impl<D: Directional, W: Widget + EvHandler> event::EvHandler for List<D, W> {
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         for child in &mut self.widgets {
             if id <= child.id() {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -181,10 +181,10 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
 impl<D: Directional, W: Widget + Handler> Handler for List<D, W> {
     type Msg = <W as Handler>::Msg;
 
-    fn handle(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
+    fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         for child in &mut self.widgets {
             if id <= child.id() {
-                return child.handle(mgr, id, event);
+                return child.event(mgr, id, event);
             }
         }
         debug_assert!(id == self.id(), "Handler::handle: bad WidgetId");

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -130,7 +130,7 @@ impl<D: Directional, W: Widget> WidgetCore for List<D, W> {
 
 impl<D: Directional, W: Widget> Widget for List<D, W> {}
 
-impl<D: Directional, W: Widget> Layout for List<D, W> {
+impl<D: Directional, W: Layout> Layout for List<D, W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let mut solver = layout::RowSolver::<Vec<u32>, _>::new(
             axis,

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -27,7 +27,7 @@ pub use button::TextButton;
 pub use checkbox::{CheckBox, CheckBoxBare};
 pub use dialog::MessageBox;
 pub use drag::DragHandle;
-pub use editbox::{EditBox, EditGuard};
+pub use editbox::{EditBox, EditBoxVoid, EditGuard};
 pub use filler::Filler;
 pub use frame::Frame;
 pub use label::Label;

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -15,7 +15,7 @@ use crate::event::{self, Action, Manager, Response, UpdateHandle, VoidMsg};
 use crate::geom::Rect;
 use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
-use crate::{Align, AlignHints, CoreData, Layout, Widget, WidgetCore, WidgetId};
+use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore, WidgetId};
 
 /// A bare radiobox (no label)
 #[derive(Clone, Widget)]
@@ -237,7 +237,7 @@ impl<M, OT: Fn(WidgetId) -> M> RadioBox<OT> {
     /// The closure `f` is called with the new state of the radiobox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn new_on<T: ToString>(f: OT, handle: UpdateHandle, label: T) -> Self {
+    pub fn new_on<T: Into<CowString>>(f: OT, handle: UpdateHandle, label: T) -> Self {
         RadioBox {
             core: Default::default(),
             layout_data: Default::default(),
@@ -256,7 +256,7 @@ impl RadioBox<()> {
     /// RadioBox labels are optional; if no label is desired, use an empty
     /// string.
     #[inline]
-    pub fn new<T: ToString>(handle: UpdateHandle, label: T) -> Self {
+    pub fn new<T: Into<CowString>>(handle: UpdateHandle, label: T) -> Self {
         RadioBox {
             core: Default::default(),
             layout_data: Default::default(),

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -55,8 +55,6 @@ impl<M> Widget for RadioBoxBare<M> {
     }
 }
 
-impl<M> event::EvHandler for RadioBoxBare<M> {}
-
 impl<M> Layout for RadioBoxBare<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.radiobox();

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -163,7 +163,7 @@ impl<M> event::Handler for RadioBoxBare<M> {
         true
     }
 
-    fn handle_action(&mut self, mgr: &mut Manager, action: Action) -> Response<M> {
+    fn action(&mut self, mgr: &mut Manager, action: Action) -> Response<M> {
         match action {
             Action::Activate => {
                 if !self.state {

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -184,6 +184,9 @@ impl<M> event::Handler for RadioBoxBare<M> {
     }
 }
 
+// TODO: derive
+impl<M> event::EvHandler for RadioBoxBare<M> {}
+
 /// A radiobox with optional label
 #[layout(horizontal, area=radiobox)]
 #[widget]

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -55,6 +55,8 @@ impl<M> Widget for RadioBoxBare<M> {
     }
 }
 
+impl<M> event::EvHandler for RadioBoxBare<M> {}
+
 impl<M> Layout for RadioBoxBare<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.radiobox();

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -18,6 +18,7 @@ use crate::macros::Widget;
 use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore, WidgetId};
 
 /// A bare radiobox (no label)
+#[widget_core(key_nav = true)]
 #[derive(Clone, Widget)]
 pub struct RadioBoxBare<OT: 'static> {
     #[widget_core]
@@ -49,10 +50,6 @@ impl<OT: 'static> Widget for RadioBoxBare<OT> {
             self.state = state;
             mgr.redraw(self.id());
         }
-    }
-
-    fn allow_focus(&self) -> bool {
-        true
     }
 }
 

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -20,7 +20,7 @@ use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore, 
 /// A bare radiobox (no label)
 #[derive(Clone, Widget)]
 pub struct RadioBoxBare<OT: 'static> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     state: bool,
     handle: UpdateHandle,
@@ -206,7 +206,7 @@ impl<M, H: Fn(WidgetId) -> M> event::Handler for RadioBoxBare<H> {
 #[handler(msg = M, generics = <M: From<VoidMsg>> where OT: Fn(WidgetId) -> M)]
 #[derive(Clone, Widget)]
 pub struct RadioBox<OT: 'static> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -7,6 +7,7 @@
 
 use std::convert::TryFrom;
 use std::fmt::{self, Debug};
+use std::rc::Rc;
 
 use super::Label;
 use crate::class::HasBool;
@@ -20,15 +21,15 @@ use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore, 
 /// A bare radiobox (no label)
 #[widget_core(key_nav = true)]
 #[derive(Clone, Widget)]
-pub struct RadioBoxBare<OT: 'static> {
+pub struct RadioBoxBare<M> {
     #[widget_core]
     core: CoreData,
     state: bool,
     handle: UpdateHandle,
-    on_activate: OT,
+    on_activate: Option<Rc<dyn Fn(WidgetId) -> M>>,
 }
 
-impl<H> Debug for RadioBoxBare<H> {
+impl<M> Debug for RadioBoxBare<M> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -38,7 +39,7 @@ impl<H> Debug for RadioBoxBare<H> {
     }
 }
 
-impl<OT: 'static> Widget for RadioBoxBare<OT> {
+impl<M> Widget for RadioBoxBare<M> {
     fn configure(&mut self, mgr: &mut Manager) {
         mgr.update_on_handle(self.handle, self.id());
     }
@@ -53,7 +54,7 @@ impl<OT: 'static> Widget for RadioBoxBare<OT> {
     }
 }
 
-impl<OT: 'static> Layout for RadioBoxBare<OT> {
+impl<M> Layout for RadioBoxBare<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.radiobox();
         self.core.rect.size = size;
@@ -74,7 +75,7 @@ impl<OT: 'static> Layout for RadioBoxBare<OT> {
     }
 }
 
-impl<M, OT: Fn(WidgetId) -> M> RadioBoxBare<OT> {
+impl<M> RadioBoxBare<M> {
     /// Construct a radiobox which calls `f` when toggled
     ///
     /// This is a shortcut for `RadioBoxBare::new().on_activate(f)`.
@@ -85,17 +86,20 @@ impl<M, OT: Fn(WidgetId) -> M> RadioBoxBare<OT> {
     /// The closure `f` is called with the new state of the radiobox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn new_on(f: OT, handle: UpdateHandle) -> Self {
+    pub fn new_on<F>(f: F, handle: UpdateHandle) -> Self
+    where
+        F: Fn(WidgetId) -> M + 'static,
+    {
         RadioBoxBare {
             core: Default::default(),
             state: false,
             handle,
-            on_activate: f,
+            on_activate: Some(Rc::new(f)),
         }
     }
 }
 
-impl RadioBoxBare<()> {
+impl RadioBoxBare<VoidMsg> {
     /// Construct a radiobox
     ///
     /// All instances of [`RadioBoxBare`] and [`RadioBox`] constructed over the
@@ -106,7 +110,7 @@ impl RadioBoxBare<()> {
             core: Default::default(),
             state: false,
             handle,
-            on_activate: (),
+            on_activate: None,
         }
     }
 
@@ -115,17 +119,20 @@ impl RadioBoxBare<()> {
     /// The closure `f` is called with the new state of the radiobox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn on_activate<M, OT: Fn(WidgetId) -> M>(self, f: OT) -> RadioBoxBare<OT> {
+    pub fn on_activate<M, F>(self, f: F) -> RadioBoxBare<M>
+    where
+        F: Fn(WidgetId) -> M + 'static,
+    {
         RadioBoxBare {
             core: self.core,
             state: self.state,
             handle: self.handle,
-            on_activate: f,
+            on_activate: Some(Rc::new(f)),
         }
     }
 }
 
-impl<OT: 'static> RadioBoxBare<OT> {
+impl<M> RadioBoxBare<M> {
     /// Set the initial state of the radiobox.
     #[inline]
     pub fn state(mut self, state: bool) -> Self {
@@ -134,7 +141,7 @@ impl<OT: 'static> RadioBoxBare<OT> {
     }
 }
 
-impl<H> HasBool for RadioBoxBare<H> {
+impl<M> HasBool for RadioBoxBare<M> {
     fn get_bool(&self) -> bool {
         self.state
     }
@@ -148,30 +155,7 @@ impl<H> HasBool for RadioBoxBare<H> {
     }
 }
 
-impl event::Handler for RadioBoxBare<()> {
-    type Msg = VoidMsg;
-
-    #[inline]
-    fn activation_via_press(&self) -> bool {
-        true
-    }
-
-    fn handle_action(&mut self, mgr: &mut Manager, action: Action) -> Response<VoidMsg> {
-        match action {
-            Action::Activate => {
-                if !self.state {
-                    self.state = true;
-                    mgr.redraw(self.id());
-                    mgr.trigger_update(self.handle, self.id().into());
-                }
-                Response::None
-            }
-            a @ _ => Response::unhandled_action(a),
-        }
-    }
-}
-
-impl<M, H: Fn(WidgetId) -> M> event::Handler for RadioBoxBare<H> {
+impl<M> event::Handler for RadioBoxBare<M> {
     type Msg = M;
 
     #[inline]
@@ -186,7 +170,11 @@ impl<M, H: Fn(WidgetId) -> M> event::Handler for RadioBoxBare<H> {
                     self.state = true;
                     mgr.redraw(self.id());
                     mgr.trigger_update(self.handle, self.id().into());
-                    ((self.on_activate)(self.id())).into()
+                    if let Some(ref f) = self.on_activate {
+                        f(self.id()).into()
+                    } else {
+                        Response::None
+                    }
                 } else {
                     Response::None
                 }
@@ -199,21 +187,20 @@ impl<M, H: Fn(WidgetId) -> M> event::Handler for RadioBoxBare<H> {
 /// A radiobox with optional label
 #[layout(horizontal, area=radiobox)]
 #[widget]
-#[handler(substitutions = (OT = ()))]
-#[handler(msg = M, generics = <M: From<VoidMsg>> where OT: Fn(WidgetId) -> M)]
+#[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[derive(Clone, Widget)]
-pub struct RadioBox<OT: 'static> {
+pub struct RadioBox<M> {
     #[widget_core]
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,
     #[widget]
-    radiobox: RadioBoxBare<OT>,
+    radiobox: RadioBoxBare<M>,
     #[widget]
     label: Label,
 }
 
-impl<H> Debug for RadioBox<H> {
+impl<M> Debug for RadioBox<M> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -223,7 +210,7 @@ impl<H> Debug for RadioBox<H> {
     }
 }
 
-impl<M, OT: Fn(WidgetId) -> M> RadioBox<OT> {
+impl<M> RadioBox<M> {
     /// Construct a radiobox with a given `label` which calls `f` when toggled.
     ///
     /// This is a shortcut for `RadioBox::new(label).on_activate(f)`.
@@ -234,7 +221,10 @@ impl<M, OT: Fn(WidgetId) -> M> RadioBox<OT> {
     /// The closure `f` is called with the new state of the radiobox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn new_on<T: Into<CowString>>(f: OT, handle: UpdateHandle, label: T) -> Self {
+    pub fn new_on<T: Into<CowString>, F>(f: F, handle: UpdateHandle, label: T) -> Self
+    where
+        F: Fn(WidgetId) -> M + 'static,
+    {
         RadioBox {
             core: Default::default(),
             layout_data: Default::default(),
@@ -244,7 +234,7 @@ impl<M, OT: Fn(WidgetId) -> M> RadioBox<OT> {
     }
 }
 
-impl RadioBox<()> {
+impl RadioBox<VoidMsg> {
     /// Construct a radiobox with a given `label`.
     ///
     /// All instances of [`RadioBoxBare`] and [`RadioBox`] constructed over the
@@ -267,7 +257,10 @@ impl RadioBox<()> {
     /// The closure `f` is called with the new state of the radiobox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn on_activate<M, OT: Fn(WidgetId) -> M>(self, f: OT) -> RadioBox<OT> {
+    pub fn on_activate<M, F>(self, f: F) -> RadioBox<M>
+    where
+        F: Fn(WidgetId) -> M + 'static,
+    {
         RadioBox {
             core: self.core,
             layout_data: self.layout_data,
@@ -277,7 +270,7 @@ impl RadioBox<()> {
     }
 }
 
-impl<OT: 'static> RadioBox<OT> {
+impl<M> RadioBox<M> {
     /// Set the initial state of the radiobox.
     #[inline]
     pub fn state(mut self, state: bool) -> Self {
@@ -286,7 +279,7 @@ impl<OT: 'static> RadioBox<OT> {
     }
 }
 
-impl<H> HasBool for RadioBox<H> {
+impl<M> HasBool for RadioBox<M> {
     #[inline]
     fn get_bool(&self) -> bool {
         self.radiobox.get_bool()

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -20,6 +20,7 @@ use crate::{Align, AlignHints, CoreData, CowString, Layout, Widget, WidgetCore, 
 
 /// A bare radiobox (no label)
 #[widget_core(key_nav = true)]
+#[handler(noderive)]
 #[derive(Clone, Widget)]
 pub struct RadioBoxBare<M> {
     #[widget_core]
@@ -184,13 +185,10 @@ impl<M> event::Handler for RadioBoxBare<M> {
     }
 }
 
-// TODO: derive
-impl<M> event::EvHandler for RadioBoxBare<M> {}
-
 /// A radiobox with optional label
 #[layout(horizontal, area=radiobox)]
 #[widget]
-#[handler(msg = M, generics = <> where M: From<VoidMsg>)]
+#[handler(msg = M; generics = <> where M: From<VoidMsg>)]
 #[derive(Clone, Widget)]
 pub struct RadioBox<M> {
     #[widget_core]

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -129,7 +129,7 @@ impl<W: Widget> ScrollRegion<W> {
     }
 }
 
-impl<W: Widget> Layout for ScrollRegion<W> {
+impl<W: Layout> Layout for ScrollRegion<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let mut rules = self.child.size_rules(size_handle, axis);
         if axis.is_horizontal() {

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -222,9 +222,11 @@ impl<W: Widget> Layout for ScrollRegion<W> {
     }
 }
 
-impl<W: Widget + event::Handler> event::Handler for ScrollRegion<W> {
+impl<W: Widget + event::EvHandler> event::Handler for ScrollRegion<W> {
     type Msg = <W as event::Handler>::Msg;
+}
 
+impl<W: Widget + event::EvHandler> event::EvHandler for ScrollRegion<W> {
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         let unhandled = |w: &mut Self, mgr: &mut Manager, event| match event {
             Event::Action(Action::Scroll(delta)) => {

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -28,7 +28,7 @@ use crate::{CoreData, Layout, TkAction, Widget, WidgetCore, WidgetId};
 #[widget]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct ScrollRegion<W: Widget> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     min_child_size: Size,
     inner_size: Size,

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -225,7 +225,7 @@ impl<W: Widget> Layout for ScrollRegion<W> {
 impl<W: Widget + event::Handler> event::Handler for ScrollRegion<W> {
     type Msg = <W as event::Handler>::Msg;
 
-    fn handle(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
+    fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         let unhandled = |w: &mut Self, mgr: &mut Manager, event| match event {
             Event::Action(Action::Scroll(delta)) => {
                 let d = match delta {
@@ -256,7 +256,7 @@ impl<W: Widget + event::Handler> event::Handler for ScrollRegion<W> {
         };
 
         if id <= self.horiz_bar.id() {
-            return match Response::<Self::Msg>::try_from(self.horiz_bar.handle(mgr, id, event)) {
+            return match Response::<Self::Msg>::try_from(self.horiz_bar.event(mgr, id, event)) {
                 Ok(Response::Unhandled(event)) => unhandled(self, mgr, event),
                 Ok(r) => r,
                 Err(msg) => {
@@ -265,7 +265,7 @@ impl<W: Widget + event::Handler> event::Handler for ScrollRegion<W> {
                 }
             };
         } else if id <= self.vert_bar.id() {
-            return match Response::<Self::Msg>::try_from(self.vert_bar.handle(mgr, id, event)) {
+            return match Response::<Self::Msg>::try_from(self.vert_bar.event(mgr, id, event)) {
                 Ok(Response::Unhandled(event)) => unhandled(self, mgr, event),
                 Ok(r) => r,
                 Err(msg) => {
@@ -316,7 +316,7 @@ impl<W: Widget + event::Handler> event::Handler for ScrollRegion<W> {
             },
         };
 
-        match self.child.handle(mgr, id, event) {
+        match self.child.event(mgr, id, event) {
             Response::None => Response::None,
             Response::Unhandled(event) => unhandled(self, mgr, event),
             e @ _ => e,

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -129,6 +129,10 @@ impl<W: Widget> ScrollRegion<W> {
     }
 }
 
+impl<W: Layout> event::Handler for ScrollRegion<W> {
+    type Msg = <W as event::Handler>::Msg;
+}
+
 impl<W: Layout> Layout for ScrollRegion<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let mut rules = self.child.size_rules(size_handle, axis);
@@ -220,13 +224,7 @@ impl<W: Layout> Layout for ScrollRegion<W> {
             self.child.draw(handle, mgr)
         });
     }
-}
 
-impl<W: Widget + event::EvHandler> event::Handler for ScrollRegion<W> {
-    type Msg = <W as event::Handler>::Msg;
-}
-
-impl<W: Widget + event::EvHandler> event::EvHandler for ScrollRegion<W> {
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         let unhandled = |w: &mut Self, mgr: &mut Manager, event| match event {
             Event::Action(Action::Scroll(delta)) => {

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -218,7 +218,9 @@ impl<D: Directional> Layout for ScrollBar<D> {
 
 impl<D: Directional> event::Handler for ScrollBar<D> {
     type Msg = u32;
+}
 
+impl<D: Directional> event::EvHandler for ScrollBar<D> {
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         let offset = if id <= self.handle.id() {
             match self.handle.event(mgr, id, event).try_into() {

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -22,7 +22,7 @@ use crate::{AlignHints, CoreData, Directional, Layout, WidgetCore, WidgetId};
 #[widget]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct ScrollBar<D: Directional> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     direction: D,
     // Terminology assumes vertical orientation:

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -219,9 +219,9 @@ impl<D: Directional> Layout for ScrollBar<D> {
 impl<D: Directional> event::Handler for ScrollBar<D> {
     type Msg = u32;
 
-    fn handle(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
+    fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         let offset = if id <= self.handle.id() {
-            match self.handle.handle(mgr, id, event).try_into() {
+            match self.handle.event(mgr, id, event).try_into() {
                 Ok(res) => return res,
                 Err(offset) => offset,
             }

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -182,6 +182,10 @@ impl<D: Directional> ScrollBar<D> {
     }
 }
 
+impl<D: Directional> event::Handler for ScrollBar<D> {
+    type Msg = u32;
+}
+
 impl<D: Directional> Layout for ScrollBar<D> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let (size, min_len) = size_handle.scrollbar();
@@ -214,13 +218,7 @@ impl<D: Directional> Layout for ScrollBar<D> {
         let hl = mgr.highlight_state(self.handle.id());
         draw_handle.scrollbar(self.core.rect, self.handle.rect(), dir, hl);
     }
-}
 
-impl<D: Directional> event::Handler for ScrollBar<D> {
-    type Msg = u32;
-}
-
-impl<D: Directional> event::EvHandler for ScrollBar<D> {
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         let offset = if id <= self.handle.id() {
             match self.handle.event(mgr, id, event).try_into() {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -156,6 +156,13 @@ where
     }
 }
 
+impl<T, D: Directional> event::Handler for Slider<T, D>
+where
+    T: SliderType,
+{
+    type Msg = T;
+}
+
 impl<T, D: Directional> Layout for Slider<T, D>
 where
     T: SliderType,
@@ -194,19 +201,7 @@ where
         let hl = mgr.highlight_state(self.handle.id());
         draw_handle.slider(self.core.rect, self.handle.rect(), dir, hl);
     }
-}
 
-impl<T, D: Directional> event::Handler for Slider<T, D>
-where
-    T: SliderType,
-{
-    type Msg = T;
-}
-
-impl<T, D: Directional> event::EvHandler for Slider<T, D>
-where
-    T: SliderType,
-{
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         let offset = if id <= self.handle.id() {
             match self.handle.event(mgr, id, event).try_into() {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -202,9 +202,9 @@ where
 {
     type Msg = T;
 
-    fn handle(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
+    fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         let offset = if id <= self.handle.id() {
-            match self.handle.handle(mgr, id, event).try_into() {
+            match self.handle.event(mgr, id, event).try_into() {
                 Ok(res) => return res,
                 Err(offset) => offset,
             }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -201,7 +201,12 @@ where
     T: SliderType,
 {
     type Msg = T;
+}
 
+impl<T, D: Directional> event::EvHandler for Slider<T, D>
+where
+    T: SliderType,
+{
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         let offset = if id <= self.handle.id() {
             match self.handle.event(mgr, id, event).try_into() {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -49,7 +49,7 @@ pub struct Slider<T, D: Directional>
 where
     T: SliderType,
 {
-    #[core]
+    #[widget_core]
     core: CoreData,
     direction: D, // TODO: also reversed direction
     // Terminology assumes vertical orientation:

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -8,16 +8,16 @@
 use std::fmt::{self, Debug};
 
 use crate::draw::SizeHandle;
-use crate::event::{Callback, EvHandler, Manager, VoidMsg};
+use crate::event::{Callback, Manager, VoidMsg};
 use crate::geom::Size;
 use crate::layout::{self};
 use crate::macros::Widget;
-use crate::{CoreData, CowString, LayoutData, Widget};
+use crate::{CoreData, CowString, Layout, LayoutData, Widget};
 
 /// The main instantiation of the [`Window`] trait.
 #[widget]
 #[layout(single)]
-#[handler(generics = <> where W: Widget + EvHandler<Msg = VoidMsg>)]
+#[handler(generics = <> where W: Layout<Msg = VoidMsg>)]
 #[derive(Widget)]
 pub struct Window<W: Widget + 'static> {
     #[widget_core]
@@ -93,7 +93,7 @@ impl<W: Widget> Window<W> {
     }
 }
 
-impl<W: Widget + EvHandler<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
+impl<W: Layout<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
     fn title(&self) -> &str {
         &self.title
     }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -8,15 +8,16 @@
 use std::fmt::{self, Debug};
 
 use crate::draw::SizeHandle;
-use crate::event::{Callback, Event, Handler, Manager, Response, VoidMsg};
+use crate::event::{Callback, EvHandler, Manager, VoidMsg};
 use crate::geom::Size;
 use crate::layout::{self};
 use crate::macros::Widget;
-use crate::{CoreData, CowString, LayoutData, Widget, WidgetId};
+use crate::{CoreData, CowString, LayoutData, Widget};
 
 /// The main instantiation of the [`Window`] trait.
 #[widget]
 #[layout(single)]
+#[handler(generics = <> where W: Widget + EvHandler<Msg = VoidMsg>)]
 #[derive(Widget)]
 pub struct Window<W: Widget + 'static> {
     #[widget_core]
@@ -92,16 +93,7 @@ impl<W: Widget> Window<W> {
     }
 }
 
-impl<W: Widget + Handler<Msg = VoidMsg> + 'static> Handler for Window<W> {
-    type Msg = VoidMsg;
-
-    fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
-        // The window itself doesn't handle events, so we can just pass through
-        self.w.event(mgr, id, event)
-    }
-}
-
-impl<W: Widget + Handler<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
+impl<W: Widget + EvHandler<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
     fn title(&self) -> &str {
         &self.title
     }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -12,7 +12,7 @@ use crate::event::{Callback, Event, Handler, Manager, Response, VoidMsg};
 use crate::geom::Size;
 use crate::layout::{self};
 use crate::macros::Widget;
-use crate::{CoreData, LayoutData, Widget, WidgetId};
+use crate::{CoreData, CowString, LayoutData, Widget, WidgetId};
 
 /// The main instantiation of the [`Window`] trait.
 #[widget]
@@ -25,7 +25,7 @@ pub struct Window<W: Widget + 'static> {
     layout_data: <Self as LayoutData>::Data,
     enforce_min: bool,
     enforce_max: bool,
-    title: String,
+    title: CowString,
     #[widget]
     w: W,
     fns: Vec<(Callback, &'static dyn Fn(&mut W, &mut Manager))>,
@@ -65,13 +65,13 @@ impl<W: Widget + Clone> Clone for Window<W> {
 
 impl<W: Widget> Window<W> {
     /// Create
-    pub fn new<T: ToString>(title: T, w: W) -> Window<W> {
+    pub fn new<T: Into<CowString>>(title: T, w: W) -> Window<W> {
         Window {
             core: Default::default(),
             layout_data: Default::default(),
             enforce_min: true,
             enforce_max: false,
-            title: title.to_string(),
+            title: title.into(),
             w,
             fns: Vec::new(),
         }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -95,9 +95,9 @@ impl<W: Widget> Window<W> {
 impl<W: Widget + Handler<Msg = VoidMsg> + 'static> Handler for Window<W> {
     type Msg = VoidMsg;
 
-    fn handle(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
+    fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         // The window itself doesn't handle events, so we can just pass through
-        self.w.handle(mgr, id, event)
+        self.w.event(mgr, id, event)
     }
 }
 

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -19,7 +19,7 @@ use crate::{CoreData, CowString, LayoutData, Widget, WidgetId};
 #[layout(single)]
 #[derive(Widget)]
 pub struct Window<W: Widget + 'static> {
-    #[core]
+    #[widget_core]
     core: CoreData,
     #[layout_data]
     layout_data: <Self as LayoutData>::Data,


### PR DESCRIPTION
Adds `CowString` and `CowStringL` aliases: string handling now uses these.

`RadioBox`, `CheckBox` and `EditBox` have had their generics modified and `Handler` implementations unified.

Adjust traits:

- some properties moved to `WidgetCore` with derive support
- rename `Handler::handle_action → action`
- move `Handler::handle → Layout::event`
- make `Layout: Handler`
- macro adjustments associated with these changes
- replace `update_timer` and `update_handle` methods with `Action` values (this allows the handlers to return a message to the parent widget)

Much of the above is motivated by the `ComboBox` implementation, which is in progress.