### PR TITLE
Key navigation: scroll, visibility

### DIFF
--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -132,6 +132,10 @@ pub enum Event {
     /// This is a specific command from a parent, e.g. [`kas::widget::MenuBar`].
     /// Most widgets can ignore this, even if they have a pop-up.
     ClosePopup,
+    /// Sent when a widget receives keyboard navigation focus
+    ///
+    /// The widget should reply with [`Response::Focus`].
+    NavFocus,
 }
 
 /// Navigation key ([`Event::NavKey`])

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -13,7 +13,7 @@ use crate::geom::{Coord, DVec2};
 use crate::WidgetId;
 
 /// Events addressed to a widget
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Event {
     /// No event
     None,
@@ -203,7 +203,7 @@ impl PressSource {
 }
 
 /// Type used by [`Event::Scroll`]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ScrollDelta {
     /// Scroll a given number of lines
     LineDelta(f32, f32),

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -128,6 +128,10 @@ impl<'a> Manager<'a> {
                 _ => (),
             };
         }
+        match event {
+            Event::NavFocus => return Response::Focus(widget.rect()),
+            _ => (),
+        }
         widget.handle(mgr, event)
     }
 }

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -87,6 +87,7 @@ pub struct ManagerState {
     modifiers: ModifiersState,
     char_focus: Option<WidgetId>,
     nav_focus: Option<WidgetId>,
+    nav_fallback: Option<WidgetId>,
     nav_stack: SmallVec<[u32; 16]>,
     hover: Option<WidgetId>,
     hover_icon: CursorIcon,
@@ -256,6 +257,14 @@ impl<'a> Manager<'a> {
             if id_action.is_none() {
                 if let Some(id) = self.mgr.accel_keys.get(&vkey).cloned() {
                     id_action = Some((id, Event::Activate));
+                }
+            }
+
+            if id_action.is_none() {
+                if let Some(id) = self.mgr.nav_fallback {
+                    if let Some(key) = NavKey::new(vkey) {
+                        id_action = Some((id, Event::NavKey(key)));
+                    }
                 }
             }
 

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -241,6 +241,9 @@ impl<'a> Manager<'a> {
 
         if vkey == VK::Tab {
             self.next_nav_focus(widget.as_widget(), self.mgr.modifiers.shift());
+            if let Some(id) = self.mgr.nav_focus {
+                self.send_event(widget, id, Event::NavFocus);
+            }
         } else if vkey == VK::Escape {
             self.unset_nav_focus();
         } else {

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -5,7 +5,7 @@
 
 //! Event manager — public API
 
-use log::trace;
+use log::{debug, trace};
 use std::time::{Duration, Instant};
 use std::u16;
 
@@ -221,6 +221,24 @@ impl<'a> Manager<'a> {
 
 /// Public API (around event manager state)
 impl<'a> Manager<'a> {
+    /// Attempts to set a fallback to receive [`Event::NavKey`]
+    ///
+    /// In case a navigation key is pressed (e.g. Left arrow) but no widget has
+    /// navigation focus, then, if a fallback has been set, that widget will
+    /// receive the key via [`Event::NavKey`]. (This does not include
+    /// [`Event::Activate`].)
+    ///
+    /// Only one widget can be a fallback, and the *first* to set itself wins.
+    /// This is primarily used to allow [`ScrollRegion`] to respond to
+    /// navigation keys when no widget has focus.
+    pub fn register_nav_fallback(&mut self, id: WidgetId) {
+        if self.mgr.nav_fallback.is_none() {
+            debug!("Manager: nav_fallback = {}", id);
+            self.mgr.nav_fallback = Some(id);
+        }
+    }
+
+    ///
     /// Adds an accelerator key for a widget
     ///
     /// If this key is pressed when the window has focus and no widget has a

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -45,7 +45,7 @@ impl ManagerState {
     /// Check whether the given widget is visually depressed
     #[inline]
     pub fn is_depressed(&self, w_id: WidgetId) -> bool {
-        for (_, id) in &self.key_events {
+        for (_, id) in &self.key_depress {
             if *id == w_id {
                 return true;
             }

--- a/src/event/manager/mgr_tk.rs
+++ b/src/event/manager/mgr_tk.rs
@@ -32,7 +32,7 @@ impl ManagerState {
             nav_stack: SmallVec::new(),
             hover: None,
             hover_icon: CursorIcon::Default,
-            key_events: Default::default(),
+            key_depress: Default::default(),
             last_mouse_coord: Coord::ZERO,
             mouse_grab: None,
             touch_grab: Default::default(),
@@ -133,7 +133,7 @@ impl ManagerState {
                 elt
             }));
 
-        do_map!(self.key_events, |elt: (u32, WidgetId)| map
+        do_map!(self.key_depress, |elt: (u32, WidgetId)| map
             .get(&elt.1)
             .map(|id| (elt.0, *id)));
     }

--- a/src/event/manager/mgr_tk.rs
+++ b/src/event/manager/mgr_tk.rs
@@ -29,6 +29,7 @@ impl ManagerState {
             modifiers: ModifiersState::empty(),
             char_focus: None,
             nav_focus: None,
+            nav_fallback: None,
             nav_stack: SmallVec::new(),
             hover: None,
             hover_icon: CursorIcon::Default,
@@ -69,6 +70,7 @@ impl ManagerState {
         self.handle_updates.clear();
         self.pending.clear();
         self.action = TkAction::None;
+        self.nav_fallback = None;
 
         let coord = self.last_mouse_coord;
         self.with(tkw, |mut mgr| {

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -6,6 +6,7 @@
 //! Event handling: Response type
 
 use super::{Event, VoidResponse};
+use kas::geom::Rect;
 
 /// Response type from [`Handler::handle`].
 ///
@@ -21,6 +22,8 @@ pub enum Response<M> {
     None,
     /// Unhandled input events get returned back up the widget tree
     Unhandled(Event),
+    /// (Keyboard) focus has changed. This region should be made visible.
+    Focus(Rect),
     /// Custom message type
     Msg(M),
 }
@@ -87,6 +90,7 @@ impl<M> Response<M> {
         match r {
             None => Ok(None),
             Unhandled(e) => Ok(Unhandled(e)),
+            Focus(rect) => Ok(Focus(rect)),
             Msg(m) => Err(m),
         }
     }

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -23,6 +23,7 @@ use kas::prelude::*;
 /// Scroll regions translate their contents by an `offset`, which has a
 /// minimum value of [`Coord::ZERO`] and a maximum value of
 /// [`ScrollRegion::max_offset`].
+#[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct ScrollRegion<W: Widget> {
@@ -41,13 +42,13 @@ pub struct ScrollRegion<W: Widget> {
     #[widget]
     vert_bar: ScrollBar<kas::Down>,
     #[widget]
-    child: W,
+    inner: W,
 }
 
 impl<W: Widget> ScrollRegion<W> {
-    /// Construct a new scroll region around a child widget
+    /// Construct a new scroll region around an inner widget
     #[inline]
-    pub fn new(child: W) -> Self {
+    pub fn new(inner: W) -> Self {
         ScrollRegion {
             core: Default::default(),
             min_child_size: Size::ZERO,
@@ -60,7 +61,7 @@ impl<W: Widget> ScrollRegion<W> {
             show_bars: (false, false),
             horiz_bar: ScrollBar::new(),
             vert_bar: ScrollBar::new(),
-            child,
+            inner,
         }
     }
 
@@ -93,13 +94,13 @@ impl<W: Widget> ScrollRegion<W> {
     /// Access inner widget directly
     #[inline]
     pub fn inner(&self) -> &W {
-        &self.child
+        &self.inner
     }
 
     /// Access inner widget directly
     #[inline]
     pub fn inner_mut(&mut self) -> &mut W {
-        &mut self.child
+        &mut self.inner
     }
 
     /// Get the maximum offset
@@ -130,9 +131,15 @@ impl<W: Widget> ScrollRegion<W> {
     }
 }
 
+impl<W: Widget> WidgetConfig for ScrollRegion<W> {
+    fn configure(&mut self, mgr: &mut Manager) {
+        mgr.register_nav_fallback(self.id());
+    }
+}
+
 impl<W: Widget> Layout for ScrollRegion<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let mut rules = self.child.size_rules(size_handle, axis);
+        let mut rules = self.inner.size_rules(size_handle, axis);
         if axis.is_horizontal() {
             self.min_child_size.0 = rules.min_size();
         } else {
@@ -172,7 +179,7 @@ impl<W: Widget> Layout for ScrollRegion<W> {
 
         let child_size = self.inner_size.max(self.min_child_size);
         let child_rect = Rect::new(pos, child_size);
-        self.child.set_rect(child_rect, AlignHints::NONE);
+        self.inner.set_rect(child_rect, AlignHints::NONE);
         self.max_offset = Coord::from(child_size) - Coord::from(self.inner_size);
         self.offset = self.offset.clamp(Coord::ZERO, self.max_offset);
 
@@ -203,7 +210,7 @@ impl<W: Widget> Layout for ScrollRegion<W> {
         self.horiz_bar
             .find_id(coord)
             .or_else(|| self.vert_bar.find_id(coord))
-            .or_else(|| self.child.find_id(coord + self.offset))
+            .or_else(|| self.inner.find_id(coord + self.offset))
             .or(Some(self.id()))
     }
 
@@ -220,7 +227,7 @@ impl<W: Widget> Layout for ScrollRegion<W> {
             size: self.inner_size,
         };
         draw_handle.clip_region(rect, self.offset, &mut |handle| {
-            self.child.draw(handle, mgr, disabled)
+            self.inner.draw(handle, mgr, disabled)
         });
     }
 }
@@ -230,6 +237,66 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
         if self.is_disabled() {
             return Response::Unhandled(event);
         }
+
+        let event = if id <= self.horiz_bar.id() {
+            match Response::<Self::Msg>::try_from(self.horiz_bar.send(mgr, id, event)) {
+                Ok(Response::Unhandled(event)) => event,
+                Ok(r) => return r,
+                Err(msg) => {
+                    *mgr += self.set_offset(Coord(msg as i32, self.offset.1));
+                    return Response::None;
+                }
+            }
+        } else if id <= self.vert_bar.id() {
+            match Response::<Self::Msg>::try_from(self.vert_bar.send(mgr, id, event)) {
+                Ok(Response::Unhandled(event)) => event,
+                Ok(r) => return r,
+                Err(msg) => {
+                    *mgr += self.set_offset(Coord(self.offset.0, msg as i32));
+                    return Response::None;
+                }
+            }
+        } else if id <= self.inner.id() {
+            let event = match event {
+                Event::PressStart {
+                    source,
+                    start_id,
+                    coord,
+                } => Event::PressStart {
+                    source,
+                    start_id,
+                    coord: coord + self.offset,
+                },
+                Event::PressMove {
+                    source,
+                    cur_id,
+                    coord,
+                    delta,
+                } => Event::PressMove {
+                    source,
+                    cur_id,
+                    coord: coord + self.offset,
+                    delta,
+                },
+                Event::PressEnd {
+                    source,
+                    end_id,
+                    coord,
+                } => Event::PressEnd {
+                    source,
+                    end_id,
+                    coord: coord + self.offset,
+                },
+                event => event,
+            };
+
+            match self.inner.send(mgr, id, event) {
+                Response::Unhandled(event) => event,
+                r => return r,
+            }
+        } else {
+            event
+        };
 
         let scroll = |w: &mut Self, mgr: &mut Manager, delta| {
             let d = match delta {
@@ -247,7 +314,7 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
             }
         };
 
-        let unhandled = |w: &mut Self, mgr: &mut Manager, event| match event {
+        match event {
             Event::NavKey(key) => {
                 let delta = match key {
                     NavKey::Left => LineDelta(-1.0, 0.0),
@@ -255,26 +322,26 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
                     NavKey::Up => LineDelta(0.0, 1.0),
                     NavKey::Down => LineDelta(0.0, -1.0),
                     NavKey::Home | NavKey::End => {
-                        let action = w.set_offset(match key {
+                        let action = self.set_offset(match key {
                             NavKey::Home => Coord::ZERO,
-                            _ => w.max_offset,
+                            _ => self.max_offset,
                         });
                         if action != TkAction::None {
                             *mgr += action
-                                + w.horiz_bar.set_value(w.offset.0 as u32)
-                                + w.vert_bar.set_value(w.offset.1 as u32);
+                                + self.horiz_bar.set_value(self.offset.0 as u32)
+                                + self.vert_bar.set_value(self.offset.1 as u32);
                         }
                         return Response::None;
                     }
-                    NavKey::PageUp => PixelDelta(Coord(0, w.core.rect.size.1 as i32 / 2)),
-                    NavKey::PageDown => PixelDelta(Coord(0, -(w.core.rect.size.1 as i32 / 2))),
+                    NavKey::PageUp => PixelDelta(Coord(0, self.core.rect.size.1 as i32 / 2)),
+                    NavKey::PageDown => PixelDelta(Coord(0, -(self.core.rect.size.1 as i32 / 2))),
                 };
-                scroll(w, mgr, delta)
+                scroll(self, mgr, delta)
             }
-            Event::Scroll(delta) => scroll(w, mgr, delta),
+            Event::Scroll(delta) => scroll(self, mgr, delta),
             Event::PressStart { source, coord, .. } if source.is_primary() => {
                 mgr.request_grab(
-                    w.id(),
+                    self.id(),
                     source,
                     coord,
                     event::GrabMode::Grab,
@@ -282,83 +349,20 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
                 );
                 Response::None
             }
+            Event::PressMove { delta, .. } => {
+                let action = self.set_offset(self.offset - delta);
+                if action != TkAction::None {
+                    *mgr += action
+                        + self.horiz_bar.set_value(self.offset.0 as u32)
+                        + self.vert_bar.set_value(self.offset.1 as u32);
+                }
+                Response::None
+            }
+            Event::PressEnd { .. } => {
+                // consume due to request
+                Response::None
+            }
             e @ _ => Response::Unhandled(e),
-        };
-
-        if id <= self.horiz_bar.id() {
-            return match Response::<Self::Msg>::try_from(self.horiz_bar.send(mgr, id, event)) {
-                Ok(Response::Unhandled(event)) => unhandled(self, mgr, event),
-                Ok(r) => r,
-                Err(msg) => {
-                    *mgr += self.set_offset(Coord(msg as i32, self.offset.1));
-                    Response::None
-                }
-            };
-        } else if id <= self.vert_bar.id() {
-            return match Response::<Self::Msg>::try_from(self.vert_bar.send(mgr, id, event)) {
-                Ok(Response::Unhandled(event)) => unhandled(self, mgr, event),
-                Ok(r) => r,
-                Err(msg) => {
-                    *mgr += self.set_offset(Coord(self.offset.0, msg as i32));
-                    Response::None
-                }
-            };
-        } else if id == self.id() {
-            return match event {
-                Event::PressMove { delta, .. } => {
-                    let action = self.set_offset(self.offset - delta);
-                    if action != TkAction::None {
-                        *mgr += action
-                            + self.horiz_bar.set_value(self.offset.0 as u32)
-                            + self.vert_bar.set_value(self.offset.1 as u32);
-                    }
-                    Response::None
-                }
-                Event::PressEnd { .. } => {
-                    // consume due to request
-                    Response::None
-                }
-                e @ _ => Response::Unhandled(e),
-            };
-        }
-
-        let event = match event {
-            Event::PressStart {
-                source,
-                start_id,
-                coord,
-            } => Event::PressStart {
-                source,
-                start_id,
-                coord: coord + self.offset,
-            },
-            Event::PressMove {
-                source,
-                cur_id,
-                coord,
-                delta,
-            } => Event::PressMove {
-                source,
-                cur_id,
-                coord: coord + self.offset,
-                delta,
-            },
-            Event::PressEnd {
-                source,
-                end_id,
-                coord,
-            } => Event::PressEnd {
-                source,
-                end_id,
-                coord: coord + self.offset,
-            },
-            event => event,
-        };
-
-        match self.child.send(mgr, id, event) {
-            Response::None => Response::None,
-            Response::Unhandled(event) => unhandled(self, mgr, event),
-            e @ _ => e,
         }
     }
 }

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -292,6 +292,13 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
 
             match self.inner.send(mgr, id, event) {
                 Response::Unhandled(event) => event,
+                Response::Focus(rect) => {
+                    let mut offset = self.offset;
+                    offset = offset.max(rect.pos_end() - self.core.rect.pos_end());
+                    offset = offset.min(rect.pos - self.core.rect.pos);
+                    *mgr += self.set_offset(offset);
+                    return Response::Focus(rect - self.offset);
+                }
                 r => return r,
             }
         } else {


### PR DESCRIPTION
This allows ScrollRegion and Mandlebrot to respond to keyboard navigation when a child widget or no widget has navigation focus.

It also ensures visibility of a widget when focussed via Tab.