### PR TITLE
MenuBar, sub-menus, fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] — 2020-04-16
+Bump version of `kas-wgpu` to fix build on docs.rs.
+
 ## [0.3.0] — 2020-02-24
 This is a decent sized release, focussing primarily on drawing, themes and
 layouts. Highlights include a new `FlatTheme`, many small visual improvements,

--- a/kas-theme/src/col.rs
+++ b/kas-theme/src/col.rs
@@ -93,8 +93,8 @@ impl ThemeColours {
             nav_focus: Colour::new(1.0, 0.7, 0.5),
             button: Colour::new(1.0, 0.9, 0.3),
             button_disabled: Colour::grey(0.7),
-            button_highlighted: Colour::new(1.0, 0.93, 0.55),
-            button_depressed: Colour::new(0.9, 0.83, 0.45),
+            button_highlighted: Colour::new(1.0, 0.95, 0.6),
+            button_depressed: Colour::new(0.8, 0.72, 0.24),
             checkbox: Colour::grey(0.4),
         }
     }

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-wgpu"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -38,4 +38,7 @@ chrono = "0.4"
 env_logger = "0.7"
 
 [package.metadata.docs.rs]
+# NOTE: clipboard feature is causing build failures
+# https://github.com/kas-gui/kas/issues/83
+no-default-features = true
 features = ["stack_dst"]

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -10,7 +10,7 @@ use kas::class::HasText;
 use kas::event::{Manager, Response, UpdateHandle, VoidMsg, VoidResponse};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::*;
-use kas::{Right, Widget, WidgetId};
+use kas::{Right, TkAction, Widget, WidgetId};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Item {
@@ -47,30 +47,34 @@ fn main() -> Result<(), kas_wgpu::Error> {
         Theme(&'static str),
         Colour(&'static str),
         Disabled(bool),
+        Quit,
     }
 
     let menubar = MenuBar::<Right, _>::new(vec![
+        SubMenu::new("App", vec![TextButton::new("Quit", Menu::Quit).boxed()]),
         SubMenu::new(
             "Theme",
             vec![
-                Box::new(TextButton::new("Shaded", Menu::Theme("shaded")))
-                    as Box<dyn Widget<Msg = Menu>>,
-                Box::new(TextButton::new("Flat", Menu::Theme("flat"))),
-            ],
-        ),
-        SubMenu::new(
-            "Colours",
-            vec![
-                Box::new(TextButton::new("Default", Menu::Colour("default"))),
-                Box::new(TextButton::new("Light", Menu::Colour("light"))),
-                Box::new(TextButton::new("Dark", Menu::Colour("dark"))),
+                TextButton::new("Shaded", Menu::Theme("shaded")).boxed(),
+                TextButton::new("Flat", Menu::Theme("flat")).boxed(),
             ],
         ),
         SubMenu::new(
             "Style",
-            vec![Box::new(
-                CheckBox::new("Disabled").on_toggle(|state| Menu::Disabled(state)),
-            )],
+            vec![
+                SubMenu::right(
+                    "Colours",
+                    vec![
+                        TextButton::new("Default", Menu::Colour("default")),
+                        TextButton::new("Light", Menu::Colour("light")),
+                        TextButton::new("Dark", Menu::Colour("dark")),
+                    ],
+                )
+                .boxed(),
+                CheckBox::new("Disabled")
+                    .on_toggle(|state| Menu::Disabled(state))
+                    .boxed(),
+            ],
         ),
     ]);
 
@@ -147,6 +151,9 @@ fn main() -> Result<(), kas_wgpu::Error> {
                         }
                         Menu::Disabled(state) => {
                             *mgr += self.gallery.inner_mut().set_disabled(state);
+                        }
+                        Menu::Quit => {
+                            *mgr += TkAction::CloseAll;
                         }
                     }
                     Response::None

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         Disabled(bool),
     }
 
-    let menubar = Row::new(vec![
+    let menubar = MenuBar::<Right, _>::new(vec![
         MenuButton::new(
             "Theme",
             Box::new(Column::new(vec![

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -50,28 +50,29 @@ fn main() -> Result<(), kas_wgpu::Error> {
     }
 
     let menubar = MenuBar::<Right, _>::new(vec![
-        MenuButton::new(
+        SubMenu::new(
             "Theme",
-            Box::new(Column::new(vec![
-                TextButton::new("Shaded", Menu::Theme("shaded")),
-                TextButton::new("Flat", Menu::Theme("flat")),
-            ])) as Box<dyn Widget<Msg = Menu>>,
+            vec![
+                Box::new(TextButton::new("Shaded", Menu::Theme("shaded")))
+                    as Box<dyn Widget<Msg = Menu>>,
+                Box::new(TextButton::new("Flat", Menu::Theme("flat"))),
+            ],
         ),
-        MenuButton::new(
+        SubMenu::new(
             "Colours",
-            Box::new(Column::new(vec![
-                TextButton::new("Default", Menu::Colour("default")),
-                TextButton::new("Light", Menu::Colour("light")),
-                TextButton::new("Dark", Menu::Colour("dark")),
-            ])),
+            vec![
+                Box::new(TextButton::new("Default", Menu::Colour("default"))),
+                Box::new(TextButton::new("Light", Menu::Colour("light"))),
+                Box::new(TextButton::new("Dark", Menu::Colour("dark"))),
+            ],
         ),
-        MenuButton::new(
+        SubMenu::new(
             "Style",
-            Box::new(CheckBox::new("Disabled").on_toggle(|state| Menu::Disabled(state))),
+            vec![Box::new(
+                CheckBox::new("Disabled").on_toggle(|state| Menu::Disabled(state)),
+            )],
         ),
     ]);
-
-    let frame = Frame::new(Label::new("Widget Gallery"));
 
     let radio = UpdateHandle::new();
     let widgets = make_widget! {
@@ -125,7 +126,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget(handler = menu)] _ = menubar,
-                #[widget] _ = frame,
+                #[widget(halign = centre)] _ = Frame::new(Label::new("Widget Gallery")),
                 #[widget(handler = activations)] gallery:
                     for<W: Widget<Msg = Item>> ScrollRegion<W> =
                     ScrollRegion::new(widgets).with_auto_bars(true),

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -470,7 +470,7 @@ impl event::Handler for Mandlebrot {
                 mgr.redraw(self.id());
                 Response::Msg(())
             }
-            Event::PressStart { source, coord } => {
+            Event::PressStart { source, coord, .. } => {
                 mgr.request_grab(
                     self.id(),
                     source,

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -188,14 +188,14 @@ where
             TkAction::None => (),
             TkAction::Redraw => self.window.request_redraw(),
             TkAction::RegionMoved => {
-                self.mgr.region_moved(&mut *self.widget);
+                self.mgr.region_moved(&mut tkw, &mut *self.widget);
                 self.window.request_redraw();
             }
             TkAction::Popup => {
                 let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw) };
                 self.widget.resize_popups(&mut size_handle);
 
-                self.mgr.region_moved(&mut *self.widget);
+                self.mgr.region_moved(&mut tkw, &mut *self.widget);
                 self.window.request_redraw();
             }
             TkAction::Reconfigure => self.reconfigure(shared),

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -13,26 +13,43 @@ use kas::layout::{AxisInfo, Margins, SizeRules};
 use kas::{Align, Direction};
 
 /// Input and highlighting state of a widget
+///
+/// Multiple instances can be combined via [`std::ops::BitOr`]: `lhs | rhs`.
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub struct InputState {
     /// Is the widget disabled?
     pub disabled: bool,
     /// Is the input state erroneous?
     pub error: bool,
-    /// "Hover" is true if the mouse is over this element or if an active touch
-    /// event is over the element.
+    /// "Hover" is true if the mouse is over this element
     pub hover: bool,
-    /// Elements such as buttons may be depressed (visually pushed) by a click
-    /// or touch event, but in this state the action can still be cancelled.
-    /// Elements can also be depressed by keyboard activation.
+    /// Elements may be depressed during interaction
     ///
-    /// If true, this likely implies `hover` is also true.
+    /// Elements such as buttons, handles and menu entries may be depressed
+    /// (visually pushed) by a click or touch event or an accelerator key.
+    /// This is often visualised by a darker colour and/or by offsetting
+    /// graphics. The `hover` state should be ignored when depressed.
     pub depress: bool,
     /// Keyboard navigation of UIs moves a "focus" from widget to widget.
     pub nav_focus: bool,
     /// "Character focus" implies this widget is ready to receive text input
     /// (e.g. typing into an input field).
     pub char_focus: bool,
+}
+
+impl std::ops::BitOr for InputState {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        InputState {
+            disabled: self.disabled || rhs.disabled,
+            error: self.error || rhs.error,
+            hover: self.hover || rhs.hover,
+            depress: self.depress || rhs.depress,
+            nav_focus: self.nav_focus || rhs.nav_focus,
+            char_focus: self.char_focus || rhs.char_focus,
+        }
+    }
 }
 
 /// Class of text drawn

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -127,6 +127,11 @@ pub enum Event {
     /// This is a specific command from a parent, e.g. [`kas::widget::MenuBar`].
     /// Most widgets can ignore this, even if they have a pop-up.
     OpenPopup,
+    /// Close popup / menu
+    ///
+    /// This is a specific command from a parent, e.g. [`kas::widget::MenuBar`].
+    /// Most widgets can ignore this, even if they have a pop-up.
+    ClosePopup,
 }
 
 /// Navigation key ([`Event::NavKey`])

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -88,6 +88,7 @@ pub enum Event {
     /// Received only given a [press grab](super::Manager::request_grab).
     PressMove {
         source: PressSource,
+        cur_id: Option<WidgetId>,
         coord: Coord,
         delta: Coord,
     },

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -82,7 +82,11 @@ pub enum Event {
         delta: DVec2,
     },
     /// A mouse button was pressed or touch event started
-    PressStart { source: PressSource, coord: Coord },
+    PressStart {
+        source: PressSource,
+        start_id: WidgetId,
+        coord: Coord,
+    },
     /// Movement of mouse or a touch press
     ///
     /// Received only given a [press grab](super::Manager::request_grab).

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -89,7 +89,7 @@ pub enum Event {
     },
     /// Movement of mouse or a touch press
     ///
-    /// Received only given a [press grab](super::Manager::request_grab).
+    /// Received only given a [press grab](Manager::request_grab).
     PressMove {
         source: PressSource,
         cur_id: Option<WidgetId>,
@@ -98,7 +98,7 @@ pub enum Event {
     },
     /// End of a click/touch press
     ///
-    /// Received only given a [press grab](super::Manager::request_grab).
+    /// Received only given a [press grab](Manager::request_grab).
     ///
     /// When `end_id == None`, this is a "cancelled press": the end of the press
     /// is outside the application window.
@@ -120,6 +120,11 @@ pub enum Event {
     /// A user-defined payload is passed. Interpretation of this payload is
     /// user-defined and unfortunately not type safe.
     HandleUpdate { handle: UpdateHandle, payload: u64 },
+    /// Open popup / menu
+    ///
+    /// This is a specific command from a parent, e.g. [`kas::widget::MenuBar`].
+    /// Most widgets can ignore this, even if they have a pop-up.
+    OpenPopup,
 }
 
 /// Navigation key ([`Event::NavKey`])

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -15,6 +15,8 @@ use crate::WidgetId;
 /// Events addressed to a widget
 #[derive(Clone, Debug)]
 pub enum Event {
+    /// No event
+    None,
     /// Widget activation, for example clicking a button or toggling a check-box
     Activate,
     /// Navigation key input

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -116,8 +116,10 @@ impl<'a> Manager<'a> {
                     mgr.request_grab(widget.id(), source, coord, GrabMode::Grab, None);
                     return Response::None;
                 }
-                Event::PressMove { .. } => {
-                    // We don't need these events, but they should not be considered *unhandled*
+                Event::PressMove { source, cur_id, .. } => {
+                    let cond = cur_id == Some(widget.id());
+                    let target = if cond { cur_id } else { None };
+                    mgr.set_grab_depress(source, target);
                     return Response::None;
                 }
                 Event::PressEnd { end_id, .. } if end_id == Some(widget.id()) => {

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -112,7 +112,7 @@ impl<'a> Manager<'a> {
         if widget.activation_via_press() {
             // Translate press events
             match event {
-                Event::PressStart { source, coord } if source.is_primary() => {
+                Event::PressStart { source, coord, .. } if source.is_primary() => {
                     mgr.request_grab(widget.id(), source, coord, GrabMode::Grab, None);
                     return Response::None;
                 }

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -1253,15 +1253,16 @@ impl<'a> Manager<'a> {
                     match grab.mode {
                         GrabMode::Grab => {
                             // Mouse grab active: send events there
+                            let start_id = grab.start_id;
                             let event = match state {
-                                ElementState::Pressed => Event::PressStart { source, coord },
+                                ElementState::Pressed => Event::PressStart { source, start_id, coord },
                                 ElementState::Released => Event::PressEnd {
                                     source,
                                     end_id: self.mgr.hover,
                                     coord,
                                 },
                             };
-                            self.send_event(widget, grab.start_id, event);
+                            self.send_event(widget, start_id, event);
                         }
                         // Pan events do not receive Start/End notifications
                         _ => (),
@@ -1270,11 +1271,11 @@ impl<'a> Manager<'a> {
                     if state == ElementState::Released {
                         self.end_mouse_grab(button);
                     }
-                } else if let Some(id) = self.mgr.hover {
+                } else if let Some(start_id) = self.mgr.hover {
                     // No mouse grab but have a hover target
                     if state == ElementState::Pressed {
-                        let event = Event::PressStart { source, coord };
-                        self.send_event(widget, id, event);
+                        let event = Event::PressStart { source, start_id, coord };
+                        self.send_event(widget, start_id, event);
                     }
                 }
             }
@@ -1286,9 +1287,9 @@ impl<'a> Manager<'a> {
                 let coord = touch.location.into();
                 match touch.phase {
                     TouchPhase::Started => {
-                        if let Some(id) = widget.find_id(coord) {
-                            let event = Event::PressStart { source, coord };
-                            self.send_event(widget, id, event);
+                        if let Some(start_id) = widget.find_id(coord) {
+                            let event = Event::PressStart { source, start_id, coord };
+                            self.send_event(widget, start_id, event);
                         }
                     }
                     TouchPhase::Moved => {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -16,11 +16,22 @@
 //!
 //! ## Event delivery
 //!
-//! Events are processed from root to leaf, targetted either at a coordinate or
-//! at a [`WidgetId`]. Events targetted at coordinates are translated to a
-//! [`WidgetId`] by [`Manager::handle_generic`]; events targetted at a
-//! [`WidgetId`] are handled by widget-specific code or returned via
-//! [`Response::Unhandled`], in which case any caller may handle the event.
+//! Events can be addressed only to a [`WidgetId`], so the first step (for
+//! mouse and touch events) is to use [`kas::Layout::find_id`] to translate a
+//! coordinate to a [`WidgetId`].
+//!
+//! Events then process from root to leaf. [`SendEvent::send`] is responsible
+//! for forwarding an event to the appropriate child. Once the target widget is
+//! reached, `send` (usually) calls [`Manager::handle_generic`] which may apply
+//! some transformations to events, then calls [`Handler::handle`] on target
+//! widget. Finally, a [`Response`] is emitted.
+//!
+//! [`Response`] has three variants: `None`, `Msg(msg)` and `Unhandled(event)`,
+//! where `msg` is a message defined by type [`Handler::Msg`] and `event` is an
+//! [`Event`]. Both `Msg` and `Unhandled` may be trapped by a parent widget's
+//! [`SendEvent::send`], with `Msg` used to trigger a custom action and
+//! `Unhandled` used to interpret a few otherwise-unused events (for example,
+//! scroll by touch drag).
 //!
 //! ## Mouse and touch events
 //!

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -7,12 +7,12 @@
 
 use super::{Event, VoidResponse};
 
-/// Response type from [`Handler::action`].
+/// Response type from [`Handler::handle`].
 ///
 /// This type wraps [`Handler::Msg`] allowing both custom messages and toolkit
 /// messages.
 ///
-/// [`Handler::action`]: super::Handler::action
+/// [`Handler::handle`]: super::Handler::handle
 /// [`Handler::Msg`]: super::Handler::Msg
 #[derive(Clone, Debug)]
 #[must_use]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -359,7 +359,15 @@ pub trait Layout: WidgetChildren {
 /// `fn foo<M>(w: &mut dyn Widget<Msg = M>)`, or, e.g.
 /// `fn foo(w: &mut dyn WidgetConfig)` (note that `WidgetConfig` is the last unparameterised
 /// trait in the widget trait family).
-pub trait Widget: event::SendEvent {}
+pub trait Widget: event::SendEvent {
+    /// Return a boxed version of the widget
+    fn boxed(self) -> Box<dyn Widget<Msg = Self::Msg>>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
+}
 
 /// Trait to describe the type needed by the layout implementation.
 ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -131,6 +131,14 @@ pub trait WidgetChildren: WidgetCore {
     /// This method may be removed in the future.
     fn get_mut(&mut self, index: usize) -> Option<&mut dyn WidgetConfig>;
 
+    /// Check whether `id` is a descendant
+    ///
+    /// This function assumes that `id` is a valid widget.
+    #[inline]
+    fn is_ancestor_of(&self, id: WidgetId) -> bool {
+        self.find(id).is_some()
+    }
+
     /// Find a child widget by identifier
     ///
     /// This requires that the widget tree has already been configured by

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -307,21 +307,29 @@ pub trait Layout: WidgetChildren {
         (0, WidgetChildren::len(self).wrapping_sub(1))
     }
 
-    /// Find a child widget by coordinate
+    /// Find a widget by coordinate
     ///
-    /// This is used by the event manager to target the correct widget given an
-    /// event from a coordinate source (mouse pointer, touch event).
-    /// Widgets may return their own Id over that of children in order to steal
-    /// events (e.g. a button using an inner label widget).
+    /// Returns the identifier of the widget containing this `coord`, if any.
+    /// Should only return `None` when `coord` is outside the widget's rect,
+    /// but this is not guaranteed.
+    ///
+    /// Implementations should:
+    ///
+    /// 1.  return `None` if `!self.rect().contains(coord)`
+    /// 2.  if, for any child (containing `coord`), `child.find_id(coord)`
+    ///     returns `Some(id)`, return that
+    /// 3.  otherwise, return `Some(self.id())`
+    ///
+    /// Exceptionally, a widget may deviate from this behaviour, but only when
+    /// the coord is within the widget's rect (example: `CheckBox` contains an
+    /// embedded `CheckBoxBare` and always forwards this child's id).
     ///
     /// This must not be called before [`Layout::set_rect`].
-    ///
-    /// In the case of an empty grid cell, the parent widget is returned
-    /// (same behaviour as with events addressed by coordinate).
-    /// The only case `None` should be expected is when `coord` is outside the
-    /// initial widget's region; however this is not guaranteed.
     #[inline]
-    fn find_id(&self, _coord: Coord) -> Option<WidgetId> {
+    fn find_id(&self, coord: Coord) -> Option<WidgetId> {
+        if !self.rect().contains(coord) {
+            return None;
+        }
         Some(self.id())
     }
 

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -59,7 +59,11 @@ impl<M: Clone + Debug + 'static> kas::Layout for ComboBox<M> {
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
-        draw_handle.button(self.core.rect, self.input_state(mgr, disabled));
+        let mut state = self.input_state(mgr, disabled);
+        if self.popup_id.is_some() {
+            state.depress = true;
+        }
+        draw_handle.button(self.core.rect, state);
         let align = (Align::Centre, Align::Centre);
         let text = &self.popup.column[self.active].get_text();
         draw_handle.text(self.core.rect, text, TextClass::Button, align);

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -193,10 +193,18 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
                 self.opening = self.popup_id.is_none();
                 Response::None
             }
-            Event::PressMove { .. } => {
+            Event::PressMove {
+                source,
+                cur_id,
+                coord,
+                ..
+            } => {
                 if self.popup_id.is_none() {
                     open_popup(self, mgr);
                 }
+                let cond = cur_id == Some(self.id()) || self.popup.rect().contains(coord);
+                let target = if cond { cur_id } else { None };
+                mgr.set_grab_depress(source, target);
                 Response::None
             }
             Event::PressEnd { end_id, coord, .. } => {

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -192,7 +192,7 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
                 }
                 Response::None
             }
-            Event::PressStart { source, coord } if source.is_primary() => {
+            Event::PressStart { source, coord, .. } if source.is_primary() => {
                 mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None);
                 self.opening = self.popup_id.is_none();
                 Response::None

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -179,7 +179,7 @@ impl event::Handler for DragHandle {
                 self.press_source = None;
                 Response::None
             }
-            e @ _ => Manager::handle_generic(self, mgr, e),
+            event => Response::Unhandled(event),
         }
     }
 }

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -68,11 +68,10 @@ impl<W: Widget> Layout for Frame<W> {
 
     #[inline]
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {
-        if let Some(id) = self.child.find_id(coord) {
-            Some(id)
-        } else {
-            Some(self.id())
+        if !self.rect().contains(coord) {
+            return None;
         }
+        self.child.find_id(coord).or(Some(self.id()))
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -345,6 +345,14 @@ impl<D: Directional, W: Widget> List<D, W> {
             false => TkAction::Reconfigure,
         }
     }
+
+    /// Iterate over childern
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a W> {
+        ListIter {
+            list: self,
+            index: 0,
+        }
+    }
 }
 
 impl<D: Directional, W: Widget> Index<usize> for List<D, W> {
@@ -358,5 +366,31 @@ impl<D: Directional, W: Widget> Index<usize> for List<D, W> {
 impl<D: Directional, W: Widget> IndexMut<usize> for List<D, W> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.widgets[index]
+    }
+}
+
+struct ListIter<'a, D: Directional, W: Widget> {
+    list: &'a List<D, W>,
+    index: usize,
+}
+impl<'a, D: Directional, W: Widget> Iterator for ListIter<'a, D, W> {
+    type Item = &'a W;
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.index;
+        if index < self.list.widgets.len() {
+            self.index = index + 1;
+            Some(&self.list.widgets[index])
+        } else {
+            None
+        }
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+impl<'a, D: Directional, W: Widget> ExactSizeIterator for ListIter<'a, D, W> {
+    fn len(&self) -> usize {
+        self.list.widgets.len() - self.index
     }
 }

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -168,18 +168,15 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
 
 impl<D: Directional, W: Widget> event::SendEvent for List<D, W> {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
-        if self.is_disabled() {
-            return Response::Unhandled(event);
-        }
-
-        for child in &mut self.widgets {
-            if id <= child.id() {
-                return child.send(mgr, id, event);
+        if !self.is_disabled() {
+            for child in &mut self.widgets {
+                if id <= child.id() {
+                    return child.send(mgr, id, event);
+                }
             }
         }
 
-        debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
-        Manager::handle_generic(self, mgr, event)
+        Response::Unhandled(event)
     }
 }
 

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -145,6 +145,10 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
     }
 
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {
+        if !self.rect().contains(coord) {
+            return None;
+        }
+
         let solver = layout::RowPositionSolver::new(self.direction);
         if let Some(child) = solver.find_child(&self.widgets, coord) {
             return child.find_id(coord);

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -118,7 +118,7 @@ impl<M, W: Widget<Msg = M>> event::Handler for MenuButton<W> {
                 }
                 Response::None
             }
-            Event::PressStart { source, coord } if source.is_primary() => {
+            Event::PressStart { source, coord, .. } if source.is_primary() => {
                 mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None);
                 self.opening = self.popup_id.is_none();
                 Response::None

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -355,7 +355,7 @@ impl<D: Directional, W: Widget<Msg = M>, M> event::Handler for MenuBar<D, W> {
                 }
             }
             Event::PressMove { source, cur_id, .. } => {
-                if cur_id.and_then(|id| self.find(id)).is_some() {
+                if cur_id.map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
                     let id = cur_id.unwrap();
                     mgr.set_grab_depress(source, Some(id));
                     self.send(mgr, id, Event::OpenPopup)
@@ -364,7 +364,7 @@ impl<D: Directional, W: Widget<Msg = M>, M> event::Handler for MenuBar<D, W> {
                 }
             }
             Event::PressEnd { coord, end_id, .. } => {
-                if end_id.and_then(|id| self.find(id)).is_some() {
+                if end_id.map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
                     // end_id is a child of self
                     let id = end_id.unwrap();
 

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -61,7 +61,11 @@ impl<W: Widget> kas::Layout for MenuButton<W> {
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
-        draw_handle.button(self.core.rect, self.input_state(mgr, disabled));
+        let mut state = self.input_state(mgr, disabled);
+        if self.popup_id.is_some() {
+            state.depress = true;
+        }
+        draw_handle.button(self.core.rect, state);
         let align = (Align::Centre, Align::Centre);
         draw_handle.text(self.core.rect, &self.label, TextClass::Button, align);
     }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -38,7 +38,7 @@ pub use filler::Filler;
 pub use frame::Frame;
 pub use label::Label;
 pub use list::*;
-pub use menu::{MenuBar, MenuButton};
+pub use menu::{MenuBar, MenuButton, SubMenu};
 pub use radiobox::{RadioBox, RadioBoxBare};
 pub use scroll::ScrollRegion;
 pub use scrollbar::ScrollBar;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -38,7 +38,7 @@ pub use filler::Filler;
 pub use frame::Frame;
 pub use label::Label;
 pub use list::*;
-pub use menu::MenuButton;
+pub use menu::{MenuBar, MenuButton};
 pub use radiobox::{RadioBox, RadioBoxBare};
 pub use scroll::ScrollRegion;
 pub use scrollbar::ScrollBar;

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -195,13 +195,15 @@ impl<W: Widget> Layout for ScrollRegion<W> {
     }
 
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {
-        if self.horiz_bar.rect().contains(coord) {
-            self.horiz_bar.find_id(coord)
-        } else if self.vert_bar.rect().contains(coord) {
-            self.vert_bar.find_id(coord)
-        } else {
-            self.child.find_id(coord + self.offset)
+        if !self.rect().contains(coord) {
+            return None;
         }
+
+        self.horiz_bar
+            .find_id(coord)
+            .or_else(|| self.vert_bar.find_id(coord))
+            .or_else(|| self.child.find_id(coord + self.offset))
+            .or(Some(self.id()))
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -305,10 +305,12 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
             },
             Event::PressMove {
                 source,
+                cur_id,
                 coord,
                 delta,
             } => Event::PressMove {
                 source,
+                cur_id,
                 coord: coord + self.offset,
                 delta,
             },

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -248,7 +248,7 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
                     Response::Unhandled(Event::Scroll(delta))
                 }
             }
-            Event::PressStart { source, coord } if source.is_primary() => {
+            Event::PressStart { source, coord, .. } if source.is_primary() => {
                 mgr.request_grab(
                     w.id(),
                     source,
@@ -299,8 +299,13 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
         }
 
         let event = match event {
-            Event::PressStart { source, coord } => Event::PressStart {
+            Event::PressStart {
                 source,
+                start_id,
+                coord,
+            } => Event::PressStart {
+                source,
+                start_id,
                 coord: coord + self.offset,
             },
             Event::PressMove {

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -213,7 +213,7 @@ impl<D: Directional> Layout for ScrollBar<D> {
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         let dir = self.direction.as_direction();
-        let state = self.input_state(mgr, disabled);
+        let state = self.handle.input_state(mgr, disabled);
         draw_handle.scrollbar(self.core.rect, self.handle.rect(), dir, state);
     }
 }

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -205,11 +205,10 @@ impl<D: Directional> Layout for ScrollBar<D> {
     }
 
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {
-        if self.handle.rect().contains(coord) {
-            Some(self.handle.id())
-        } else {
-            Some(self.id())
+        if !self.rect().contains(coord) {
+            return None;
         }
+        self.handle.find_id(coord).or(Some(self.id()))
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -197,12 +197,8 @@ impl<T: SliderType, D: Directional> Layout for Slider<T, D> {
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
-        // Depending on whether we get the input state for self or
-        // self.handle we can highlight when over the slider or just the
-        // handle. But for key-nav, we want highlight-state of self.
-        let state = self.input_state(mgr, disabled);
-
         let dir = self.direction.as_direction();
+        let state = self.input_state(mgr, disabled) | self.handle.input_state(mgr, disabled);
         draw_handle.slider(self.core.rect, self.handle.rect(), dir, state);
     }
 }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -190,11 +190,10 @@ impl<T: SliderType, D: Directional> Layout for Slider<T, D> {
     }
 
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {
-        if self.handle.rect().contains(coord) {
-            Some(self.handle.id())
-        } else {
-            Some(self.id())
+        if !self.rect().contains(coord) {
+            return None;
         }
+        self.handle.find_id(coord).or(Some(self.id()))
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -214,11 +214,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
 
 impl<D: Directional, W: Widget> event::SendEvent for Splitter<D, W> {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
-        if self.is_disabled() {
-            return Response::Unhandled(event);
-        }
-
-        if self.widgets.len() > 0 {
+        if !self.is_disabled() && self.widgets.len() > 0 {
             assert!(self.handles.len() + 1 == self.widgets.len());
             let mut n = 0;
             loop {
@@ -245,8 +241,7 @@ impl<D: Directional, W: Widget> event::SendEvent for Splitter<D, W> {
             }
         }
 
-        debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
-        Manager::handle_generic(self, mgr, event)
+        Response::Unhandled(event)
     }
 }
 

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -175,18 +175,22 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
     }
 
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {
+        if !self.rect().contains(coord) {
+            return None;
+        }
+
         // find_child should gracefully handle the case that a coord is between
         // widgets, so there's no harm (and only a small performance loss) in
         // calling it twice.
 
         let solver = layout::RowPositionSolver::new(self.direction);
         if let Some(child) = solver.find_child(&self.widgets, coord) {
-            return child.find_id(coord);
+            return child.find_id(coord).or(Some(self.id()));
         }
 
         let solver = layout::RowPositionSolver::new(self.direction);
         if let Some(child) = solver.find_child(&self.handles, coord) {
-            return child.find_id(coord);
+            return child.find_id(coord).or(Some(self.id()));
         }
 
         Some(self.id())

--- a/src/widget/stack.rs
+++ b/src/widget/stack.rs
@@ -91,18 +91,15 @@ impl<W: Widget> Layout for Stack<W> {
 
 impl<W: Widget> event::SendEvent for Stack<W> {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
-        if self.is_disabled() {
-            return Response::Unhandled(event);
-        }
-
-        for child in &mut self.widgets {
-            if id <= child.id() {
-                return child.send(mgr, id, event);
+        if !self.is_disabled() {
+            for child in &mut self.widgets {
+                if id <= child.id() {
+                    return child.send(mgr, id, event);
+                }
             }
         }
 
-        debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
-        Manager::handle_generic(self, mgr, event)
+        Response::Unhandled(event)
     }
 }
 

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -197,7 +197,8 @@ impl<W: Widget<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
 
             let is_reversed = popup.direction.is_reversed();
             let place_in = |rp, rs: u32, cp: i32, cs, ideal, m: (u16, u16)| -> (i32, u32) {
-                let before = (cp.saturating_sub(rp + m.1 as i32)) as u32;
+                let before: i32 = cp - (rp + m.1 as i32);
+                let before = before.max(0) as u32;
                 let after = rs.saturating_sub(cs + before + m.0 as u32);
                 if after >= ideal {
                     if is_reversed && before >= ideal {

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -114,12 +114,15 @@ impl<W: Widget> Layout for Window<W> {
 
     #[inline]
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {
+        if !self.rect().contains(coord) {
+            return None;
+        }
         for popup in self.popups.iter().rev() {
             if let Some(id) = self.w.find(popup.1.id).and_then(|w| w.find_id(coord)) {
                 return Some(id);
             }
         }
-        self.w.find_id(coord)
+        self.w.find_id(coord).or(Some(self.id()))
     }
 
     #[inline]

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -140,16 +140,10 @@ impl<W: Widget> Layout for Window<W> {
 
 impl<W: Widget<Msg = VoidMsg> + 'static> event::SendEvent for Window<W> {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
-        if self.is_disabled() {
-            return Response::Unhandled(event);
+        if !self.is_disabled() && id <= self.w.id() {
+            return self.w.send(mgr, id, event);
         }
-
-        if id <= self.w.id() {
-            self.w.send(mgr, id, event)
-        } else {
-            debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
-            Manager::handle_generic(self, mgr, event)
-        }
+        Response::Unhandled(event)
     }
 }
 


### PR DESCRIPTION
Implements a `MenuBar` and sub-menus.

This PR focusses on correct input handling and highlighting of entries, not on graphics. Any widget can be put inside a menu, although it should only receive `Event::Activate` and special `OpenPopup` / `ClosePopup` commands, not direct pointer input.

This does not use appropriate graphics for menus. Although this could be achieved by passing some type of `context` parameter into `Layout::draw` (replacing `disabled: bool`), it should also affect `size_rules`. Special menu widgets may be a better option.