### PR TITLE
Depth buffer, WGPU update, misc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ internal_doc = []
 conv = "0.3"
 log = "0.4"
 rusttype = "0.8"
-smallvec = "1.1"
+smallvec = "1.4"
 stack_dst = { version = "0.6", features = ["unsize"], optional = true }
 bitflags = "1" # only used without winit
 

--- a/kas-theme/Cargo.toml
+++ b/kas-theme/Cargo.toml
@@ -20,7 +20,7 @@ gat = []
 stack_dst = ["kas/stack_dst", "stack_dst_"]
 
 [dependencies]
-font-kit = { version = "0.4.0", optional = true }
+font-kit = { version = "0.6.0", optional = true }
 lazy_static = "1.4.0"
 log = "0.4"
 stack_dst_ = { version = "0.6", package = "stack_dst", features = ["unsize"], optional = true }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -217,6 +217,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         let inner = outer.shrink(self.window.dims.frame as f32);
         self.draw
             .rounded_frame(self.pass, outer, inner, 0.5, self.cols.frame);
+        let inner = outer.shrink(self.window.dims.frame as f32 / 3.0);
         self.draw.rect(self.pass, inner, self.cols.background);
     }
 

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -91,7 +91,7 @@ where
             cols: transmute::<&'a ThemeColours, &'static ThemeColours>(&self.cols),
             rect,
             offset: Coord::ZERO,
-            pass: Pass::default(),
+            pass: super::START_PASS,
         }
     }
     #[cfg(feature = "gat")]
@@ -107,7 +107,7 @@ where
             cols: &self.cols,
             rect,
             offset: Coord::ZERO,
-            pass: Pass::default(),
+            pass: super::START_PASS,
         }
     }
 

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -242,7 +242,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
                 TextClass::Button | TextClass::Edit => false,
             },
         };
-        self.draw.text(rect + self.offset, text, props);
+        self.draw.text(self.pass, rect + self.offset, text, props);
     }
 
     fn menu_entry(&mut self, rect: Rect, state: InputState) {

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -189,6 +189,11 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         let rect = rect + self.offset;
         let depth = self.pass.depth() + super::relative_region_depth(class);
         let pass = self.draw.add_clip_region(rect, depth);
+        if depth < self.pass.depth() {
+            // draw to depth buffer to enable correct text rendering
+            self.draw
+                .rect(pass, (rect + self.offset).into(), self.cols.background);
+        }
         let mut handle = DrawHandle {
             draw: self.draw,
             window: self.window,

--- a/kas-theme/src/lib.rs
+++ b/kas-theme/src/lib.rs
@@ -54,8 +54,9 @@ pub use traits::{Theme, Window};
 /// **Feature gated**: this is only available with feature `stack_dst`.
 pub type StackDst<T> = stack_dst_::ValueA<T, [usize; 8]>;
 
+/// The initial [`Pass`] value for a window
 // NOTE: depth values between 0 and 1 are drawn.
-const START_PASS: Pass = Pass::new_pass_with_depth(0, 0.01);
+pub const START_PASS: Pass = Pass::new_pass_with_depth(0, 0.01);
 fn relative_region_depth(class: ClipRegion) -> f32 {
     match class {
         ClipRegion::Popup => 0.01,

--- a/kas-theme/src/lib.rs
+++ b/kas-theme/src/lib.rs
@@ -30,7 +30,7 @@ mod theme_dst;
 mod traits;
 
 pub use kas;
-use kas::draw::ClipRegion;
+use kas::draw::{ClipRegion, Pass};
 
 pub use col::ThemeColours;
 pub use dim::{Dimensions, DimensionsParams, DimensionsWindow};
@@ -54,9 +54,11 @@ pub use traits::{Theme, Window};
 /// **Feature gated**: this is only available with feature `stack_dst`.
 pub type StackDst<T> = stack_dst_::ValueA<T, [usize; 8]>;
 
+// NOTE: depth values between 0 and 1 are drawn.
+const START_PASS: Pass = Pass::new_pass_with_depth(0, 0.01);
 fn relative_region_depth(class: ClipRegion) -> f32 {
     match class {
-        ClipRegion::Popup => 100000.0,
-        ClipRegion::Scroll => -100.0,
+        ClipRegion::Popup => 0.01,
+        ClipRegion::Scroll => -1e-5,
     }
 }

--- a/kas-theme/src/lib.rs
+++ b/kas-theme/src/lib.rs
@@ -30,6 +30,7 @@ mod theme_dst;
 mod traits;
 
 pub use kas;
+use kas::draw::ClipRegion;
 
 pub use col::ThemeColours;
 pub use dim::{Dimensions, DimensionsParams, DimensionsWindow};
@@ -52,3 +53,10 @@ pub use traits::{Theme, Window};
 ///
 /// **Feature gated**: this is only available with feature `stack_dst`.
 pub type StackDst<T> = stack_dst_::ValueA<T, [usize; 8]>;
+
+fn relative_region_depth(class: ClipRegion) -> f32 {
+    match class {
+        ClipRegion::Popup => 100000.0,
+        ClipRegion::Scroll => -100.0,
+    }
+}

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -248,7 +248,7 @@ where
                 TextClass::Button | TextClass::Edit => false,
             },
         };
-        self.draw.text(rect + self.offset, text, props);
+        self.draw.text(self.pass, rect + self.offset, text, props);
     }
 
     fn menu_entry(&mut self, rect: Rect, state: InputState) {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -189,6 +189,11 @@ where
         let rect = rect + self.offset;
         let depth = self.pass.depth() + super::relative_region_depth(class);
         let pass = self.draw.add_clip_region(rect, depth);
+        if depth < self.pass.depth() {
+            // draw to depth buffer to enable correct text rendering
+            self.draw
+                .rect(pass, (rect + self.offset).into(), self.cols.background);
+        }
         let mut handle = DrawHandle {
             draw: self.draw,
             window: self.window,

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -9,8 +9,8 @@ use std::f32;
 
 use crate::{Dimensions, DimensionsParams, DimensionsWindow, Theme, ThemeColours};
 use kas::draw::{
-    self, Colour, Draw, DrawRounded, DrawShaded, DrawShared, DrawText, DrawTextShared, FontId,
-    InputState, Region, TextClass, TextProperties,
+    self, ClipRegion, Colour, Draw, DrawRounded, DrawShaded, DrawShared, DrawText, DrawTextShared,
+    FontId, InputState, Pass, TextClass, TextProperties,
 };
 use kas::geom::*;
 use kas::{Align, Direction, Directional, ThemeAction, ThemeApi};
@@ -48,7 +48,7 @@ pub struct DrawHandle<'a, D: Draw> {
     cols: &'a ThemeColours,
     rect: Rect,
     offset: Coord,
-    pass: Region,
+    pass: Pass,
 }
 
 impl<D: DrawShared + DrawTextShared + 'static> Theme<D> for ShadedTheme
@@ -89,7 +89,7 @@ where
             cols: transmute::<&'a ThemeColours, &'static ThemeColours>(&self.cols),
             rect,
             offset: Coord::ZERO,
-            pass: Region::default(),
+            pass: Pass::default(),
         }
     }
     #[cfg(feature = "gat")]
@@ -105,7 +105,7 @@ where
             cols: &self.cols,
             rect,
             offset: Coord::ZERO,
-            pass: Region::default(),
+            pass: Pass::default(),
         }
     }
 
@@ -131,13 +131,13 @@ impl ThemeApi for ShadedTheme {
 }
 
 impl<'a, D: Draw + DrawRounded + DrawShaded> DrawHandle<'a, D> {
-    /// Draw an edit region with optional navigation highlight.
+    /// Draw an edit box with optional navigation highlight.
     /// Return the inner rect.
     ///
     /// - `outer`: define position via outer rect
     /// - `bg_col`: colour of background
     /// - `nav_col`: colour of navigation highlight, if visible
-    fn draw_edit_region(&mut self, outer: Rect, bg_col: Colour, nav_col: Option<Colour>) -> Quad {
+    fn draw_edit_box(&mut self, outer: Rect, bg_col: Colour, nav_col: Option<Colour>) -> Quad {
         let mut outer = Quad::from(outer);
         let mut inner = outer.shrink(self.window.dims.frame as f32);
 
@@ -175,7 +175,7 @@ impl<'a, D> draw::DrawHandle for DrawHandle<'a, D>
 where
     D: Draw + DrawRounded + DrawShaded + DrawText + 'static,
 {
-    fn draw_device(&mut self) -> (kas::draw::Region, Coord, &mut dyn kas::draw::Draw) {
+    fn draw_device(&mut self) -> (kas::draw::Pass, Coord, &mut dyn kas::draw::Draw) {
         (self.pass, self.offset, self.draw)
     }
 
@@ -183,10 +183,12 @@ where
         &mut self,
         rect: Rect,
         offset: Coord,
+        class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn draw::DrawHandle),
     ) {
         let rect = rect + self.offset;
-        let pass = self.draw.add_clip_region(rect);
+        let depth = self.pass.depth() + super::relative_region_depth(class);
+        let pass = self.draw.add_clip_region(rect, depth);
         let mut handle = DrawHandle {
             draw: self.draw,
             window: self.window,
@@ -273,14 +275,14 @@ where
 
     fn edit_box(&mut self, rect: Rect, state: InputState) {
         let bg_col = self.cols.bg_col(state);
-        self.draw_edit_region(rect + self.offset, bg_col, self.cols.nav_region(state));
+        self.draw_edit_box(rect + self.offset, bg_col, self.cols.nav_region(state));
     }
 
     fn checkbox(&mut self, rect: Rect, checked: bool, state: InputState) {
         let bg_col = self.cols.bg_col(state);
         let nav_col = self.cols.nav_region(state).or(Some(bg_col));
 
-        let inner = self.draw_edit_region(rect + self.offset, bg_col, nav_col);
+        let inner = self.draw_edit_box(rect + self.offset, bg_col, nav_col);
 
         if let Some(col) = self.cols.check_mark_state(state, checked) {
             self.draw.shaded_square(self.pass, inner, (0.0, 0.4), col);
@@ -291,7 +293,7 @@ where
         let bg_col = self.cols.bg_col(state);
         let nav_col = self.cols.nav_region(state).or(Some(bg_col));
 
-        let inner = self.draw_edit_region(rect + self.offset, bg_col, nav_col);
+        let inner = self.draw_edit_box(rect + self.offset, bg_col, nav_col);
 
         if let Some(col) = self.cols.check_mark_state(state, checked) {
             self.draw.shaded_circle(self.pass, inner, (0.0, 1.0), col);

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -89,7 +89,7 @@ where
             cols: transmute::<&'a ThemeColours, &'static ThemeColours>(&self.cols),
             rect,
             offset: Coord::ZERO,
-            pass: Pass::default(),
+            pass: super::START_PASS,
         }
     }
     #[cfg(feature = "gat")]
@@ -105,7 +105,7 @@ where
             cols: &self.cols,
             rect,
             offset: Coord::ZERO,
-            pass: Pass::default(),
+            pass: super::START_PASS,
         }
     }
 

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -21,11 +21,13 @@ stack_dst = ["kas-theme/stack_dst"]
 [dependencies]
 kas = { path = "..", version = "0.3.0", features = ["winit"] }
 kas-theme = { path = "../kas-theme", version = "0.3.0" }
+bytemuck = "1.2"
+futures = "0.3"
 log = "0.4"
 shaderc = "0.6.1"
 smallvec = "1.1"
-wgpu = "0.4.0"
-wgpu_glyph = "0.6.0"
+wgpu = "0.5.0"
+wgpu_glyph = "0.8.0"
 winit = "0.22.0"
 
 [dependencies.clipboard]

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -107,8 +107,8 @@ impl Layout for Clock {
             align: (Align::Centre, Align::Centre),
             ..TextProperties::default()
         };
-        draw.text(self.date_rect + offset, &self.date, props);
-        draw.text(self.time_rect + offset, &self.time, props);
+        draw.text(pass, self.date_rect + offset, &self.date, props);
+        draw.text(pass, self.time_rect + offset, &self.time, props);
     }
 }
 

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -70,18 +70,18 @@ impl Layout for Clock {
         //
         // Note: offset is used for scroll-regions, and should be zero here;
         // we add it anyway as is recommended.
-        let (region, offset, draw) = draw_handle.draw_device();
+        let (pass, offset, draw) = draw_handle.draw_device();
         let draw = draw.as_any_mut().downcast_mut::<DrawWindow<()>>().unwrap();
 
         let rect = Quad::from(self.core.rect + offset);
-        draw.circle(region, rect, 0.95, col_face);
+        draw.circle(pass, rect, 0.95, col_face);
 
         let half = (rect.b.1 - rect.a.1) / 2.0;
         let centre = rect.a + half;
 
         let mut line_seg = |t: f32, r1: f32, r2: f32, w, col| {
             let v = Vec2(t.sin(), -t.cos());
-            draw.rounded_line(region, centre + v * r1, centre + v * r2, w, col);
+            draw.rounded_line(pass, centre + v * r1, centre + v * r2, w, col);
         };
 
         let w = half * 0.015625;

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -117,7 +117,12 @@ struct PipeBuilder;
 impl CustomPipeBuilder for PipeBuilder {
     type Pipe = Pipe;
 
-    fn build(&mut self, device: &wgpu::Device, _: wgpu::TextureFormat) -> Self::Pipe {
+    fn build(
+        &mut self,
+        device: &wgpu::Device,
+        tex_format: wgpu::TextureFormat,
+        depth_format: wgpu::TextureFormat,
+    ) -> Self::Pipe {
         // Note: real apps should compile shaders once and share between windows
         let shaders = Shaders::compile(device);
 
@@ -165,12 +170,20 @@ impl CustomPipeBuilder for PipeBuilder {
             }),
             primitive_topology: wgpu::PrimitiveTopology::TriangleList,
             color_states: &[wgpu::ColorStateDescriptor {
-                format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                format: tex_format,
                 color_blend: wgpu::BlendDescriptor::REPLACE,
                 alpha_blend: wgpu::BlendDescriptor::REPLACE,
                 write_mask: wgpu::ColorWrite::ALL,
             }],
-            depth_stencil_state: None,
+            depth_stencil_state: Some(wgpu::DepthStencilStateDescriptor {
+                format: depth_format,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::Always,
+                stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_read_mask: 0,
+                stencil_write_mask: 0,
+            }),
             vertex_state: wgpu::VertexStateDescriptor {
                 index_format: wgpu::IndexFormat::Uint16,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
@@ -323,7 +336,7 @@ impl CustomPipe for Pipe {
         }
     }
 
-    fn render<'a>(
+    fn render_pass<'a>(
         &'a self,
         window: &'a mut Self::Window,
         _: &wgpu::Device,

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -176,18 +176,7 @@ impl CustomPipeBuilder for PipeBuilder {
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,
-                    attributes: &[
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float3,
-                            offset: 0,
-                            shader_location: 0,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: (size_of::<Vec3>()) as u64,
-                            shader_location: 1,
-                        },
-                    ],
+                    attributes: &wgpu::vertex_attr_array![0 => Float3, 1 => Float2],
                 }],
             },
             sample_count: 1,

--- a/kas-wgpu/src/draw/custom.rs
+++ b/kas-wgpu/src/draw/custom.rs
@@ -68,17 +68,17 @@ pub trait CustomPipe {
     ) {
     }
 
-    /// Do a render pass.
+    /// Do a render pass
     ///
     /// Rendering uses one pass per region, where each region has its own
     /// scissor rect. For example, scroll regions and popups are each rendered
     /// in their own pass. This method may be called multiple times per frame.
-    fn render(
-        &self,
-        window: &mut Self::Window,
+    fn render<'a>(
+        &'a self,
+        window: &'a mut Self::Window,
         device: &wgpu::Device,
         pass: usize,
-        rpass: &mut wgpu::RenderPass,
+        rpass: &mut wgpu::RenderPass<'a>,
     );
 }
 

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -149,7 +149,7 @@ impl<C: CustomPipe> DrawPipe<C> {
             depth_store_op: wgpu::StoreOp::Store,
             stencil_load_op: wgpu::LoadOp::Clear,
             stencil_store_op: wgpu::StoreOp::Store,
-            clear_depth: 0.0,
+            clear_depth: kas_theme::START_PASS.depth(),
             clear_stencil: 0,
         };
 

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -9,7 +9,7 @@ use std::f32;
 use wgpu_glyph::{GlyphCruncher, HorizontalAlign, Layout, Scale, Section, VerticalAlign};
 
 use super::{CustomPipe, CustomWindow, DrawPipe, DrawWindow};
-use kas::draw::{DrawText, DrawTextShared, Font, FontId, TextProperties};
+use kas::draw::{DrawText, DrawTextShared, Font, FontId, Pass, TextProperties};
 use kas::geom::{Coord, Rect, Vec2};
 use kas::Align;
 
@@ -22,7 +22,7 @@ impl<C: CustomPipe + 'static> DrawTextShared for DrawPipe<C> {
 }
 
 impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
-    fn text(&mut self, rect: Rect, text: &str, props: TextProperties) {
+    fn text(&mut self, pass: Pass, rect: Rect, text: &str, props: TextProperties) {
         let bounds = Coord::from(rect.size);
 
         // TODO: support justified alignment
@@ -51,7 +51,7 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
             bounds: Vec2::from(bounds).into(),
             scale: Scale::uniform(props.scale),
             color: props.col.into(),
-            z: 0.0,
+            z: pass.depth(),
             layout,
             font_id: wgpu_glyph::FontId(props.font.0),
         });

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -18,6 +18,8 @@ const OFFSET: f32 = 0.125;
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 struct Vertex(Vec2, Rgb, f32, Vec2, Vec2);
+unsafe impl bytemuck::Zeroable for Vertex {}
+unsafe impl bytemuck::Pod for Vertex {}
 
 /// A pipeline for rendering rounded shapes
 pub struct Pipeline {
@@ -32,15 +34,43 @@ pub struct Window {
     passes: Vec<Vec<Vertex>>,
 }
 
+/// Buffer used during render pass
+///
+/// This buffer must not be dropped before the render pass.
+pub struct RenderBuffer<'a> {
+    pipe: &'a wgpu::RenderPipeline,
+    vertices: &'a mut Vec<Vertex>,
+    bind_group: &'a wgpu::BindGroup,
+    buffer: wgpu::Buffer,
+}
+
+impl<'a> RenderBuffer<'a> {
+    /// Do the render
+    pub fn render(&'a self, rpass: &mut wgpu::RenderPass<'a>) {
+        let count = self.vertices.len() as u32;
+        rpass.set_pipeline(self.pipe);
+        rpass.set_bind_group(0, self.bind_group, &[]);
+        rpass.set_vertex_buffer(0, &self.buffer, 0, 0);
+        rpass.draw(0..count, 0..1);
+    }
+}
+
+impl<'a> Drop for RenderBuffer<'a> {
+    fn drop(&mut self) {
+        self.vertices.clear();
+    }
+}
+
 impl Pipeline {
     /// Construct
     pub fn new(device: &wgpu::Device, shaders: &ShaderManager) -> Self {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            bindings: &[wgpu::BindGroupLayoutBinding {
+            bindings: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
                 visibility: wgpu::ShaderStage::VERTEX,
                 ty: wgpu::BindingType::UniformBuffer { dynamic: false },
             }],
+            label: None,
         });
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -80,39 +110,42 @@ impl Pipeline {
                 write_mask: wgpu::ColorWrite::ALL,
             }],
             depth_stencil_state: None,
-            index_format: wgpu::IndexFormat::Uint16,
-            vertex_buffers: &[wgpu::VertexBufferDescriptor {
-                stride: size_of::<Vertex>() as wgpu::BufferAddress,
-                step_mode: wgpu::InputStepMode::Vertex,
-                attributes: &[
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float2,
-                        offset: 0,
-                        shader_location: 0,
-                    },
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float3,
-                        offset: size_of::<Vec2>() as u64,
-                        shader_location: 1,
-                    },
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float,
-                        offset: (size_of::<Vec2>() + size_of::<Rgb>()) as u64,
-                        shader_location: 2,
-                    },
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float2,
-                        offset: (size_of::<Vec2>() + size_of::<Rgb>() + size_of::<f32>()) as u64,
-                        shader_location: 3,
-                    },
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float2,
-                        offset: (2 * size_of::<Vec2>() + size_of::<Rgb>() + size_of::<f32>())
-                            as u64,
-                        shader_location: 4,
-                    },
-                ],
-            }],
+            vertex_state: wgpu::VertexStateDescriptor {
+                index_format: wgpu::IndexFormat::Uint16,
+                vertex_buffers: &[wgpu::VertexBufferDescriptor {
+                    stride: size_of::<Vertex>() as wgpu::BufferAddress,
+                    step_mode: wgpu::InputStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float2,
+                            offset: 0,
+                            shader_location: 0,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float3,
+                            offset: size_of::<Vec2>() as u64,
+                            shader_location: 1,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float,
+                            offset: (size_of::<Vec2>() + size_of::<Rgb>()) as u64,
+                            shader_location: 2,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float2,
+                            offset: (size_of::<Vec2>() + size_of::<Rgb>() + size_of::<f32>())
+                                as u64,
+                            shader_location: 3,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float2,
+                            offset: (2 * size_of::<Vec2>() + size_of::<Rgb>() + size_of::<f32>())
+                                as u64,
+                            shader_location: 4,
+                        },
+                    ],
+                }],
+            },
             sample_count: 1,
             sample_mask: !0,
             alpha_to_coverage_enabled: false,
@@ -126,14 +159,11 @@ impl Pipeline {
 
     /// Construct per-window state
     pub fn new_window(&self, device: &wgpu::Device, size: Size) -> Window {
+        let usage = wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST;
+
         type Scale = [f32; 2];
-        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
-        let scale_buf = device
-            .create_buffer_mapped(
-                scale_factor.len(),
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
-            .fill_from_slice(&scale_factor);
+        let scale_factor: Scale = [2.0 / size.0 as f32, -2.0 / size.1 as f32];
+        let scale_buf = device.create_buffer_with_data(bytemuck::cast_slice(&scale_factor), usage);
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             layout: &self.bind_group_layout,
@@ -144,6 +174,7 @@ impl Pipeline {
                     range: 0..(size_of::<Scale>() as u64),
                 },
             }],
+            label: None,
         });
 
         Window {
@@ -153,29 +184,27 @@ impl Pipeline {
         }
     }
 
-    /// Render queued triangles and clear the queue
-    pub fn render(
-        &self,
-        window: &mut Window,
+    /// Construct a render buffer
+    pub fn render_buf<'a>(
+        &'a self,
+        window: &'a mut Window,
         device: &wgpu::Device,
         pass: usize,
-        rpass: &mut wgpu::RenderPass,
-    ) {
-        if pass >= window.passes.len() {
-            return;
+    ) -> Option<RenderBuffer<'a>> {
+        if pass >= window.passes.len() || window.passes[pass].len() == 0 {
+            return None;
         }
-        let v = &mut window.passes[pass];
+
+        let vertices = &mut window.passes[pass];
         let buffer = device
-            .create_buffer_mapped(v.len(), wgpu::BufferUsage::VERTEX)
-            .fill_from_slice(&v);
-        let count = v.len() as u32;
+            .create_buffer_with_data(bytemuck::cast_slice(&vertices), wgpu::BufferUsage::VERTEX);
 
-        rpass.set_pipeline(&self.render_pipeline);
-        rpass.set_bind_group(0, &window.bind_group, &[]);
-        rpass.set_vertex_buffers(0, &[(&buffer, 0)]);
-        rpass.draw(0..count, 0..1);
-
-        v.clear();
+        Some(RenderBuffer {
+            pipe: &self.render_pipeline,
+            vertices,
+            bind_group: &window.bind_group,
+            buffer,
+        })
     }
 }
 
@@ -187,10 +216,11 @@ impl Window {
         size: Size,
     ) {
         type Scale = [f32; 2];
-        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
-        let scale_buf = device
-            .create_buffer_mapped(scale_factor.len(), wgpu::BufferUsage::COPY_SRC)
-            .fill_from_slice(&scale_factor);
+        let scale_factor: Scale = [2.0 / size.0 as f32, -2.0 / size.1 as f32];
+        let scale_buf = device.create_buffer_with_data(
+            bytemuck::cast_slice(&scale_factor),
+            wgpu::BufferUsage::COPY_SRC,
+        );
         let byte_len = size_of::<Scale>() as u64;
 
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &self.scale_buf, 0, byte_len);

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -115,34 +115,12 @@ impl Pipeline {
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,
-                    attributes: &[
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: 0,
-                            shader_location: 0,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float3,
-                            offset: size_of::<Vec2>() as u64,
-                            shader_location: 1,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float,
-                            offset: (size_of::<Vec2>() + size_of::<Rgb>()) as u64,
-                            shader_location: 2,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: (size_of::<Vec2>() + size_of::<Rgb>() + size_of::<f32>())
-                                as u64,
-                            shader_location: 3,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: (2 * size_of::<Vec2>() + size_of::<Rgb>() + size_of::<f32>())
-                                as u64,
-                            shader_location: 4,
-                        },
+                    attributes: &wgpu::vertex_attr_array![
+                        0 => Float2,
+                        1 => Float3,
+                        2 => Float,
+                        3 => Float2,
+                        4 => Float2
                     ],
                 }],
             },

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -8,7 +8,7 @@
 use std::mem::size_of;
 
 use crate::draw::{Rgb, ShaderManager};
-use kas::draw::Colour;
+use kas::draw::{Colour, Pass};
 use kas::geom::{Quad, Size, Vec2};
 
 /// Offset relative to the size of a pixel used by the fragment shader to
@@ -196,7 +196,7 @@ impl Window {
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &self.scale_buf, 0, byte_len);
     }
 
-    pub fn line(&mut self, pass: usize, p1: Vec2, p2: Vec2, radius: f32, col: Colour) {
+    pub fn line(&mut self, pass: Pass, p1: Vec2, p2: Vec2, radius: f32, col: Colour) {
         if p1 == p2 {
             let a = p1 - radius;
             let b = p2 + radius;
@@ -229,7 +229,7 @@ impl Window {
         let p2 = Vertex(p2, col, 0.0, n0, p);
 
         #[rustfmt::skip]
-        self.add_vertices(pass, &[
+        self.add_vertices(pass.pass(), &[
             ab1, p1, mb1,
             aa1, p1, ab1,
             ma1, p1, aa1,
@@ -244,7 +244,7 @@ impl Window {
     }
 
     /// Bounds on input: `0 ≤ inner_radius ≤ 1`.
-    pub fn circle(&mut self, pass: usize, rect: Quad, inner_radius: f32, col: Colour) {
+    pub fn circle(&mut self, pass: Pass, rect: Quad, inner_radius: f32, col: Colour) {
         let aa = rect.a;
         let bb = rect.b;
 
@@ -277,7 +277,7 @@ impl Window {
         let mid = Vertex(mid, col, inner, n0, p);
 
         #[rustfmt::skip]
-        self.add_vertices(pass, &[
+        self.add_vertices(pass.pass(), &[
             ba, mid, aa,
             bb, mid, ba,
             ab, mid, bb,
@@ -288,7 +288,7 @@ impl Window {
     /// Bounds on input: `aa < cc < dd < bb`, `0 ≤ inner_radius ≤ 1`.
     pub fn rounded_frame(
         &mut self,
-        pass: usize,
+        pass: Pass,
         outer: Quad,
         inner: Quad,
         inner_radius: f32,
@@ -362,7 +362,7 @@ impl Window {
         // TODO: the four sides are simple rectangles, hence could use simpler rendering
 
         #[rustfmt::skip]
-        self.add_vertices(pass, &[
+        self.add_vertices(pass.pass(), &[
             // top bar: ba - dc - cc - aa
             ba, dc, da,
             da, dc, ca,

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -116,7 +116,7 @@ impl Pipeline {
                 },
                 write_mask: wgpu::ColorWrite::ALL,
             }],
-            depth_stencil_state: None,
+            depth_stencil_state: Some(super::DEPTH_DESC),
             vertex_state: wgpu::VertexStateDescriptor {
                 index_format: wgpu::IndexFormat::Uint16,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {

--- a/kas-wgpu/src/draw/shaded_round.rs
+++ b/kas-wgpu/src/draw/shaded_round.rs
@@ -9,7 +9,7 @@ use std::f32::consts::FRAC_PI_2;
 use std::mem::size_of;
 
 use crate::draw::{Rgb, ShaderManager};
-use kas::draw::Colour;
+use kas::draw::{Colour, Pass};
 use kas::geom::{Quad, Size, Vec2};
 
 /// Offset relative to the size of a pixel used by the fragment shader to
@@ -219,7 +219,7 @@ impl Window {
     }
 
     /// Bounds on input: `0 ≤ inner_radius ≤ 1`.
-    pub fn circle(&mut self, pass: usize, rect: Quad, mut norm: Vec2, col: Colour) {
+    pub fn circle(&mut self, pass: Pass, rect: Quad, mut norm: Vec2, col: Colour) {
         let aa = rect.a;
         let bb = rect.b;
 
@@ -254,7 +254,7 @@ impl Window {
         let mid = Vertex(mid, col, n0, adjust, p);
 
         #[rustfmt::skip]
-        self.add_vertices(pass, &[
+        self.add_vertices(pass.pass(), &[
             aa, ba, mid,
             mid, ba, bb,
             bb, ab, mid,
@@ -265,7 +265,7 @@ impl Window {
     /// Bounds on input: `aa < cc < dd < bb` and `-1 ≤ norm ≤ 1`.
     pub fn shaded_frame(
         &mut self,
-        pass: usize,
+        pass: Pass,
         outer: Quad,
         inner: Quad,
         mut norm: Vec2,
@@ -339,7 +339,7 @@ impl Window {
         let dd = Vertex(dd, col, n0, adjust, pbb);
 
         #[rustfmt::skip]
-        self.add_vertices(pass, &[
+        self.add_vertices(pass.pass(), &[
             // top bar: ba - dc - cc - aa
             ba, dc, da,
             da, dc, ca,

--- a/kas-wgpu/src/draw/shaded_round.rs
+++ b/kas-wgpu/src/draw/shaded_round.rs
@@ -123,7 +123,7 @@ impl Pipeline {
                 },
                 write_mask: wgpu::ColorWrite::ALL,
             }],
-            depth_stencil_state: None,
+            depth_stencil_state: Some(super::DEPTH_DESC),
             vertex_state: wgpu::VertexStateDescriptor {
                 index_format: wgpu::IndexFormat::Uint16,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {

--- a/kas-wgpu/src/draw/shaded_round.rs
+++ b/kas-wgpu/src/draw/shaded_round.rs
@@ -19,6 +19,8 @@ const OFFSET: f32 = 0.125;
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 struct Vertex(Vec2, Rgb, Vec2, Vec2, Vec2);
+unsafe impl bytemuck::Zeroable for Vertex {}
+unsafe impl bytemuck::Pod for Vertex {}
 
 /// A pipeline for rendering rounded shapes
 pub struct Pipeline {
@@ -33,22 +35,50 @@ pub struct Window {
     passes: Vec<Vec<Vertex>>,
 }
 
+/// Buffer used during render pass
+///
+/// This buffer must not be dropped before the render pass.
+pub struct RenderBuffer<'a> {
+    pipe: &'a wgpu::RenderPipeline,
+    vertices: &'a mut Vec<Vertex>,
+    bind_group: &'a wgpu::BindGroup,
+    buffer: wgpu::Buffer,
+}
+
+impl<'a> RenderBuffer<'a> {
+    /// Do the render
+    pub fn render(&'a self, rpass: &mut wgpu::RenderPass<'a>) {
+        let count = self.vertices.len() as u32;
+        rpass.set_pipeline(self.pipe);
+        rpass.set_bind_group(0, self.bind_group, &[]);
+        rpass.set_vertex_buffer(0, &self.buffer, 0, 0);
+        rpass.draw(0..count, 0..1);
+    }
+}
+
+impl<'a> Drop for RenderBuffer<'a> {
+    fn drop(&mut self) {
+        self.vertices.clear();
+    }
+}
+
 impl Pipeline {
     /// Construct
     pub fn new(device: &wgpu::Device, shaders: &ShaderManager) -> Self {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[
-                wgpu::BindGroupLayoutBinding {
+                wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStage::VERTEX,
                     ty: wgpu::BindingType::UniformBuffer { dynamic: false },
                 },
-                wgpu::BindGroupLayoutBinding {
+                wgpu::BindGroupLayoutEntry {
                     binding: 1,
                     visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::UniformBuffer { dynamic: false },
                 },
             ],
+            label: None,
         });
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             bind_group_layouts: &[&bind_group_layout],
@@ -87,38 +117,40 @@ impl Pipeline {
                 write_mask: wgpu::ColorWrite::ALL,
             }],
             depth_stencil_state: None,
-            index_format: wgpu::IndexFormat::Uint16,
-            vertex_buffers: &[wgpu::VertexBufferDescriptor {
-                stride: size_of::<Vertex>() as wgpu::BufferAddress,
-                step_mode: wgpu::InputStepMode::Vertex,
-                attributes: &[
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float2,
-                        offset: 0,
-                        shader_location: 0,
-                    },
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float3,
-                        offset: size_of::<Vec2>() as u64,
-                        shader_location: 1,
-                    },
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float2,
-                        offset: (size_of::<Vec2>() + size_of::<Rgb>()) as u64,
-                        shader_location: 2,
-                    },
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float2,
-                        offset: (2 * size_of::<Vec2>() + size_of::<Rgb>()) as u64,
-                        shader_location: 3,
-                    },
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float2,
-                        offset: (3 * size_of::<Vec2>() + size_of::<Rgb>()) as u64,
-                        shader_location: 4,
-                    },
-                ],
-            }],
+            vertex_state: wgpu::VertexStateDescriptor {
+                index_format: wgpu::IndexFormat::Uint16,
+                vertex_buffers: &[wgpu::VertexBufferDescriptor {
+                    stride: size_of::<Vertex>() as wgpu::BufferAddress,
+                    step_mode: wgpu::InputStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float2,
+                            offset: 0,
+                            shader_location: 0,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float3,
+                            offset: size_of::<Vec2>() as u64,
+                            shader_location: 1,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float2,
+                            offset: (size_of::<Vec2>() + size_of::<Rgb>()) as u64,
+                            shader_location: 2,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float2,
+                            offset: (2 * size_of::<Vec2>() + size_of::<Rgb>()) as u64,
+                            shader_location: 3,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            format: wgpu::VertexFormat::Float2,
+                            offset: (3 * size_of::<Vec2>() + size_of::<Rgb>()) as u64,
+                            shader_location: 4,
+                        },
+                    ],
+                }],
+            },
             sample_count: 1,
             sample_mask: !0,
             alpha_to_coverage_enabled: false,
@@ -132,21 +164,14 @@ impl Pipeline {
 
     /// Construct per-window state
     pub fn new_window(&self, device: &wgpu::Device, size: Size, light_norm: [f32; 3]) -> Window {
-        type Scale = [f32; 2];
-        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
-        let scale_buf = device
-            .create_buffer_mapped(
-                scale_factor.len(),
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
-            .fill_from_slice(&scale_factor);
+        let usage = wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST;
 
-        let light_norm_buf = device
-            .create_buffer_mapped(
-                light_norm.len(),
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
-            .fill_from_slice(&light_norm);
+        type Scale = [f32; 2];
+        let scale_factor: Scale = [2.0 / size.0 as f32, -2.0 / size.1 as f32];
+        let scale_buf = device.create_buffer_with_data(bytemuck::cast_slice(&scale_factor), usage);
+
+        let light_norm_buf =
+            device.create_buffer_with_data(bytemuck::cast_slice(&light_norm), usage);
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             layout: &self.bind_group_layout,
@@ -166,6 +191,7 @@ impl Pipeline {
                     },
                 },
             ],
+            label: None,
         });
 
         Window {
@@ -175,29 +201,27 @@ impl Pipeline {
         }
     }
 
-    /// Render queued triangles and clear the queue
-    pub fn render(
-        &self,
-        window: &mut Window,
+    /// Construct a render buffer
+    pub fn render_buf<'a>(
+        &'a self,
+        window: &'a mut Window,
         device: &wgpu::Device,
         pass: usize,
-        rpass: &mut wgpu::RenderPass,
-    ) {
-        if pass >= window.passes.len() {
-            return;
+    ) -> Option<RenderBuffer<'a>> {
+        if pass >= window.passes.len() || window.passes[pass].len() == 0 {
+            return None;
         }
-        let v = &mut window.passes[pass];
+
+        let vertices = &mut window.passes[pass];
         let buffer = device
-            .create_buffer_mapped(v.len(), wgpu::BufferUsage::VERTEX)
-            .fill_from_slice(&v);
-        let count = v.len() as u32;
+            .create_buffer_with_data(bytemuck::cast_slice(&vertices), wgpu::BufferUsage::VERTEX);
 
-        rpass.set_pipeline(&self.render_pipeline);
-        rpass.set_bind_group(0, &window.bind_group, &[]);
-        rpass.set_vertex_buffers(0, &[(&buffer, 0)]);
-        rpass.draw(0..count, 0..1);
-
-        v.clear();
+        Some(RenderBuffer {
+            pipe: &self.render_pipeline,
+            vertices,
+            bind_group: &window.bind_group,
+            buffer,
+        })
     }
 }
 
@@ -209,10 +233,11 @@ impl Window {
         size: Size,
     ) {
         type Scale = [f32; 2];
-        let scale_factor: Scale = [2.0 / size.0 as f32, 2.0 / size.1 as f32];
-        let scale_buf = device
-            .create_buffer_mapped(scale_factor.len(), wgpu::BufferUsage::COPY_SRC)
-            .fill_from_slice(&scale_factor);
+        let scale_factor: Scale = [2.0 / size.0 as f32, -2.0 / size.1 as f32];
+        let scale_buf = device.create_buffer_with_data(
+            bytemuck::cast_slice(&scale_factor),
+            wgpu::BufferUsage::COPY_SRC,
+        );
         let byte_len = size_of::<Scale>() as u64;
 
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &self.scale_buf, 0, byte_len);

--- a/kas-wgpu/src/draw/shaded_round.rs
+++ b/kas-wgpu/src/draw/shaded_round.rs
@@ -122,32 +122,12 @@ impl Pipeline {
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,
-                    attributes: &[
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: 0,
-                            shader_location: 0,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float3,
-                            offset: size_of::<Vec2>() as u64,
-                            shader_location: 1,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: (size_of::<Vec2>() + size_of::<Rgb>()) as u64,
-                            shader_location: 2,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: (2 * size_of::<Vec2>() + size_of::<Rgb>()) as u64,
-                            shader_location: 3,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: (3 * size_of::<Vec2>() + size_of::<Rgb>()) as u64,
-                            shader_location: 4,
-                        },
+                    attributes: &wgpu::vertex_attr_array![
+                        0 => Float2,
+                        1 => Float3,
+                        2 => Float2,
+                        3 => Float2,
+                        4 => Float2
                     ],
                 }],
             },

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -9,7 +9,7 @@ use std::f32;
 use std::mem::size_of;
 
 use crate::draw::{Rgb, ShaderManager};
-use kas::draw::Colour;
+use kas::draw::{Colour, Pass};
 use kas::geom::{Quad, Size, Vec2};
 
 #[repr(C)]
@@ -198,7 +198,7 @@ impl Window {
     }
 
     /// Add a rectangle to the buffer
-    pub fn rect(&mut self, pass: usize, rect: Quad, col: Colour) {
+    pub fn rect(&mut self, pass: Pass, rect: Quad, col: Colour) {
         let aa = rect.a;
         let bb = rect.b;
 
@@ -214,7 +214,7 @@ impl Window {
         let t = Vec2(0.0, 0.0);
 
         #[rustfmt::skip]
-        self.add_vertices(pass, &[
+        self.add_vertices(pass.pass(), &[
             Vertex(aa, col, t), Vertex(ba, col, t), Vertex(ab, col, t),
             Vertex(ab, col, t), Vertex(ba, col, t), Vertex(bb, col, t),
         ]);
@@ -223,7 +223,7 @@ impl Window {
     /// Add a rect to the buffer, defined by two outer corners, `aa` and `bb`.
     ///
     /// Bounds on input: `aa < cc` and `-1 ≤ norm ≤ 1`.
-    pub fn shaded_rect(&mut self, pass: usize, rect: Quad, mut norm: Vec2, col: Colour) {
+    pub fn shaded_rect(&mut self, pass: Pass, rect: Quad, mut norm: Vec2, col: Colour) {
         let aa = rect.a;
         let bb = rect.b;
 
@@ -246,7 +246,7 @@ impl Window {
         let tr = (Vec2(norm.1, 0.0), Vec2(norm.0, 0.0));
 
         #[rustfmt::skip]
-        self.add_vertices(pass, &[
+        self.add_vertices(pass.pass(), &[
             Vertex(ba, col, tt.0), Vertex(mid, col, tt.1), Vertex(aa, col, tt.0),
             Vertex(aa, col, tl.0), Vertex(mid, col, tl.1), Vertex(ab, col, tl.0),
             Vertex(ab, col, tb.0), Vertex(mid, col, tb.1), Vertex(bb, col, tb.0),
@@ -255,7 +255,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn frame(&mut self, pass: usize, outer: Quad, inner: Quad, col: Colour) {
+    pub fn frame(&mut self, pass: Pass, outer: Quad, inner: Quad, col: Colour) {
         let norm = Vec2::splat(0.0);
         self.shaded_frame(pass, outer, inner, norm, col);
     }
@@ -266,7 +266,7 @@ impl Window {
     /// Bounds on input: `aa < cc < dd < bb` and `-1 ≤ norm ≤ 1`.
     pub fn shaded_frame(
         &mut self,
-        pass: usize,
+        pass: Pass,
         outer: Quad,
         inner: Quad,
         mut norm: Vec2,
@@ -306,7 +306,7 @@ impl Window {
         let tr = (Vec2(norm.1, 0.0), Vec2(norm.0, 0.0));
 
         #[rustfmt::skip]
-        self.add_vertices(pass, &[
+        self.add_vertices(pass.pass(), &[
             // top bar: ba - dc - cc - aa
             Vertex(ba, col, tt.0), Vertex(dc, col, tt.1), Vertex(aa, col, tt.0),
             Vertex(aa, col, tt.0), Vertex(dc, col, tt.1), Vertex(cc, col, tt.1),

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -111,23 +111,7 @@ impl Pipeline {
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,
-                    attributes: &[
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: 0,
-                            shader_location: 0,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float3,
-                            offset: size_of::<Vec2>() as u64,
-                            shader_location: 1,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            format: wgpu::VertexFormat::Float2,
-                            offset: (size_of::<Vec2>() + size_of::<Rgb>()) as u64,
-                            shader_location: 2,
-                        },
-                    ],
+                    attributes: &wgpu::vertex_attr_array![0 => Float2, 1 => Float3, 2 => Float2],
                 }],
             },
             sample_count: 1,

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -105,7 +105,7 @@ impl Pipeline {
                 alpha_blend: wgpu::BlendDescriptor::REPLACE,
                 write_mask: wgpu::ColorWrite::ALL,
             }],
-            depth_stencil_state: None,
+            depth_stencil_state: Some(super::DEPTH_DESC),
             vertex_state: wgpu::VertexStateDescriptor {
                 index_format: wgpu::IndexFormat::Uint16,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -10,11 +10,11 @@ use std::mem::size_of;
 
 use crate::draw::{Rgb, ShaderManager};
 use kas::draw::{Colour, Pass};
-use kas::geom::{Quad, Size, Vec2};
+use kas::geom::{Quad, Size, Vec2, Vec3};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-struct Vertex(Vec2, Rgb, Vec2);
+struct Vertex(Vec3, Rgb, Vec2);
 unsafe impl bytemuck::Zeroable for Vertex {}
 unsafe impl bytemuck::Pod for Vertex {}
 
@@ -111,7 +111,7 @@ impl Pipeline {
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,
-                    attributes: &wgpu::vertex_attr_array![0 => Float2, 1 => Float3, 2 => Float2],
+                    attributes: &wgpu::vertex_attr_array![0 => Float3, 1 => Float3, 2 => Float2],
                 }],
             },
             sample_count: 1,
@@ -216,8 +216,11 @@ impl Window {
             return;
         }
 
-        let ab = Vec2(aa.0, bb.1);
-        let ba = Vec2(bb.0, aa.1);
+        let depth = pass.depth();
+        let ab = Vec3(aa.0, bb.1, depth);
+        let ba = Vec3(bb.0, aa.1, depth);
+        let aa = Vec3::from2(aa, depth);
+        let bb = Vec3::from2(bb, depth);
 
         let col = col.into();
         let t = Vec2(0.0, 0.0);
@@ -244,9 +247,12 @@ impl Window {
             norm = Vec2::splat(0.0);
         }
 
-        let ab = Vec2(aa.0, bb.1);
-        let ba = Vec2(bb.0, aa.1);
-        let mid = (aa + bb) * 0.5;
+        let depth = pass.depth();
+        let mid = Vec3::from2((aa + bb) * 0.5, depth);
+        let ab = Vec3(aa.0, bb.1, depth);
+        let ba = Vec3(bb.0, aa.1, depth);
+        let aa = Vec3::from2(aa, depth);
+        let bb = Vec3::from2(bb, depth);
 
         let col = col.into();
         let tt = (Vec2(0.0, -norm.1), Vec2(0.0, -norm.0));
@@ -303,10 +309,15 @@ impl Window {
             norm = Vec2::splat(0.0);
         }
 
-        let ab = Vec2(aa.0, bb.1);
-        let ba = Vec2(bb.0, aa.1);
-        let cd = Vec2(cc.0, dd.1);
-        let dc = Vec2(dd.0, cc.1);
+        let depth = pass.depth();
+        let ab = Vec3(aa.0, bb.1, depth);
+        let ba = Vec3(bb.0, aa.1, depth);
+        let cd = Vec3(cc.0, dd.1, depth);
+        let dc = Vec3(dd.0, cc.1, depth);
+        let aa = Vec3::from2(aa, depth);
+        let bb = Vec3::from2(bb, depth);
+        let cc = Vec3::from2(cc, depth);
+        let dd = Vec3::from2(dd, depth);
 
         let col = col.into();
         let tt = (Vec2(0.0, -norm.1), Vec2(0.0, -norm.0));

--- a/kas-wgpu/src/draw/shaders/scaled3122.vert
+++ b/kas-wgpu/src/draw/shaders/scaled3122.vert
@@ -6,7 +6,7 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec2 a_pos;
+layout(location = 0) in vec3 a_pos;
 layout(location = 1) in vec3 a_col;
 layout(location = 2) in float a1;
 layout(location = 3) in vec2 a2;
@@ -24,7 +24,7 @@ layout(set = 0, binding = 0) uniform Locals {
 const vec2 offset = { -1.0, 1.0 };
 
 void main() {
-    gl_Position = vec4(scale * a_pos + offset, 0.0, 1.0);
+    gl_Position = vec4(scale * a_pos.xy + offset, a_pos.z, 1.0);
     b_col = a_col;
     b1 = a1;
     b2 = a2;

--- a/kas-wgpu/src/draw/shaders/scaled3122.vert
+++ b/kas-wgpu/src/draw/shaders/scaled3122.vert
@@ -21,10 +21,10 @@ layout(set = 0, binding = 0) uniform Locals {
     vec2 scale;
 };
 
-const vec2 offset = { 1.0, 1.0 };
+const vec2 offset = { -1.0, 1.0 };
 
 void main() {
-    gl_Position = vec4(scale * a_pos - offset, 0.0, 1.0);
+    gl_Position = vec4(scale * a_pos + offset, 0.0, 1.0);
     b_col = a_col;
     b1 = a1;
     b2 = a2;

--- a/kas-wgpu/src/draw/shaders/scaled32.vert
+++ b/kas-wgpu/src/draw/shaders/scaled32.vert
@@ -17,10 +17,10 @@ layout(set = 0, binding = 0) uniform Locals {
     vec2 scale;
 };
 
-const vec2 offset = { 1.0, 1.0 };
+const vec2 offset = { -1.0, 1.0 };
 
 void main() {
-    gl_Position = vec4(scale * a_pos - offset, 0.0, 1.0);
+    gl_Position = vec4(scale * a_pos + offset, 0.0, 1.0);
     b_col = a_col;
     b1 = a1;
 }

--- a/kas-wgpu/src/draw/shaders/scaled32.vert
+++ b/kas-wgpu/src/draw/shaders/scaled32.vert
@@ -6,7 +6,7 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec2 a_pos;
+layout(location = 0) in vec3 a_pos;
 layout(location = 1) in vec3 a_col;
 layout(location = 2) in vec2 a1;
 
@@ -20,7 +20,7 @@ layout(set = 0, binding = 0) uniform Locals {
 const vec2 offset = { -1.0, 1.0 };
 
 void main() {
-    gl_Position = vec4(scale * a_pos + offset, 0.0, 1.0);
+    gl_Position = vec4(scale * a_pos.xy + offset, a_pos.z, 1.0);
     b_col = a_col;
     b1 = a1;
 }

--- a/kas-wgpu/src/draw/shaders/scaled322.vert
+++ b/kas-wgpu/src/draw/shaders/scaled322.vert
@@ -19,10 +19,10 @@ layout(set = 0, binding = 0) uniform Locals {
     vec2 scale;
 };
 
-const vec2 offset = { 1.0, 1.0 };
+const vec2 offset = { -1.0, 1.0 };
 
 void main() {
-    gl_Position = vec4(scale * a_pos - offset, 0.0, 1.0);
+    gl_Position = vec4(scale * a_pos + offset, 0.0, 1.0);
     b_col = a_col;
     b1 = a1;
     b2 = a2;

--- a/kas-wgpu/src/draw/shaders/scaled322.vert
+++ b/kas-wgpu/src/draw/shaders/scaled322.vert
@@ -6,7 +6,7 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec2 a_pos;
+layout(location = 0) in vec3 a_pos;
 layout(location = 1) in vec3 a_col;
 layout(location = 2) in vec2 a1;
 layout(location = 3) in vec2 a2;
@@ -22,7 +22,7 @@ layout(set = 0, binding = 0) uniform Locals {
 const vec2 offset = { -1.0, 1.0 };
 
 void main() {
-    gl_Position = vec4(scale * a_pos + offset, 0.0, 1.0);
+    gl_Position = vec4(scale * a_pos.xy + offset, a_pos.z, 1.0);
     b_col = a_col;
     b1 = a1;
     b2 = a2;

--- a/kas-wgpu/src/draw/shaders/scaled3222.vert
+++ b/kas-wgpu/src/draw/shaders/scaled3222.vert
@@ -21,10 +21,10 @@ layout(set = 0, binding = 0) uniform Locals {
     vec2 scale;
 };
 
-const vec2 offset = { 1.0, 1.0 };
+const vec2 offset = { -1.0, 1.0 };
 
 void main() {
-    gl_Position = vec4(scale * a_pos - offset, 0.0, 1.0);
+    gl_Position = vec4(scale * a_pos + offset, 0.0, 1.0);
     b_col = a_col;
     b1 = a1;
     b2 = a2;

--- a/kas-wgpu/src/draw/shaders/scaled3222.vert
+++ b/kas-wgpu/src/draw/shaders/scaled3222.vert
@@ -6,7 +6,7 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec2 a_pos;
+layout(location = 0) in vec3 a_pos;
 layout(location = 1) in vec3 a_col;
 layout(location = 2) in vec2 a1;
 layout(location = 3) in vec2 a2;
@@ -24,7 +24,7 @@ layout(set = 0, binding = 0) uniform Locals {
 const vec2 offset = { -1.0, 1.0 };
 
 void main() {
-    gl_Position = vec4(scale * a_pos + offset, 0.0, 1.0);
+    gl_Position = vec4(scale * a_pos.xy + offset, a_pos.z, 1.0);
     b_col = a_col;
     b1 = a1;
     b2 = a2;

--- a/kas-wgpu/src/options.rs
+++ b/kas-wgpu/src/options.rs
@@ -93,7 +93,11 @@ impl Options {
     pub(crate) fn adapter_options(&self) -> wgpu::RequestAdapterOptions {
         wgpu::RequestAdapterOptions {
             power_preference: self.power_preference,
-            backends: self.backends,
+            compatible_surface: None,
         }
+    }
+
+    pub(crate) fn backend(&self) -> BackendBit {
+        self.backends
     }
 }

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -90,7 +90,7 @@ where
             format: TEX_FORMAT,
             width: size.0,
             height: size.1,
-            present_mode: wgpu::PresentMode::Vsync,
+            present_mode: wgpu::PresentMode::Fifo,
         };
         let swap_chain = shared.device.create_swap_chain(&surface, &sc_desc);
 
@@ -357,7 +357,7 @@ where
         self.widget.draw(&mut draw_handle, &self.mgr, false);
         drop(draw_handle);
 
-        let frame = self.swap_chain.get_next_texture();
+        let frame = self.swap_chain.get_next_texture().unwrap();
         let clear_color = to_wgpu_color(shared.theme.clear_colour());
         shared.render(&mut self.draw, &frame.view, clear_color);
     }

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -58,14 +58,14 @@ pub use text::{DrawText, DrawTextShared, Font, FontId, TextProperties};
 /// Users normally need only pass this value.
 ///
 /// Custom render pipes should extract the pass number and depth value.
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone)]
 pub struct Pass(u32, f32);
 
 impl Pass {
     /// Construct a new pass from a `u32` identifier and depth value
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[inline]
-    pub fn new_pass_with_depth(n: u32, d: f32) -> Self {
+    pub const fn new_pass_with_depth(n: u32, d: f32) -> Self {
         Pass(n, d)
     }
 

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -50,14 +50,39 @@ use std::any::Any;
 use crate::geom::{Quad, Rect, Vec2};
 
 pub use colour::Colour;
-pub use handle::{DrawHandle, InputState, SizeHandle, TextClass};
+pub use handle::{ClipRegion, DrawHandle, InputState, SizeHandle, TextClass};
 pub use text::{DrawText, DrawTextShared, Font, FontId, TextProperties};
 
-/// Type returned by [`Draw::add_clip_region`].
+/// Pass identifier
 ///
-/// Supports [`Default`], which may be used to target the root region.
+/// Users normally need only pass this value.
+///
+/// Custom render pipes should extract the pass number and depth value.
 #[derive(Copy, Clone, Default)]
-pub struct Region(pub usize);
+pub struct Pass(u32, f32);
+
+impl Pass {
+    /// Construct a new pass from a `u32` identifier and depth value
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    #[inline]
+    pub fn new_pass_with_depth(n: u32, d: f32) -> Self {
+        Pass(n, d)
+    }
+
+    /// The pass number
+    ///
+    /// This value is returned as `usize` but is always safe to store `as u32`.
+    #[inline]
+    pub fn pass(self) -> usize {
+        self.0 as usize
+    }
+
+    /// The depth value
+    #[inline]
+    pub fn depth(self) -> f32 {
+        self.1
+    }
+}
 
 /// Bounds on type shared across [`Draw`] implementations
 pub trait DrawShared {
@@ -71,10 +96,9 @@ pub trait DrawShared {
 /// type conversions can be performed with `from` and `into`. Integral
 /// coordinates align with pixels, non-integral coordinates may also be used.
 ///
-/// All draw operations target some region identified by a handle of type
-/// [`Region`]; this may be the whole window, some sub-region, or perhaps
-/// something else such as a texture. In general the user doesn't need to know
-/// what this is, but merely pass the given handle.
+/// Draw operations take place over multiple render passes, identified by a
+/// handle of type [`Pass`]. In general the user only needs to pass this value
+/// into methods as required. [`Draw::add_clip_region`] creates a new [`Pass`].
 ///
 /// The primitives provided by this trait all draw solid areas, replacing prior
 /// contents.
@@ -88,15 +112,17 @@ pub trait Draw: Any {
     /// Add a clip region
     ///
     /// Clip regions are cleared each frame and so must be recreated on demand.
-    fn add_clip_region(&mut self, region: Rect) -> Region;
+    /// Each region has an associated depth value. The theme is responsible for
+    /// assigning depth values.
+    fn add_clip_region(&mut self, rect: Rect, depth: f32) -> Pass;
 
     /// Draw a rectangle of uniform colour
-    fn rect(&mut self, region: Region, rect: Quad, col: Colour);
+    fn rect(&mut self, pass: Pass, rect: Quad, col: Colour);
 
     /// Draw a frame of uniform colour
     ///
     /// The frame is defined by the area inside `outer` and not inside `inner`.
-    fn frame(&mut self, region: Region, outer: Quad, inner: Quad, col: Colour);
+    fn frame(&mut self, pass: Pass, outer: Quad, inner: Quad, col: Colour);
 }
 
 /// Drawing commands for rounded shapes
@@ -115,7 +141,7 @@ pub trait DrawRounded: Draw {
     ///
     /// Note that for rectangular, axis-aligned lines, [`Draw::rect`] should be
     /// preferred.
-    fn rounded_line(&mut self, region: Region, p1: Vec2, p2: Vec2, radius: f32, col: Colour);
+    fn rounded_line(&mut self, pass: Pass, p1: Vec2, p2: Vec2, radius: f32, col: Colour);
 
     /// Draw a circle or oval of uniform colour
     ///
@@ -124,7 +150,7 @@ pub trait DrawRounded: Draw {
     /// The `inner_radius` parameter gives the inner radius relative to the
     /// outer radius: a value of `0.0` will result in the whole shape being
     /// painted, while `1.0` will result in a zero-width line on the outer edge.
-    fn circle(&mut self, region: Region, rect: Quad, inner_radius: f32, col: Colour);
+    fn circle(&mut self, pass: Pass, rect: Quad, inner_radius: f32, col: Colour);
 
     /// Draw a frame with rounded corners and uniform colour
     ///
@@ -139,7 +165,7 @@ pub trait DrawRounded: Draw {
     /// allocated area.
     fn rounded_frame(
         &mut self,
-        region: Region,
+        pass: Pass,
         outer: Quad,
         inner: Quad,
         inner_radius: f32,
@@ -160,15 +186,15 @@ pub trait DrawRounded: Draw {
 /// 0 is perpendicular to the screen towards the viewer, and 1 points outwards.
 pub trait DrawShaded: Draw {
     /// Add a shaded square to the draw buffer
-    fn shaded_square(&mut self, region: Region, rect: Quad, norm: (f32, f32), col: Colour);
+    fn shaded_square(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Colour);
 
     /// Add a shaded circle to the draw buffer
-    fn shaded_circle(&mut self, region: Region, rect: Quad, norm: (f32, f32), col: Colour);
+    fn shaded_circle(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Colour);
 
     /// Add a square shaded frame to the draw buffer.
     fn shaded_square_frame(
         &mut self,
-        region: Region,
+        pass: Pass,
         outer: Quad,
         inner: Quad,
         norm: (f32, f32),
@@ -178,7 +204,7 @@ pub trait DrawShaded: Draw {
     /// Add a rounded shaded frame to the draw buffer.
     fn shaded_round_frame(
         &mut self,
-        region: Region,
+        pass: Pass,
         outer: Quad,
         inner: Quad,
         norm: (f32, f32),

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -7,7 +7,7 @@
 
 pub use rusttype::Font;
 
-use super::{Colour, Draw, DrawShared};
+use super::{Colour, Draw, DrawShared, Pass};
 use crate::geom::Rect;
 use crate::Align;
 
@@ -56,7 +56,7 @@ pub trait DrawText: Draw {
     ///
     /// This allows text to be drawn according to a high-level API, and should
     /// satisfy most uses.
-    fn text(&mut self, rect: Rect, text: &str, props: TextProperties);
+    fn text(&mut self, pass: Pass, rect: Rect, text: &str, props: TextProperties);
 
     /// Calculate size bound on text
     ///

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -9,7 +9,7 @@
 use winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize, Pixel};
 
 mod vector;
-pub use vector::{DVec2, Quad, Vec2};
+pub use vector::{DVec2, Quad, Vec2, Vec3};
 
 /// An `(x, y)` coordinate.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -84,202 +84,6 @@ impl From<Rect> for Quad {
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Vec2(pub f32, pub f32);
 
-impl Vec2 {
-    /// Zero
-    pub const ZERO: Vec2 = Vec2(0.0, 0.0);
-
-    /// Constructs a new instance with each element initialized to `value`.
-    #[inline]
-    pub const fn splat(value: f32) -> Self {
-        Vec2(value, value)
-    }
-
-    /// Take the minimum component
-    #[inline]
-    pub fn min_comp(self) -> f32 {
-        self.0.min(self.1)
-    }
-
-    /// For each component, return `±1` with the same sign as `self`.
-    #[inline]
-    pub fn sign(self) -> Self {
-        let one = 1f32;
-        Vec2(one.copysign(self.0), one.copysign(self.1))
-    }
-
-    /// True when for all components, `lhs < rhs`
-    #[inline]
-    pub fn lt(self, rhs: Self) -> bool {
-        self.0 < rhs.0 && self.1 < rhs.1
-    }
-
-    /// True when for all components, `lhs ≤ rhs`
-    #[inline]
-    pub fn le(self, rhs: Self) -> bool {
-        self.0 <= rhs.0 && self.1 <= rhs.1
-    }
-
-    /// True when for all components, `lhs ≥ rhs`
-    #[inline]
-    pub fn ge(self, rhs: Self) -> bool {
-        self.0 >= rhs.0 && self.1 >= rhs.1
-    }
-
-    /// True when for all components, `lhs > rhs`
-    #[inline]
-    pub fn gt(self, rhs: Self) -> bool {
-        self.0 > rhs.0 && self.1 > rhs.1
-    }
-
-    /// Multiply two vectors as if they are complex numbers
-    #[inline]
-    pub fn complex_mul(self, rhs: Self) -> Self {
-        Vec2(
-            self.0 * rhs.0 - self.1 * rhs.1,
-            self.0 * rhs.1 + self.1 * rhs.0,
-        )
-    }
-
-    /// Divide by a second vector as if they are complex numbers
-    #[inline]
-    pub fn complex_div(self, rhs: Self) -> Self {
-        self.complex_mul(rhs.complex_inv())
-    }
-
-    /// Take the complex reciprocal
-    #[inline]
-    pub fn complex_inv(self) -> Self {
-        let ssi = 1.0 / self.sum_square();
-        Vec2(self.0 * ssi, -self.1 * ssi)
-    }
-
-    /// Return the sum of the terms
-    #[inline]
-    pub fn sum(self) -> f32 {
-        self.0 + self.1
-    }
-
-    /// Return the sum of the square of the terms
-    #[inline]
-    pub fn sum_square(self) -> f32 {
-        self.0 * self.0 + self.1 * self.1
-    }
-}
-
-impl Neg for Vec2 {
-    type Output = Vec2;
-    #[inline]
-    fn neg(self) -> Self::Output {
-        Vec2(-self.0, -self.1)
-    }
-}
-
-impl Add<Vec2> for Vec2 {
-    type Output = Vec2;
-    #[inline]
-    fn add(self, rhs: Vec2) -> Self::Output {
-        Vec2(self.0 + rhs.0, self.1 + rhs.1)
-    }
-}
-
-impl Add<f32> for Vec2 {
-    type Output = Vec2;
-    #[inline]
-    fn add(self, rhs: f32) -> Self::Output {
-        Vec2(self.0 + rhs, self.1 + rhs)
-    }
-}
-
-impl Sub<Vec2> for Vec2 {
-    type Output = Vec2;
-    #[inline]
-    fn sub(self, rhs: Vec2) -> Self::Output {
-        Vec2(self.0 - rhs.0, self.1 - rhs.1)
-    }
-}
-
-impl Sub<f32> for Vec2 {
-    type Output = Vec2;
-    #[inline]
-    fn sub(self, rhs: f32) -> Self::Output {
-        Vec2(self.0 - rhs, self.1 - rhs)
-    }
-}
-
-impl Mul<Vec2> for Vec2 {
-    type Output = Vec2;
-    #[inline]
-    fn mul(self, rhs: Vec2) -> Self::Output {
-        Vec2(self.0 * rhs.0, self.1 * rhs.1)
-    }
-}
-
-impl Mul<f32> for Vec2 {
-    type Output = Vec2;
-    #[inline]
-    fn mul(self, rhs: f32) -> Self::Output {
-        Vec2(self.0 * rhs, self.1 * rhs)
-    }
-}
-
-impl Div<Vec2> for Vec2 {
-    type Output = Vec2;
-    #[inline]
-    fn div(self, rhs: Vec2) -> Self::Output {
-        Vec2(self.0 / rhs.0, self.1 / rhs.1)
-    }
-}
-
-impl Div<f32> for Vec2 {
-    type Output = Vec2;
-    #[inline]
-    fn div(self, rhs: f32) -> Self::Output {
-        Vec2(self.0 / rhs, self.1 / rhs)
-    }
-}
-
-impl From<(f32, f32)> for Vec2 {
-    #[inline]
-    fn from(arg: (f32, f32)) -> Self {
-        Vec2(arg.0, arg.1)
-    }
-}
-
-impl From<Vec2> for (f32, f32) {
-    #[inline]
-    fn from(v: Vec2) -> Self {
-        (v.0, v.1)
-    }
-}
-
-impl From<Coord> for Vec2 {
-    #[inline]
-    fn from(arg: Coord) -> Self {
-        Vec2(arg.0 as f32, arg.1 as f32)
-    }
-}
-
-impl From<Size> for Vec2 {
-    #[inline]
-    fn from(arg: Size) -> Self {
-        Vec2(arg.0 as f32, arg.1 as f32)
-    }
-}
-
-impl From<Vec2> for Coord {
-    #[inline]
-    fn from(arg: Vec2) -> Self {
-        Coord(arg.0.round() as i32, arg.1.round() as i32)
-    }
-}
-
-impl From<Vec2> for Size {
-    #[inline]
-    fn from(arg: Vec2) -> Self {
-        Size(arg.0.round() as u32, arg.1.round() as u32)
-    }
-}
-
 /// 2D vector (double precision)
 ///
 /// Usually used as either a coordinate or a difference of coordinates, but
@@ -293,199 +97,205 @@ impl From<Vec2> for Size {
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct DVec2(pub f64, pub f64);
 
-impl DVec2 {
-    /// Zero
-    pub const ZERO: DVec2 = DVec2(0.0, 0.0);
+macro_rules! impl_vec2 {
+    ($T:ident, $f:ty) => {
+        impl $T {
+            /// Zero
+            pub const ZERO: $T = $T(0.0, 0.0);
 
-    /// Constructs a new instance with each element initialized to `value`.
-    #[inline]
-    pub const fn splat(value: f64) -> Self {
-        DVec2(value, value)
-    }
+            /// Constructs a new instance with each element initialized to `value`.
+            #[inline]
+            pub const fn splat(value: $f) -> Self {
+                $T(value, value)
+            }
 
-    /// For each component, return `±1` with the same sign as `self`.
-    #[inline]
-    pub fn sign(self) -> Self {
-        let one = 1f64;
-        DVec2(one.copysign(self.0), one.copysign(self.1))
-    }
+            /// Take the minimum component
+            #[inline]
+            pub fn min_comp(self) -> $f {
+                self.0.min(self.1)
+            }
 
-    /// True when for all components, `lhs < rhs`
-    #[inline]
-    pub fn lt(self, rhs: Self) -> bool {
-        self.0 < rhs.0 && self.1 < rhs.1
-    }
+            /// For each component, return `±1` with the same sign as `self`.
+            #[inline]
+            pub fn sign(self) -> Self {
+                let one: $f = 1.0;
+                $T(one.copysign(self.0), one.copysign(self.1))
+            }
 
-    /// True when for all components, `lhs ≤ rhs`
-    #[inline]
-    pub fn le(self, rhs: Self) -> bool {
-        self.0 <= rhs.0 && self.1 <= rhs.1
-    }
+            /// True when for all components, `lhs < rhs`
+            #[inline]
+            pub fn lt(self, rhs: Self) -> bool {
+                self.0 < rhs.0 && self.1 < rhs.1
+            }
 
-    /// True when for all components, `lhs ≥ rhs`
-    #[inline]
-    pub fn ge(self, rhs: Self) -> bool {
-        self.0 >= rhs.0 && self.1 >= rhs.1
-    }
+            /// True when for all components, `lhs ≤ rhs`
+            #[inline]
+            pub fn le(self, rhs: Self) -> bool {
+                self.0 <= rhs.0 && self.1 <= rhs.1
+            }
 
-    /// True when for all components, `lhs > rhs`
-    #[inline]
-    pub fn gt(self, rhs: Self) -> bool {
-        self.0 > rhs.0 && self.1 > rhs.1
-    }
+            /// True when for all components, `lhs ≥ rhs`
+            #[inline]
+            pub fn ge(self, rhs: Self) -> bool {
+                self.0 >= rhs.0 && self.1 >= rhs.1
+            }
 
-    /// Multiply two vectors as if they are complex numbers
-    #[inline]
-    pub fn complex_mul(self, rhs: Self) -> Self {
-        DVec2(
-            self.0 * rhs.0 - self.1 * rhs.1,
-            self.0 * rhs.1 + self.1 * rhs.0,
-        )
-    }
+            /// True when for all components, `lhs > rhs`
+            #[inline]
+            pub fn gt(self, rhs: Self) -> bool {
+                self.0 > rhs.0 && self.1 > rhs.1
+            }
 
-    /// Divide by a second vector as if they are complex numbers
-    #[inline]
-    pub fn complex_div(self, rhs: Self) -> Self {
-        self.complex_mul(rhs.complex_inv())
-    }
+            /// Multiply two vectors as if they are complex numbers
+            #[inline]
+            pub fn complex_mul(self, rhs: Self) -> Self {
+                $T(
+                    self.0 * rhs.0 - self.1 * rhs.1,
+                    self.0 * rhs.1 + self.1 * rhs.0,
+                )
+            }
 
-    /// Take the complex reciprocal
-    #[inline]
-    pub fn complex_inv(self) -> Self {
-        let ssi = 1.0 / self.sum_square();
-        DVec2(self.0 * ssi, -self.1 * ssi)
-    }
+            /// Divide by a second vector as if they are complex numbers
+            #[inline]
+            pub fn complex_div(self, rhs: Self) -> Self {
+                self.complex_mul(rhs.complex_inv())
+            }
 
-    /// Return the sum of the terms
-    #[inline]
-    pub fn sum(self) -> f64 {
-        self.0 + self.1
-    }
+            /// Take the complex reciprocal
+            #[inline]
+            pub fn complex_inv(self) -> Self {
+                let ssi = 1.0 / self.sum_square();
+                $T(self.0 * ssi, -self.1 * ssi)
+            }
 
-    /// Return the sum of the square of the terms
-    #[inline]
-    pub fn sum_square(self) -> f64 {
-        self.0 * self.0 + self.1 * self.1
-    }
+            /// Return the sum of the terms
+            #[inline]
+            pub fn sum(self) -> $f {
+                self.0 + self.1
+            }
+
+            /// Return the sum of the square of the terms
+            #[inline]
+            pub fn sum_square(self) -> $f {
+                self.0 * self.0 + self.1 * self.1
+            }
+        }
+
+        impl Neg for $T {
+            type Output = $T;
+            #[inline]
+            fn neg(self) -> Self::Output {
+                $T(-self.0, -self.1)
+            }
+        }
+
+        impl Add<$T> for $T {
+            type Output = $T;
+            #[inline]
+            fn add(self, rhs: $T) -> Self::Output {
+                $T(self.0 + rhs.0, self.1 + rhs.1)
+            }
+        }
+
+        impl Add<$f> for $T {
+            type Output = $T;
+            #[inline]
+            fn add(self, rhs: $f) -> Self::Output {
+                $T(self.0 + rhs, self.1 + rhs)
+            }
+        }
+
+        impl Sub<$T> for $T {
+            type Output = $T;
+            #[inline]
+            fn sub(self, rhs: $T) -> Self::Output {
+                $T(self.0 - rhs.0, self.1 - rhs.1)
+            }
+        }
+
+        impl Sub<$f> for $T {
+            type Output = $T;
+            #[inline]
+            fn sub(self, rhs: $f) -> Self::Output {
+                $T(self.0 - rhs, self.1 - rhs)
+            }
+        }
+
+        impl Mul<$T> for $T {
+            type Output = $T;
+            #[inline]
+            fn mul(self, rhs: $T) -> Self::Output {
+                $T(self.0 * rhs.0, self.1 * rhs.1)
+            }
+        }
+
+        impl Mul<$f> for $T {
+            type Output = $T;
+            #[inline]
+            fn mul(self, rhs: $f) -> Self::Output {
+                $T(self.0 * rhs, self.1 * rhs)
+            }
+        }
+
+        impl Div<$T> for $T {
+            type Output = $T;
+            #[inline]
+            fn div(self, rhs: $T) -> Self::Output {
+                $T(self.0 / rhs.0, self.1 / rhs.1)
+            }
+        }
+
+        impl Div<$f> for $T {
+            type Output = $T;
+            #[inline]
+            fn div(self, rhs: $f) -> Self::Output {
+                $T(self.0 / rhs, self.1 / rhs)
+            }
+        }
+
+        impl From<($f, $f)> for $T {
+            #[inline]
+            fn from(arg: ($f, $f)) -> Self {
+                $T(arg.0, arg.1)
+            }
+        }
+
+        impl From<$T> for ($f, $f) {
+            #[inline]
+            fn from(v: $T) -> Self {
+                (v.0, v.1)
+            }
+        }
+
+        impl From<Coord> for $T {
+            #[inline]
+            fn from(arg: Coord) -> Self {
+                $T(arg.0 as $f, arg.1 as $f)
+            }
+        }
+
+        impl From<Size> for $T {
+            #[inline]
+            fn from(arg: Size) -> Self {
+                $T(arg.0 as $f, arg.1 as $f)
+            }
+        }
+
+        impl From<$T> for Coord {
+            #[inline]
+            fn from(arg: $T) -> Self {
+                Coord(arg.0.round() as i32, arg.1.round() as i32)
+            }
+        }
+
+        impl From<$T> for Size {
+            #[inline]
+            fn from(arg: $T) -> Self {
+                Size(arg.0.round() as u32, arg.1.round() as u32)
+            }
+        }
+    };
 }
 
-impl Neg for DVec2 {
-    type Output = DVec2;
-    #[inline]
-    fn neg(self) -> Self::Output {
-        DVec2(-self.0, -self.1)
-    }
-}
-
-impl Add<DVec2> for DVec2 {
-    type Output = DVec2;
-    #[inline]
-    fn add(self, rhs: DVec2) -> Self::Output {
-        DVec2(self.0 + rhs.0, self.1 + rhs.1)
-    }
-}
-
-impl Add<f64> for DVec2 {
-    type Output = DVec2;
-    #[inline]
-    fn add(self, rhs: f64) -> Self::Output {
-        DVec2(self.0 + rhs, self.1 + rhs)
-    }
-}
-
-impl Sub<DVec2> for DVec2 {
-    type Output = DVec2;
-    #[inline]
-    fn sub(self, rhs: DVec2) -> Self::Output {
-        DVec2(self.0 - rhs.0, self.1 - rhs.1)
-    }
-}
-
-impl Sub<f64> for DVec2 {
-    type Output = DVec2;
-    #[inline]
-    fn sub(self, rhs: f64) -> Self::Output {
-        DVec2(self.0 - rhs, self.1 - rhs)
-    }
-}
-
-impl Mul<DVec2> for DVec2 {
-    type Output = DVec2;
-    #[inline]
-    fn mul(self, rhs: DVec2) -> Self::Output {
-        DVec2(self.0 * rhs.0, self.1 * rhs.1)
-    }
-}
-
-impl Mul<f64> for DVec2 {
-    type Output = DVec2;
-    #[inline]
-    fn mul(self, rhs: f64) -> Self::Output {
-        DVec2(self.0 * rhs, self.1 * rhs)
-    }
-}
-
-impl Div<DVec2> for DVec2 {
-    type Output = DVec2;
-    #[inline]
-    fn div(self, rhs: DVec2) -> Self::Output {
-        DVec2(self.0 / rhs.0, self.1 / rhs.1)
-    }
-}
-
-impl Div<f64> for DVec2 {
-    type Output = DVec2;
-    #[inline]
-    fn div(self, rhs: f64) -> Self::Output {
-        DVec2(self.0 / rhs, self.1 / rhs)
-    }
-}
-
-impl From<(f64, f64)> for DVec2 {
-    #[inline]
-    fn from(arg: (f64, f64)) -> Self {
-        DVec2(arg.0, arg.1)
-    }
-}
-
-impl From<DVec2> for (f64, f64) {
-    #[inline]
-    fn from(v: DVec2) -> Self {
-        (v.0, v.1)
-    }
-}
-
-impl From<Coord> for DVec2 {
-    #[inline]
-    fn from(arg: Coord) -> Self {
-        DVec2(arg.0 as f64, arg.1 as f64)
-    }
-}
-
-impl From<Size> for DVec2 {
-    #[inline]
-    fn from(arg: Size) -> Self {
-        DVec2(arg.0 as f64, arg.1 as f64)
-    }
-}
-
-impl From<Vec2> for DVec2 {
-    #[inline]
-    fn from(arg: Vec2) -> Self {
-        DVec2(arg.0 as f64, arg.1 as f64)
-    }
-}
-
-impl From<DVec2> for Coord {
-    #[inline]
-    fn from(arg: DVec2) -> Self {
-        Coord(arg.0.round() as i32, arg.1.round() as i32)
-    }
-}
-
-impl From<DVec2> for Size {
-    #[inline]
-    fn from(arg: DVec2) -> Self {
-        Size(arg.0.round() as u32, arg.1.round() as u32)
-    }
-}
+impl_vec2!(Vec2, f32);
+impl_vec2!(DVec2, f64);

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -79,7 +79,7 @@ impl From<Rect> for Quad {
 /// Vectors are partially ordered and support component-wise comparison via
 /// methods like `lhs.lt(rhs)`. The `PartialOrd` trait is not implemented since
 /// it implements `lhs ≤ rhs` as `lhs < rhs || lhs == rhs` which is wrong for
-/// vectors (consider for `lhs = (0, 1), rhs = (1, 1)`).
+/// vectors (consider for `lhs = (0, 1), rhs = (1, 0)`).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Vec2(pub f32, pub f32);
@@ -92,7 +92,7 @@ pub struct Vec2(pub f32, pub f32);
 /// Vectors are partially ordered and support component-wise comparison via
 /// methods like `lhs.lt(rhs)`. The `PartialOrd` trait is not implemented since
 /// it implements `lhs ≤ rhs` as `lhs < rhs || lhs == rhs` which is wrong for
-/// vectors (consider for `lhs = (0, 1), rhs = (1, 1)`).
+/// vectors (consider for `lhs = (0, 1), rhs = (1, 0)`).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct DVec2(pub f64, pub f64);
@@ -299,3 +299,18 @@ macro_rules! impl_vec2 {
 
 impl_vec2!(Vec2, f32);
 impl_vec2!(DVec2, f64);
+
+/// 3D vector
+///
+/// Usually used for a 2D coordinate with a depth value.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Vec3(pub f32, pub f32, pub f32);
+
+impl Vec3 {
+    /// Construct from a [`Vec2`] and third value
+    #[inline]
+    pub fn from2(v: Vec2, z: f32) -> Self {
+        Vec3(v.0, v.1, z)
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -146,9 +146,6 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// If the widget is disabled, this returns `None` without recursing children.
     fn find(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
-        if self.is_disabled() {
-            return None;
-        }
         if id == self.id() {
             return Some(self.as_widget());
         } else if id > self.id() {
@@ -294,6 +291,20 @@ pub trait Layout: WidgetChildren {
     #[inline]
     fn set_rect(&mut self, rect: Rect, _align: AlignHints) {
         self.core_data_mut().rect = rect;
+    }
+
+    /// Get translation of a child
+    ///
+    /// Children may live in a translated coordinate space relative to their
+    /// parent. This method returns an offset which should be *added* to a
+    /// coordinate to translate *into* the child's coordinate space or
+    /// subtracted to translate out.
+    ///
+    /// In most cases, the translation will be zero. Widgets should return
+    /// [`Coord::ZERO`] for non-existant children.
+    #[inline]
+    fn translation(&self, _child_index: usize) -> Coord {
+        Coord::ZERO
     }
 
     /// Iterate through children in spatial order

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -246,7 +246,7 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
                     mgr.set_nav_focus(id);
                 }
             }
-            Event::PressEnd { end_id, coord, .. } => {
+            Event::PressEnd { end_id, .. } => {
                 if let Some(id) = end_id {
                     if id == self.id() {
                         if self.opening {
@@ -255,7 +255,7 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
                             }
                             return Response::None;
                         }
-                    } else if self.popup_id.is_some() && self.popup.rect().contains(coord) {
+                    } else if self.popup_id.is_some() && self.popup.is_ancestor_of(id) {
                         let r = self.popup.send(mgr, id, Event::Activate);
                         return self.map_response(mgr, r);
                     }

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -200,7 +200,9 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
                 direction: Direction::Down,
             });
             s.popup_id = Some(id);
-            mgr.next_nav_focus(s, false);
+            if let Some(id) = s.popup.inner.inner.get(s.active).map(|w| w.id()) {
+                mgr.set_nav_focus(id);
+            }
         };
         match event {
             Event::Activate => {
@@ -237,9 +239,12 @@ impl<M: Clone + Debug + 'static> event::Handler for ComboBox<M> {
                 if self.popup_id.is_none() {
                     open_popup(self, mgr);
                 }
-                let cond = cur_id == Some(self.id()) || self.popup.rect().contains(coord);
+                let cond = self.popup.inner.inner.rect().contains(coord);
                 let target = if cond { cur_id } else { None };
                 mgr.set_grab_depress(source, target);
+                if let Some(id) = target {
+                    mgr.set_nav_focus(id);
+                }
             }
             Event::PressEnd { end_id, coord, .. } => {
                 if let Some(id) = end_id {

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -202,6 +202,14 @@ impl<W: Widget> Layout for ScrollRegion<W> {
         }
     }
 
+    #[inline]
+    fn translation(&self, child_index: usize) -> Coord {
+        match child_index {
+            2 => self.offset,
+            _ => Coord::ZERO,
+        }
+    }
+
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {
         if !self.rect().contains(coord) {
             return None;

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -8,7 +8,7 @@
 use std::fmt::Debug;
 
 use super::ScrollBar;
-use kas::draw::{DrawHandle, SizeHandle, TextClass};
+use kas::draw::{ClipRegion, DrawHandle, SizeHandle, TextClass};
 use kas::event::ScrollDelta::{LineDelta, PixelDelta};
 use kas::event::{Event, Manager, NavKey, Response};
 use kas::layout::{AxisInfo, SizeRules};
@@ -226,7 +226,7 @@ impl<W: Widget> Layout for ScrollRegion<W> {
             pos: self.core.rect.pos,
             size: self.inner_size,
         };
-        draw_handle.clip_region(rect, self.offset, &mut |handle| {
+        draw_handle.clip_region(rect, self.offset, ClipRegion::Scroll, &mut |handle| {
             self.inner.draw(handle, mgr, disabled)
         });
     }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -8,7 +8,7 @@
 use smallvec::SmallVec;
 use std::fmt::{self, Debug};
 
-use kas::draw::{DrawHandle, SizeHandle};
+use kas::draw::{ClipRegion, DrawHandle, SizeHandle};
 use kas::event::{Callback, Event, Manager, Response, VoidMsg};
 use kas::layout::{AxisInfo, SizeRules};
 use kas::prelude::*;
@@ -131,7 +131,8 @@ impl<W: Widget> Layout for Window<W> {
         let disabled = disabled || self.is_disabled();
         self.w.draw(draw_handle, mgr, disabled);
         for popup in &self.popups {
-            draw_handle.clip_region(self.core.rect, Coord::ZERO, &mut |draw_handle| {
+            let class = ClipRegion::Popup;
+            draw_handle.clip_region(self.core.rect, Coord::ZERO, class, &mut |draw_handle| {
                 self.find(popup.1.id)
                     .map(|w| w.draw(draw_handle, mgr, disabled));
             });


### PR DESCRIPTION
This adds a depth buffer, which is only written to by most draw pipes but used for depth-testing when rendering text (and optionally with custom pipes). This lets us prevent text from spilling over pop-ups and scroll regions. Ultimately we could stick with this approach or could use indirect rendering for pop-ups (and possibly also scroll regions).

Also:

- update to wgpu 0.5, font-kit 0.6 and smallvec 1.4
- fix visible hole inside flat-theme menu frame
- improve nav focus for ComboBox (initial and under cursor)
- fix pop-up position for a pop-up spawned from a widget inside a ScrollRegion