### PR TITLE
Remove noperspective specifyer in fragment shaders

### DIFF
--- a/kas-wgpu/src/draw/shaders/flat_round.frag
+++ b/kas-wgpu/src/draw/shaders/flat_round.frag
@@ -10,8 +10,8 @@ precision mediump float;
 
 layout(location = 0) flat in vec3 fragColor;
 layout(location = 1) flat in float inner;
-layout(location = 2) noperspective in vec2 pos;
-layout(location = 3) noperspective in vec2 off;
+layout(location = 2) in vec2 pos;
+layout(location = 3) in vec2 off;
 
 layout(location = 0) out vec4 outColor;
 

--- a/kas-wgpu/src/draw/shaders/shaded_round.frag
+++ b/kas-wgpu/src/draw/shaders/shaded_round.frag
@@ -9,9 +9,9 @@
 precision mediump float;
 
 layout(location = 0) flat in vec3 fragColor;
-layout(location = 1) noperspective in vec2 dir;
+layout(location = 1) in vec2 dir;
 layout(location = 2) flat in vec2 adjust;
-layout(location = 3) noperspective in vec2 off;
+layout(location = 3) in vec2 off;
 
 layout(location = 0) out vec4 outColor;
 

--- a/kas-wgpu/src/draw/shaders/shaded_square.frag
+++ b/kas-wgpu/src/draw/shaders/shaded_square.frag
@@ -9,7 +9,7 @@
 precision mediump float;
 
 layout(location = 0) flat in vec3 fragColor;
-layout(location = 1) noperspective in vec2 norm2;
+layout(location = 1) in vec2 norm2;
 
 layout(location = 0) out vec4 outColor;
 


### PR DESCRIPTION
This causes render problems on Intel Linux and isn't needed.