### PR TITLE
Reversed direction support

### DIFF
--- a/kas-macros/src/args.rs
+++ b/kas-macros/src/args.rs
@@ -180,8 +180,10 @@ mod kw {
     custom_keyword!(msg);
     custom_keyword!(generics);
     custom_keyword!(single);
-    custom_keyword!(horizontal);
-    custom_keyword!(vertical);
+    custom_keyword!(right);
+    custom_keyword!(left);
+    custom_keyword!(down);
+    custom_keyword!(up);
     custom_keyword!(grid);
     custom_keyword!(substitutions);
     custom_keyword!(halign);
@@ -514,8 +516,10 @@ impl Parse for WidgetArgs {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum LayoutType {
     Single,
-    Horizontal,
-    Vertical,
+    Right,
+    Left,
+    Down,
+    Up,
     Grid,
 }
 
@@ -545,19 +549,25 @@ impl Parse for LayoutArgs {
             LayoutType::Single
         } else if lookahead.peek(kw::row) {
             let _: kw::row = content.parse()?;
-            LayoutType::Horizontal
-        } else if lookahead.peek(kw::horizontal) {
-            let _: kw::horizontal = content.parse()?;
-            LayoutType::Horizontal
+            LayoutType::Right
+        } else if lookahead.peek(kw::right) {
+            let _: kw::right = content.parse()?;
+            LayoutType::Right
+        } else if lookahead.peek(kw::left) {
+            let _: kw::left = content.parse()?;
+            LayoutType::Left
         } else if lookahead.peek(kw::col) {
             let _: kw::col = content.parse()?;
-            LayoutType::Vertical
+            LayoutType::Down
         } else if lookahead.peek(kw::column) {
             let _: kw::column = content.parse()?;
-            LayoutType::Vertical
-        } else if lookahead.peek(kw::vertical) {
-            let _: kw::vertical = content.parse()?;
-            LayoutType::Vertical
+            LayoutType::Down
+        } else if lookahead.peek(kw::down) {
+            let _: kw::down = content.parse()?;
+            LayoutType::Down
+        } else if lookahead.peek(kw::up) {
+            let _: kw::up = content.parse()?;
+            LayoutType::Up
         } else if lookahead.peek(kw::grid) {
             let _: kw::grid = content.parse()?;
             LayoutType::Grid

--- a/kas-macros/src/args.rs
+++ b/kas-macros/src/args.rs
@@ -195,6 +195,7 @@ mod kw {
     custom_keyword!(config);
     custom_keyword!(noauto);
     custom_keyword!(children);
+    custom_keyword!(column);
 }
 
 #[derive(Debug)]
@@ -281,6 +282,10 @@ impl Parse for WidgetAttrArgs {
             let lookahead = content.lookahead1();
             if args.col.is_none() && lookahead.peek(kw::col) {
                 let _: kw::col = content.parse()?;
+                let _: Eq = content.parse()?;
+                args.col = Some(content.parse()?);
+            } else if args.col.is_none() && lookahead.peek(kw::column) {
+                let _: kw::column = content.parse()?;
                 let _: Eq = content.parse()?;
                 args.col = Some(content.parse()?);
             } else if args.row.is_none() && lookahead.peek(kw::row) {
@@ -538,9 +543,18 @@ impl Parse for LayoutArgs {
         let layout = if lookahead.peek(kw::single) {
             let _: kw::single = content.parse()?;
             LayoutType::Single
+        } else if lookahead.peek(kw::row) {
+            let _: kw::row = content.parse()?;
+            LayoutType::Horizontal
         } else if lookahead.peek(kw::horizontal) {
             let _: kw::horizontal = content.parse()?;
             LayoutType::Horizontal
+        } else if lookahead.peek(kw::col) {
+            let _: kw::col = content.parse()?;
+            LayoutType::Vertical
+        } else if lookahead.peek(kw::column) {
+            let _: kw::column = content.parse()?;
+            LayoutType::Vertical
         } else if lookahead.peek(kw::vertical) {
             let _: kw::vertical = content.parse()?;
             LayoutType::Vertical

--- a/kas-macros/src/layout.rs
+++ b/kas-macros/src/layout.rs
@@ -82,7 +82,7 @@ pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<To
                 Self::Data,
             >;
             type Setter = kas::layout::RowSetter::<
-                kas::Horizontal,
+                kas::Right,
                 #col_temp,
                 Self::Data,
             >;
@@ -96,7 +96,7 @@ pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<To
                 Self::Data,
             >;
             type Setter = kas::layout::RowSetter::<
-                kas::Vertical,
+                kas::Down,
                 #row_temp,
                 Self::Data,
             >;
@@ -230,8 +230,9 @@ pub(crate) fn derive(
 
     let dim = match layout.layout {
         LayoutType::Single => quote! { () },
-        LayoutType::Horizontal => quote! { (kas::Horizontal, #cols) },
-        LayoutType::Vertical => quote! { (kas::Vertical, #rows) },
+        // TODO: reversed directions
+        LayoutType::Horizontal => quote! { (kas::Right, #cols) },
+        LayoutType::Vertical => quote! { (kas::Down, #rows) },
         LayoutType::Grid => quote! { (#cols, #rows) },
     };
 

--- a/kas-macros/src/layout.rs
+++ b/kas-macros/src/layout.rs
@@ -32,11 +32,11 @@ pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<To
 
         match layout.layout {
             LayoutType::Single => (),
-            LayoutType::Horizontal => {
+            LayoutType::Right | LayoutType::Left => {
                 cols += 1;
                 rows = 1;
             }
-            LayoutType::Vertical => {
+            LayoutType::Down | LayoutType::Up => {
                 cols = 1;
                 rows += 1;
             }
@@ -73,7 +73,7 @@ pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<To
             type Solver = kas::layout::SingleSolver;
             type Setter = kas::layout::SingleSetter;
         },
-        LayoutType::Horizontal => quote! {
+        LayoutType::Right => quote! {
             type Data = kas::layout::FixedRowStorage::<
                 [kas::layout::SizeRules; #cols + 1]
             >;
@@ -87,7 +87,21 @@ pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<To
                 Self::Data,
             >;
         },
-        LayoutType::Vertical => quote! {
+        LayoutType::Left => quote! {
+            type Data = kas::layout::FixedRowStorage::<
+                [kas::layout::SizeRules; #cols + 1]
+            >;
+            type Solver = kas::layout::RowSolver::<
+                #col_temp,
+                Self::Data,
+            >;
+            type Setter = kas::layout::RowSetter::<
+                kas::Left,
+                #col_temp,
+                Self::Data,
+            >;
+        },
+        LayoutType::Down => quote! {
             type Data = kas::layout::FixedRowStorage::<
                 [kas::layout::SizeRules; #rows + 1],
             >;
@@ -97,6 +111,20 @@ pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<To
             >;
             type Setter = kas::layout::RowSetter::<
                 kas::Down,
+                #row_temp,
+                Self::Data,
+            >;
+        },
+        LayoutType::Up => quote! {
+            type Data = kas::layout::FixedRowStorage::<
+                [kas::layout::SizeRules; #rows + 1],
+            >;
+            type Solver = kas::layout::RowSolver::<
+                #row_temp,
+                Self::Data,
+            >;
+            type Setter = kas::layout::RowSetter::<
+                kas::Up,
                 #row_temp,
                 Self::Data,
             >;
@@ -160,14 +188,14 @@ pub(crate) fn derive(
 
         let child_info = match layout.layout {
             LayoutType::Single => quote! { () },
-            LayoutType::Horizontal => {
+            LayoutType::Right | LayoutType::Left => {
                 let col = cols;
                 cols += 1;
                 rows = 1;
 
                 quote! { #col }
             }
-            LayoutType::Vertical => {
+            LayoutType::Down | LayoutType::Up => {
                 let row = rows;
                 cols = 1;
                 rows += 1;
@@ -230,9 +258,10 @@ pub(crate) fn derive(
 
     let dim = match layout.layout {
         LayoutType::Single => quote! { () },
-        // TODO: reversed directions
-        LayoutType::Horizontal => quote! { (kas::Right, #cols) },
-        LayoutType::Vertical => quote! { (kas::Down, #rows) },
+        LayoutType::Right => quote! { (kas::Right, #cols) },
+        LayoutType::Left => quote! { (kas::Left, #cols) },
+        LayoutType::Down => quote! { (kas::Down, #rows) },
+        LayoutType::Up => quote! { (kas::Up, #rows) },
         LayoutType::Grid => quote! { (#cols, #rows) },
     };
 

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -13,7 +13,6 @@ use std::f32;
 use kas::draw::{self, DrawText, FontId, TextClass};
 use kas::geom::{Size, Vec2};
 use kas::layout::{AxisInfo, Margins, SizeRules, StretchPolicy};
-use kas::Direction::{Horizontal, Vertical};
 
 /// Parameterisation of [`Dimensions`]
 ///
@@ -151,9 +150,9 @@ impl<'a, Draw: DrawText> draw::SizeHandle for SizeHandle<'a, Draw> {
         let font_scale = self.dims.font_scale;
         let line_height = self.dims.line_height;
         let mut bounds = (f32::INFINITY, f32::INFINITY);
-        if let Some(size) = axis.size_other_if_fixed(Horizontal) {
+        if let Some(size) = axis.size_other_if_fixed(false) {
             bounds.1 = size as f32;
-        } else if let Some(size) = axis.size_other_if_fixed(Vertical) {
+        } else if let Some(size) = axis.size_other_if_fixed(true) {
             bounds.0 = size as f32;
         }
         let line_wrap = match class {

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -16,7 +16,7 @@ use kas::draw::{
 };
 use kas::event::HighlightState;
 use kas::geom::*;
-use kas::{Align, Direction, ThemeAction, ThemeApi};
+use kas::{Align, Direction, Directional, ThemeAction, ThemeApi};
 
 /// A theme with flat (unshaded) rendering
 #[derive(Clone, Debug)]
@@ -303,9 +303,9 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
     fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
         // track
         let mut outer = Quad::from(rect + self.offset);
-        outer = match dir {
-            Direction::Horizontal => outer.shrink_vec(Vec2(0.0, outer.size().1 * (3.0 / 8.0))),
-            Direction::Vertical => outer.shrink_vec(Vec2(outer.size().0 * (3.0 / 8.0), 0.0)),
+        outer = match dir.is_horizontal() {
+            true => outer.shrink_vec(Vec2(0.0, outer.size().1 * (3.0 / 8.0))),
+            false => outer.shrink_vec(Vec2(outer.size().0 * (3.0 / 8.0), 0.0)),
         };
         let inner = outer.shrink(outer.size().min_comp() / 2.0);
         let col = self.cols.frame;

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -14,7 +14,7 @@ use kas::draw::{
 };
 use kas::event::HighlightState;
 use kas::geom::*;
-use kas::{Align, Direction, ThemeAction, ThemeApi};
+use kas::{Align, Direction, Directional, ThemeAction, ThemeApi};
 
 /// A theme using simple shading to give apparent depth to elements
 #[derive(Clone, Debug)]
@@ -303,9 +303,9 @@ where
     fn slider(&mut self, rect: Rect, h_rect: Rect, dir: Direction, highlights: HighlightState) {
         // track
         let mut outer = Quad::from(rect + self.offset);
-        outer = match dir {
-            Direction::Horizontal => outer.shrink_vec(Vec2(0.0, outer.size().1 * (3.0 / 8.0))),
-            Direction::Vertical => outer.shrink_vec(Vec2(outer.size().0 * (3.0 / 8.0), 0.0)),
+        outer = match dir.is_horizontal() {
+            true => outer.shrink_vec(Vec2(0.0, outer.size().1 * (3.0 / 8.0))),
+            false => outer.shrink_vec(Vec2(outer.size().0 * (3.0 / 8.0), 0.0)),
         };
         let inner = outer.shrink(outer.size().min_comp() / 2.0);
         let norm = (0.0, -0.7);

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         }
     };
     let content = make_widget! {
-        #[layout(vertical)]
+        #[layout(column)]
         #[handler(msg = VoidMsg)]
         struct {
             #[widget] display: impl HasText = EditBox::new("0").editable(false).multi_line(true),

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -17,7 +17,7 @@ use kas::event::{self, Action, Event, Handler, Manager, ManagerState, Response};
 use kas::geom::*;
 use kas::layout::{AxisInfo, SizeRules, StretchPolicy};
 use kas::widget::Window;
-use kas::{Align, AlignHints, Direction, Layout, WidgetConfig, WidgetCore};
+use kas::{Align, AlignHints, Layout, WidgetConfig, WidgetCore};
 use kas_wgpu::draw::DrawWindow;
 
 #[handler(event)]
@@ -37,7 +37,7 @@ struct Clock {
 impl Layout for Clock {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
         // Always use value for horiz axis: we want a square shape
-        let axis = AxisInfo::new(Direction::Horizontal, None);
+        let axis = AxisInfo::new(false, None);
         let text_req = size_handle.text_bound("0000-00-00", TextClass::Label, axis);
         // extra makes default size larger without affecting min size
         let extra = SizeRules::new(0, 100, (0, 0), StretchPolicy::HighUtility);

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
     let buttons = make_widget! {
-        #[layout(horizontal)]
+        #[layout(row)]
         #[handler(msg = Message)]
         struct {
             #[widget] _ = TextButton::new("−", Message::Decr),
@@ -32,7 +32,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new(
         "Counter",
         make_widget! {
-            #[layout(vertical)]
+            #[layout(column)]
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget(halign=centre)] display: Label = Label::new("0"),

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -65,7 +65,7 @@ impl EditGuard for ListEntryGuard {
 // activating any RadioBox sends a message to all others using the same
 // UpdateHandle, which is quite slow with thousands of entries!
 // (This issue does not occur when RadioBoxes are independent.)
-#[layout(vertical)]
+#[layout(column)]
 #[handler(msg=EntryMsg)]
 #[derive(Clone, Debug, Widget)]
 struct ListEntry {
@@ -99,7 +99,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
     let controls = make_widget! {
-        #[layout(horizontal)]
+        #[layout(row)]
         #[handler(msg = usize)]
         struct {
             #[widget] _ = Label::new("Number of rows:"),
@@ -137,7 +137,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new(
         "Dynamic widget demo",
         make_widget! {
-            #[layout(vertical)]
+            #[layout(column)]
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget] _ = Label::new("Demonstration of dynamic widget creation / deletion"),

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -73,12 +73,12 @@ fn main() -> Result<(), kas_wgpu::Error> {
     };
 
     let top_box = Frame::new(make_widget! {
-        #[layout(vertical)]
+        #[layout(column)]
         #[handler(msg = VoidMsg)]
         struct {
             #[widget(halign=centre)] _ = Label::new("Widget Gallery"),
             #[widget(handler=set_theme)] _ = make_widget! {
-                #[layout(horizontal)]
+                #[layout(row)]
                 #[handler(msg = &'static str)]
                 struct {
                     #[widget] _ = TextButton::new("Flat", "flat"),
@@ -86,7 +86,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 }
             },
             #[widget(handler=set_colour)] _ = make_widget! {
-                #[layout(horizontal)]
+                #[layout(row)]
                 #[handler(msg = &'static str)]
                 struct {
                     #[widget] _ = TextButton::new("Default", "default"),
@@ -119,7 +119,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new(
         "Widget Gallery",
         make_widget! {
-            #[layout(vertical)]
+            #[layout(column)]
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget] _ = top_box,

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -9,7 +9,7 @@
 use kas::event::{Manager, Response, UpdateHandle, VoidMsg, VoidResponse};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::*;
-use kas::{Horizontal, WidgetId};
+use kas::{Right, WidgetId};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Item {
@@ -52,10 +52,10 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 [("One", 1), ("Two", 2), ("Three", 3)].iter().cloned().collect(),
             #[widget(row=7, col=0)] _ = Label::new("Slider"),
             #[widget(row=7, col=1, handler = handle_slider)] _ =
-                Slider::<i32, Horizontal>::new(-2, 2, 1).with_value(0),
+                Slider::<i32, Right>::new(-2, 2, 1).with_value(0),
             #[widget(row=8, col=0)] _ = Label::new("ScrollBar"),
             #[widget(row=8, col=1, handler = handle_scroll)] _ =
-                ScrollBar::<Horizontal>::new().with_limits(5, 2),
+                ScrollBar::<Right>::new().with_limits(5, 2),
             #[widget(row=9)] _ = Label::new("Child window"),
             #[widget(row=9, col = 1)] _ = TextButton::new("Open", Item::Popup),
         }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -520,7 +520,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         struct {
             #[widget(cspan=2)] label: Label = Label::new(mbrot.loc()),
             #[widget(row=1, halign=centre)] iters: Label = Label::new("64").reserve("000"),
-            #[widget(row=2, handler = iter)] _: Slider<i32, Vertical> = slider,
+            #[widget(row=2, handler = iter)] _: Slider<i32, kas::Up> = slider,
             #[widget(col=1, row=1, rspan=2, handler = mbrot)] mbrot: Mandlebrot = mbrot,
         }
         impl {

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -24,7 +24,7 @@ enum Control {
 // There's no reason for this, but it demonstrates usage of Toolkit::add_boxed
 fn make_window() -> Box<dyn kas::Window> {
     let stopwatch = make_widget! {
-        #[layout(horizontal)]
+        #[layout(row)]
         #[handler(event)]
         struct {
             #[widget] display: impl HasText = Frame::new(Label::new("0.000")),

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
     let buttons = make_widget! {
-        #[layout(horizontal)]
+        #[layout(row)]
         #[handler(msg = Message)]
         struct {
             #[widget] _ = TextButton::new("−", Message::Decr),
@@ -42,7 +42,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new(
         "Counter",
         make_widget! {
-            #[layout(vertical)]
+            #[layout(column)]
             #[handler(event)]
             #[widget(config=noauto)]
             struct {

--- a/src/data.rs
+++ b/src/data.rs
@@ -190,48 +190,55 @@ impl CompleteAlignment {
 /// Trait over directional types
 ///
 /// Using a generic `<D: Directional>` over [`Direction`] allows compile-time
-/// substitution via the [`Horizontal`] and [`Vertical`] instantiations.
+/// substitution via the [`Right`], [`Down`], [`Left`] and [`Up`] instantiations.
 pub trait Directional: Copy + Sized + std::fmt::Debug {
     fn as_direction(self) -> Direction;
 
     #[inline]
     fn is_vertical(self) -> bool {
-        self.as_direction() == Direction::Vertical
+        ((self.as_direction() as u32) & 1) == 1
     }
 
     #[inline]
     fn is_horizontal(self) -> bool {
-        self.as_direction() == Direction::Horizontal
+        ((self.as_direction() as u32) & 1) == 0
     }
-}
 
-/// Fixed instantiation of [`Directional`]
-#[derive(Copy, Clone, Default, Debug)]
-pub struct Horizontal;
-impl Directional for Horizontal {
+    /// Left or Up
     #[inline]
-    fn as_direction(self) -> Direction {
-        Direction::Horizontal
+    fn is_reversed(self) -> bool {
+        ((self.as_direction() as u32) & 2) == 2
     }
 }
 
-/// Fixed instantiation of [`Directional`]
-#[derive(Copy, Clone, Default, Debug)]
-pub struct Vertical;
-impl Directional for Vertical {
-    #[inline]
-    fn as_direction(self) -> Direction {
-        Direction::Vertical
-    }
+macro_rules! fixed {
+    ($d:ident) => {
+        /// Fixed instantiation of [`Directional`]
+        #[derive(Copy, Clone, Default, Debug)]
+        pub struct $d;
+        impl Directional for $d {
+            #[inline]
+            fn as_direction(self) -> Direction {
+                Direction::$d
+            }
+        }
+    };
+    ($d:ident, $($dd:ident),*) => {
+        fixed!($d);
+        fixed!($($dd),*);
+    };
 }
+fixed!(Right, Down, Left, Up);
 
-/// Horizontal / vertical direction
+/// Axis-aligned directions
 ///
 /// This is a variable instantiation of [`Directional`].
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum Direction {
-    Horizontal = 0,
-    Vertical = 1,
+    Right = 0,
+    Down = 1,
+    Left = 2,
+    Up = 3,
 }
 
 impl Directional for Direction {

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -281,6 +281,12 @@ impl Rect {
         Rect { pos, size }
     }
 
+    /// Get pos + size
+    #[inline]
+    pub fn pos_end(&self) -> Coord {
+        self.pos + self.size
+    }
+
     /// Check whether the given coordinate is contained within this rect
     #[inline]
     pub fn contains(&self, c: Coord) -> bool {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -15,7 +15,6 @@ mod sizer;
 mod storage;
 
 use crate::geom::Size;
-use crate::{Direction, Directional};
 
 pub use grid_solver::{GridChildInfo, GridSetter, GridSolver};
 pub use row_solver::{RowPositionSolver, RowSetter, RowSolver};
@@ -42,20 +41,11 @@ impl AxisInfo {
     ///
     /// This method is *usually* not required by user code.
     #[inline]
-    pub fn new(dir: Direction, fixed: Option<u32>) -> Self {
+    pub fn new(vertical: bool, fixed: Option<u32>) -> Self {
         AxisInfo {
-            vertical: dir.is_vertical(),
+            vertical,
             has_fixed: fixed.is_some(),
             other_axis: fixed.unwrap_or(0),
-        }
-    }
-
-    /// Get the axis's direction
-    #[inline]
-    pub fn dir(&self) -> Direction {
-        match self.vertical {
-            false => Direction::Horizontal,
-            true => Direction::Vertical,
         }
     }
 
@@ -81,10 +71,10 @@ impl AxisInfo {
         }
     }
 
-    /// Size of other axis, if fixed and `direction` matches this axis.
+    /// Size of other axis, if fixed and `vertical` matches this axis.
     #[inline]
-    pub fn size_other_if_fixed(&self, dir: Direction) -> Option<u32> {
-        if dir.is_vertical() == self.vertical && self.has_fixed {
+    pub fn size_other_if_fixed(&self, vertical: bool) -> Option<u32> {
+        if vertical == self.vertical && self.has_fixed {
             Some(self.other_axis)
         } else {
             None

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -8,7 +8,6 @@
 use std::iter::Sum;
 
 use crate::geom::Size;
-use crate::Direction;
 
 // TODO: new Margin model
 /// Margin sizes
@@ -164,20 +163,21 @@ impl SizeRules {
 
     /// Construct fixed-size rules from given data
     #[inline]
-    pub fn extract_fixed(dir: Direction, size: Size, margin: Margins) -> Self {
-        match dir {
-            Direction::Horizontal => SizeRules {
+    pub fn extract_fixed(vertical: bool, size: Size, margin: Margins) -> Self {
+        if !vertical {
+            SizeRules {
                 a: size.0,
                 b: size.0,
                 m: (margin.first.0, margin.last.0),
                 stretch: StretchPolicy::Fixed,
-            },
-            Direction::Vertical => SizeRules {
+            }
+        } else {
+            SizeRules {
                 a: size.1,
                 b: size.1,
                 m: (margin.first.1, margin.last.1),
                 stretch: StretchPolicy::Fixed,
-            },
+            }
         }
     }
 

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -11,7 +11,6 @@ use std::fmt;
 use super::{AxisInfo, SizeRules};
 use crate::draw::SizeHandle;
 use crate::geom::{Coord, Rect, Size};
-use crate::Direction::{Horizontal, Vertical};
 use crate::{AlignHints, WidgetConfig};
 
 /// A [`SizeRules`] solver for layouts
@@ -61,8 +60,8 @@ pub trait RulesSetter {
 pub fn solve(widget: &mut dyn WidgetConfig, size_handle: &mut dyn SizeHandle) -> (Size, Size) {
     // We call size_rules not because we want the result, but because our
     // spec requires that we do so before calling set_rect.
-    let w = widget.size_rules(size_handle, AxisInfo::new(Horizontal, None));
-    let h = widget.size_rules(size_handle, AxisInfo::new(Vertical, Some(w.ideal_size())));
+    let w = widget.size_rules(size_handle, AxisInfo::new(false, None));
+    let h = widget.size_rules(size_handle, AxisInfo::new(true, Some(w.ideal_size())));
 
     let min = Size(w.min_size(), h.min_size());
     let ideal = Size(w.ideal_size(), h.ideal_size());
@@ -81,14 +80,14 @@ pub fn solve_and_set(
 ) -> (Size, Size) {
     // We call size_rules not because we want the result, but because our
     // spec requires that we do so before calling set_rect.
-    let w = widget.size_rules(size_handle, AxisInfo::new(Horizontal, None));
+    let w = widget.size_rules(size_handle, AxisInfo::new(false, None));
     let wm = w.margins();
     let mut width = rect.size.0;
     if include_margins {
         width -= (wm.0 + wm.1) as u32;
     }
 
-    let h = widget.size_rules(size_handle, AxisInfo::new(Vertical, Some(width)));
+    let h = widget.size_rules(size_handle, AxisInfo::new(true, Some(width)));
     let hm = h.margins();
 
     if include_margins {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -113,7 +113,7 @@
 //! The following attribute parameters are expected:
 //!
 //! -   (first position): one of `single`, `grid`,
-//!     `horizontal`, `vertical`, `col`, `column`, `row`
+//!     `right`, `left`, `down`, `up`, `col`, `column`, `row`
 //! -   (optional): `area=FIELD` where `FIELD` is a child widget; if specified,
 //!     the area of self is considered to refer to child `FIELD`. This causes
 //!     the [`kas::Layout::find_id`] function to directly return the child's Id.
@@ -121,10 +121,12 @@
 //! Child widgets are arranged as specified by the first parameter:
 //!
 //! -   `single` — the widget wraps a single child, with no border or margin
-//! -   `col`, `column` or `vertical` — child widgets are arranged in a vertical
+//! -   `col`, `column` or `down` — child widgets are arranged in a vertical
 //!     column, top-to-bottom
-//! -   `row` or `horizontal` — child widgets are arranged in a horizontal row,
+//! -   `up` — reversed column
+//! -   `row` or `right` — child widgets are arranged in a horizontal row,
 //!     left-to-right
+//! -   `left` — reversed row
 //! -   `grid` — child widgets are arranged in a grid; position is specified
 //!     via parameters to the `#[widget]` attribute on child fields
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -112,7 +112,8 @@
 //!
 //! The following attribute parameters are expected:
 //!
-//! -   (first position): one of `single`, `horizontal`, `vertical`, `grid`
+//! -   (first position): one of `single`, `grid`,
+//!     `horizontal`, `vertical`, `col`, `column`, `row`
 //! -   (optional): `area=FIELD` where `FIELD` is a child widget; if specified,
 //!     the area of self is considered to refer to child `FIELD`. This causes
 //!     the [`kas::Layout::find_id`] function to directly return the child's Id.
@@ -120,10 +121,10 @@
 //! Child widgets are arranged as specified by the first parameter:
 //!
 //! -   `single` — the widget wraps a single child, with no border or margin
-//! -   `vertical` — child widgets are arranged in a vertical column, in order
-//!     of child fields
-//! -   `horizontal` — child widgets are arranged in a horizontal row, in order
-//!     of child fields
+//! -   `col`, `column` or `vertical` — child widgets are arranged in a vertical
+//!     column, top-to-bottom
+//! -   `row` or `horizontal` — child widgets are arranged in a horizontal row,
+//!     left-to-right
 //! -   `grid` — child widgets are arranged in a grid; position is specified
 //!     via parameters to the `#[widget]` attribute on child fields
 //!
@@ -203,7 +204,7 @@
 //!
 //! The first four affect positioning are only used by the `grid` layout:
 //!
-//! -   `col = ...` — grid column, from left (defaults to 0)
+//! -   `col = ...` or `column = ...` — grid column, from left (defaults to 0)
 //! -   `row = ...` — grid row, from top (defaults to 0)
 //! -   `cspan = ...` — number of columns to span (defaults to 1)
 //! -   `rspan = ...` — number of rows to span (defaults to 1)
@@ -242,7 +243,7 @@
 //! #[derive(Debug)]
 //! enum ChildMessage { A }
 //!
-//! #[layout(vertical)]
+//! #[layout(column)]
 //! #[handler(generics = <> where W: Widget<Msg = ChildMessage>)]
 //! #[derive(Debug, Widget)]
 //! struct MyWidget<W: Widget> {
@@ -285,7 +286,7 @@
 //!     Check(bool),
 //! }
 //! let widget = make_widget! {
-//!     #[layout(vertical)]
+//!     #[layout(column)]
 //!     #[handler(msg = VoidMsg)]
 //!     struct {
 //!         #[widget] _ = Label::new("Widget Gallery"),
@@ -342,7 +343,7 @@
 //! ```nocompile
 //! let widget = make_widget! {
 //!     #[widget]
-//!     #[layout(vertical)]
+//!     #[layout(column)]
 //!     #[handler(msg = VoidMsg)]
 //!     struct {
 //!         ...
@@ -383,7 +384,7 @@
 //! }
 //!
 //! let button_box = make_widget!{
-//!     #[layout(horizontal)]
+//!     #[layout(row)]
 //!     #[handler(msg = OkCancel)]
 //!     struct {
 //!         #[widget] _ = TextButton::new("Ok", OkCancel::Ok),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,7 +16,7 @@
 pub use kas::geom::{Coord, Rect, Size};
 pub use kas::macros::*;
 pub use kas::{class, draw, event, geom, layout, widget};
-pub use kas::{Align, AlignHints, Direction, Directional, Horizontal, Vertical, WidgetId};
+pub use kas::{Align, AlignHints, Direction, Directional, WidgetId};
 pub use kas::{CloneTo, Layout, ThemeApi, Widget, WidgetChildren, WidgetConfig, WidgetCore};
 pub use kas::{CoreData, LayoutData};
 pub use kas::{CowString, CowStringL};

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -43,7 +43,7 @@ impl<M: Clone + Debug> Layout for TextButton<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let sides = size_handle.button_surround();
         let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis.dir(), sides.0 + sides.1, margins);
+        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), sides.0 + sides.1, margins);
 
         let content_rules = size_handle.text_bound(&self.label, TextClass::Button, axis);
         content_rules.surrounded_by(frame_rules, true)

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -41,7 +41,7 @@ impl<M> Layout for CheckBoxBare<M> {
         let size = size_handle.checkbox();
         self.core.rect.size = size;
         let margins = size_handle.outer_margins();
-        SizeRules::extract_fixed(axis.dir(), size, margins)
+        SizeRules::extract_fixed(axis.is_vertical(), size, margins)
     }
 
     fn set_rect(&mut self, _size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -148,7 +148,7 @@ impl<M> event::Handler for CheckBoxBare<M> {
 
 /// A checkable box with optional label
 // TODO: use a generic wrapper for CheckBox and RadioBox?
-#[layout(horizontal, area=checkbox)]
+#[layout(row, area=checkbox)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[derive(Clone, Default, Widget)]
 pub struct CheckBox<M> {

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -160,7 +160,7 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
                 } else {
                     let id = mgr.add_popup(kas::Popup {
                         parent: self.id(),
-                        direction: Direction::Vertical,
+                        direction: Direction::Down,
                         overlay: Box::new(ComboPopup::new(self.column.clone(), self.handle)),
                     });
                     self.popup = Some(id);

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -45,7 +45,7 @@ impl<M: Clone + Debug + 'static> kas::Layout for ComboBox<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let sides = size_handle.button_surround();
         let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis.dir(), sides.0 + sides.1, margins);
+        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), sides.0 + sides.1, margins);
 
         // TODO: should we calculate a bound over all choices or assume some default?
         let content_rules = size_handle.text_bound(self.text(), TextClass::Button, axis);

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -20,7 +20,7 @@ enum DialogButton {
 }
 
 /// A simple message box.
-#[layout(vertical)]
+#[layout(column)]
 #[handler]
 #[derive(Clone, Debug, Widget)]
 pub struct MessageBox {

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -154,7 +154,7 @@ impl<G: 'static> Layout for EditBox<G> {
         let frame_size = frame_offset + frame_sides.1 + inner;
 
         let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis.dir(), frame_size, margins);
+        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), frame_size, margins);
 
         let class = if self.multi_line {
             TextClass::EditMulti

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -45,7 +45,7 @@ impl<W: Widget> Layout for Frame<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.frame();
         let margins = Margins::ZERO;
-        let frame_rules = SizeRules::extract_fixed(axis.dir(), size + size, margins);
+        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, margins);
 
         let child_rules = self.child.size_rules(size_handle, axis);
         let m = child_rules.margins();

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -15,26 +15,26 @@ use kas::prelude::*;
 /// A generic row widget
 ///
 /// See documentation of [`List`] type.
-pub type Row<W> = List<Horizontal, W>;
+pub type Row<W> = List<kas::Right, W>;
 
 /// A generic column widget
 ///
 /// See documentation of [`List`] type.
-pub type Column<W> = List<Vertical, W>;
+pub type Column<W> = List<kas::Down, W>;
 
 /// A row of boxed widgets
 ///
 /// This is parameterised over handler message type.
 ///
 /// See documentation of [`List`] type.
-pub type BoxRow<M> = BoxList<Horizontal, M>;
+pub type BoxRow<M> = BoxList<kas::Right, M>;
 
 /// A column of boxed widgets
 ///
 /// This is parameterised over handler message type.
 ///
 /// See documentation of [`List`] type.
-pub type BoxColumn<M> = BoxList<Vertical, M>;
+pub type BoxColumn<M> = BoxList<kas::Down, M>;
 
 /// A row/column of boxed widgets
 ///

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -90,7 +90,7 @@ impl<M> Layout for RadioBoxBare<M> {
         let size = size_handle.radiobox();
         self.core.rect.size = size;
         let margins = size_handle.outer_margins();
-        SizeRules::extract_fixed(axis.dir(), size, margins)
+        SizeRules::extract_fixed(axis.is_vertical(), size, margins)
     }
 
     fn set_rect(&mut self, _size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -185,7 +185,7 @@ impl<M> HasBool for RadioBoxBare<M> {
 }
 
 /// A radiobox with optional label
-#[layout(horizontal, area=radiobox)]
+#[layout(row, area=radiobox)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[derive(Clone, Widget)]
 pub struct RadioBox<M> {

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -35,9 +35,9 @@ pub struct ScrollRegion<W: Widget> {
     auto_bars: bool,
     show_bars: (bool, bool),
     #[widget]
-    horiz_bar: ScrollBar<Horizontal>,
+    horiz_bar: ScrollBar<kas::Right>,
     #[widget]
-    vert_bar: ScrollBar<Vertical>,
+    vert_bar: ScrollBar<kas::Down>,
     #[widget]
     child: W,
 }

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -145,25 +145,31 @@ impl<D: Directional> ScrollBar<D> {
         let len = self.len() - self.handle_len;
         let lhs = self.value as u64 * len as u64;
         let rhs = self.max_value as u64;
-        let pos = if rhs == 0 {
+        let mut pos = if rhs == 0 {
             0
         } else {
-            (((lhs + (rhs / 2)) / rhs) as u32).min(len) as i32
+            (((lhs + (rhs / 2)) / rhs) as u32).min(len)
         };
+        if self.direction.is_reversed() {
+            pos = len - pos;
+        }
         match self.direction.is_vertical() {
-            false => Coord(pos, 0),
-            true => Coord(0, pos),
+            false => Coord(pos as i32, 0),
+            true => Coord(0, pos as i32),
         }
     }
 
     // true if not equal to old value
     fn set_offset(&mut self, offset: Coord) -> bool {
-        let offset = match self.direction.is_vertical() {
+        let len = self.len() - self.handle_len;
+        let mut offset = match self.direction.is_vertical() {
             false => offset.0,
             true => offset.1,
-        };
+        } as u32;
+        if self.direction.is_reversed() {
+            offset = len - offset;
+        }
 
-        let len = self.len() - self.handle_len;
         let lhs = offset as u64 * self.max_value as u64;
         let rhs = len as u64;
         if rhs == 0 {

--- a/src/widget/separator.rs
+++ b/src/widget/separator.rs
@@ -34,7 +34,7 @@ impl Separator {
 
 impl Layout for Separator {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        SizeRules::extract_fixed(axis.dir(), size_handle.frame(), Default::default())
+        SizeRules::extract_fixed(axis.is_vertical(), size_handle.frame(), Default::default())
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState) {


### PR DESCRIPTION
This PR replaces `Horizontal` and `Vertical` with `Right`, `Left`, `Up`, `Down`:

- slider and scrollbar can be reversed
- dynamic and static rows and columns can be reversed (warning: keyboard navigation is not intuitive since only the positions of widgets are reversed)
- pop-ups may be positioned explicitly in any direction now, but still with automatic flip to the opposite direction where more space is required

The biggest breaking change is that `layout(vertical)` should be replaced with `layout(column)` or `layout(down)`, etc.