### PR TITLE
ComboBox, popups, scrollbar tracks

### DIFF
--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -279,7 +279,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     {
                         use kas::{WidgetCore, event::Response};
                         #ev_to_num {
-                            debug_assert!(id == self.id(), "Layout::event: bad WidgetId");
+                            debug_assert!(id == self.id(), "EventHandler::event: bad WidgetId");
                             kas::event::Manager::handle_generic(self, mgr, event)
                         }
                     }

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -101,14 +101,10 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let mut get_rules = quote! {};
     let mut get_mut_rules = quote! {};
-    let mut walk_rules = quote! {};
-    let mut walk_mut_rules = quote! {};
     for (i, child) in args.children.iter().enumerate() {
         let ident = &child.ident;
         get_rules.append_all(quote! { #i => Some(&self.#ident), });
         get_mut_rules.append_all(quote! { #i => Some(&mut self.#ident), });
-        walk_rules.append_all(quote! { self.#ident.walk(f); });
-        walk_mut_rules.append_all(quote! { self.#ident.walk_mut(f); });
     }
 
     let mut toks = quote! {
@@ -144,14 +140,6 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     #get_mut_rules
                     _ => None
                 }
-            }
-            fn walk(&self, f: &mut dyn FnMut(&dyn kas::WidgetConfig)) {
-                #walk_rules
-                f(self);
-            }
-            fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn kas::WidgetConfig)) {
-                #walk_mut_rules
-                f(self);
             }
         }
     };

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -122,24 +122,32 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
             fn as_widget(&self) -> &dyn kas::WidgetConfig { self }
             fn as_widget_mut(&mut self) -> &mut dyn kas::WidgetConfig { self }
-
-            fn len(&self) -> usize {
-                #count
-            }
-            fn get(&self, _index: usize) -> Option<&dyn kas::WidgetConfig> {
-                match _index {
-                    #get_rules
-                    _ => None
-                }
-            }
-            fn get_mut(&mut self, _index: usize) -> Option<&mut dyn kas::WidgetConfig> {
-                match _index {
-                    #get_mut_rules
-                    _ => None
-                }
-            }
         }
     };
+
+    if args.widget.children {
+        toks.append_all(quote! {
+            impl #impl_generics kas::WidgetChildren
+                for #name #ty_generics #where_clause
+            {
+                fn len(&self) -> usize {
+                    #count
+                }
+                fn get(&self, _index: usize) -> Option<&dyn kas::WidgetConfig> {
+                    match _index {
+                        #get_rules
+                        _ => None
+                    }
+                }
+                fn get_mut(&mut self, _index: usize) -> Option<&mut dyn kas::WidgetConfig> {
+                    match _index {
+                        #get_mut_rules
+                        _ => None
+                    }
+                }
+            }
+        });
+    }
 
     if let Some(config) = args.widget.config {
         let key_nav = config.key_nav;

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -81,10 +81,7 @@ impl<'a> ToTokens for SubstTyGenerics<'a> {
 /// Macro to derive widget traits
 ///
 /// See the [`kas::macros`](../kas/macros/index.html) module documentation.
-#[proc_macro_derive(
-    Widget,
-    attributes(widget_core, widget_config, widget, layout, handler, layout_data)
-)]
+#[proc_macro_derive(Widget, attributes(widget_core, widget, layout, handler, layout_data))]
 pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut ast = parse_macro_input!(input as syn::DeriveInput);
 
@@ -144,7 +141,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
     };
 
-    if let Some(config) = args.widget_config {
+    if let Some(config) = args.widget.config {
         let key_nav = config.key_nav;
         let cursor_icon = config.cursor_icon;
 

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -129,9 +129,9 @@ impl<'a, Draw: DrawText> draw::SizeHandle for SizeHandle<'a, Draw> {
         self.dims.scale_factor
     }
 
-    fn outer_frame(&self) -> (Size, Size) {
+    fn frame(&self) -> Size {
         let f = self.dims.frame as u32;
-        (Size::uniform(f), Size::uniform(f))
+        Size::uniform(f)
     }
 
     fn inner_margin(&self) -> Size {
@@ -164,6 +164,7 @@ impl<'a, Draw: DrawText> draw::SizeHandle for SizeHandle<'a, Draw> {
             .draw
             .text_bound(text, font_id, font_scale, bounds, line_wrap);
 
+        let margins = (self.dims.margin as u16, self.dims.margin as u16);
         if axis.is_horizontal() {
             let bound = bounds.0 as u32;
             let min = match class {
@@ -171,7 +172,6 @@ impl<'a, Draw: DrawText> draw::SizeHandle for SizeHandle<'a, Draw> {
                 _ => bound.min(self.dims.min_line_length),
             };
             let ideal = bound.min(self.dims.max_line_length);
-            let margins = (self.dims.margin as u16, self.dims.margin as u16);
             SizeRules::new(min, ideal, margins, StretchPolicy::LowUtility)
         } else {
             let min = match class {
@@ -183,7 +183,7 @@ impl<'a, Draw: DrawText> draw::SizeHandle for SizeHandle<'a, Draw> {
                 TextClass::Button | TextClass::Edit => StretchPolicy::Fixed,
                 _ => StretchPolicy::Filler,
             };
-            SizeRules::new(min, ideal, (0, 0), stretch)
+            SizeRules::new(min, ideal, margins, stretch)
         }
     }
 

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -200,6 +200,13 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             .rounded_frame(self.pass, outer, inner, 0.5, self.cols.frame);
     }
 
+    fn separator(&mut self, rect: Rect) {
+        let outer = Quad::from(rect + self.offset);
+        let inner = outer.shrink(outer.size().min_comp() / 2.0);
+        self.draw
+            .rounded_frame(self.pass, outer, inner, 0.5, self.cols.frame);
+    }
+
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
         let props = TextProperties {
             font: self.window.dims.font_id,

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -42,7 +42,7 @@ const DIMS: DimensionsParams = DimensionsParams {
     frame_size: 4.0,
     button_frame: 6.0,
     scrollbar_size: Vec2::splat(8.0),
-    slider_size: Vec2(10.0, 25.0),
+    slider_size: Vec2(12.0, 25.0),
 };
 
 pub struct DrawHandle<'a, D: Draw> {
@@ -153,6 +153,14 @@ impl<'a, D: Draw + DrawRounded> DrawHandle<'a, D> {
         }
 
         inner2
+    }
+
+    /// Draw a handle (for slider, scrollbar)
+    fn draw_handle(&mut self, rect: Rect, highlights: HighlightState) {
+        let outer = Quad::from(rect + self.offset);
+        let inner = outer.shrink(outer.size().min_comp() / 2.0);
+        let col = self.cols.scrollbar_state(highlights);
+        self.draw.rounded_frame(self.pass, outer, inner, 0.0, col);
     }
 }
 
@@ -267,19 +275,15 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         }
     }
 
-    fn scrollbar(
-        &mut self,
-        _rect: Rect,
-        h_rect: Rect,
-        _dir: Direction,
-        highlights: HighlightState,
-    ) {
-        // TODO: also draw slider behind handle: needs an extra layer?
-
-        let outer = Quad::from(h_rect + self.offset);
+    fn scrollbar(&mut self, rect: Rect, h_rect: Rect, _dir: Direction, highlights: HighlightState) {
+        // track
+        let outer = Quad::from(rect + self.offset);
         let inner = outer.shrink(outer.size().min_comp() / 2.0);
-        let col = self.cols.scrollbar_state(highlights);
+        let col = self.cols.frame;
         self.draw.rounded_frame(self.pass, outer, inner, 0.0, col);
+
+        // handle
+        self.draw_handle(h_rect, highlights);
     }
 
     fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
@@ -294,6 +298,6 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         self.draw.rounded_frame(self.pass, outer, inner, 0.0, col);
 
         // handle
-        self.scrollbar(rect, h_rect, dir, highlights);
+        self.draw_handle(h_rect, highlights);
     }
 }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -15,7 +15,7 @@ use kas::draw::{
     TextClass, TextProperties,
 };
 use kas::event::HighlightState;
-use kas::geom::{Coord, Rect, Vec2};
+use kas::geom::*;
 use kas::{Align, Direction, ThemeAction, ThemeApi};
 
 /// A theme with flat (unshaded) rendering
@@ -136,9 +136,10 @@ impl ThemeApi for FlatTheme {
 impl<'a, D: Draw + DrawRounded> DrawHandle<'a, D> {
     /// Draw an edit region with optional navigation highlight.
     /// Return the inner rect.
-    fn draw_edit_region(&mut self, outer: Rect, nav_col: Option<Colour>) -> Rect {
-        let inner1 = outer.shrink(self.window.dims.frame / 2);
-        let inner2 = outer.shrink(self.window.dims.frame);
+    fn draw_edit_region(&mut self, outer: Rect, nav_col: Option<Colour>) -> Quad {
+        let outer = Quad::from(outer);
+        let inner1 = outer.shrink(self.window.dims.frame as f32 / 2.0);
+        let inner2 = outer.shrink(self.window.dims.frame as f32);
 
         self.draw.rect(self.pass, inner1, self.cols.text_area);
 
@@ -185,8 +186,8 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
     }
 
     fn outer_frame(&mut self, rect: Rect) {
-        let outer = rect + self.offset;
-        let inner = outer.shrink(self.window.dims.frame);
+        let outer = Quad::from(rect + self.offset);
+        let inner = outer.shrink(self.window.dims.frame as f32);
         self.draw
             .rounded_frame(self.pass, outer, inner, 0.5, self.cols.frame);
     }
@@ -210,15 +211,15 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
     }
 
     fn button(&mut self, rect: Rect, highlights: HighlightState) {
-        let outer = rect + self.offset;
+        let outer = Quad::from(rect + self.offset);
         let col = self.cols.button_state(highlights);
 
-        let inner = outer.shrink(self.window.dims.button_frame);
+        let inner = outer.shrink(self.window.dims.button_frame as f32);
         self.draw.rounded_frame(self.pass, outer, inner, 0.0, col);
         self.draw.rect(self.pass, inner, col);
 
         if let Some(col) = self.cols.nav_region(highlights) {
-            let outer = outer.shrink(self.window.dims.button_frame / 3);
+            let outer = outer.shrink(self.window.dims.button_frame as f32 / 3.0);
             self.draw.rounded_frame(self.pass, outer, inner, 0.5, col);
         }
     }
@@ -239,14 +240,13 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         let inner = self.draw_edit_region(rect + self.offset, nav_col);
 
         if let Some(col) = self.cols.check_mark_state(highlights, checked) {
-            let radius = (inner.size.0 + inner.size.1) / 16;
-            let inner = inner.shrink(self.window.dims.margin + radius);
-            let p1 = inner.pos;
-            let p2 = inner.pos + inner.size;
+            let radius = inner.size().sum() * (1.0 / 16.0);
+            let inner = inner.shrink(self.window.dims.margin as f32 + radius);
             let radius = radius as f32;
-            self.draw.rounded_line(self.pass, p1, p2, radius, col);
             self.draw
-                .rounded_line(self.pass, Coord(p1.0, p2.1), Coord(p2.0, p1.1), radius, col);
+                .rounded_line(self.pass, inner.a, inner.b, radius, col);
+            self.draw
+                .rounded_line(self.pass, inner.ab(), inner.ba(), radius, col);
         }
     }
 
@@ -262,7 +262,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         let inner = self.draw_edit_region(rect + self.offset, nav_col);
 
         if let Some(col) = self.cols.check_mark_state(highlights, checked) {
-            let inner = inner.shrink(self.window.dims.margin);
+            let inner = inner.shrink(self.window.dims.margin as f32);
             self.draw.circle(self.pass, inner, 0.3, col);
         }
     }
@@ -276,32 +276,20 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
     ) {
         // TODO: also draw slider behind handle: needs an extra layer?
 
-        let outer = h_rect + self.offset;
-        let half_width = outer.size.0.min(outer.size.1) / 2;
-        let inner = outer.shrink(half_width);
+        let outer = Quad::from(h_rect + self.offset);
+        let inner = outer.shrink(outer.size().min_comp() / 2.0);
         let col = self.cols.scrollbar_state(highlights);
         self.draw.rounded_frame(self.pass, outer, inner, 0.0, col);
-        self.draw.rect(self.pass, inner, col);
     }
 
     fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
         // track
-        let mut outer = rect + self.offset;
-        // TODO: draw with floats; ints are too inaccurate!
-        let half;
-        match dir {
-            Direction::Horizontal => {
-                half = outer.size.1 / 8;
-                outer.pos.1 += 3 * half as i32;
-                outer.size.1 -= 6 * half;
-            }
-            Direction::Vertical => {
-                half = outer.size.0 / 8;
-                outer.pos.0 += 3 * half as i32;
-                outer.size.0 -= 6 * half;
-            }
+        let mut outer = Quad::from(rect + self.offset);
+        outer = match dir {
+            Direction::Horizontal => outer.shrink_vec(Vec2(0.0, outer.size().1 * (3.0 / 8.0))),
+            Direction::Vertical => outer.shrink_vec(Vec2(outer.size().0 * (3.0 / 8.0), 0.0)),
         };
-        let inner = outer.shrink(half);
+        let inner = outer.shrink(outer.size().min_comp() / 2.0);
         let col = self.cols.frame;
         self.draw.rounded_frame(self.pass, outer, inner, 0.0, col);
 

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -40,7 +40,7 @@ const DIMS: DimensionsParams = DimensionsParams {
     frame_size: 5.0,
     button_frame: 5.0,
     scrollbar_size: Vec2::splat(8.0),
-    slider_size: Vec2(10.0, 25.0),
+    slider_size: Vec2(12.0, 25.0),
 };
 
 pub struct DrawHandle<'a, D: Draw> {
@@ -150,6 +150,15 @@ impl<'a, D: Draw + DrawShaded> DrawHandle<'a, D> {
         self.draw.rect(self.pass, inner, self.cols.text_area);
         inner
     }
+
+    /// Draw a handle (for slider, scrollbar)
+    fn draw_handle(&mut self, rect: Rect, highlights: HighlightState) {
+        let outer = Quad::from(rect + self.offset);
+        let inner = outer.shrink(outer.size().min_comp() / 2.0);
+        let col = self.cols.scrollbar_state(highlights);
+        self.draw
+            .shaded_round_frame(self.pass, outer, inner, (0.0, 0.6), col);
+    }
 }
 
 impl<'a, D> draw::DrawHandle for DrawHandle<'a, D>
@@ -187,8 +196,10 @@ where
     fn outer_frame(&mut self, rect: Rect) {
         let outer = Quad::from(rect + self.offset);
         let inner = outer.shrink(self.window.dims.frame as f32);
+        let norm = (0.7, -0.7);
+        let col = self.cols.background;
         self.draw
-            .shaded_round_frame(self.pass, outer, inner, (0.6, -0.6), self.cols.background);
+            .shaded_round_frame(self.pass, outer, inner, norm, col);
     }
 
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
@@ -260,35 +271,33 @@ where
         }
     }
 
-    fn scrollbar(
-        &mut self,
-        _rect: Rect,
-        h_rect: Rect,
-        _dir: Direction,
-        highlights: HighlightState,
-    ) {
-        // TODO: also draw slider behind handle: needs an extra layer?
-
-        let outer = Quad::from(h_rect + self.offset);
+    fn scrollbar(&mut self, rect: Rect, h_rect: Rect, _dir: Direction, highlights: HighlightState) {
+        // track
+        let outer = Quad::from(rect + self.offset);
         let inner = outer.shrink(outer.size().min_comp() / 2.0);
-        let col = self.cols.scrollbar_state(highlights);
+        let norm = (0.0, -0.7);
+        let col = self.cols.background;
         self.draw
-            .shaded_round_frame(self.pass, outer, inner, (0.0, 0.6), col);
+            .shaded_round_frame(self.pass, outer, inner, norm, col);
+
+        // handle
+        self.draw_handle(h_rect, highlights);
     }
 
     fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
         // track
-        let mut outer = Quad::from(h_rect + self.offset);
+        let mut outer = Quad::from(rect + self.offset);
         outer = match dir {
             Direction::Horizontal => outer.shrink_vec(Vec2(0.0, outer.size().1 * (3.0 / 8.0))),
             Direction::Vertical => outer.shrink_vec(Vec2(outer.size().0 * (3.0 / 8.0), 0.0)),
         };
         let inner = outer.shrink(outer.size().min_comp() / 2.0);
+        let norm = (0.0, -0.7);
         let col = self.cols.background;
         self.draw
-            .shaded_round_frame(self.pass, outer, inner, (0.0, -0.8), col);
+            .shaded_round_frame(self.pass, outer, inner, norm, col);
 
         // handle
-        self.scrollbar(rect, h_rect, dir, highlights);
+        self.draw_handle(h_rect, highlights);
     }
 }

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -202,6 +202,15 @@ where
             .shaded_round_frame(self.pass, outer, inner, norm, col);
     }
 
+    fn separator(&mut self, rect: Rect) {
+        let outer = Quad::from(rect + self.offset);
+        let inner = outer.shrink(outer.size().min_comp() / 2.0);
+        let norm = (0.0, -0.7);
+        let col = self.cols.background;
+        self.draw
+            .shaded_round_frame(self.pass, outer, inner, norm, col);
+    }
+
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
         let props = TextProperties {
             font: self.window.dims.font_id,

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -31,7 +31,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
     let buttons = make_widget! {
-        #[widget_config]
         #[layout(grid)]
         #[handler(msg = Key)]
         struct {
@@ -73,7 +72,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
         }
     };
     let content = make_widget! {
-        #[widget_config]
         #[layout(vertical)]
         #[handler(msg = VoidMsg)]
         struct {

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 
 use kas::draw::{Colour, DrawHandle, DrawRounded, DrawText, SizeHandle, TextClass, TextProperties};
 use kas::event::{self, Action, Event, Handler, Manager, ManagerState, Response};
-use kas::geom::{Coord, Rect, Size};
-use kas::layout::{AxisInfo, SizeRules};
+use kas::geom::*;
+use kas::layout::{AxisInfo, SizeRules, StretchPolicy};
 use kas::widget::Window;
 use kas::{Align, AlignHints, Direction, Layout, WidgetConfig, WidgetCore};
 use kas_wgpu::draw::DrawWindow;
@@ -37,7 +37,10 @@ impl Layout for Clock {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
         // Always use value for horiz axis: we want a square shape
         let axis = AxisInfo::new(Direction::Horizontal, None);
-        size_handle.text_bound("0000-00-00", TextClass::Label, axis)
+        let text_req = size_handle.text_bound("0000-00-00", TextClass::Label, axis);
+        // extra makes default size larger without affecting min size
+        let extra = SizeRules::new(0, 100, (0, 0), StretchPolicy::HighUtility);
+        text_req.surrounded_by(extra, false)
     }
 
     #[inline]
@@ -69,19 +72,17 @@ impl Layout for Clock {
         let (region, offset, draw) = draw_handle.draw_device();
         let draw = draw.as_any_mut().downcast_mut::<DrawWindow<()>>().unwrap();
 
-        draw.circle(region, self.core.rect + offset, 0.95, col_face);
+        let rect = Quad::from(self.core.rect + offset);
+        draw.circle(region, rect, 0.95, col_face);
 
-        let half = (self.core.rect.size.1 / 2) as i32;
-        let c = self.core.rect.pos + offset + Coord(half, half);
+        let half = (rect.b.1 - rect.a.1) / 2.0;
+        let centre = rect.a + half;
 
         let mut line_seg = |t: f32, r1: f32, r2: f32, w, col| {
-            let (sin, cos) = (t.sin(), -t.cos());
-            let p1 = Coord((r1 * sin).round() as i32, (r1 * cos).round() as i32);
-            let p2 = Coord((r2 * sin).round() as i32, (r2 * cos).round() as i32);
-            draw.rounded_line(region, c + p1, c + p2, w, col);
+            let v = Vec2(t.sin(), -t.cos());
+            draw.rounded_line(region, centre + v * r1, centre + v * r2, w, col);
         };
 
-        let half = half as f32;
         let w = half * 0.015625;
         let l = w * 5.0;
         let r = half - w;
@@ -91,27 +92,13 @@ impl Layout for Clock {
         }
 
         let secs = self.now.time().num_seconds_from_midnight();
-        line_seg(
-            (secs % (12 * 3600)) as f32 * (PI / (6.0 * 3600.0)),
-            0.0,
-            half * 0.55,
-            half * 0.03,
-            col_hands,
-        );
-        line_seg(
-            (secs % 3600) as f32 * (PI / 1800.0),
-            0.0,
-            half * 0.8,
-            half * 0.015,
-            col_hands,
-        );
-        line_seg(
-            (secs % 60) as f32 * (PI / 30.0),
-            0.0,
-            half * 0.9,
-            half * 0.005,
-            col_secs,
-        );
+        let a_sec = (secs % 60) as f32 * (PI / 30.0);
+        let a_min = (secs % 3600) as f32 * (PI / 1800.0);
+        let a_hour = (secs % (12 * 3600)) as f32 * (PI / (12.0 * 1800.0));
+
+        line_seg(a_hour, 0.0, half * 0.55, half * 0.03, col_hands);
+        line_seg(a_min, 0.0, half * 0.8, half * 0.015, col_hands);
+        line_seg(a_sec, 0.0, half * 0.9, half * 0.005, col_secs);
 
         let props = TextProperties {
             scale: self.font_scale,

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -21,6 +21,7 @@ use kas::{Align, AlignHints, Direction, Layout, WidgetConfig, WidgetCore};
 use kas_wgpu::draw::DrawWindow;
 
 #[handler(event)]
+#[widget(config = noauto)]
 #[derive(Clone, Debug, kas :: macros :: Widget)]
 struct Clock {
     #[widget_core]

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -22,7 +22,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
     let buttons = make_widget! {
-        #[widget_config]
         #[layout(horizontal)]
         #[handler(msg = Message)]
         struct {
@@ -33,7 +32,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new(
         "Counter",
         make_widget! {
-            #[widget_config]
             #[layout(vertical)]
             #[handler(msg = VoidMsg)]
             struct {

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -118,7 +118,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
     let widgets = make_widget! {
-        #[widget_config]
         #[layout(grid)]
         #[handler(msg = Item)]
         struct {
@@ -135,7 +134,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new(
         "Theme demo",
         make_widget! {
-            #[widget_config]
             #[layout(single)]
             #[handler(msg = VoidMsg)]
             struct {

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -144,6 +144,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget(handler = set_len)] controls -> usize = controls,
                 #[widget] _ = Label::new("Contents of selected entry:"),
                 #[widget] display: Label = Label::new("Entry #0"),
+                #[widget] _ = Separator::new(),
                 #[widget(handler = set_radio)] list: ScrollRegion<Column<ListEntry>> =
                     ScrollRegion::new(Column::new(entries)).with_bars(false, true),
                 #[widget] _ = Filler::maximise(),

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -22,7 +22,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
     let controls = make_widget! {
-        #[widget_config]
         #[layout(horizontal)]
         #[handler(msg = usize)]
         struct {
@@ -54,7 +53,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let mut window = Window::new(
         "Dynamic widget demo",
         make_widget! {
-            #[widget_config]
             #[layout(vertical)]
             #[handler(msg = VoidMsg)]
             struct {

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -28,7 +28,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
 
     let radio = UpdateHandle::new();
     let widgets = make_widget! {
-        #[widget_config]
         #[layout(grid)]
         #[handler(msg = Item)]
         struct {
@@ -74,13 +73,11 @@ fn main() -> Result<(), kas_wgpu::Error> {
     };
 
     let top_box = Frame::new(make_widget! {
-        #[widget_config]
         #[layout(vertical)]
         #[handler(msg = VoidMsg)]
         struct {
             #[widget(halign=centre)] _ = Label::new("Widget Gallery"),
             #[widget(handler=set_theme)] _ = make_widget! {
-                #[widget_config]
                 #[layout(horizontal)]
                 #[handler(msg = &'static str)]
                 struct {
@@ -89,7 +86,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 }
             },
             #[widget(handler=set_colour)] _ = make_widget! {
-                #[widget_config]
                 #[layout(horizontal)]
                 #[handler(msg = &'static str)]
                 struct {
@@ -123,7 +119,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new(
         "Widget Gallery",
         make_widget! {
-            #[widget_config]
             #[layout(vertical)]
             #[handler(msg = VoidMsg)]
             struct {

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -15,6 +15,7 @@ use kas::{Horizontal, WidgetId};
 enum Item {
     Button,
     Check(bool),
+    Combo(i32),
     Radio(WidgetId),
     Edit(String),
     Slider(i32),
@@ -47,16 +48,22 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[widget(row=5, col=0)] _ = Label::new("RadioBox"),
             #[widget(row=5, col=1)] _ = RadioBox::new(radio, "radio box 2").state(true)
                 .on_activate(|id| Item::Radio(id)),
-            #[widget(row=6, col=0)] _ = Label::new("Slider"),
-            #[widget(row=6, col=1, handler = handle_slider)] _ =
+            #[widget(row=6, col=0)] _ = Label::new("ComboBox"),
+            #[widget(row=6, col=1, handler = handle_combo)] _: ComboBox<i32> =
+                [("One", 1), ("Two", 2), ("Three", 3)].iter().cloned().collect(),
+            #[widget(row=7, col=0)] _ = Label::new("Slider"),
+            #[widget(row=7, col=1, handler = handle_slider)] _ =
                 Slider::<i32, Horizontal>::new(-2, 2).with_value(0),
-            #[widget(row=7, col=0)] _ = Label::new("ScrollBar"),
-            #[widget(row=7, col=1, handler = handle_scroll)] _ =
+            #[widget(row=8, col=0)] _ = Label::new("ScrollBar"),
+            #[widget(row=8, col=1, handler = handle_scroll)] _ =
                 ScrollBar::<Horizontal>::new().with_limits(5, 2),
-            #[widget(row=8)] _ = Label::new("Child window"),
-            #[widget(row=8, col = 1)] _ = TextButton::new("Open", Item::Popup),
+            #[widget(row=9)] _ = Label::new("Child window"),
+            #[widget(row=9, col = 1)] _ = TextButton::new("Open", Item::Popup),
         }
         impl {
+            fn handle_combo(&mut self, _: &mut Manager, msg: i32) -> Response<Item> {
+                Response::Msg(Item::Combo(msg))
+            }
             fn handle_slider(&mut self, _: &mut Manager, msg: i32) -> Response<Item> {
                 Response::Msg(Item::Slider(msg))
             }
@@ -129,8 +136,9 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 {
                     match item {
                         Item::Button => println!("Clicked!"),
-                        Item::Check(b) => println!("Checkbox: {}", b),
-                        Item::Radio(id) => println!("Radiobox: {}", id),
+                        Item::Check(b) => println!("CheckBox: {}", b),
+                        Item::Combo(c) => println!("ComboBox: {}", c),
+                        Item::Radio(id) => println!("RadioBox: {}", id),
                         Item::Edit(s) => println!("Edited: {}", s),
                         Item::Slider(p) => println!("Slider: {}", p),
                         Item::Scroll(p) => println!("ScrollBar: {}", p),

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -19,7 +19,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new(
         "Layout demo",
         make_widget! {
-            #[widget_config]
             #[layout(grid)]
             #[handler(msg = VoidMsg)]
             struct {

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -390,7 +390,6 @@ impl PipeWindow {
     }
 }
 
-#[widget_config]
 #[handler(action, msg = ())]
 #[derive(Clone, Debug, kas :: macros :: Widget)]
 struct Mandlebrot {
@@ -516,7 +515,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let slider = Slider::new(0, 256).with_value(64);
 
     let window = make_widget! {
-        #[widget_config]
         #[layout(grid)]
         #[handler(msg = event::VoidMsg)]
         struct {

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -48,7 +48,7 @@ const FRAGMENT: &'static str = "
 
 precision highp float;
 
-layout(location = 0) in vec2 cf;
+layout(location = 0) noperspective in vec2 cf;
 
 layout(location = 0) out vec4 outColor;
 

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -77,7 +77,7 @@ fn make_window() -> Box<dyn kas::Window> {
     };
 
     let mut window = Window::new("Stopwatch", stopwatch);
-    window.set_enforce_size(true, true);
+    window.set_restrict_dimensions(true, true);
     Box::new(window)
 }
 

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -24,7 +24,6 @@ enum Control {
 // There's no reason for this, but it demonstrates usage of Toolkit::add_boxed
 fn make_window() -> Box<dyn kas::Window> {
     let stopwatch = make_widget! {
-        #[widget_config]
         #[layout(horizontal)]
         #[handler(event)]
         struct {

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -29,7 +29,6 @@ fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
     let buttons = make_widget! {
-        #[widget_config]
         #[layout(horizontal)]
         #[handler(msg = Message)]
         struct {
@@ -45,6 +44,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         make_widget! {
             #[layout(vertical)]
             #[handler(event)]
+            #[widget(config=noauto)]
             struct {
                 #[widget(halign=centre)] display: Label = Label::new("0"),
                 #[widget(handler = handle_button)] buttons -> Message = buttons,

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -14,7 +14,7 @@ use super::{
     DrawWindow, ShaderManager, TEX_FORMAT,
 };
 use kas::draw::{Colour, Draw, DrawRounded, DrawShaded, DrawShared, Region};
-use kas::geom::{Coord, Rect, Size, Vec2};
+use kas::geom::{Coord, Quad, Rect, Size, Vec2};
 
 impl<C: CustomPipe> DrawPipe<C> {
     /// Construct
@@ -169,24 +169,24 @@ impl<CW: CustomWindow + 'static> Draw for DrawWindow<CW> {
     }
 
     #[inline]
-    fn rect(&mut self, pass: Region, rect: Rect, col: Colour) {
+    fn rect(&mut self, pass: Region, rect: Quad, col: Colour) {
         self.shaded_square.rect(pass.0, rect, col);
     }
 
     #[inline]
-    fn frame(&mut self, pass: Region, outer: Rect, inner: Rect, col: Colour) {
+    fn frame(&mut self, pass: Region, outer: Quad, inner: Quad, col: Colour) {
         self.shaded_square.frame(pass.0, outer, inner, col);
     }
 }
 
 impl<CW: CustomWindow + 'static> DrawRounded for DrawWindow<CW> {
     #[inline]
-    fn rounded_line(&mut self, pass: Region, p1: Coord, p2: Coord, radius: f32, col: Colour) {
+    fn rounded_line(&mut self, pass: Region, p1: Vec2, p2: Vec2, radius: f32, col: Colour) {
         self.flat_round.line(pass.0, p1, p2, radius, col);
     }
 
     #[inline]
-    fn circle(&mut self, pass: Region, rect: Rect, inner_radius: f32, col: Colour) {
+    fn circle(&mut self, pass: Region, rect: Quad, inner_radius: f32, col: Colour) {
         self.flat_round.circle(pass.0, rect, inner_radius, col);
     }
 
@@ -194,8 +194,8 @@ impl<CW: CustomWindow + 'static> DrawRounded for DrawWindow<CW> {
     fn rounded_frame(
         &mut self,
         pass: Region,
-        outer: Rect,
-        inner: Rect,
+        outer: Quad,
+        inner: Quad,
         inner_radius: f32,
         col: Colour,
     ) {
@@ -206,13 +206,13 @@ impl<CW: CustomWindow + 'static> DrawRounded for DrawWindow<CW> {
 
 impl<CW: CustomWindow + 'static> DrawShaded for DrawWindow<CW> {
     #[inline]
-    fn shaded_square(&mut self, pass: Region, rect: Rect, norm: (f32, f32), col: Colour) {
+    fn shaded_square(&mut self, pass: Region, rect: Quad, norm: (f32, f32), col: Colour) {
         self.shaded_square
             .shaded_rect(pass.0, rect, Vec2::from(norm), col);
     }
 
     #[inline]
-    fn shaded_circle(&mut self, pass: Region, rect: Rect, norm: (f32, f32), col: Colour) {
+    fn shaded_circle(&mut self, pass: Region, rect: Quad, norm: (f32, f32), col: Colour) {
         self.shaded_round
             .circle(pass.0, rect, Vec2::from(norm), col);
     }
@@ -221,8 +221,8 @@ impl<CW: CustomWindow + 'static> DrawShaded for DrawWindow<CW> {
     fn shaded_square_frame(
         &mut self,
         pass: Region,
-        outer: Rect,
-        inner: Rect,
+        outer: Quad,
+        inner: Quad,
         norm: (f32, f32),
         col: Colour,
     ) {
@@ -234,8 +234,8 @@ impl<CW: CustomWindow + 'static> DrawShaded for DrawWindow<CW> {
     fn shaded_round_frame(
         &mut self,
         pass: Region,
-        outer: Rect,
-        inner: Rect,
+        outer: Quad,
+        inner: Quad,
         norm: (f32, f32),
         col: Colour,
     ) {

--- a/kas-wgpu/src/draw/shaded_round.rs
+++ b/kas-wgpu/src/draw/shaded_round.rs
@@ -10,7 +10,7 @@ use std::mem::size_of;
 
 use crate::draw::{Rgb, ShaderManager};
 use kas::draw::Colour;
-use kas::geom::{Rect, Size, Vec2};
+use kas::geom::{Quad, Size, Vec2};
 
 /// Offset relative to the size of a pixel used by the fragment shader to
 /// implement multi-sampling.
@@ -219,9 +219,9 @@ impl Window {
     }
 
     /// Bounds on input: `0 ≤ inner_radius ≤ 1`.
-    pub fn circle(&mut self, pass: usize, rect: Rect, mut norm: Vec2, col: Colour) {
-        let aa = Vec2::from(rect.pos);
-        let bb = aa + Vec2::from(rect.size);
+    pub fn circle(&mut self, pass: usize, rect: Quad, mut norm: Vec2, col: Colour) {
+        let aa = rect.a;
+        let bb = rect.b;
 
         if !aa.lt(bb) {
             // zero / negative size: nothing to draw
@@ -266,15 +266,15 @@ impl Window {
     pub fn shaded_frame(
         &mut self,
         pass: usize,
-        outer: Rect,
-        inner: Rect,
+        outer: Quad,
+        inner: Quad,
         mut norm: Vec2,
         col: Colour,
     ) {
-        let aa = Vec2::from(outer.pos);
-        let bb = aa + Vec2::from(outer.size);
-        let mut cc = Vec2::from(inner.pos);
-        let mut dd = cc + Vec2::from(inner.size);
+        let aa = outer.a;
+        let bb = outer.b;
+        let mut cc = inner.a;
+        let mut dd = inner.b;
 
         if !aa.lt(bb) {
             // zero / negative size: nothing to draw

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -10,7 +10,7 @@ use std::mem::size_of;
 
 use crate::draw::{Rgb, ShaderManager};
 use kas::draw::Colour;
-use kas::geom::{Rect, Size, Vec2};
+use kas::geom::{Quad, Size, Vec2};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -198,11 +198,10 @@ impl Window {
     }
 
     /// Add a rectangle to the buffer
-    pub fn rect(&mut self, pass: usize, rect: Rect, col: Colour) {
-        let pos = Vec2::from(rect.pos);
-        let size = Vec2::from(rect.size);
+    pub fn rect(&mut self, pass: usize, rect: Quad, col: Colour) {
+        let aa = rect.a;
+        let bb = rect.b;
 
-        let (aa, bb) = (pos, pos + size);
         if !aa.lt(bb) {
             // zero / negative size: nothing to draw
             return;
@@ -224,9 +223,9 @@ impl Window {
     /// Add a rect to the buffer, defined by two outer corners, `aa` and `bb`.
     ///
     /// Bounds on input: `aa < cc` and `-1 ≤ norm ≤ 1`.
-    pub fn shaded_rect(&mut self, pass: usize, rect: Rect, mut norm: Vec2, col: Colour) {
-        let aa = Vec2::from(rect.pos);
-        let bb = aa + Vec2::from(rect.size);
+    pub fn shaded_rect(&mut self, pass: usize, rect: Quad, mut norm: Vec2, col: Colour) {
+        let aa = rect.a;
+        let bb = rect.b;
 
         if !aa.lt(bb) {
             // zero / negative size: nothing to draw
@@ -256,7 +255,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn frame(&mut self, pass: usize, outer: Rect, inner: Rect, col: Colour) {
+    pub fn frame(&mut self, pass: usize, outer: Quad, inner: Quad, col: Colour) {
         let norm = Vec2::splat(0.0);
         self.shaded_frame(pass, outer, inner, norm, col);
     }
@@ -268,15 +267,15 @@ impl Window {
     pub fn shaded_frame(
         &mut self,
         pass: usize,
-        outer: Rect,
-        inner: Rect,
+        outer: Quad,
+        inner: Quad,
         mut norm: Vec2,
         col: Colour,
     ) {
-        let aa = Vec2::from(outer.pos);
-        let bb = aa + Vec2::from(outer.size);
-        let mut cc = Vec2::from(inner.pos);
-        let mut dd = cc + Vec2::from(inner.size);
+        let aa = outer.a;
+        let bb = outer.b;
+        let mut cc = inner.a;
+        let mut dd = inner.b;
 
         if !aa.lt(bb) {
             // zero / negative size: nothing to draw

--- a/kas-wgpu/src/draw/shaders/flat_round.frag
+++ b/kas-wgpu/src/draw/shaders/flat_round.frag
@@ -8,10 +8,10 @@
 
 precision mediump float;
 
-layout(location = 0) in vec3 fragColor;
-layout(location = 1) in float inner;
-layout(location = 2) in vec2 pos;
-layout(location = 3) in vec2 off;
+layout(location = 0) flat in vec3 fragColor;
+layout(location = 1) flat in float inner;
+layout(location = 2) noperspective in vec2 pos;
+layout(location = 3) noperspective in vec2 off;
 
 layout(location = 0) out vec4 outColor;
 

--- a/kas-wgpu/src/draw/shaders/shaded_round.frag
+++ b/kas-wgpu/src/draw/shaders/shaded_round.frag
@@ -8,10 +8,10 @@
 
 precision mediump float;
 
-layout(location = 0) in vec3 fragColor;
-layout(location = 1) in vec2 dir;
-layout(location = 2) in vec2 adjust;
-layout(location = 3) in vec2 off;
+layout(location = 0) flat in vec3 fragColor;
+layout(location = 1) noperspective in vec2 dir;
+layout(location = 2) flat in vec2 adjust;
+layout(location = 3) noperspective in vec2 off;
 
 layout(location = 0) out vec4 outColor;
 
@@ -42,7 +42,7 @@ void main() {
     float z = sqrt(max(1.0 - ss, 0));
     float h = sqrt(ss);
     float t = adjust.x + adjust.y * atan(h, z);
-    vec2 normh;
+    vec2 normh = vec2(0.0);
     if (h > 0.0) {
         normh = dir * (sin(t) / h);
         z = cos(t);
@@ -54,6 +54,6 @@ void main() {
     // float z = sqrt(1.0 - adjust.y * ss);
     // vec3 norm = vec3(dir * sqrt(adjust.y), z);
 
-    vec3 c = fragColor * max(dot(norm, lightNorm), 0);
+    vec3 c = fragColor * dot(norm, lightNorm);
     outColor = vec4(c, alpha);
 }

--- a/kas-wgpu/src/draw/shaders/shaded_square.frag
+++ b/kas-wgpu/src/draw/shaders/shaded_square.frag
@@ -8,8 +8,8 @@
 
 precision mediump float;
 
-layout(location = 0) in vec3 fragColor;
-layout(location = 1) in vec2 norm2;
+layout(location = 0) flat in vec3 fragColor;
+layout(location = 1) noperspective in vec2 norm2;
 
 layout(location = 0) out vec4 outColor;
 
@@ -21,6 +21,6 @@ layout(set = 0, binding = 1) uniform Locals {
 void main() {
     float n3 = 1.0 - sqrt(norm2.x * norm2.x + norm2.y * norm2.y);
     vec3 norm = vec3(norm2, n3);
-    vec3 c = fragColor * max(dot(norm, lightNorm), 0);
+    vec3 c = fragColor * dot(norm, lightNorm);
     outColor = vec4(c, 1.0);
 }

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -198,13 +198,15 @@ where
         // Create and init() any new windows.
         while let Some(pending) = self.shared.pending.pop() {
             match pending {
-                PendingAction::AddPopup(id, popup) => {
+                PendingAction::AddPopup(parent_id, id, popup) => {
                     debug!("Adding overlay");
                     // TODO: support pop-ups as a special window, where available
-                    self.windows
-                        .get_mut(&id)
-                        .unwrap()
-                        .add_popup(&mut self.shared, popup);
+                    self.windows.get_mut(&parent_id).unwrap().add_popup(
+                        &mut self.shared,
+                        id,
+                        popup,
+                    );
+                    self.id_map.insert(id, parent_id);
                 }
                 PendingAction::AddWindow(id, widget) => {
                     debug!("Adding window {}", widget.title());

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -126,10 +126,6 @@ where
                     StartCause::Poll => (),
                     StartCause::Init => {
                         debug!("Wakeup: init");
-
-                        for window in self.windows.values_mut() {
-                            window.init(&mut self.shared);
-                        }
                     }
                 }
             }
@@ -213,11 +209,8 @@ where
                 PendingAction::AddWindow(id, widget) => {
                     debug!("Adding window {}", widget.title());
                     match Window::new(&mut self.shared, elwt, widget) {
-                        Ok(mut window) => {
+                        Ok(window) => {
                             let wid = window.window.id();
-
-                            window.init(&mut self.shared);
-
                             self.id_map.insert(id, wid);
                             self.windows.insert(wid, window);
                         }

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -202,13 +202,13 @@ where
         // Create and init() any new windows.
         while let Some(pending) = self.shared.pending.pop() {
             match pending {
-                PendingAction::AddOverlay(id, widget) => {
+                PendingAction::AddPopup(id, popup) => {
                     debug!("Adding overlay");
                     // TODO: support pop-ups as a special window, where available
                     self.windows
                         .get_mut(&id)
                         .unwrap()
-                        .add_overlay(&mut self.shared, widget);
+                        .add_popup(&mut self.shared, popup);
                 }
                 PendingAction::AddWindow(id, widget) => {
                     debug!("Adding window {}", widget.title());

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -41,12 +41,15 @@ where
     T::Window: kas_theme::Window<DrawWindow<C::Window>>,
 {
     pub(crate) fn new(
-        mut windows: Vec<(WindowId, Window<C::Window, T::Window>)>,
+        mut windows: Vec<Window<C::Window, T::Window>>,
         shared: SharedState<C, T>,
     ) -> Self {
-        let id_map = windows.iter().map(|(id, w)| (*id, w.window.id())).collect();
+        let id_map = windows
+            .iter()
+            .map(|w| (w.window_id, w.window.id()))
+            .collect();
         Loop {
-            windows: windows.drain(..).map(|(_, w)| (w.window.id(), w)).collect(),
+            windows: windows.drain(..).map(|w| (w.window.id(), w)).collect(),
             id_map,
             shared,
             resumes: vec![],
@@ -159,6 +162,7 @@ where
 
                 for window_id in &to_close {
                     if let Some(window) = self.windows.remove(window_id) {
+                        self.id_map.remove(&window.window_id);
                         if window.handle_closure(&mut self.shared) == TkAction::CloseAll {
                             close_all = true;
                         }
@@ -210,7 +214,7 @@ where
                 }
                 PendingAction::AddWindow(id, widget) => {
                     debug!("Adding window {}", widget.title());
-                    match Window::new(&mut self.shared, elwt, widget) {
+                    match Window::new(&mut self.shared, elwt, id, widget) {
                         Ok(window) => {
                             let wid = window.window.id();
                             self.id_map.insert(id, wid);
@@ -222,10 +226,11 @@ where
                     };
                 }
                 PendingAction::CloseWindow(id) => {
-                    if let Some(id) = self.id_map.get(&id) {
-                        if let Some(window) = self.windows.get_mut(&id) {
+                    if let Some(wwid) = self.id_map.get(&id) {
+                        if let Some(window) = self.windows.get_mut(&wwid) {
                             window.send_action(TkAction::Close);
                         }
+                        self.id_map.remove(&id);
                     }
                 }
                 PendingAction::ThemeResize => {

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -202,6 +202,14 @@ where
         // Create and init() any new windows.
         while let Some(pending) = self.shared.pending.pop() {
             match pending {
+                PendingAction::AddOverlay(id, widget) => {
+                    debug!("Adding overlay");
+                    // TODO: support pop-ups as a special window, where available
+                    self.windows
+                        .get_mut(&id)
+                        .unwrap()
+                        .add_overlay(&mut self.shared, widget);
+                }
                 PendingAction::AddWindow(id, widget) => {
                     debug!("Adding window {}", widget.title());
                     match Window::new(&mut self.shared, elwt, widget) {

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -228,7 +228,7 @@ where
                 PendingAction::CloseWindow(id) => {
                     if let Some(wwid) = self.id_map.get(&id) {
                         if let Some(window) = self.windows.get_mut(&wwid) {
-                            window.send_action(TkAction::Close);
+                            window.send_close(&mut self.shared, id);
                         }
                         self.id_map.remove(&id);
                     }

--- a/kas-wgpu/src/lib.rs
+++ b/kas-wgpu/src/lib.rs
@@ -90,7 +90,7 @@ where
     T::Window: kas_theme::Window<DrawWindow<C::Window>>,
 {
     el: EventLoop<ProxyAction>,
-    windows: Vec<(WindowId, Window<C::Window, T::Window>)>,
+    windows: Vec<Window<C::Window, T::Window>>,
     shared: SharedState<C, T>,
 }
 
@@ -143,9 +143,9 @@ where
 
     /// Add a boxed window directly
     pub fn add_boxed(&mut self, widget: Box<dyn kas::Window>) -> Result<WindowId, Error> {
-        let win = Window::new(&mut self.shared, &self.el, widget)?;
         let id = self.shared.next_window_id();
-        self.windows.push((id, win));
+        let win = Window::new(&mut self.shared, &self.el, id, widget)?;
+        self.windows.push(win);
         Ok(id)
     }
 

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -136,7 +136,7 @@ where
 }
 
 pub enum PendingAction {
-    AddOverlay(winit::window::WindowId, Box<dyn kas::Overlay>),
+    AddPopup(winit::window::WindowId, kas::Popup),
     AddWindow(WindowId, Box<dyn kas::Window>),
     CloseWindow(WindowId),
     ThemeResize,

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -136,6 +136,7 @@ where
 }
 
 pub enum PendingAction {
+    AddOverlay(winit::window::WindowId, Box<dyn kas::Overlay>),
     AddWindow(WindowId, Box<dyn kas::Window>),
     CloseWindow(WindowId),
     ThemeResize,

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -136,7 +136,7 @@ where
 }
 
 pub enum PendingAction {
-    AddPopup(winit::window::WindowId, kas::Popup),
+    AddPopup(winit::window::WindowId, WindowId, kas::Popup),
     AddWindow(WindowId, Box<dyn kas::Window>),
     CloseWindow(WindowId),
     ThemeResize,

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -243,6 +243,20 @@ where
     pub fn send_action(&mut self, action: TkAction) {
         self.mgr.send_action(action);
     }
+
+    pub fn send_close<C, T>(&mut self, shared: &mut SharedState<C, T>, id: WindowId)
+    where
+        C: CustomPipe<Window = CW>,
+        T: Theme<DrawPipe<C>, Window = TW>,
+    {
+        if id == self.window_id {
+            self.mgr.send_action(TkAction::Close);
+        } else {
+            let mut tkw = TkWindow::new(&self.window, shared);
+            let mut mgr = self.mgr.manager(&mut tkw);
+            self.widget.remove_popup(&mut mgr, id);
+        }
+    }
 }
 
 // Internal functions

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -90,7 +90,8 @@ where
         };
         let swap_chain = shared.device.create_swap_chain(&surface, &sc_desc);
 
-        let mgr = ManagerState::new(scale_factor);
+        let mut mgr = ManagerState::new(scale_factor);
+        mgr.send_action(TkAction::Reconfigure);
 
         Ok(Window {
             widget,
@@ -102,21 +103,6 @@ where
             draw,
             theme_window,
         })
-    }
-
-    /// Called by the `Toolkit` when the event loop starts to initialise
-    /// windows. Optionally returns a callback time.
-    ///
-    /// `init` should always return an action of at least `TkAction::Reconfigure`.
-    pub fn init<C, T>(&mut self, shared: &mut SharedState<C, T>)
-    where
-        C: CustomPipe<Window = CW>,
-        T: Theme<DrawPipe<C>, Window = TW>,
-    {
-        debug!("Window::init");
-        let mut tkw = TkWindow::new(&self.window, shared);
-        let mut mgr = self.mgr.manager(&mut tkw);
-        mgr.send_action(TkAction::Reconfigure);
     }
 
     /// Recompute layout of widgets and redraw

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -8,7 +8,7 @@
 use log::{debug, info, trace};
 use std::time::Instant;
 
-use kas::event::{Callback, CursorIcon, ManagerState, UpdateHandle};
+use kas::event::{CursorIcon, ManagerState, UpdateHandle};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout;
 use kas::{ThemeAction, ThemeApi, TkAction, WindowId};
@@ -117,15 +117,6 @@ where
         let mut tkw = TkWindow::new(&self.window, shared);
         let mut mgr = self.mgr.manager(&mut tkw);
         mgr.send_action(TkAction::Reconfigure);
-
-        for (i, condition) in self.widget.callbacks() {
-            match condition {
-                Callback::Start => {
-                    self.widget.trigger_callback(i, &mut mgr);
-                }
-                Callback::Close => (),
-            }
-        }
     }
 
     /// Recompute layout of widgets and redraw
@@ -215,16 +206,7 @@ where
     {
         let mut tkw = TkWindow::new(&self.window, shared);
         let mut mgr = self.mgr.manager(&mut tkw);
-
-        for (i, condition) in self.widget.callbacks() {
-            match condition {
-                Callback::Start => (),
-                Callback::Close => {
-                    self.widget.trigger_callback(i, &mut mgr);
-                }
-            }
-        }
-
+        self.widget.handle_closure(&mut mgr);
         mgr.finish(&mut *self.widget)
     }
 

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -135,10 +135,11 @@ where
         T: Theme<DrawPipe<C>, Window = TW>,
     {
         debug!("Window::reconfigure");
-        self.apply_size();
 
         let mut tkw = TkWindow::new(&self.window, shared);
         self.mgr.configure(&mut tkw, &mut *self.widget);
+
+        self.apply_size();
     }
 
     pub fn theme_resize<C, T>(&mut self, shared: &SharedState<C, T>)

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -26,6 +26,7 @@ use crate::ProxyAction;
 /// Per-window data
 pub(crate) struct Window<CW: CustomWindow, TW> {
     pub(crate) widget: Box<dyn kas::Window>,
+    pub(crate) window_id: WindowId,
     mgr: ManagerState,
     /// The winit window
     pub(crate) window: winit::window::Window,
@@ -46,6 +47,7 @@ where
     pub fn new<C, T>(
         shared: &mut SharedState<C, T>,
         elwt: &EventLoopWindowTarget<ProxyAction>,
+        window_id: WindowId,
         mut widget: Box<dyn kas::Window>,
     ) -> Result<Self, OsError>
     where
@@ -95,6 +97,7 @@ where
 
         Ok(Window {
             widget,
+            window_id,
             mgr,
             window,
             surface,

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -57,8 +57,8 @@ pub trait SizeHandle {
 
     /// Size of a frame around child widget(s)
     ///
-    /// Returns `(top_left, bottom_right)` dimensions as two `Size`s.
-    fn outer_frame(&self) -> (Size, Size);
+    /// Returns dimensions of the frame on each side.
+    fn frame(&self) -> Size;
 
     /// The margin around content within a widget
     ///
@@ -78,12 +78,14 @@ pub trait SizeHandle {
 
     /// Size of the sides of a button.
     ///
-    /// Includes each side (as in `outer_frame`), minus the content area (to be added separately).
+    /// Returns `(top_left, bottom_right)` dimensions as two `Size`s.
+    /// Excludes size of content area.
     fn button_surround(&self) -> (Size, Size);
 
     /// Size of the sides of an edit box.
     ///
-    /// Includes each side (as in `outer_frame`), minus the content area (to be added separately).
+    /// Returns `(top_left, bottom_right)` dimensions as two `Size`s.
+    /// Excludes size of content area.
     fn edit_surround(&self) -> (Size, Size);
 
     /// Size of the element drawn by [`DrawHandle::checkbox`].
@@ -155,10 +157,13 @@ pub trait DrawHandle {
     /// that method; otherwise this returns the window's `rect`.
     fn target_rect(&self) -> Rect;
 
-    /// Draw a frame in the given [`Rect`]
+    /// Draw a frame inside the given `rect`
     ///
-    /// The frame dimensions should equal those of [`SizeHandle::outer_frame`].
+    /// The frame dimensions equal those of [`SizeHandle::frame`] on each side.
     fn outer_frame(&mut self, rect: Rect);
+
+    /// Draw a separator in the given `rect`
+    fn separator(&mut self, rect: Rect);
 
     /// Draw some text using the standard font
     ///
@@ -205,8 +210,8 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
         self.deref().scale_factor()
     }
 
-    fn outer_frame(&self) -> (Size, Size) {
-        self.deref().outer_frame()
+    fn frame(&self) -> Size {
+        self.deref().frame()
     }
     fn inner_margin(&self) -> Size {
         self.deref().inner_margin()
@@ -252,8 +257,8 @@ where
         self.deref().scale_factor()
     }
 
-    fn outer_frame(&self) -> (Size, Size) {
-        self.deref().outer_frame()
+    fn frame(&self) -> Size {
+        self.deref().frame()
     }
     fn inner_margin(&self) -> Size {
         self.deref().inner_margin()
@@ -301,7 +306,10 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         self.deref().target_rect()
     }
     fn outer_frame(&mut self, rect: Rect) {
-        self.deref_mut().outer_frame(rect)
+        self.deref_mut().outer_frame(rect);
+    }
+    fn separator(&mut self, rect: Rect) {
+        self.deref_mut().separator(rect);
     }
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
         self.deref_mut().text(rect, text, class, align)
@@ -341,7 +349,10 @@ where
         self.deref().target_rect()
     }
     fn outer_frame(&mut self, rect: Rect) {
-        self.deref_mut().outer_frame(rect)
+        self.deref_mut().outer_frame(rect);
+    }
+    fn separator(&mut self, rect: Rect) {
+        self.deref_mut().separator(rect);
     }
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
         self.deref_mut().text(rect, text, class, align)

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -47,7 +47,7 @@ mod text;
 
 use std::any::Any;
 
-use crate::geom::{Coord, Rect};
+use crate::geom::{Quad, Rect, Vec2};
 
 pub use colour::Colour;
 pub use handle::{DrawHandle, SizeHandle, TextClass};
@@ -65,6 +65,11 @@ pub trait DrawShared {
 }
 
 /// Base abstraction over drawing
+///
+/// Unlike [`DrawHandle`], coordinates are specified via a [`Vec2`] and
+/// rectangular regions via [`Quad`]. The same coordinate system is used, hence
+/// type conversions can be performed with `from` and `into`. Integral
+/// coordinates align with pixels, non-integral coordinates may also be used.
 ///
 /// All draw operations target some region identified by a handle of type
 /// [`Region`]; this may be the whole window, some sub-region, or perhaps
@@ -86,12 +91,12 @@ pub trait Draw: Any {
     fn add_clip_region(&mut self, region: Rect) -> Region;
 
     /// Draw a rectangle of uniform colour
-    fn rect(&mut self, region: Region, rect: Rect, col: Colour);
+    fn rect(&mut self, region: Region, rect: Quad, col: Colour);
 
     /// Draw a frame of uniform colour
     ///
     /// The frame is defined by the area inside `outer` and not inside `inner`.
-    fn frame(&mut self, region: Region, outer: Rect, inner: Rect, col: Colour);
+    fn frame(&mut self, region: Region, outer: Quad, inner: Quad, col: Colour);
 }
 
 /// Drawing commands for rounded shapes
@@ -110,7 +115,7 @@ pub trait DrawRounded: Draw {
     ///
     /// Note that for rectangular, axis-aligned lines, [`Draw::rect`] should be
     /// preferred.
-    fn rounded_line(&mut self, region: Region, p1: Coord, p2: Coord, radius: f32, col: Colour);
+    fn rounded_line(&mut self, region: Region, p1: Vec2, p2: Vec2, radius: f32, col: Colour);
 
     /// Draw a circle or oval of uniform colour
     ///
@@ -119,7 +124,7 @@ pub trait DrawRounded: Draw {
     /// The `inner_radius` parameter gives the inner radius relative to the
     /// outer radius: a value of `0.0` will result in the whole shape being
     /// painted, while `1.0` will result in a zero-width line on the outer edge.
-    fn circle(&mut self, region: Region, rect: Rect, inner_radius: f32, col: Colour);
+    fn circle(&mut self, region: Region, rect: Quad, inner_radius: f32, col: Colour);
 
     /// Draw a frame with rounded corners and uniform colour
     ///
@@ -135,8 +140,8 @@ pub trait DrawRounded: Draw {
     fn rounded_frame(
         &mut self,
         region: Region,
-        outer: Rect,
-        inner: Rect,
+        outer: Quad,
+        inner: Quad,
         inner_radius: f32,
         col: Colour,
     );
@@ -155,17 +160,17 @@ pub trait DrawRounded: Draw {
 /// 0 is perpendicular to the screen towards the viewer, and 1 points outwards.
 pub trait DrawShaded: Draw {
     /// Add a shaded square to the draw buffer
-    fn shaded_square(&mut self, region: Region, rect: Rect, norm: (f32, f32), col: Colour);
+    fn shaded_square(&mut self, region: Region, rect: Quad, norm: (f32, f32), col: Colour);
 
     /// Add a shaded circle to the draw buffer
-    fn shaded_circle(&mut self, region: Region, rect: Rect, norm: (f32, f32), col: Colour);
+    fn shaded_circle(&mut self, region: Region, rect: Quad, norm: (f32, f32), col: Colour);
 
     /// Add a square shaded frame to the draw buffer.
     fn shaded_square_frame(
         &mut self,
         region: Region,
-        outer: Rect,
-        inner: Rect,
+        outer: Quad,
+        inner: Quad,
         norm: (f32, f32),
         col: Colour,
     );
@@ -174,8 +179,8 @@ pub trait DrawShaded: Draw {
     fn shaded_round_frame(
         &mut self,
         region: Region,
-        outer: Rect,
-        inner: Rect,
+        outer: Quad,
+        inner: Quad,
         norm: (f32, f32),
         col: Colour,
     );

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -507,8 +507,8 @@ impl<'a> Manager<'a> {
     /// The pop-up should be placed *next to* the specified `rect`, in the given
     /// `direction`.
     #[inline]
-    pub fn add_popup(&mut self, popup: kas::Popup) {
-        self.tkw.add_popup(popup);
+    pub fn add_popup(&mut self, popup: kas::Popup) -> WindowId {
+        self.tkw.add_popup(popup)
     }
 
     /// Add a window

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -495,7 +495,7 @@ impl<'a> Manager<'a> {
         self.mgr.send_action(action);
     }
 
-    /// Add a pop-up
+    /// Add an overlay (pop-up)
     ///
     /// A pop-up is a box used for things like tool-tips and menus which is
     /// drawn on top of other content and has focus for input.
@@ -503,10 +503,12 @@ impl<'a> Manager<'a> {
     /// Depending on the host environment, the pop-up may be a special type of
     /// window without borders and with precise placement, or may be a layer
     /// drawn in an existing window.
+    ///
+    /// The pop-up should be placed *next to* the specified `rect`, in the given
+    /// `direction`.
     #[inline]
-    // TODO: parameters
-    pub fn add_overlay(&mut self, widget: Box<dyn kas::Overlay>) {
-        self.tkw.add_overlay(widget);
+    pub fn add_popup(&mut self, popup: kas::Popup) {
+        self.tkw.add_popup(popup);
     }
 
     /// Add a window

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -242,6 +242,7 @@ impl ManagerState {
             .map(|id| (elt.0, *id)));
     }
 
+    /// Update the widgets under the cursor and touch events
     pub fn region_moved<W: Widget + ?Sized>(&mut self, widget: &mut W) {
         // Note: redraw is already implied.
 
@@ -492,6 +493,20 @@ impl<'a> Manager<'a> {
     #[inline]
     pub fn send_action(&mut self, action: TkAction) {
         self.mgr.send_action(action);
+    }
+
+    /// Add a pop-up
+    ///
+    /// A pop-up is a box used for things like tool-tips and menus which is
+    /// drawn on top of other content and has focus for input.
+    ///
+    /// Depending on the host environment, the pop-up may be a special type of
+    /// window without borders and with precise placement, or may be a layer
+    /// drawn in an existing window.
+    #[inline]
+    // TODO: parameters
+    pub fn add_overlay(&mut self, widget: Box<dyn kas::Overlay>) {
+        self.tkw.add_overlay(widget);
     }
 
     /// Add a window
@@ -797,6 +812,18 @@ impl<'a> Manager<'a> {
 /// Toolkit API
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 impl<'a> Manager<'a> {
+    // Hack to make TkAction::Close on an overlay close only that.
+    // This is not quite correct, since it could mask a legitimate Close
+    // event (e.g. a pop-up menu to close the window).
+    pub(crate) fn replace_action_close_with_reconfigure(&mut self) -> bool {
+        if self.mgr.action == TkAction::Close {
+            self.mgr.action = TkAction::Reconfigure;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Update, after receiving all events
     pub fn finish<W>(mut self, widget: &mut W) -> TkAction
     where

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -41,7 +41,7 @@ impl Coord {
     ///
     /// In the case that `min > max`, the `min` value is returned.
     #[inline]
-    pub fn clamped(self, min: Self, max: Self) -> Self {
+    pub fn clamp(self, min: Self, max: Self) -> Self {
         self.min(max).max(min)
     }
 

--- a/src/layout/grid_solver.rs
+++ b/src/layout/grid_solver.rs
@@ -239,24 +239,28 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> GridSetter<RT, CT, S> {
 
         storage.set_dims(cols + 1, rows + 1);
 
-        SizeRules::solve_seq(widths.as_mut(), storage.widths(), rect.size.0);
-        w_offsets.as_mut()[0] = 0;
-        for i in 1..w_offsets.as_ref().len() {
-            let i1 = i - 1;
-            let m1 = storage.widths()[i1].margins().1;
-            let m0 = storage.widths()[i].margins().0;
-            w_offsets.as_mut()[i] =
-                w_offsets.as_ref()[i1] + widths.as_ref()[i1] + m1.max(m0) as u32;
+        if cols > 0 {
+            SizeRules::solve_seq(widths.as_mut(), storage.widths(), rect.size.0);
+            w_offsets.as_mut()[0] = 0;
+            for i in 1..w_offsets.as_ref().len() {
+                let i1 = i - 1;
+                let m1 = storage.widths()[i1].margins().1;
+                let m0 = storage.widths()[i].margins().0;
+                w_offsets.as_mut()[i] =
+                    w_offsets.as_ref()[i1] + widths.as_ref()[i1] + m1.max(m0) as u32;
+            }
         }
 
-        SizeRules::solve_seq(heights.as_mut(), storage.heights(), rect.size.1);
-        h_offsets.as_mut()[0] = 0;
-        for i in 1..h_offsets.as_ref().len() {
-            let i1 = i - 1;
-            let m1 = storage.heights()[i1].margins().1;
-            let m0 = storage.heights()[i].margins().0;
-            h_offsets.as_mut()[i] =
-                h_offsets.as_ref()[i1] + heights.as_ref()[i1] + m1.max(m0) as u32;
+        if rows > 0 {
+            SizeRules::solve_seq(heights.as_mut(), storage.heights(), rect.size.1);
+            h_offsets.as_mut()[0] = 0;
+            for i in 1..h_offsets.as_ref().len() {
+                let i1 = i - 1;
+                let m1 = storage.heights()[i1].margins().1;
+                let m0 = storage.heights()[i].margins().0;
+                h_offsets.as_mut()[i] =
+                    h_offsets.as_ref()[i1] + heights.as_ref()[i1] + m1.max(m0) as u32;
+            }
         }
 
         GridSetter {

--- a/src/layout/row_solver.rs
+++ b/src/layout/row_solver.rs
@@ -115,13 +115,15 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
             false => (rect.pos.1, rect.size.1),
         };
 
-        SizeRules::solve_seq(widths.as_mut(), storage.as_ref(), width);
-        offsets.as_mut()[0] = pos as u32;
-        for i in 1..offsets.as_ref().len() {
-            let i1 = i - 1;
-            let m1 = storage.as_ref()[i1].margins().1;
-            let m0 = storage.as_ref()[i].margins().0;
-            offsets.as_mut()[i] = offsets.as_ref()[i1] + widths.as_ref()[i1] + m1.max(m0) as u32;
+        if dim.1 > 0 {
+            SizeRules::solve_seq(widths.as_mut(), storage.as_ref(), width);
+            offsets.as_mut()[0] = pos as u32;
+            for i in 1..offsets.as_ref().len() {
+                let i1 = i - 1;
+                let m1 = storage.as_ref()[i1].margins().1;
+                let m0 = storage.as_ref()[i].margins().0;
+                offsets.as_mut()[i] = offsets.as_ref()[i1] + widths.as_ref()[i1] + m1.max(m0) as u32;
+            }
         }
 
         RowSetter {

--- a/src/layout/row_solver.rs
+++ b/src/layout/row_solver.rs
@@ -122,7 +122,8 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
                 let i1 = i - 1;
                 let m1 = storage.as_ref()[i1].margins().1;
                 let m0 = storage.as_ref()[i].margins().0;
-                offsets.as_mut()[i] = offsets.as_ref()[i1] + widths.as_ref()[i1] + m1.max(m0) as u32;
+                offsets.as_mut()[i] =
+                    offsets.as_ref()[i1] + widths.as_ref()[i1] + m1.max(m0) as u32;
             }
         }
 

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -73,8 +73,8 @@ pub fn solve<L: Layout>(widget: &mut L, size_handle: &mut dyn SizeHandle) -> (Si
 /// Solve and assign widget layout
 ///
 /// Return min and ideal sizes.
-pub fn solve_and_set<L: WidgetConfig>(
-    widget: &mut L,
+pub fn solve_and_set(
+    widget: &mut dyn WidgetConfig,
     size_handle: &mut dyn SizeHandle,
     size: Size,
 ) -> (Size, Size) {

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -12,7 +12,7 @@ use super::{AxisInfo, SizeRules};
 use crate::draw::SizeHandle;
 use crate::geom::{Coord, Rect, Size};
 use crate::Direction::{Horizontal, Vertical};
-use crate::{AlignHints, Layout, WidgetConfig};
+use crate::{AlignHints, WidgetConfig};
 
 /// A [`SizeRules`] solver for layouts
 ///
@@ -58,7 +58,7 @@ pub trait RulesSetter {
 /// Calculate required size of widget
 ///
 /// Return min and ideal sizes.
-pub fn solve<L: Layout>(widget: &mut L, size_handle: &mut dyn SizeHandle) -> (Size, Size) {
+pub fn solve(widget: &mut dyn WidgetConfig, size_handle: &mut dyn SizeHandle) -> (Size, Size) {
     // We call size_rules not because we want the result, but because our
     // spec requires that we do so before calling set_rect.
     let w = widget.size_rules(size_handle, AxisInfo::new(Horizontal, None));
@@ -76,27 +76,31 @@ pub fn solve<L: Layout>(widget: &mut L, size_handle: &mut dyn SizeHandle) -> (Si
 pub fn solve_and_set(
     widget: &mut dyn WidgetConfig,
     size_handle: &mut dyn SizeHandle,
-    size: Size,
+    mut rect: Rect,
+    include_margins: bool,
 ) -> (Size, Size) {
     // We call size_rules not because we want the result, but because our
     // spec requires that we do so before calling set_rect.
     let w = widget.size_rules(size_handle, AxisInfo::new(Horizontal, None));
-    let m = w.margins();
-    let x = m.0 as i32;
-    let width = size.0 - (m.0 + m.1) as u32;
+    let wm = w.margins();
+    let mut width = rect.size.0;
+    if include_margins {
+        width -= (wm.0 + wm.1) as u32;
+    }
 
     let h = widget.size_rules(size_handle, AxisInfo::new(Vertical, Some(width)));
-    let m = h.margins();
-    let y = m.0 as i32;
-    let height = size.1 - (m.0 + m.1) as u32;
+    let hm = h.margins();
 
-    let pos = Coord(x, y);
-    let size = Size(width, height);
-    widget.set_rect(size_handle, Rect { pos, size }, AlignHints::NONE);
+    if include_margins {
+        rect.pos += Coord(wm.0 as i32, hm.0 as i32);
+        rect.size.0 = width;
+        rect.size.1 -= (hm.0 + hm.1) as u32;
+    }
+    widget.set_rect(size_handle, rect, AlignHints::NONE);
 
     trace!(
         "layout::solve_and_set for size={:?} has rules {:?}, {:?} and hierarchy:{}",
-        size,
+        rect.size,
         w,
         h,
         WidgetHeirarchy(widget, 0),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,7 +50,6 @@
 //! use kas::event::VoidMsg;
 //! use kas::{CoreData, Layout, LayoutData, Widget};
 //!
-//! #[widget_config]
 //! #[layout(single)]
 //! #[handler(generics = <> where W: Widget<Msg = VoidMsg>)]
 //! #[derive(Clone, Debug, Widget)]
@@ -63,7 +62,7 @@
 //! #### WidgetCore
 //!
 //! The [`WidgetCore`] trait is always implemented by this macro. The
-//! `#[widget_core]` attribute may be used to parameterise this implementation,
+//! `#[widget]` attribute may be used to parameterise this implementation,
 //! for example:
 //! ```
 //! use kas::draw::{DrawHandle, SizeHandle};
@@ -71,8 +70,7 @@
 //! use kas::macros::Widget;
 //! use kas::{event, CoreData, Layout};
 //!
-//! #[widget_config]
-//! #[widget_core(key_nav = true)]
+//! #[widget(config(key_nav = true))]
 //! #[handler]
 //! #[derive(Clone, Debug, Default, Widget)]
 //! struct MyWidget {
@@ -89,13 +87,18 @@
 //! }
 //! ```
 //!
-//! The `#[widget_core]` attribute supports the following parameters, each
-//! with the specified default value:
+//! The `#[widget]` attribute supports the following syntax:
 //!
-//! -   `key_nav = false`: a boolean, describing whether the widget supports
-//!     keyboard navigation (see [`WidgetConfig::key_nav`])
-//! -   `cursor_icon = kas::event::CursorIcon::Default`: the cursor icon to use
-//!     when the mouse hovers over this widget (see [`WidgetConfig::cursor_icon`])
+//! -   `config = noauto`: opt out of deriving the [`WidgetConfig`] trait; use
+//!     this to implement the trait manually (e.g. to use [`WidgetConfig::configure`])
+//! -   `confg(noauto)`: same as above
+//! -   `confg(PARAMS)`: derive [`WidgetConfig`] but with the following `PARAMS`
+//!     specified:
+//!
+//!     -   `key_nav = false`: a boolean, describing whether the widget supports
+//!         keyboard navigation (see [`WidgetConfig::key_nav`])
+//!     -   `cursor_icon = kas::event::CursorIcon::Default`: the cursor icon to use
+//!         when the mouse hovers over this widget (see [`WidgetConfig::cursor_icon`])
 //!
 //! #### Widget
 //!
@@ -171,7 +174,6 @@
 //! # use kas::macros::Widget;
 //! # use kas::{CoreData, Layout, Widget, event::Handler};
 //! #[layout(single)]
-//! #[widget_config]
 //! #[handler(msg = <W as Handler>::Msg, generics = <> where W: Layout)]
 //! #[derive(Clone, Debug, Default, Widget)]
 //! pub struct Frame<W: Widget> {
@@ -240,7 +242,6 @@
 //! #[derive(Debug)]
 //! enum ChildMessage { A }
 //!
-//! #[widget_config]
 //! #[layout(vertical)]
 //! #[handler(generics = <> where W: Widget<Msg = ChildMessage>)]
 //! #[derive(Debug, Widget)]
@@ -284,7 +285,6 @@
 //!     Check(bool),
 //! }
 //! let widget = make_widget! {
-//!     #[widget_config]
 //!     #[layout(vertical)]
 //!     #[handler(msg = VoidMsg)]
 //!     struct {
@@ -383,7 +383,6 @@
 //! }
 //!
 //! let button_box = make_widget!{
-//!     #[widget_config]
 //!     #[layout(horizontal)]
 //!     #[handler(msg = OkCancel)]
 //!     struct {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,7 +17,7 @@ pub use kas::geom::{Coord, Rect, Size};
 pub use kas::macros::*;
 pub use kas::{class, draw, event, geom, layout, widget};
 pub use kas::{Align, AlignHints, Direction, Directional, Horizontal, Vertical, WidgetId};
-pub use kas::{CloneTo, Layout, ThemeApi, Widget, WidgetConfig, WidgetCore};
+pub use kas::{CloneTo, Layout, ThemeApi, Widget, WidgetChildren, WidgetConfig, WidgetCore};
 pub use kas::{CoreData, LayoutData};
 pub use kas::{CowString, CowStringL};
 pub use kas::{TkAction, TkWindow};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,7 +17,7 @@ pub use kas::geom::{Coord, Rect, Size};
 pub use kas::macros::*;
 pub use kas::{class, draw, event, geom, layout, widget};
 pub use kas::{Align, AlignHints, Direction, Directional, Horizontal, Vertical, WidgetId};
-pub use kas::{CloneTo, Layout, ThemeApi, Widget, WidgetConfig, WidgetCore, Window};
+pub use kas::{CloneTo, Layout, ThemeApi, Widget, WidgetConfig, WidgetCore};
 pub use kas::{CoreData, LayoutData};
 pub use kas::{CowString, CowStringL};
 pub use kas::{TkAction, TkWindow};

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -75,6 +75,12 @@ pub enum TkAction {
 /// This is implemented by a KAS toolkit on a window handle.
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 pub trait TkWindow {
+    /// Add an overlay
+    ///
+    /// An overlay is a layer which appears on top of the current window, both
+    /// graphically and in terms of events. Multiple overlays are possible.
+    fn add_overlay(&mut self, widget: Box<dyn kas::Overlay>);
+
     /// Add a window
     ///
     /// Toolkits typically allow windows to be added directly, before start of

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -18,7 +18,7 @@ use std::num::NonZeroU32;
 
 use crate::{event, ThemeAction, ThemeApi};
 
-/// Identifier for a window added to a toolkit
+/// Identifier for a window or pop-up
 ///
 /// Identifiers should always be unique.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -75,14 +75,14 @@ pub enum TkAction {
 /// This is implemented by a KAS toolkit on a window handle.
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 pub trait TkWindow {
-    /// Add an overlay
+    /// Add a pop-up
     ///
-    /// An overlay is a layer which appears on top of the current window, both
-    /// graphically and in terms of events. Multiple overlays are possible.
+    /// A pop-up may be presented as an overlay layer in the current window or
+    /// via a new borderless window.
     ///
-    /// The pop-up should be placed *next to* the specified `rect`, in the given
-    /// `direction`.
-    fn add_popup(&mut self, popup: kas::Popup);
+    /// Pop-ups support position hints: they are placed *next to* the specified
+    /// `rect`, preferably in the given `direction`.
+    fn add_popup(&mut self, popup: kas::Popup) -> WindowId;
 
     /// Add a window
     ///

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -79,7 +79,10 @@ pub trait TkWindow {
     ///
     /// An overlay is a layer which appears on top of the current window, both
     /// graphically and in terms of events. Multiple overlays are possible.
-    fn add_overlay(&mut self, widget: Box<dyn kas::Overlay>);
+    ///
+    /// The pop-up should be placed *next to* the specified `rect`, in the given
+    /// `direction`.
+    fn add_popup(&mut self, popup: kas::Popup);
 
     /// Add a window
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,7 +12,7 @@ use crate::draw::{DrawHandle, SizeHandle};
 use crate::event::{self, Manager, ManagerState};
 use crate::geom::{Coord, Rect, Size};
 use crate::layout::{self, AxisInfo, SizeRules};
-use crate::{AlignHints, CoreData, WidgetId};
+use crate::{AlignHints, CoreData, Direction, WidgetId};
 
 mod impls;
 
@@ -313,8 +313,15 @@ pub trait Overlay: Widget<Msg = event::VoidMsg> {
     fn resize(
         &mut self,
         size_handle: &mut dyn SizeHandle,
-        size: Size,
+        rect: Rect,
     ) -> (Option<Size>, Option<Size>);
+}
+
+/// A pop-up is an overlay with parent & position information
+pub struct Popup {
+    pub parent: WidgetId,
+    pub direction: Direction,
+    pub overlay: Box<dyn kas::Overlay>,
 }
 
 /// A root window extends [`Overlay`] with callbacks and overlay layers
@@ -323,12 +330,7 @@ pub trait Window: Overlay {
     fn title(&self) -> &str;
 
     /// Add an overlay layer
-    fn add_overlay(
-        &mut self,
-        size_handle: &mut dyn SizeHandle,
-        mgr: &mut Manager,
-        overlay: Box<dyn kas::Overlay>,
-    );
+    fn add_popup(&mut self, size_handle: &mut dyn SizeHandle, mgr: &mut Manager, popup: Popup);
 
     /// Get a list of available callbacks.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -297,16 +297,11 @@ pub trait LayoutData {
     type Setter: layout::RulesSetter;
 }
 
-/// A window is a drawable interactive region provided by windowing system.
-// TODO: should this be a trait, instead of simply a struct? Should it be
-// implemented by dialogs? Note that from the toolkit perspective, it seems a
-// Window should be a Widget. So alternatives are (1) use a struct instead of a
-// trait or (2) allow any Widget to derive Window (i.e. implement required
-// functionality with macros instead of the generic code below).
-pub trait Window: Widget<Msg = event::VoidMsg> {
-    /// Get the window title
-    fn title(&self) -> &str;
-
+/// A simplified window used for pop-ups
+///
+/// An `Overlay` may be given a dedicated window by the windowing system or may
+/// be drawn as an overlay on the current window.
+pub trait Overlay: Widget<Msg = event::VoidMsg> {
     /// Calculate required size
     ///
     /// Returns optional minimum size, and ideal size.
@@ -320,6 +315,20 @@ pub trait Window: Widget<Msg = event::VoidMsg> {
         size_handle: &mut dyn SizeHandle,
         size: Size,
     ) -> (Option<Size>, Option<Size>);
+}
+
+/// A root window extends [`Overlay`] with callbacks and overlay layers
+pub trait Window: Overlay {
+    /// Get the window title
+    fn title(&self) -> &str;
+
+    /// Add an overlay layer
+    fn add_overlay(
+        &mut self,
+        size_handle: &mut dyn SizeHandle,
+        mgr: &mut Manager,
+        overlay: Box<dyn kas::Overlay>,
+    );
 
     /// Get a list of available callbacks.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -63,7 +63,15 @@ pub trait WidgetCore: fmt::Debug {
     fn as_widget(&self) -> &dyn WidgetConfig;
     /// Erase type
     fn as_widget_mut(&mut self) -> &mut dyn WidgetConfig;
+}
 
+/// Listing of a widget's children
+///
+/// Usually this is implemented by `derive(Widget)`, but for dynamic widgets it
+/// may have to be implemented manually. Note that if the results of these
+/// methods ever change, one must send [`TkAction::Reconfigure`].
+/// TODO: full reconfigure may be too slow; find a better option.
+pub trait WidgetChildren: WidgetCore {
     /// Get the number of child widgets
     fn len(&self) -> usize;
 
@@ -198,7 +206,7 @@ pub trait WidgetConfig: Layout {
 /// as well as low-level event handling.
 ///
 /// For a description of the widget size model, see [`SizeRules`].
-pub trait Layout: WidgetCore {
+pub trait Layout: WidgetChildren {
     /// Get size rules for the given axis.
     ///
     /// This method takes `&mut self` to allow local caching of child widget

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -133,13 +133,27 @@ pub trait WidgetCore: fmt::Debug {
     ///
     /// This walk is iterative (nonconcurrent), depth-first, and always calls
     /// `f` on self *after* walking through all children.
-    fn walk(&self, f: &mut dyn FnMut(&dyn WidgetConfig));
+    fn walk(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {
+        for i in 0..self.len() {
+            if let Some(w) = self.get(i) {
+                w.walk(f);
+            }
+        }
+        f(self.as_widget());
+    }
 
     /// Walk through all widgets, calling `f` once on each.
     ///
     /// This walk is iterative (nonconcurrent), depth-first, and always calls
     /// `f` on self *after* walking through all children.
-    fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn WidgetConfig));
+    fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn WidgetConfig)) {
+        for i in 0..self.len() {
+            if let Some(w) = self.get_mut(i) {
+                w.walk_mut(f);
+            }
+        }
+        f(self.as_widget_mut());
+    }
 }
 
 /// Widget configuration

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,7 +12,7 @@ use crate::draw::{DrawHandle, SizeHandle};
 use crate::event::{self, Manager, ManagerState};
 use crate::geom::{Coord, Rect};
 use crate::layout::{self, AxisInfo, SizeRules};
-use crate::{AlignHints, CoreData, Direction, WidgetId};
+use crate::{AlignHints, CoreData, Direction, WidgetId, WindowId};
 
 mod impls;
 
@@ -323,8 +323,16 @@ pub trait Window: Widget<Msg = event::VoidMsg> {
     /// windows.
     fn restrict_dimensions(&self) -> (bool, bool);
 
-    /// Add an overlay layer
-    fn add_popup(&mut self, size_handle: &mut dyn SizeHandle, mgr: &mut Manager, popup: Popup);
+    /// Add a pop-up as a layer in the current window
+    ///
+    /// Each [`Popup`] is assigned a [`WindowId`]; both are passed.
+    fn add_popup(
+        &mut self,
+        size_handle: &mut dyn SizeHandle,
+        mgr: &mut Manager,
+        id: WindowId,
+        popup: Popup,
+    );
 
     /// Handle closure of self
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -334,6 +334,11 @@ pub trait Window: Widget<Msg = event::VoidMsg> {
         popup: Popup,
     );
 
+    /// Trigger closure of a pop-up
+    ///
+    /// If the given `id` refers to a pop-up, it should be closed.
+    fn remove_popup(&mut self, mgr: &mut Manager, id: WindowId);
+
     /// Handle closure of self
     ///
     /// This allows for actions on destruction, but doesn't need to do anything.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -179,8 +179,10 @@ pub trait WidgetConfig: Layout {
     /// Widgets are *configured* on window creation and when
     /// [`kas::TkAction::Reconfigure`] is sent.
     ///
-    /// Configuration happens after resizing. This method is called after
-    /// a [`WidgetId`] has been assigned to self and to each child.
+    /// Configure is called before resizing (but after calculation of the
+    /// initial window size). This method is called after
+    /// a [`WidgetId`] has been assigned to self, and after `configure` has
+    /// been called on each child.
     ///
     /// The default implementation of this method does nothing.
     fn configure(&mut self, _: &mut Manager) {}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -326,14 +326,10 @@ pub trait Window: Widget<Msg = event::VoidMsg> {
     /// Add an overlay layer
     fn add_popup(&mut self, size_handle: &mut dyn SizeHandle, mgr: &mut Manager, popup: Popup);
 
-    /// Get a list of available callbacks.
+    /// Handle closure of self
     ///
-    /// This returns a sequence of `(index, condition)` values. The toolkit
-    /// should call `trigger_callback(index, mgr)` whenever the condition is met.
-    fn callbacks(&self) -> Vec<(usize, event::Callback)>;
-
-    /// Trigger a callback (see `iter_callbacks`).
-    fn trigger_callback(&mut self, index: usize, mgr: &mut Manager);
+    /// This allows for actions on destruction, but doesn't need to do anything.
+    fn handle_closure(&mut self, _mgr: &mut Manager) {}
 }
 
 /// Return value of [`ThemeApi`] functions

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -30,7 +30,9 @@ impl<M> WidgetCore for Box<dyn Widget<Msg = M>> {
     fn as_widget_mut(&mut self) -> &mut dyn WidgetConfig {
         self.as_mut().as_widget_mut()
     }
+}
 
+impl<M> WidgetChildren for Box<dyn Widget<Msg = M>> {
     fn len(&self) -> usize {
         self.as_ref().len()
     }
@@ -39,6 +41,13 @@ impl<M> WidgetCore for Box<dyn Widget<Msg = M>> {
     }
     fn get_mut(&mut self, index: usize) -> Option<&mut dyn WidgetConfig> {
         self.as_mut().get_mut(index)
+    }
+
+    fn find(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+        self.as_ref().find(id)
+    }
+    fn find_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
+        self.as_mut().find_mut(id)
     }
 
     fn walk(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -16,6 +16,7 @@ use kas::prelude::*;
 
 /// A push-button with a text label
 #[handler(event)]
+#[widget(config=noauto)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct TextButton<M: Clone + Debug> {
     #[widget_core]

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -16,7 +16,7 @@ use kas::layout::{AxisInfo, SizeRules};
 use kas::prelude::*;
 
 /// A bare checkbox (no label)
-#[widget_config(key_nav = true)]
+#[widget(config(key_nav = true))]
 #[handler(event)]
 #[derive(Clone, Default, Widget)]
 pub struct CheckBoxBare<M> {
@@ -149,7 +149,6 @@ impl<M> event::Handler for CheckBoxBare<M> {
 /// A checkable box with optional label
 // TODO: use a generic wrapper for CheckBox and RadioBox?
 #[layout(horizontal, area=checkbox)]
-#[widget_config]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[derive(Clone, Default, Widget)]
 pub struct CheckBox<M> {

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -16,8 +16,7 @@ use kas::layout::{AxisInfo, SizeRules};
 use kas::prelude::*;
 
 /// A bare checkbox (no label)
-#[widget_config]
-#[widget_core(key_nav = true)]
+#[widget_config(key_nav = true)]
 #[handler(event)]
 #[derive(Clone, Default, Widget)]
 pub struct CheckBoxBare<M> {

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -13,7 +13,7 @@ use crate::class::HasText;
 use crate::draw::{DrawHandle, SizeHandle, TextClass};
 use crate::event::{self, Action, Event, Manager, Response, UpdateHandle};
 use crate::geom::*;
-use crate::layout::{self, AxisInfo, SizeRules};
+use crate::layout::{AxisInfo, SizeRules};
 use crate::macros::Widget;
 use crate::{Align, CoreData, CowString, Direction, TkAction, WidgetCore, WidgetId};
 
@@ -208,21 +208,5 @@ impl event::EventHandler for ComboPopup {
         } else {
             Response::Unhandled(event)
         }
-    }
-}
-
-impl kas::Overlay for ComboPopup {
-    fn find_size(&mut self, size_handle: &mut dyn SizeHandle) -> (Option<Size>, Size) {
-        let (min, ideal) = layout::solve(self, size_handle);
-        (Some(min), ideal)
-    }
-
-    fn resize(
-        &mut self,
-        size_handle: &mut dyn SizeHandle,
-        rect: Rect,
-    ) -> (Option<Size>, Option<Size>) {
-        let (min, ideal) = layout::solve_and_set(self, size_handle, rect, true);
-        (Some(min), Some(ideal))
     }
 }

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -1,0 +1,119 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Combobox
+
+use std::fmt::Debug;
+use std::iter::FromIterator;
+
+use crate::draw::{DrawHandle, SizeHandle, TextClass};
+use crate::event::{self, Action, Manager, Response};
+use crate::geom::Rect;
+use crate::layout::{AxisInfo, SizeRules};
+use crate::macros::Widget;
+use crate::{Align, AlignHints, CoreData, CowString, Layout, WidgetCore};
+
+/// A pop-up multiple choice menu
+#[widget_config(key_nav = true)]
+#[handler(event)]
+#[derive(Clone, Debug, Default, Widget)]
+pub struct ComboBox<M: Clone + Debug> {
+    #[widget_core]
+    core: CoreData,
+    // text_rect: Rect,
+    choices: Vec<(CowString, M)>,
+    active: usize,
+}
+
+impl<M: Clone + Debug> Layout for ComboBox<M> {
+    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        let sides = size_handle.button_surround();
+        let margins = size_handle.outer_margins();
+        let frame_rules = SizeRules::extract_fixed(axis.dir(), sides.0 + sides.1, margins);
+
+        // TODO: should we calculate a bound over all choices or assume some default?
+        let content_rules = size_handle.text_bound(self.text(), TextClass::Button, axis);
+        content_rules.surrounded_by(frame_rules, true)
+    }
+
+    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, _align: AlignHints) {
+        self.core.rect = rect;
+
+        // In theory, text rendering should be restricted as in EditBox.
+        // In practice, it sometimes overflows a tiny bit, and looks better if
+        // we let it overflow. Since the text is centred this is okay.
+        // self.text_rect = ...
+    }
+
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState) {
+        draw_handle.button(self.core.rect, mgr.highlight_state(self.id()));
+        let align = (Align::Centre, Align::Centre);
+        draw_handle.text(self.core.rect, self.text(), TextClass::Button, align);
+    }
+}
+
+impl<M: Clone + Debug> ComboBox<M> {
+    /// Construct a combobox
+    ///
+    /// A combobox presents a menu with a fixed set of choices when clicked.
+    /// Each choice has some corresponding message of type `M` which is emitted
+    /// by the event handler when this choice is selected.
+    ///
+    /// `ComboBox` implements [`FromIterator`] and thus may also be constructed
+    /// with [`std::iter::Iterator::collect`]:
+    /// ```
+    /// # use kas::widget::ComboBox;
+    /// let combobox: ComboBox<i32> = [("one", 1), ("two", 2), ("three", 3)].iter().cloned().collect();
+    /// ```
+    pub fn new(choices: Vec<(CowString, M)>) -> Self {
+        assert!(
+            choices.len() > 0,
+            "ComboBox::new: expected at least one choice"
+        );
+        ComboBox {
+            core: Default::default(),
+            choices,
+            active: 0,
+        }
+    }
+
+    /// Get the text of the active choice
+    pub fn text(&self) -> &str {
+        &self.choices[self.active].0
+    }
+
+    /// Add a choice to the combobox, in last position
+    pub fn push<T: Into<CowString>>(&mut self, label: CowString, msg: M) {
+        self.choices.push((label.into(), msg));
+    }
+}
+
+impl<T: Into<CowString>, M: Clone + Debug> FromIterator<(T, M)> for ComboBox<M> {
+    fn from_iter<I: IntoIterator<Item = (T, M)>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut choices = Vec::with_capacity(iter.size_hint().1.unwrap_or(0));
+        for (label, msg) in iter {
+            choices.push((label.into(), msg));
+        }
+        ComboBox::new(choices)
+    }
+}
+
+impl<M: Clone + Debug> event::Handler for ComboBox<M> {
+    type Msg = M;
+
+    #[inline]
+    fn activation_via_press(&self) -> bool {
+        true
+    }
+
+    fn action(&mut self, _: &mut Manager, action: Action) -> Response<M> {
+        match action {
+            // TODO
+            Action::Activate => self.choices[self.active].1.clone().into(),
+            a @ _ => Response::unhandled_action(a),
+        }
+    }
+}

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -15,7 +15,7 @@ use crate::event::{self, Action, Event, Manager, Response, UpdateHandle};
 use crate::geom::*;
 use crate::layout::{self, AxisInfo, SizeRules};
 use crate::macros::Widget;
-use crate::{Align, CoreData, CowString, TkAction, WidgetCore, WidgetId};
+use crate::{Align, CoreData, CowString, Direction, TkAction, WidgetCore, WidgetId};
 
 /// A pop-up multiple choice menu
 #[handler(event)]
@@ -153,7 +153,11 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
     fn action(&mut self, mgr: &mut Manager, action: Action) -> Response<M> {
         match action {
             Action::Activate => {
-                mgr.add_overlay(Box::new(ComboPopup::new(self.column.clone(), self.handle)));
+                mgr.add_popup(kas::Popup {
+                    parent: self.id(),
+                    direction: Direction::Vertical,
+                    overlay: Box::new(ComboPopup::new(self.column.clone(), self.handle)),
+                });
                 Response::None
             }
             Action::HandleUpdate { payload, .. } => {
@@ -216,9 +220,9 @@ impl kas::Overlay for ComboPopup {
     fn resize(
         &mut self,
         size_handle: &mut dyn SizeHandle,
-        size: Size,
+        rect: Rect,
     ) -> (Option<Size>, Option<Size>) {
-        let (min, ideal) = layout::solve_and_set(self, size_handle, size);
+        let (min, ideal) = layout::solve_and_set(self, size_handle, rect, true);
         (Some(min), Some(ideal))
     }
 }

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -11,7 +11,7 @@ use std::iter::FromIterator;
 use super::{Column, TextButton};
 use crate::class::HasText;
 use crate::draw::{DrawHandle, SizeHandle, TextClass};
-use crate::event::{self, Action, Callback, Event, Manager, Response, UpdateHandle};
+use crate::event::{self, Action, Event, Manager, Response, UpdateHandle};
 use crate::geom::*;
 use crate::layout::{self, AxisInfo, SizeRules};
 use crate::macros::Widget;
@@ -153,7 +153,7 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
     fn action(&mut self, mgr: &mut Manager, action: Action) -> Response<M> {
         match action {
             Action::Activate => {
-                mgr.add_window(Box::new(ComboPopup::new(self.column.clone(), self.handle)));
+                mgr.add_overlay(Box::new(ComboPopup::new(self.column.clone(), self.handle)));
                 Response::None
             }
             Action::HandleUpdate { payload, .. } => {
@@ -207,11 +207,7 @@ impl event::EventHandler for ComboPopup {
     }
 }
 
-impl kas::Window for ComboPopup {
-    fn title(&self) -> &str {
-        &"Choices"
-    }
-
+impl kas::Overlay for ComboPopup {
     fn find_size(&mut self, size_handle: &mut dyn SizeHandle) -> (Option<Size>, Size) {
         let (min, ideal) = layout::solve(self, size_handle);
         (Some(min), ideal)
@@ -225,10 +221,4 @@ impl kas::Window for ComboPopup {
         let (min, ideal) = layout::solve_and_set(self, size_handle, size);
         (Some(min), Some(ideal))
     }
-
-    fn callbacks(&self) -> Vec<(usize, Callback)> {
-        vec![]
-    }
-
-    fn trigger_callback(&mut self, _: usize, _: &mut Manager) {}
 }

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -19,6 +19,7 @@ use crate::{Align, CoreData, CowString, TkAction, WidgetCore, WidgetId};
 
 /// A pop-up multiple choice menu
 #[handler(event)]
+#[widget(config=noauto)]
 #[derive(Clone, Debug, Widget)]
 pub struct ComboBox<M: Clone + Debug + 'static> {
     #[widget_core]
@@ -167,7 +168,6 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
     }
 }
 
-#[widget_config]
 #[layout(single)]
 #[handler(action)]
 #[derive(Clone, Debug, Widget)]

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -63,9 +63,9 @@ impl kas::Overlay for MessageBox {
     fn resize(
         &mut self,
         size_handle: &mut dyn SizeHandle,
-        size: Size,
+        rect: Rect,
     ) -> (Option<Size>, Option<Size>) {
-        let (min, ideal) = layout::solve_and_set(self, size_handle, size);
+        let (min, ideal) = layout::solve_and_set(self, size_handle, rect, true);
         (Some(min), Some(ideal))
     }
 }
@@ -76,7 +76,7 @@ impl kas::Window for MessageBox {
     }
 
     // do not support overlays (yet?)
-    fn add_overlay(&mut self, _: &mut dyn SizeHandle, _: &mut Manager, _: Box<dyn kas::Overlay>) {}
+    fn add_popup(&mut self, _: &mut dyn SizeHandle, _: &mut Manager, _: kas::Popup) {}
 
     // doesn't support callbacks, so doesn't need to do anything here
     fn callbacks(&self) -> Vec<(usize, Callback)> {

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -12,6 +12,7 @@ use kas::draw::SizeHandle;
 use kas::event::{Manager, Response, VoidMsg};
 use kas::prelude::*;
 use kas::widget::{Label, TextButton};
+use kas::WindowId;
 
 #[derive(Clone, Debug, VoidMsg)]
 enum DialogButton {
@@ -63,5 +64,5 @@ impl kas::Window for MessageBox {
     }
 
     // do not support overlays (yet?)
-    fn add_popup(&mut self, _: &mut dyn SizeHandle, _: &mut Manager, _: kas::Popup) {}
+    fn add_popup(&mut self, _: &mut dyn SizeHandle, _: &mut Manager, _: WindowId, _: kas::Popup) {}
 }

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -10,7 +10,6 @@
 
 use kas::draw::SizeHandle;
 use kas::event::{Callback, Manager, Response, VoidMsg};
-use kas::layout;
 use kas::prelude::*;
 use kas::widget::{Label, TextButton};
 
@@ -54,25 +53,13 @@ impl MessageBox {
     }
 }
 
-impl kas::Overlay for MessageBox {
-    fn find_size(&mut self, size_handle: &mut dyn SizeHandle) -> (Option<Size>, Size) {
-        let (min, ideal) = layout::solve(self, size_handle);
-        (Some(min), ideal)
-    }
-
-    fn resize(
-        &mut self,
-        size_handle: &mut dyn SizeHandle,
-        rect: Rect,
-    ) -> (Option<Size>, Option<Size>) {
-        let (min, ideal) = layout::solve_and_set(self, size_handle, rect, true);
-        (Some(min), Some(ideal))
-    }
-}
-
 impl kas::Window for MessageBox {
     fn title(&self) -> &str {
         &self.title
+    }
+
+    fn restrict_dimensions(&self) -> (bool, bool) {
+        (true, true)
     }
 
     // do not support overlays (yet?)

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -55,7 +55,7 @@ impl MessageBox {
     }
 }
 
-impl Window for MessageBox {
+impl kas::Window for MessageBox {
     fn title(&self) -> &str {
         &self.title
     }

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -64,5 +64,9 @@ impl kas::Window for MessageBox {
     }
 
     // do not support overlays (yet?)
-    fn add_popup(&mut self, _: &mut dyn SizeHandle, _: &mut Manager, _: WindowId, _: kas::Popup) {}
+    fn add_popup(&mut self, _: &mut dyn SizeHandle, _: &mut Manager, _: WindowId, _: kas::Popup) {
+        panic!("MessageBox does not (currently) support pop-ups");
+    }
+
+    fn remove_popup(&mut self, _: &mut Manager, _: WindowId) {}
 }

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -20,7 +20,6 @@ enum DialogButton {
 }
 
 /// A simple message box.
-#[widget_config]
 #[layout(vertical)]
 #[handler]
 #[derive(Clone, Debug, Widget)]

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -9,7 +9,7 @@
 //! customisation.
 
 use kas::draw::SizeHandle;
-use kas::event::{Callback, Manager, Response, VoidMsg};
+use kas::event::{Manager, Response, VoidMsg};
 use kas::prelude::*;
 use kas::widget::{Label, TextButton};
 
@@ -64,10 +64,4 @@ impl kas::Window for MessageBox {
 
     // do not support overlays (yet?)
     fn add_popup(&mut self, _: &mut dyn SizeHandle, _: &mut Manager, _: kas::Popup) {}
-
-    // doesn't support callbacks, so doesn't need to do anything here
-    fn callbacks(&self) -> Vec<(usize, Callback)> {
-        Vec::new()
-    }
-    fn trigger_callback(&mut self, _index: usize, _: &mut Manager) {}
 }

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -54,11 +54,7 @@ impl MessageBox {
     }
 }
 
-impl kas::Window for MessageBox {
-    fn title(&self) -> &str {
-        &self.title
-    }
-
+impl kas::Overlay for MessageBox {
     fn find_size(&mut self, size_handle: &mut dyn SizeHandle) -> (Option<Size>, Size) {
         let (min, ideal) = layout::solve(self, size_handle);
         (Some(min), ideal)
@@ -72,6 +68,15 @@ impl kas::Window for MessageBox {
         let (min, ideal) = layout::solve_and_set(self, size_handle, size);
         (Some(min), Some(ideal))
     }
+}
+
+impl kas::Window for MessageBox {
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    // do not support overlays (yet?)
+    fn add_overlay(&mut self, _: &mut dyn SizeHandle, _: &mut Manager, _: Box<dyn kas::Overlay>) {}
 
     // doesn't support callbacks, so doesn't need to do anything here
     fn callbacks(&self) -> Vec<(usize, Callback)> {

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -77,7 +77,7 @@ impl DragHandle {
     /// Returns the new offset (after clamping input), and a boolean which
     /// is true if the offset is different from the previous offset.
     pub fn set_offset(&mut self, offset: Coord) -> (Coord, bool) {
-        let offset = offset.clamped(Coord::ZERO, self.max_offset());
+        let offset = offset.clamp(Coord::ZERO, self.max_offset());
         let handle_pos = self.track.pos + offset;
         if handle_pos != self.core.rect.pos {
             self.core.rect.pos = handle_pos;

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -27,7 +27,6 @@ use kas::prelude::*;
 /// 3.  [`Layout::draw`] does nothing. The parent should handle all drawing.
 /// 4.  Optionally, this widget can handle clicks on the track area via
 ///     [`DragHandle::handle_press_on_track`].
-#[widget_config]
 #[handler(action, msg = Coord)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct DragHandle {

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -119,7 +119,7 @@ impl<F: Fn(&str) -> Option<M>, M> EditGuard for EditEdit<F, M> {
 }
 
 /// An editable, single-line text box.
-#[widget_config(key_nav = true, cursor_icon = event::CursorIcon::Text)]
+#[widget(config(key_nav = true, cursor_icon = event::CursorIcon::Text))]
 #[handler(event, generics = <> where G: EditGuard)]
 #[derive(Clone, Default, Widget)]
 pub struct EditBox<G: 'static> {

--- a/src/widget/filler.rs
+++ b/src/widget/filler.rs
@@ -13,7 +13,6 @@ use kas::prelude::*;
 ///
 /// This widget has zero minimum size but can expand according to the given
 /// stretch policy.
-#[widget_config]
 #[handler]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct Filler {

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -43,19 +43,19 @@ impl<W: Widget> Frame<W> {
 
 impl<W: Widget> Layout for Frame<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let sides = size_handle.outer_frame();
+        let size = size_handle.frame();
         let margins = Margins::ZERO;
-        let frame_rules = SizeRules::extract_fixed(axis.dir(), sides.0 + sides.1, margins);
+        let frame_rules = SizeRules::extract_fixed(axis.dir(), size + size, margins);
 
         let child_rules = self.child.size_rules(size_handle, axis);
         let m = child_rules.margins();
 
         if axis.is_horizontal() {
-            self.m0.0 = (sides.0).0 + m.0 as u32;
-            self.m1.0 = (sides.1).0 + m.1 as u32;
+            self.m0.0 = size.0 + m.0 as u32;
+            self.m1.0 = size.0 + m.1 as u32;
         } else {
-            self.m0.1 = (sides.0).1 + m.0 as u32;
-            self.m1.1 = (sides.1).1 + m.1 as u32;
+            self.m0.1 = size.1 + m.0 as u32;
+            self.m1.1 = size.1 + m.1 as u32;
         }
 
         child_rules.surrounded_by(frame_rules, true)

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -17,7 +17,6 @@ use kas::prelude::*;
 ///
 /// This widget provides a simple abstraction: drawing a frame around its
 /// contents.
-#[widget_config]
 #[handler(action, msg = <W as Handler>::Msg)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct Frame<W: Widget> {

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -12,7 +12,6 @@ use kas::layout::{AxisInfo, SizeRules};
 use kas::prelude::*;
 
 /// A simple text label
-#[widget_config]
 #[handler]
 #[derive(Clone, Default, Debug, Widget)]
 pub struct Label {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -66,42 +66,18 @@ pub type BoxList<D, M> = List<D, Box<dyn Widget<Msg = M>>>;
 /// children.
 ///
 /// [`make_widget`]: ../macros/index.html#the-make_widget-macro
-#[derive(Clone, Default, Debug)]
+#[handler(action, msg=<W as event::Handler>::Msg)]
+#[widget(children=noauto)]
+#[derive(Clone, Default, Debug, Widget)]
 pub struct List<D: Directional, W: Widget> {
+    #[widget_core]
     core: CoreData,
     widgets: Vec<W>,
     data: layout::DynRowStorage,
     direction: D,
 }
 
-impl<D: Directional, W: Widget> WidgetConfig for List<D, W> {}
-
-// We implement this manually, because the derive implementation cannot handle
-// vectors of child widgets.
-impl<D: Directional, W: Widget> WidgetCore for List<D, W> {
-    #[inline]
-    fn core_data(&self) -> &CoreData {
-        &self.core
-    }
-    #[inline]
-    fn core_data_mut(&mut self) -> &mut CoreData {
-        &mut self.core
-    }
-
-    #[inline]
-    fn widget_name(&self) -> &'static str {
-        "List"
-    }
-
-    #[inline]
-    fn as_widget(&self) -> &dyn WidgetConfig {
-        self
-    }
-    #[inline]
-    fn as_widget_mut(&mut self) -> &mut dyn WidgetConfig {
-        self
-    }
-
+impl<D: Directional, W: Widget> WidgetChildren for List<D, W> {
     #[inline]
     fn len(&self) -> usize {
         self.widgets.len()
@@ -164,10 +140,6 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
     }
 }
 
-impl<D: Directional, W: Widget> event::Handler for List<D, W> {
-    type Msg = <W as event::Handler>::Msg;
-}
-
 impl<D: Directional, W: Widget> event::EventHandler for List<D, W> {
     fn event(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         for child in &mut self.widgets {
@@ -179,8 +151,6 @@ impl<D: Directional, W: Widget> event::EventHandler for List<D, W> {
         Response::Unhandled(event)
     }
 }
-
-impl<D: Directional, W: Widget> Widget for List<D, W> {}
 
 impl<D: Directional + Default, W: Widget> List<D, W> {
     /// Construct a new instance

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -5,6 +5,8 @@
 
 //! Dynamic widgets
 
+use std::ops::{Index, IndexMut};
+
 use kas::draw::{DrawHandle, SizeHandle};
 use kas::event::{Event, Manager, Response};
 use kas::layout::{AxisInfo, RulesSetter, RulesSolver, SizeRules};
@@ -351,5 +353,19 @@ impl<D: Directional, W: Widget> List<D, W> {
         if len != self.widgets.len() {
             mgr.send_action(TkAction::Reconfigure);
         }
+    }
+}
+
+impl<D: Directional, W: Widget> Index<usize> for List<D, W> {
+    type Output = W;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.widgets[index]
+    }
+}
+
+impl<D: Directional, W: Widget> IndexMut<usize> for List<D, W> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.widgets[index]
     }
 }

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -147,8 +147,9 @@ impl<D: Directional, W: Widget> event::EventHandler for List<D, W> {
                 return child.event(mgr, id, event);
             }
         }
-        debug_assert!(id == self.id(), "Handler::handle: bad WidgetId");
-        Response::Unhandled(event)
+
+        debug_assert!(id == self.id(), "EventHandler::event: bad WidgetId");
+        Manager::handle_generic(self, mgr, event)
     }
 }
 

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -127,9 +127,7 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
             return child.find_id(coord);
         }
 
-        // We should return Some(self), but hit a borrow check error.
-        // This should however be unreachable anyway.
-        None
+        Some(self.id())
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState) {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -114,19 +114,6 @@ impl<D: Directional, W: Widget> WidgetCore for List<D, W> {
     fn get_mut(&mut self, index: usize) -> Option<&mut dyn WidgetConfig> {
         self.widgets.get_mut(index).map(|w| w.as_widget_mut())
     }
-
-    fn walk(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {
-        for child in &self.widgets {
-            child.walk(f);
-        }
-        f(self)
-    }
-    fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn WidgetConfig)) {
-        for child in &mut self.widgets {
-            child.walk_mut(f);
-        }
-        f(self)
-    }
 }
 
 impl<D: Directional, W: Widget> Layout for List<D, W> {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -21,6 +21,7 @@ mod list;
 mod radiobox;
 mod scroll;
 mod scrollbar;
+mod separator;
 mod slider;
 mod window;
 
@@ -37,5 +38,6 @@ pub use list::{BoxColumn, BoxList, BoxRow, Column, List, Row};
 pub use radiobox::{RadioBox, RadioBoxBare};
 pub use scroll::ScrollRegion;
 pub use scrollbar::ScrollBar;
+pub use separator::Separator;
 pub use slider::Slider;
 pub use window::Window;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -10,6 +10,7 @@
 
 mod button;
 mod checkbox;
+mod combobox;
 mod dialog;
 mod drag;
 mod editbox;
@@ -25,6 +26,7 @@ mod window;
 
 pub use button::TextButton;
 pub use checkbox::{CheckBox, CheckBoxBare};
+pub use combobox::ComboBox;
 pub use dialog::MessageBox;
 pub use drag::DragHandle;
 pub use editbox::{EditBox, EditBoxVoid, EditGuard};

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -18,6 +18,7 @@ use kas::prelude::*;
 
 /// A bare radiobox (no label)
 #[handler(event)]
+#[widget(config=noauto)]
 #[derive(Clone, Widget)]
 pub struct RadioBoxBare<M> {
     #[widget_core]
@@ -185,7 +186,6 @@ impl<M> HasBool for RadioBoxBare<M> {
 
 /// A radiobox with optional label
 #[layout(horizontal, area=radiobox)]
-#[widget_config]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[derive(Clone, Widget)]
 pub struct RadioBox<M> {

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -22,7 +22,6 @@ use kas::prelude::*;
 /// Scroll regions translate their contents by an `offset`, which has a
 /// minimum value of [`Coord::ZERO`] and a maximum value of
 /// [`ScrollRegion::max_offset`].
-#[widget_config]
 #[handler(action, msg = <W as event::Handler>::Msg)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct ScrollRegion<W: Widget> {

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -117,7 +117,7 @@ impl<W: Widget> ScrollRegion<W> {
     /// Returns true if the offset is not identical to the old offset.
     #[inline]
     pub fn set_offset(&mut self, mgr: &mut Manager, offset: Coord) -> bool {
-        let offset = offset.max(Coord::ZERO).min(self.max_offset);
+        let offset = offset.clamp(Coord::ZERO, self.max_offset);
         if offset != self.offset {
             self.offset = offset;
             mgr.send_action(TkAction::RegionMoved);
@@ -173,7 +173,7 @@ impl<W: Widget> Layout for ScrollRegion<W> {
         self.child
             .set_rect(size_handle, child_rect, AlignHints::NONE);
         self.max_offset = Coord::from(child_size) - Coord::from(self.inner_size);
-        self.offset = self.offset.max(Coord::ZERO).min(self.max_offset);
+        self.offset = self.offset.clamp(Coord::ZERO, self.max_offset);
 
         if self.show_bars.0 {
             let pos = Coord(pos.0, pos.1 + self.inner_size.1 as i32);

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -17,7 +17,6 @@ use kas::prelude::*;
 ///
 /// Scroll bars allow user-input of a value between 0 and a defined maximum,
 /// and allow the size of the handle to be specified.
-#[widget_config]
 #[handler(action, msg = u32)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct ScrollBar<D: Directional> {

--- a/src/widget/separator.rs
+++ b/src/widget/separator.rs
@@ -1,0 +1,43 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! A separator
+
+use std::fmt::Debug;
+
+use kas::draw::{DrawHandle, SizeHandle};
+use kas::layout::{AxisInfo, SizeRules};
+use kas::prelude::*;
+
+/// A separator
+///
+/// This widget draws a bar when in a list. It may expand larger than expected
+/// if no other widget will fill spare space.
+#[handler]
+#[derive(Clone, Debug, Default, Widget)]
+pub struct Separator {
+    #[widget_core]
+    core: CoreData,
+}
+
+impl Separator {
+    /// Construct a frame
+    #[inline]
+    pub fn new() -> Self {
+        Separator {
+            core: Default::default(),
+        }
+    }
+}
+
+impl Layout for Separator {
+    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        SizeRules::extract_fixed(axis.dir(), size_handle.frame(), Default::default())
+    }
+
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState) {
+        draw_handle.separator(self.core.rect);
+    }
+}

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -41,7 +41,6 @@ impl<
 /// A slider
 ///
 /// Sliders allow user input of a value from a fixed range.
-#[widget_config]
 #[handler(action, msg = T)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct Slider<T: SliderType, D: Directional> {

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -13,7 +13,6 @@ use kas::layout::{AxisInfo, SizeRules};
 use kas::prelude::*;
 
 /// The main instantiation of the [`Window`] trait.
-#[widget_config]
 #[handler(generics = <> where W: Widget<Msg = VoidMsg>)]
 #[derive(Widget)]
 pub struct Window<W: Widget + 'static> {

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -242,6 +242,16 @@ impl<W: Widget<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
         self.popups.push((id, popup));
     }
 
+    fn remove_popup(&mut self, mgr: &mut Manager, id: WindowId) {
+        for i in 0..self.popups.len() {
+            if id == self.popups[i].0 {
+                self.popups.remove(i);
+                mgr.send_action(TkAction::Reconfigure);
+                return;
+            }
+        }
+    }
+
     fn handle_closure(&mut self, mgr: &mut Manager) {
         for (condition, f) in &self.fns {
             match condition {


### PR DESCRIPTION
This PR adds the `ComboBox` widget and drawing for `ScrollBar` and `Slider` tracks.

Unfortunately `winit` doesn't yet support precisely-positioned pop-up widgets (usually drawn via a special borderless window); eventually we should use these (where available); this remains a TODO item and even so may require a back-up option on some platforms.

Instead, this PR implements support for pop-ups as an overlay on an existing window. This works, but fonts are not currently clipped correctly. Font clipping is an existing issue so I chose not to fix it here, although it may be that the two clipping issues require separate solutions.

Event handling for the `ComboBox` is not quite what you may be used to since (a) currently pop-ups do not prevent interaction with other widgets, (b) pop-ups do not close when clicking on other widgets, (c) the combo-box does not support drag-selection. Probably this will be reviewed when implementing menu bars.

Additionally, this PR includes some graphical fixes, including finally drawing the tracks for scrollbars (and sliders, on the shaded theme). Draw APIs now use floating point types since sometimes objects drawn by themes do not align to pixels; in practice this appears to work fine (after a shader fix).