### PR TITLE
Add Alt+Key accelerator keys

### DIFF
--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -11,7 +11,7 @@ use std::marker::Unsize;
 use crate::{StackDst, Theme, ThemeDst, WindowDst};
 use kas::draw::{Colour, DrawHandle, DrawShared};
 use kas::geom::Rect;
-use kas::{CowString, ThemeAction, ThemeApi};
+use kas::{string::CowString, ThemeAction, ThemeApi};
 
 /// Wrapper around mutliple themes, supporting run-time switching
 ///

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -35,44 +35,47 @@ fn main() -> Result<(), kas_wgpu::Error> {
         #[handler(msg = Key)]
         #[widget(config=noauto)]
         struct {
+            // Buttons get keyboard bindings through the "&" item (e.g. "&1"
+            // binds both main and numpad 1 key) and via `with_keys`.
             #[widget(col = 0, row = 0)]
-            _ = TextButton::new("clear", Key::Clear).with_keys(&[VK::Delete]),
+            _ = TextButton::new("&clear", Key::Clear).with_keys(&[VK::Delete]),
             #[widget(col = 1, row = 0)]
-            _ = TextButton::new("÷", Key::Divide).with_keys(&[VK::Divide, VK::Slash]),
+            _ = TextButton::new("&÷", Key::Divide).with_keys(&[VK::Slash]),
             #[widget(col = 2, row = 0)]
-            _ = TextButton::new("×", Key::Multiply).with_keys(&[VK::Multiply]),
+            // TODO: bind VK::Asterisk when this gets added to winit!
+            _ = TextButton::new("&×", Key::Multiply),
             #[widget(col = 3, row = 0)]
-            _ = TextButton::new("−", Key::Subtract).with_keys(&[VK::Subtract]),
+            _ = TextButton::new("&−", Key::Subtract),
             #[widget(col = 0, row = 1)]
-            _ = TextButton::new("7", Key::Char('7')).with_keys(&[VK::Key7, VK::Numpad7]),
+            _ = TextButton::new("&7", Key::Char('7')),
             #[widget(col = 1, row = 1)]
-            _ = TextButton::new("8", Key::Char('8')).with_keys(&[VK::Key8, VK::Numpad8]),
+            _ = TextButton::new("&8", Key::Char('8')),
             #[widget(col = 2, row = 1)]
-            _ = TextButton::new("9", Key::Char('9')).with_keys(&[VK::Key9, VK::Numpad9]),
+            _ = TextButton::new("&9", Key::Char('9')),
             #[widget(col = 3, row = 1, rspan = 2)]
-            _ = TextButton::new("+", Key::Add).with_keys(&[VK::Add]),
+            _ = TextButton::new("&+", Key::Add),
             #[widget(col = 0, row = 2)]
-            _ = TextButton::new("4", Key::Char('4')).with_keys(&[VK::Key4, VK::Numpad4]),
+            _ = TextButton::new("&4", Key::Char('4')),
             #[widget(col = 1, row = 2)]
-            _ = TextButton::new("5", Key::Char('5')).with_keys(&[VK::Key5, VK::Numpad5]),
+            _ = TextButton::new("&5", Key::Char('5')),
             #[widget(col = 2, row = 2)]
-            _ = TextButton::new("6", Key::Char('6')).with_keys(&[VK::Key6, VK::Numpad6]),
+            _ = TextButton::new("&6", Key::Char('6')),
             #[widget(col = 0, row = 3)]
-            _ = TextButton::new("1", Key::Char('1')).with_keys(&[VK::Key1, VK::Numpad1]),
+            _ = TextButton::new("&1", Key::Char('1')),
             #[widget(col = 1, row = 3)]
-            _ = TextButton::new("2", Key::Char('2')).with_keys(&[VK::Key2, VK::Numpad2]),
+            _ = TextButton::new("&2", Key::Char('2')),
             #[widget(col = 2, row = 3)]
-            _ = TextButton::new("3", Key::Char('3')).with_keys(&[VK::Key3, VK::Numpad3]),
+            _ = TextButton::new("&3", Key::Char('3')),
             #[widget(col = 3, row = 3, rspan = 2)]
-            _ = TextButton::new("=", Key::Equals)
-                .with_keys(&[VK::Equals, VK::Return, VK::NumpadEnter, VK::NumpadEquals]),
+            _ = TextButton::new("&=", Key::Equals).with_keys(&[VK::Return, VK::NumpadEnter]),
             #[widget(col = 0, row = 4, cspan = 2)]
-            _ = TextButton::new("0", Key::Char('0')).with_keys(&[VK::Key0, VK::Numpad0]),
+            _ = TextButton::new("&0", Key::Char('0')),
             #[widget(col = 2, row = 4)]
-            _ = TextButton::new(".", Key::Char('.')).with_keys(&[VK::Period]),
+            _ = TextButton::new("&.", Key::Char('.')),
         }
         impl kas::WidgetConfig {
             fn configure(&mut self, mgr: &mut Manager) {
+                // Enable key bindings without Alt held:
                 mgr.enable_alt_bypass(true);
             }
         }

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -33,6 +33,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let buttons = make_widget! {
         #[layout(grid)]
         #[handler(msg = Key)]
+        #[widget(config=noauto)]
         struct {
             #[widget(col = 0, row = 0)]
             _ = TextButton::new("clear", Key::Clear).with_keys(&[VK::Delete]),
@@ -69,6 +70,11 @@ fn main() -> Result<(), kas_wgpu::Error> {
             _ = TextButton::new("0", Key::Char('0')).with_keys(&[VK::Key0, VK::Numpad0]),
             #[widget(col = 2, row = 4)]
             _ = TextButton::new(".", Key::Char('.')).with_keys(&[VK::Period]),
+        }
+        impl kas::WidgetConfig {
+            fn configure(&mut self, mgr: &mut Manager) {
+                mgr.enable_alt_bypass(true);
+            }
         }
     };
     let content = make_widget! {

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -122,10 +122,10 @@ fn main() -> Result<(), kas_wgpu::Error> {
         #[handler(msg = Item)]
         struct {
             #[widget(row=1, col=1)] _ = Label::new("Custom theme demo\nChoose your colour!"),
-            #[widget(row=0, col=1)] _ = TextButton::new("White", Item::White),
-            #[widget(row=1, col=2)] _ = TextButton::new("Red", Item::Red),
-            #[widget(row=2, col=1)] _ = TextButton::new("Yellow", Item::Yellow),
-            #[widget(row=1, col=0)] _ = TextButton::new("Green", Item::Green),
+            #[widget(row=0, col=1)] _ = TextButton::new("&White", Item::White),
+            #[widget(row=1, col=2)] _ = TextButton::new("&Red", Item::Red),
+            #[widget(row=2, col=1)] _ = TextButton::new("&Yellow", Item::Yellow),
+            #[widget(row=1, col=0)] _ = TextButton::new("&Green", Item::Green),
         }
     };
 

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -54,23 +54,23 @@ fn main() -> Result<(), kas_wgpu::Error> {
     }
 
     let themes = vec![
-        MenuEntry::new("Shaded", Menu::Theme("shaded")).boxed(),
-        MenuEntry::new("Flat", Menu::Theme("flat")).boxed(),
+        MenuEntry::new("&Shaded", Menu::Theme("shaded")).boxed(),
+        MenuEntry::new("&Flat", Menu::Theme("flat")).boxed(),
     ];
     let colours = vec![
-        MenuEntry::new("Default", Menu::Colour("default")),
-        MenuEntry::new("Light", Menu::Colour("light")),
-        MenuEntry::new("Dark", Menu::Colour("dark")),
+        MenuEntry::new("&Default", Menu::Colour("default")),
+        MenuEntry::new("&Light", Menu::Colour("light")),
+        MenuEntry::new("Dar&k", Menu::Colour("dark")),
     ];
     let menubar = MenuBar::<Right, _>::new(vec![
-        SubMenu::new("App", vec![MenuEntry::new("Quit", Menu::Quit).boxed()]),
-        SubMenu::new("Theme", themes),
+        SubMenu::new("&App", vec![MenuEntry::new("&Quit", Menu::Quit).boxed()]),
+        SubMenu::new("&Theme", themes),
         SubMenu::new(
-            "Style",
+            "&Style",
             vec![
-                SubMenu::right("Colours", colours).boxed(),
+                SubMenu::right("&Colours", colours).boxed(),
                 Separator::infer().boxed(),
-                MenuToggle::new_on(|state| Menu::Disabled(state), "Disabled").boxed(),
+                MenuToggle::new_on(|state| Menu::Disabled(state), "&Disabled").boxed(),
             ],
         ),
     ]);
@@ -85,15 +85,15 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[widget(row=1, col=0)] _ = Label::new("EditBox"),
             #[widget(row=1, col=1)] _ = EditBox::new("edit me").with_guard(Guard),
             #[widget(row=2, col=0)] _ = Label::new("TextButton"),
-            #[widget(row=2, col=1)] _ = TextButton::new("Press me", Item::Button),
+            #[widget(row=2, col=1)] _ = TextButton::new("&Press me", Item::Button),
             #[widget(row=3, col=0)] _ = Label::new("CheckBox"),
-            #[widget(row=3, col=1)] _ = CheckBox::new("Check me").state(true)
+            #[widget(row=3, col=1)] _ = CheckBox::new("&Check me").state(true)
                 .on_toggle(|check| Item::Check(check)),
             #[widget(row=4, col=0)] _ = Label::new("RadioBox"),
-            #[widget(row=4, col=1)] _ = RadioBox::new(radio, "radio box 1").state(false)
+            #[widget(row=4, col=1)] _ = RadioBox::new(radio, "radio box &1").state(false)
                 .on_activate(|id| Item::Radio(id)),
             #[widget(row=5, col=0)] _ = Label::new("RadioBox"),
-            #[widget(row=5, col=1)] _ = RadioBox::new(radio, "radio box 2").state(true)
+            #[widget(row=5, col=1)] _ = RadioBox::new(radio, "radio box &2").state(true)
                 .on_activate(|id| Item::Radio(id)),
             #[widget(row=6, col=0)] _ = Label::new("ComboBox"),
             #[widget(row=6, col=1, handler = handle_combo)] cb: ComboBox<i32> =
@@ -105,7 +105,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[widget(row=8, col=1, handler = handle_scroll)] sc =
                 ScrollBar::<Right>::new().with_limits(5, 2),
             #[widget(row=9)] _ = Label::new("Child window"),
-            #[widget(row=9, col = 1)] _ = TextButton::new("Open", Item::Popup),
+            #[widget(row=9, col = 1)] _ = TextButton::new("&Open", Item::Popup),
         }
         impl {
             fn handle_combo(&mut self, _: &mut Manager, msg: i32) -> Response<Item> {

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -27,8 +27,8 @@ fn make_window() -> Box<dyn kas::Window> {
         #[layout(row)]
         struct {
             #[widget] display: impl HasText = Frame::new(Label::new("0.000")),
-            #[widget(handler = handle_button)] b_reset = TextButton::new("reset", Control::Reset),
-            #[widget(handler = handle_button)] b_start = TextButton::new("start / stop", Control::Start),
+            #[widget(handler = handle_button)] b_reset = TextButton::new("&reset", Control::Reset),
+            #[widget(handler = handle_button)] b_start = TextButton::new("&start / &stop", Control::Start),
             saved: Duration = Duration::default(),
             start: Option<Instant> = None,
         }

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -25,6 +25,7 @@ enum Control {
 fn make_window() -> Box<dyn kas::Window> {
     let stopwatch = make_widget! {
         #[layout(row)]
+        #[widget(config=noauto)]
         struct {
             #[widget] display: impl HasText = Frame::new(Label::new("0.000")),
             #[widget(handler = handle_button)] b_reset = TextButton::new("&reset", Control::Reset),
@@ -51,6 +52,11 @@ fn make_window() -> Box<dyn kas::Window> {
                     }
                 }
                 Response::None
+            }
+        }
+        impl kas::WidgetConfig {
+            fn configure(&mut self, mgr: &mut Manager) {
+                mgr.enable_alt_bypass(true);
             }
         }
         impl Handler {

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -11,6 +11,7 @@ use std::num::NonZeroU32;
 use crate::draw::{CustomPipe, CustomPipeBuilder, DrawPipe, DrawWindow, ShaderManager};
 use crate::{Error, Options, WindowId};
 use kas::event::UpdateHandle;
+use kas::string::{CowString, CowStringL};
 use kas_theme::Theme;
 
 #[cfg(feature = "clipboard")]
@@ -109,12 +110,12 @@ where
 
     #[cfg(not(feature = "clipboard"))]
     #[inline]
-    pub fn get_clipboard(&mut self) -> Option<kas::CowString> {
+    pub fn get_clipboard(&mut self) -> Option<CowString> {
         None
     }
 
     #[cfg(feature = "clipboard")]
-    pub fn get_clipboard(&mut self) -> Option<kas::CowString> {
+    pub fn get_clipboard(&mut self) -> Option<CowString> {
         self.clipboard
             .as_mut()
             .and_then(|cb| match cb.get_contents() {
@@ -128,10 +129,10 @@ where
 
     #[cfg(not(feature = "clipboard"))]
     #[inline]
-    pub fn set_clipboard<'c>(&mut self, content: kas::CowStringL<'c>) {}
+    pub fn set_clipboard<'c>(&mut self, content: CowStringL<'c>) {}
 
     #[cfg(feature = "clipboard")]
-    pub fn set_clipboard<'c>(&mut self, content: kas::CowStringL<'c>) {
+    pub fn set_clipboard<'c>(&mut self, content: CowStringL<'c>) {
         self.clipboard.as_mut().map(|cb| {
             cb.set_contents(content.into())
                 .unwrap_or_else(|e| warn!("Failed to set clipboard contents: {:?}", e))

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -11,6 +11,7 @@ use std::time::Instant;
 use kas::event::{CursorIcon, ManagerState, UpdateHandle};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
+use kas::string::{CowString, CowStringL};
 use kas::{ThemeAction, ThemeApi, TkAction, WindowId};
 use kas_theme::Theme;
 use winit::dpi::PhysicalSize;
@@ -424,12 +425,12 @@ where
     }
 
     #[inline]
-    fn get_clipboard(&mut self) -> Option<kas::CowString> {
+    fn get_clipboard(&mut self) -> Option<CowString> {
         self.shared.get_clipboard()
     }
 
     #[inline]
-    fn set_clipboard<'c>(&mut self, content: kas::CowStringL<'c>) {
+    fn set_clipboard<'c>(&mut self, content: CowStringL<'c>) {
         self.shared.set_clipboard(content);
     }
 

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -151,6 +151,7 @@ where
     {
         // Note: resize must be handled here to update self.swap_chain.
         match event {
+            WindowEvent::Destroyed => (),
             WindowEvent::Resized(size) => self.do_resize(shared, size),
             WindowEvent::ScaleFactorChanged {
                 scale_factor,

--- a/src/class.rs
+++ b/src/class.rs
@@ -5,7 +5,7 @@
 
 //! Class-specific widget traits
 
-use crate::{CowString, TkAction};
+use crate::{string::CowString, TkAction};
 
 /// Functionality for widgets which can be toggled or selected: check boxes,
 /// radio buttons, toggle switches.

--- a/src/data.rs
+++ b/src/data.rs
@@ -17,6 +17,9 @@ use crate::geom::{Rect, Size};
 /// All widgets are assigned an identifier which is unique within the window.
 /// This type may be tested for equality and order.
 ///
+/// This type is small and cheap to copy. Internally it is "NonZero", thus
+/// `Option<WidgetId>` is a free extension (requires no extra memory).
+///
 /// Identifiers are assigned when configured and when re-configured
 /// (via [`kas::TkAction::Reconfigure`]). Since user-code is not notified of a
 /// re-configure, user-code should not store a `WidgetId`.
@@ -75,6 +78,12 @@ impl fmt::Display for WidgetId {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "#{}", self.0)
     }
+}
+
+#[test]
+fn size_of_option_widget_id() {
+    use std::mem::size_of;
+    assert_eq!(size_of::<WidgetId>(), size_of::<Option<WidgetId>>());
 }
 
 /// Common widget data

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -398,3 +398,39 @@ impl<'a> Manager<'a> {
         self.send_event(widget, id, event);
     }
 }
+
+/// Helper used during widget configuration
+pub struct ConfigureManager<'a: 'b, 'b> {
+    id: &'b mut WidgetId,
+    map: &'b mut HashMap<WidgetId, WidgetId>,
+    mgr: &'b mut Manager<'a>,
+}
+
+impl<'a: 'b, 'b> ConfigureManager<'a, 'b> {
+    /// Reborrow self to pass to a child
+    pub fn child<'c>(&'c mut self) -> ConfigureManager<'a, 'c>
+    where
+        'b: 'c,
+    {
+        ConfigureManager {
+            id: &mut *self.id,
+            map: &mut *self.map,
+            mgr: &mut *self.mgr,
+        }
+    }
+
+    /// Get a new [`WidgetId`] for the widget
+    ///
+    /// Pass the old ID (`self.id()`), even if not yet configured.
+    pub fn next_id(&mut self, old_id: WidgetId) -> WidgetId {
+        let id = *self.id;
+        *self.id = id.next();
+        self.map.insert(old_id, id);
+        id
+    }
+
+    /// Get access to the wrapped [`Manager`]
+    pub fn mgr(&mut self) -> &mut Manager<'a> {
+        self.mgr
+    }
+}

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -245,6 +245,9 @@ impl<'a> Manager<'a> {
         }
 
         if vkey == VK::LAlt || vkey == VK::RAlt {
+            if self.mgr.alt_keys.is_empty() {
+                self.mgr.send_action(TkAction::Redraw);
+            }
             self.mgr.alt_keys.push(scancode);
         } else if vkey == VK::Tab {
             if !self.next_nav_focus(widget.as_widget(), self.mgr.modifiers.shift()) {
@@ -337,7 +340,9 @@ impl<'a> Manager<'a> {
         }
 
         if remove(&mut self.mgr.alt_keys, |item| *item == scancode).is_some() {
-            self.mgr.send_action(TkAction::Redraw);
+            if self.mgr.alt_keys.is_empty() {
+                self.mgr.send_action(TkAction::Redraw);
+            }
             return;
         }
 

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -263,9 +263,11 @@ impl<'a> Manager<'a> {
     ///
     /// This should be set from [`WidgetConfig::configure`].
     #[inline]
-    pub fn add_accel_key(&mut self, key: VirtualKeyCode, id: WidgetId) {
+    pub fn add_accel_keys(&mut self, id: WidgetId, keys: &[VirtualKeyCode]) {
         if !self.read_only {
-            self.mgr.accel_keys.insert(key, id);
+            for key in keys {
+                self.mgr.accel_keys.insert(*key, id);
+            }
         }
     }
 

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -25,6 +25,16 @@ impl<'a> std::ops::AddAssign<TkAction> for Manager<'a> {
 
 /// Public API (around event manager state)
 impl ManagerState {
+    /// True when accelerator key labels should be shown
+    ///
+    /// (True when Alt is held.)
+    ///
+    /// This is a fast check.
+    #[inline]
+    pub fn show_accel_labels(&self) -> bool {
+        !self.alt_keys.is_empty()
+    }
+
     /// Get whether this widget has a grab on character input
     #[inline]
     pub fn char_focus(&self, w_id: WidgetId) -> bool {

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -11,6 +11,7 @@ use std::u16;
 
 use super::*;
 use crate::geom::Coord;
+use crate::string::{CowString, CowStringL};
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
 use crate::{ThemeAction, ThemeApi, TkAction, WidgetId, WindowId};
@@ -218,13 +219,13 @@ impl<'a> Manager<'a> {
     /// In case of failure, paste actions will simply fail. The implementation
     /// may wish to log an appropriate warning message.
     #[inline]
-    pub fn get_clipboard(&mut self) -> Option<crate::CowString> {
+    pub fn get_clipboard(&mut self) -> Option<CowString> {
         self.tkw.get_clipboard()
     }
 
     /// Attempt to set clipboard contents
     #[inline]
-    pub fn set_clipboard<'c>(&mut self, content: crate::CowStringL<'c>) {
+    pub fn set_clipboard<'c>(&mut self, content: CowStringL<'c>) {
         self.tkw.set_clipboard(content)
     }
 

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -264,10 +264,23 @@ impl<'a> Manager<'a> {
     /// widgets have been configured to finish configuration of this new layer
     /// and to make the previous layer in the stack current.
     ///
+    /// If `alt_bypass` is true, then this layer's accelerator keys will be
+    /// active even without Alt pressed.
+    ///
     /// When run, the base layer is used when no pop-up is active, otherwise
     /// the layer (if any) associated with the top pop-up is used.
-    pub fn push_accel_layer(&mut self) {
-        self.mgr.accel_stack.push(HashMap::new());
+    pub fn push_accel_layer(&mut self, alt_bypass: bool) {
+        self.mgr.accel_stack.push((alt_bypass, HashMap::new()));
+    }
+
+    /// Enable `alt_bypass` for the current layer
+    ///
+    /// This may be called by a child widget during configure, e.g. to enable
+    /// alt-bypass for the base layer. See also [`Manager::push_accel_layer`].
+    pub fn enable_alt_bypass(&mut self, alt_bypass: bool) {
+        if let Some(layer) = self.mgr.accel_stack.last_mut() {
+            layer.0 = alt_bypass;
+        }
     }
 
     /// Finish configuration of an accelerator key layer
@@ -302,7 +315,7 @@ impl<'a> Manager<'a> {
         if !self.read_only {
             if let Some(last) = self.mgr.accel_stack.last_mut() {
                 for key in keys {
-                    last.insert(*key, id);
+                    last.1.insert(*key, id);
                 }
             }
         }

--- a/src/event/manager/mgr_tk.rs
+++ b/src/event/manager/mgr_tk.rs
@@ -38,7 +38,8 @@ impl ManagerState {
             mouse_grab: None,
             touch_grab: Default::default(),
             pan_grab: SmallVec::new(),
-            accel_keys: HashMap::new(),
+            accel_stack: vec![],
+            accel_layers: HashMap::new(),
             popups: Default::default(),
             new_popups: Default::default(),
             popup_removed: Default::default(),
@@ -67,7 +68,8 @@ impl ManagerState {
         let mut id = WidgetId::FIRST;
 
         // We re-set these instead of remapping:
-        self.accel_keys.clear();
+        self.accel_stack.clear();
+        self.accel_layers.clear();
         self.time_updates.clear();
         self.handle_updates.clear();
         self.pending.clear();
@@ -76,11 +78,15 @@ impl ManagerState {
 
         let coord = self.last_mouse_coord;
         self.with(tkw, |mut mgr| {
+            mgr.push_accel_layer();
             widget.configure_recurse(ConfigureManager {
                 id: &mut id,
                 map: &mut map,
                 mgr: &mut mgr,
             });
+            mgr.pop_accel_layer(widget.id());
+            debug_assert!(mgr.mgr.accel_stack.is_empty());
+
             let hover = widget.find_id(coord);
             mgr.set_hover(widget, hover);
         });

--- a/src/event/manager/mgr_tk.rs
+++ b/src/event/manager/mgr_tk.rs
@@ -76,11 +76,10 @@ impl ManagerState {
 
         let coord = self.last_mouse_coord;
         self.with(tkw, |mut mgr| {
-            widget.walk_mut(&mut |widget| {
-                map.insert(widget.id(), id);
-                widget.core_data_mut().id = id;
-                widget.configure(&mut mgr);
-                id = id.next();
+            widget.configure_recurse(ConfigureManager {
+                id: &mut id,
+                map: &mut map,
+                mgr: &mut mgr,
             });
             let hover = widget.find_id(coord);
             mgr.set_hover(widget, hover);

--- a/src/event/manager/mgr_tk.rs
+++ b/src/event/manager/mgr_tk.rs
@@ -40,6 +40,7 @@ impl ManagerState {
             pan_grab: SmallVec::new(),
             accel_stack: vec![],
             accel_layers: HashMap::new(),
+            alt_keys: SmallVec::new(),
             popups: Default::default(),
             new_popups: Default::default(),
             popup_removed: Default::default(),
@@ -78,7 +79,7 @@ impl ManagerState {
 
         let coord = self.last_mouse_coord;
         self.with(tkw, |mut mgr| {
-            mgr.push_accel_layer();
+            mgr.push_accel_layer(false);
             widget.configure_recurse(ConfigureManager {
                 id: &mut id,
                 map: &mut map,

--- a/src/event/manager/mgr_tk.rs
+++ b/src/event/manager/mgr_tk.rs
@@ -348,22 +348,18 @@ impl<'a> Manager<'a> {
         // Unhandled events here, so we can freely ignore all responses.
 
         match event {
-            // Resized(size) [handled by toolkit]
-            // Moved(position)
-            CloseRequested => {
-                self.send_action(TkAction::Close);
-            }
-            // Destroyed
-            // DroppedFile(PathBuf),
-            // HoveredFile(PathBuf),
-            // HoveredFileCancelled,
+            CloseRequested => self.send_action(TkAction::Close),
+            /* Not yet supported: see #98
+            DroppedFile(path) => ,
+            HoveredFile(path) => ,
+            HoveredFileCancelled => ,
+            */
             ReceivedCharacter(c) if c != '\u{1b}' /* escape */ => {
                 if let Some(id) = self.mgr.char_focus {
                     let event = Event::ReceivedCharacter(c);
                     self.send_event(widget, id, event);
                 }
             }
-            // Focused(bool),
             KeyboardInput { input, is_synthetic, .. } => {
                 if input.state == ElementState::Pressed && !is_synthetic {
                     if let Some(vkey) = input.virtual_keycode {
@@ -462,7 +458,6 @@ impl<'a> Manager<'a> {
             }
             // TouchpadPressure { pressure: f32, stage: i64, },
             // AxisMotion { axis: AxisId, value: f64, },
-            // RedrawRequested [handled by toolkit]
             Touch(touch) => {
                 let source = PressSource::Touch(touch.id);
                 let coord = touch.location.into();
@@ -545,7 +540,6 @@ impl<'a> Manager<'a> {
                     }
                 }
             }
-            // HiDpiFactorChanged(factor) [handled by toolkit]
             _ => (),
         }
     }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -87,7 +87,7 @@ pub use callback::Callback;
 pub use enums::{CursorIcon, ModifiersState, MouseButton, VirtualKeyCode};
 pub use events::*;
 pub use handler::{Handler, SendEvent};
-pub use manager::{GrabMode, Manager, ManagerState};
+pub use manager::{ConfigureManager, GrabMode, Manager, ManagerState};
 pub use response::Response;
 pub use update::UpdateHandle;
 

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -74,8 +74,8 @@ mod manager;
 mod response;
 mod update;
 
+use smallvec::SmallVec;
 use std::fmt::Debug;
-// use std::path::PathBuf;
 
 #[cfg(feature = "winit")]
 pub use winit::event::{ModifiersState, MouseButton, VirtualKeyCode};
@@ -90,6 +90,20 @@ pub use handler::{Handler, SendEvent};
 pub use manager::{GrabMode, Manager, ManagerState};
 pub use response::Response;
 pub use update::UpdateHandle;
+
+/// A type supporting a small number of key bindings
+///
+/// This type may be used where it is desirable to support a small number of
+/// key bindings. The type is allowed to silently ignore extra bindings beyond
+/// some *small* number of at least 3. (Currently numbers over 5 are accepted
+/// but cause allocation.)
+pub type VirtualKeyCodes = SmallVec<[VirtualKeyCode; 5]>;
+
+#[test]
+fn size_of_virtual_key_codes() {
+    // Currently sized to maximise use of available space on 64-bit platforms
+    assert!(std::mem::size_of::<VirtualKeyCodes>() <= 32);
+}
 
 /// A void message
 ///

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -130,4 +130,4 @@ impl_void_msg!(bool, char,);
 impl_void_msg!(u8, u16, u32, u64, u128, usize,);
 impl_void_msg!(i8, i16, i32, i64, i128, isize,);
 impl_void_msg!(f32, f64,);
-impl_void_msg!(&'static str, String, kas::CowString,);
+impl_void_msg!(&'static str, String, kas::string::CowString,);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod event;
 pub mod geom;
 pub mod layout;
 pub mod prelude;
+pub mod string;
 pub mod widget;
 
 // macro re-exports
@@ -50,9 +51,3 @@ pub mod macros;
 pub use crate::data::*;
 pub use crate::toolkit::*;
 pub use crate::traits::*;
-
-/// Convenience definition: `Cow<'a, str>`
-pub type CowStringL<'a> = std::borrow::Cow<'a, str>;
-
-/// Convenience definition: `Cow<'static, str>`
-pub type CowString = CowStringL<'static>;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,9 +15,9 @@
 
 pub use kas::geom::{Coord, Rect, Size};
 pub use kas::macros::*;
+pub use kas::string::{CowString, CowStringL};
 pub use kas::{class, draw, event, geom, layout, widget};
 pub use kas::{Align, AlignHints, Direction, Directional, WidgetId};
 pub use kas::{Boxed, TkAction, TkWindow};
 pub use kas::{CloneTo, Layout, ThemeApi, Widget, WidgetChildren, WidgetConfig, WidgetCore};
 pub use kas::{CoreData, LayoutData};
-pub use kas::{CowString, CowStringL};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,7 +15,7 @@
 
 pub use kas::geom::{Coord, Rect, Size};
 pub use kas::macros::*;
-pub use kas::string::{CowString, CowStringL};
+pub use kas::string::{AccelString, CowString, CowStringL, LabelString};
 pub use kas::{class, draw, event, geom, layout, widget};
 pub use kas::{Align, AlignHints, Direction, Directional, WidgetId};
 pub use kas::{Boxed, TkAction, TkWindow};

--- a/src/string.rs
+++ b/src/string.rs
@@ -9,9 +9,10 @@
 //! Hopefully it can be replaced with a real mark-up processor without too
 //! much API breakage.
 
+use smallvec::smallvec;
 use std::ops::Deref;
 
-use kas::event::{VirtualKeyCode, VirtualKeyCodes};
+use kas::event::{VirtualKeyCode as VK, VirtualKeyCodes};
 
 /// Convenience definition: `Cow<'a, str>`
 pub type CowStringL<'a> = std::borrow::Cow<'a, str>;
@@ -132,9 +133,10 @@ impl AccelString {
                 Some(c) => {
                     buf.push(c);
                     bufu.push(c);
-                    if let Some(key) = find_vkey(c) {
+                    let vkeys = find_vkeys(c);
+                    if !vkeys.is_empty() {
+                        keys.extend(vkeys);
                         bufu.push(underline);
-                        keys.push(key);
                     }
                     let i = c.len_utf8();
                     s = &s[i..];
@@ -151,7 +153,7 @@ impl AccelString {
     }
 
     /// Get the key bindings
-    pub fn keys(&self) -> &[VirtualKeyCode] {
+    pub fn keys(&self) -> &[VK] {
         &self.keys
     }
 
@@ -192,44 +194,64 @@ impl From<String> for AccelString {
     }
 }
 
-fn find_vkey(c: char) -> Option<VirtualKeyCode> {
-    Some(match c.to_ascii_uppercase() {
-        '0' => VirtualKeyCode::Key0,
-        '1' => VirtualKeyCode::Key1,
-        '2' => VirtualKeyCode::Key2,
-        '3' => VirtualKeyCode::Key3,
-        '4' => VirtualKeyCode::Key4,
-        '5' => VirtualKeyCode::Key5,
-        '6' => VirtualKeyCode::Key6,
-        '7' => VirtualKeyCode::Key7,
-        '8' => VirtualKeyCode::Key8,
-        '9' => VirtualKeyCode::Key9,
-        'A' => VirtualKeyCode::A,
-        'B' => VirtualKeyCode::B,
-        'C' => VirtualKeyCode::C,
-        'D' => VirtualKeyCode::D,
-        'E' => VirtualKeyCode::E,
-        'F' => VirtualKeyCode::F,
-        'G' => VirtualKeyCode::G,
-        'H' => VirtualKeyCode::H,
-        'I' => VirtualKeyCode::I,
-        'J' => VirtualKeyCode::J,
-        'K' => VirtualKeyCode::K,
-        'L' => VirtualKeyCode::L,
-        'M' => VirtualKeyCode::M,
-        'N' => VirtualKeyCode::N,
-        'O' => VirtualKeyCode::O,
-        'P' => VirtualKeyCode::P,
-        'Q' => VirtualKeyCode::Q,
-        'R' => VirtualKeyCode::R,
-        'S' => VirtualKeyCode::S,
-        'T' => VirtualKeyCode::T,
-        'U' => VirtualKeyCode::U,
-        'V' => VirtualKeyCode::V,
-        'W' => VirtualKeyCode::W,
-        'X' => VirtualKeyCode::X,
-        'Y' => VirtualKeyCode::Y,
-        'Z' => VirtualKeyCode::Z,
-        _ => return None,
-    })
+fn find_vkeys(c: char) -> VirtualKeyCodes {
+    // TODO: lots of keys aren't yet available in VirtualKeyCode!
+    // NOTE: some of these bindings are a little inaccurate. It isn't obvious
+    // whether prefer strict or more flexible bindings here.
+    // NOTE: we add a couple of non-unicode bindings. How many should we add?
+    match c.to_ascii_uppercase() {
+        '\'' => smallvec![VK::Apostrophe],
+        '+' => smallvec![VK::Add],
+        ',' => smallvec![VK::Comma],
+        '-' => smallvec![VK::Minus],
+        '.' => smallvec![VK::Period],
+        '/' => smallvec![VK::Slash],
+        '0' => smallvec![VK::Key0, VK::Numpad0],
+        '1' => smallvec![VK::Key1, VK::Numpad1],
+        '2' => smallvec![VK::Key2, VK::Numpad2],
+        '3' => smallvec![VK::Key3, VK::Numpad3],
+        '4' => smallvec![VK::Key4, VK::Numpad4],
+        '5' => smallvec![VK::Key5, VK::Numpad5],
+        '6' => smallvec![VK::Key6, VK::Numpad6],
+        '7' => smallvec![VK::Key7, VK::Numpad7],
+        '8' => smallvec![VK::Key8, VK::Numpad8],
+        '9' => smallvec![VK::Key9, VK::Numpad9],
+        ':' => smallvec![VK::Colon],
+        ';' => smallvec![VK::Semicolon],
+        '=' => smallvec![VK::Equals, VK::NumpadEquals],
+        '`' => smallvec![VK::Grave],
+        'A' => smallvec![VK::A],
+        'B' => smallvec![VK::B],
+        'C' => smallvec![VK::C],
+        'D' => smallvec![VK::D],
+        'E' => smallvec![VK::E],
+        'F' => smallvec![VK::F],
+        'G' => smallvec![VK::G],
+        'H' => smallvec![VK::H],
+        'I' => smallvec![VK::I],
+        'J' => smallvec![VK::J],
+        'K' => smallvec![VK::K],
+        'L' => smallvec![VK::L],
+        'M' => smallvec![VK::M],
+        'N' => smallvec![VK::N],
+        'O' => smallvec![VK::O],
+        'P' => smallvec![VK::P],
+        'Q' => smallvec![VK::Q],
+        'R' => smallvec![VK::R],
+        'S' => smallvec![VK::S],
+        'T' => smallvec![VK::T],
+        'U' => smallvec![VK::U],
+        'V' => smallvec![VK::V],
+        'W' => smallvec![VK::W],
+        'X' => smallvec![VK::X],
+        'Y' => smallvec![VK::Y],
+        'Z' => smallvec![VK::Z],
+        '[' => smallvec![VK::LBracket],
+        ']' => smallvec![VK::RBracket],
+        '^' => smallvec![VK::Caret],
+        '÷' => smallvec![VK::Divide],
+        '×' => smallvec![VK::Multiply],
+        '−' => smallvec![VK::Subtract],
+        _ => smallvec![],
+    }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -11,6 +11,8 @@
 
 use std::ops::Deref;
 
+use kas::event::{VirtualKeyCode, VirtualKeyCodes};
+
 /// Convenience definition: `Cow<'a, str>`
 pub type CowStringL<'a> = std::borrow::Cow<'a, str>;
 
@@ -98,6 +100,8 @@ impl Deref for LabelString {
 pub struct AccelString {
     label: CowString,
     underlined: CowString,
+    // TODO: is it worth using such a large structure here instead of Option?
+    keys: VirtualKeyCodes,
 }
 
 impl AccelString {
@@ -111,6 +115,8 @@ impl AccelString {
         // underlining, but Unicode diacritics are good enough.
         let underline = '\u{0332}';
         let mut bufu = String::with_capacity(s.len() + underline.len_utf8() - "&".len());
+        let mut keys = VirtualKeyCodes::new();
+
         while let Some(mut i) = s.find("&") {
             buf.push_str(&s[..i]);
             bufu.push_str(&s[..i]);
@@ -126,7 +132,10 @@ impl AccelString {
                 Some(c) => {
                     buf.push(c);
                     bufu.push(c);
-                    bufu.push(underline);
+                    if let Some(key) = find_vkey(c) {
+                        bufu.push(underline);
+                        keys.push(key);
+                    }
                     let i = c.len_utf8();
                     s = &s[i..];
                 }
@@ -137,7 +146,13 @@ impl AccelString {
         AccelString {
             label: buf.into(),
             underlined: bufu.into(),
+            keys,
         }
+    }
+
+    /// Get the key bindings
+    pub fn keys(&self) -> &[VirtualKeyCode] {
+        &self.keys
     }
 }
 
@@ -150,6 +165,7 @@ impl From<CowString> for AccelString {
             AccelString {
                 label: input.clone(),
                 underlined: input,
+                keys: Default::default(),
             }
         }
     }
@@ -172,4 +188,46 @@ impl Deref for AccelString {
     fn deref(&self) -> &str {
         &self.underlined // TODO
     }
+}
+
+fn find_vkey(c: char) -> Option<VirtualKeyCode> {
+    Some(match c.to_ascii_uppercase() {
+        '0' => VirtualKeyCode::Key0,
+        '1' => VirtualKeyCode::Key1,
+        '2' => VirtualKeyCode::Key2,
+        '3' => VirtualKeyCode::Key3,
+        '4' => VirtualKeyCode::Key4,
+        '5' => VirtualKeyCode::Key5,
+        '6' => VirtualKeyCode::Key6,
+        '7' => VirtualKeyCode::Key7,
+        '8' => VirtualKeyCode::Key8,
+        '9' => VirtualKeyCode::Key9,
+        'A' => VirtualKeyCode::A,
+        'B' => VirtualKeyCode::B,
+        'C' => VirtualKeyCode::C,
+        'D' => VirtualKeyCode::D,
+        'E' => VirtualKeyCode::E,
+        'F' => VirtualKeyCode::F,
+        'G' => VirtualKeyCode::G,
+        'H' => VirtualKeyCode::H,
+        'I' => VirtualKeyCode::I,
+        'J' => VirtualKeyCode::J,
+        'K' => VirtualKeyCode::K,
+        'L' => VirtualKeyCode::L,
+        'M' => VirtualKeyCode::M,
+        'N' => VirtualKeyCode::N,
+        'O' => VirtualKeyCode::O,
+        'P' => VirtualKeyCode::P,
+        'Q' => VirtualKeyCode::Q,
+        'R' => VirtualKeyCode::R,
+        'S' => VirtualKeyCode::S,
+        'T' => VirtualKeyCode::T,
+        'U' => VirtualKeyCode::U,
+        'V' => VirtualKeyCode::V,
+        'W' => VirtualKeyCode::W,
+        'X' => VirtualKeyCode::X,
+        'Y' => VirtualKeyCode::Y,
+        'Z' => VirtualKeyCode::Z,
+        _ => return None,
+    })
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -154,6 +154,15 @@ impl AccelString {
     pub fn keys(&self) -> &[VirtualKeyCode] {
         &self.keys
     }
+
+    /// Get the text, depending on mode
+    pub fn get(&self, show_labels: bool) -> &str {
+        if show_labels {
+            &self.underlined
+        } else {
+            &self.label
+        }
+    }
 }
 
 impl From<CowString> for AccelString {
@@ -180,13 +189,6 @@ impl From<&'static str> for AccelString {
 impl From<String> for AccelString {
     fn from(input: String) -> Self {
         CowString::from(input).into()
-    }
-}
-
-impl Deref for AccelString {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.underlined // TODO
     }
 }
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -4,9 +4,172 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 //! Text processing
+//!
+//! The functionality here is deliberately a quick hack to get things working.
+//! Hopefully it can be replaced with a real mark-up processor without too
+//! much API breakage.
+
+use std::ops::Deref;
 
 /// Convenience definition: `Cow<'a, str>`
 pub type CowStringL<'a> = std::borrow::Cow<'a, str>;
 
 /// Convenience definition: `Cow<'static, str>`
 pub type CowString = CowStringL<'static>;
+
+/// A label string
+///
+/// This is a label which supports markup.
+///
+/// Markup: `&&` translates to `&`; `&x` for any `x` translates to `x`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LabelString {
+    label: CowString,
+}
+
+impl LabelString {
+    /// Parse a `&str`
+    ///
+    /// Since we require `'static` for references and don't yet have
+    /// specialisation, this parser always allocates. Prefer to use `from`.
+    pub fn parse(mut s: &str) -> Self {
+        let mut buf = String::with_capacity(s.len());
+        while let Some(mut i) = s.find("&") {
+            buf.push_str(&s[..i]);
+            i += "&".len();
+            s = &s[i..];
+
+            match s.chars().next() {
+                None => {
+                    // Ending with '&' is an error, but we can ignore it
+                    s = &s[0..0];
+                    break;
+                }
+                Some(c) => {
+                    buf.push(c);
+                    let i = c.len_utf8();
+                    s = &s[i..];
+                }
+            }
+        }
+        buf.push_str(s);
+        LabelString { label: buf.into() }
+    }
+}
+
+impl From<CowString> for LabelString {
+    fn from(input: CowString) -> Self {
+        if input.as_bytes().contains(&b'&') {
+            Self::parse(&input)
+        } else {
+            // fast path: we can use the raw input
+            LabelString { label: input }
+        }
+    }
+}
+
+impl From<&'static str> for LabelString {
+    fn from(input: &'static str) -> Self {
+        CowString::from(input).into()
+    }
+}
+
+impl From<String> for LabelString {
+    fn from(input: String) -> Self {
+        CowString::from(input).into()
+    }
+}
+
+impl Deref for LabelString {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.label
+    }
+}
+
+/// An accelerator key string
+///
+/// This is a label which supports highlighting of accelerator keys.
+///
+/// Markup: `&&` translates to `&`; `&x` for any `x` translates to `x` and
+/// identifies `x` as an "accelerator key"; this may be drawn underlined and
+/// may support keyboard access via e.g. `Alt+X`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct AccelString {
+    label: CowString,
+    underlined: CowString,
+}
+
+impl AccelString {
+    /// Parse a `&str`
+    ///
+    /// Since we require `'static` for references and don't yet have
+    /// specialisation, this parser always allocates. Prefer to use `from`.
+    pub fn parse(mut s: &str) -> Self {
+        let mut buf = String::with_capacity(s.len());
+        // NOTE: our text display doesn't yet support
+        // underlining, but Unicode diacritics are good enough.
+        let underline = '\u{0332}';
+        let mut bufu = String::with_capacity(s.len() + underline.len_utf8() - "&".len());
+        while let Some(mut i) = s.find("&") {
+            buf.push_str(&s[..i]);
+            bufu.push_str(&s[..i]);
+            i += "&".len();
+            s = &s[i..];
+
+            match s.chars().next() {
+                None => {
+                    // Ending with '&' is an error, but we can ignore it
+                    s = &s[0..0];
+                    break;
+                }
+                Some(c) => {
+                    buf.push(c);
+                    bufu.push(c);
+                    bufu.push(underline);
+                    let i = c.len_utf8();
+                    s = &s[i..];
+                }
+            }
+        }
+        buf.push_str(s);
+        bufu.push_str(s);
+        AccelString {
+            label: buf.into(),
+            underlined: bufu.into(),
+        }
+    }
+}
+
+impl From<CowString> for AccelString {
+    fn from(input: CowString) -> Self {
+        if input.as_bytes().contains(&b'&') {
+            Self::parse(&input)
+        } else {
+            // fast path: we can use the raw input
+            AccelString {
+                label: input.clone(),
+                underlined: input,
+            }
+        }
+    }
+}
+
+impl From<&'static str> for AccelString {
+    fn from(input: &'static str) -> Self {
+        CowString::from(input).into()
+    }
+}
+
+impl From<String> for AccelString {
+    fn from(input: String) -> Self {
+        CowString::from(input).into()
+    }
+}
+
+impl Deref for AccelString {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.underlined // TODO
+    }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,12 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Text processing
+
+/// Convenience definition: `Cow<'a, str>`
+pub type CowStringL<'a> = std::borrow::Cow<'a, str>;
+
+/// Convenience definition: `Cow<'static, str>`
+pub type CowString = CowStringL<'static>;

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -16,6 +16,7 @@
 
 use std::num::NonZeroU32;
 
+use crate::string::{CowString, CowStringL};
 use crate::{event, ThemeAction, ThemeApi};
 
 /// Identifier for a window or pop-up
@@ -136,10 +137,10 @@ pub trait TkWindow {
     ///
     /// In case of failure, paste actions will simply fail. The implementation
     /// may wish to log an appropriate warning message.
-    fn get_clipboard(&mut self) -> Option<crate::CowString>;
+    fn get_clipboard(&mut self) -> Option<CowString>;
 
     /// Attempt to set clipboard contents
-    fn set_clipboard<'c>(&mut self, content: crate::CowStringL<'c>);
+    fn set_clipboard<'c>(&mut self, content: CowStringL<'c>);
 
     /// Adjust the theme
     fn adjust_theme(&mut self, f: &mut dyn FnMut(&mut dyn ThemeApi) -> ThemeAction);

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -44,7 +44,7 @@ impl<M: Clone + Debug + 'static> Layout for TextButton<M> {
         let margins = size_handle.outer_margins();
         let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), sides.0 + sides.1, margins);
 
-        let content_rules = size_handle.text_bound(&self.label, TextClass::Button, axis);
+        let content_rules = size_handle.text_bound(self.label.get(false), TextClass::Button, axis);
         content_rules.surrounded_by(frame_rules, true)
     }
 
@@ -59,8 +59,9 @@ impl<M: Clone + Debug + 'static> Layout for TextButton<M> {
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         draw_handle.button(self.core.rect, self.input_state(mgr, disabled));
+        let text = self.label.get(mgr.show_accel_labels());
         let align = (Align::Centre, Align::Centre);
-        draw_handle.text(self.core.rect, &self.label, TextClass::Button, align);
+        draw_handle.text(self.core.rect, text, TextClass::Button, align);
     }
 }
 
@@ -100,7 +101,7 @@ impl<M: Clone + Debug + 'static> TextButton<M> {
 
 impl<M: Clone + Debug + 'static> HasText for TextButton<M> {
     fn get_text(&self) -> &str {
-        &self.label
+        self.label.get(false)
     }
 
     fn set_cow_string(&mut self, text: CowString) -> TkAction {

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -29,9 +29,7 @@ pub struct TextButton<M: Clone + Debug + 'static> {
 
 impl<M: Clone + Debug + 'static> WidgetConfig for TextButton<M> {
     fn configure(&mut self, mgr: &mut Manager) {
-        for key in &self.keys {
-            mgr.add_accel_key(*key, self.id());
-        }
+        mgr.add_accel_keys(self.id(), &self.keys);
     }
 
     fn key_nav(&self) -> bool {

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 
 use kas::class::HasText;
 use kas::draw::{DrawHandle, SizeHandle, TextClass};
-use kas::event::{Event, Manager, Response, VirtualKeyCode};
+use kas::event::{Event, Manager, Response, VirtualKeyCode, VirtualKeyCodes};
 use kas::layout::{AxisInfo, SizeRules};
 use kas::prelude::*;
 
@@ -21,7 +21,7 @@ use kas::prelude::*;
 pub struct TextButton<M: Clone + Debug + 'static> {
     #[widget_core]
     core: kas::CoreData,
-    keys: SmallVec<[VirtualKeyCode; 4]>,
+    keys: VirtualKeyCodes,
     // text_rect: Rect,
     label: AccelString,
     msg: M,

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -30,6 +30,7 @@ pub struct TextButton<M: Clone + Debug + 'static> {
 impl<M: Clone + Debug + 'static> WidgetConfig for TextButton<M> {
     fn configure(&mut self, mgr: &mut Manager) {
         mgr.add_accel_keys(self.id(), &self.keys);
+        mgr.add_accel_keys(self.id(), self.label.keys());
     }
 
     fn key_nav(&self) -> bool {

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -29,6 +29,7 @@ pub struct TextButton<M: Clone + Debug + 'static> {
 
 impl<M: Clone + Debug + 'static> WidgetConfig for TextButton<M> {
     fn configure(&mut self, mgr: &mut Manager) {
+        // TODO: consider merging these two lists?
         mgr.add_accel_keys(self.id(), &self.keys);
         mgr.add_accel_keys(self.id(), self.label.keys());
     }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -23,7 +23,7 @@ pub struct TextButton<M: Clone + Debug + 'static> {
     core: kas::CoreData,
     keys: SmallVec<[VirtualKeyCode; 4]>,
     // text_rect: Rect,
-    label: CowString,
+    label: AccelString,
     msg: M,
 }
 
@@ -72,7 +72,7 @@ impl<M: Clone + Debug + 'static> TextButton<M> {
     /// type supporting `Clone` is valid, though it is recommended to use a
     /// simple `Copy` type (e.g. an enum). Click actions must be implemented on
     /// the parent (or other ancestor).
-    pub fn new<S: Into<CowString>>(label: S, msg: M) -> Self {
+    pub fn new<S: Into<AccelString>>(label: S, msg: M) -> Self {
         TextButton {
             core: Default::default(),
             keys: SmallVec::new(),
@@ -105,7 +105,7 @@ impl<M: Clone + Debug + 'static> HasText for TextButton<M> {
     }
 
     fn set_cow_string(&mut self, text: CowString) -> TkAction {
-        self.label = text;
+        self.label = text.into();
         TkAction::Redraw
     }
 }

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -182,7 +182,7 @@ impl<M: 'static> CheckBox<M> {
     /// The closure `f` is called with the new state of the checkbox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn new_on<T: Into<CowString>, F>(f: F, label: T) -> Self
+    pub fn new_on<T: Into<AccelString>, F>(f: F, label: T) -> Self
     where
         F: Fn(bool) -> M + 'static,
     {
@@ -201,7 +201,7 @@ impl CheckBox<VoidMsg> {
     /// CheckBox labels are optional; if no label is desired, use an empty
     /// string.
     #[inline]
-    pub fn new<T: Into<CowString>>(label: T) -> Self {
+    pub fn new<T: Into<AccelString>>(label: T) -> Self {
         CheckBox {
             core: Default::default(),
             layout_data: Default::default(),

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -149,6 +149,7 @@ impl<M: 'static> event::Handler for CheckBoxBare<M> {
 // TODO: use a generic wrapper for CheckBox and RadioBox?
 #[layout(row, area=checkbox)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
+#[widget(config=noauto)]
 #[derive(Clone, Default, Widget)]
 pub struct CheckBox<M: 'static> {
     #[widget_core]
@@ -234,6 +235,12 @@ impl<M: 'static> CheckBox<M> {
     pub fn state(mut self, state: bool) -> Self {
         self.checkbox = self.checkbox.state(state);
         self
+    }
+}
+
+impl<M: 'static> WidgetConfig for CheckBox<M> {
+    fn configure(&mut self, mgr: &mut Manager) {
+        mgr.add_accel_keys(self.checkbox.id(), self.label.keys());
     }
 }
 

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 use std::rc::Rc;
 
-use super::Label;
+use super::AccelLabel;
 use kas::class::HasBool;
 use kas::draw::{DrawHandle, SizeHandle};
 use kas::event::{Event, Manager, Response, VoidMsg};
@@ -158,7 +158,7 @@ pub struct CheckBox<M: 'static> {
     #[widget]
     checkbox: CheckBoxBare<M>,
     #[widget]
-    label: Label,
+    label: AccelLabel,
 }
 
 impl<M: 'static> Debug for CheckBox<M> {
@@ -190,7 +190,7 @@ impl<M: 'static> CheckBox<M> {
             core: Default::default(),
             layout_data: Default::default(),
             checkbox: CheckBoxBare::new_on(f),
-            label: Label::new(label),
+            label: AccelLabel::new(label),
         }
     }
 }
@@ -206,7 +206,7 @@ impl CheckBox<VoidMsg> {
             core: Default::default(),
             layout_data: Default::default(),
             checkbox: CheckBoxBare::new(),
-            label: Label::new(label),
+            label: AccelLabel::new(label),
         }
     }
 

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -161,7 +161,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     }
 }
 
-impl<T: Into<CowString>, M: Clone + Debug> FromIterator<(T, M)> for ComboBox<M> {
+impl<T: Into<AccelString>, M: Clone + Debug> FromIterator<(T, M)> for ComboBox<M> {
     fn from_iter<I: IntoIterator<Item = (T, M)>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let len = iter.size_hint().1.unwrap_or(0);

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -41,7 +41,7 @@ impl MessageBox {
             layout_data: Default::default(),
             title: title.into(),
             label: Label::new(message),
-            button: TextButton::new("Ok", DialogButton::Close),
+            button: TextButton::new("&Ok", DialogButton::Close),
         }
     }
 

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -35,7 +35,7 @@ pub struct MessageBox {
 }
 
 impl MessageBox {
-    pub fn new<T: Into<CowString>, M: Into<CowString>>(title: T, message: M) -> Self {
+    pub fn new<T: Into<CowString>, M: Into<LabelString>>(title: T, message: M) -> Self {
         MessageBox {
             core: Default::default(),
             layout_data: Default::default(),

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -9,7 +9,7 @@
 //! customisation.
 
 use kas::draw::SizeHandle;
-use kas::event::{Manager, Response, VoidMsg};
+use kas::event::{Manager, Response, VirtualKeyCode, VoidMsg};
 use kas::prelude::*;
 use kas::widget::{Label, TextButton};
 use kas::WindowId;
@@ -21,6 +21,7 @@ enum DialogButton {
 
 /// A simple message box.
 #[layout(column)]
+#[widget(config=noauto)]
 #[derive(Clone, Debug, Widget)]
 pub struct MessageBox {
     #[widget_core]
@@ -41,7 +42,11 @@ impl MessageBox {
             layout_data: Default::default(),
             title: title.into(),
             label: Label::new(message),
-            button: TextButton::new("&Ok", DialogButton::Close),
+            button: TextButton::new("Ok", DialogButton::Close).with_keys(&[
+                VirtualKeyCode::Return,
+                VirtualKeyCode::Space,
+                VirtualKeyCode::NumpadEnter,
+            ]),
         }
     }
 
@@ -50,6 +55,12 @@ impl MessageBox {
             DialogButton::Close => mgr.send_action(TkAction::Close),
         };
         Response::None
+    }
+}
+
+impl kas::WidgetConfig for MessageBox {
+    fn configure(&mut self, mgr: &mut Manager) {
+        mgr.enable_alt_bypass(true);
     }
 }
 

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -120,6 +120,11 @@ impl AccelLabel {
             text: text.into(),
         }
     }
+
+    /// Get the accelerator keys
+    pub fn keys(&self) -> &[event::VirtualKeyCode] {
+        self.text.keys()
+    }
 }
 
 impl HasText for AccelLabel {

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -77,3 +77,58 @@ impl HasText for Label {
         TkAction::Redraw
     }
 }
+
+/// A label supporting an accelerator key
+#[derive(Clone, Default, Debug, Widget)]
+pub struct AccelLabel {
+    #[widget_core]
+    core: CoreData,
+    align: (Align, Align),
+    text: CowString,
+}
+
+impl Layout for AccelLabel {
+    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        let rules = size_handle.text_bound(&self.text, TextClass::Label, axis);
+        if axis.is_horizontal() {
+            self.core.rect.size.0 = rules.ideal_size();
+        } else {
+            self.core.rect.size.1 = rules.ideal_size();
+        }
+        rules
+    }
+
+    fn set_rect(&mut self, rect: Rect, align: AlignHints) {
+        self.align = (
+            align.horiz.unwrap_or(Align::Begin),
+            align.vert.unwrap_or(Align::Centre),
+        );
+        self.core.rect = rect;
+    }
+
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
+        draw_handle.text(self.core.rect, &self.text, TextClass::Label, self.align);
+    }
+}
+
+impl AccelLabel {
+    /// Construct a new, empty instance
+    pub fn new<T: Into<CowString>>(text: T) -> Self {
+        AccelLabel {
+            core: Default::default(),
+            align: Default::default(),
+            text: text.into(),
+        }
+    }
+}
+
+impl HasText for AccelLabel {
+    fn get_text(&self) -> &str {
+        &self.text
+    }
+
+    fn set_cow_string(&mut self, text: CowString) -> TkAction {
+        self.text = text.into();
+        TkAction::Redraw
+    }
+}

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -89,7 +89,7 @@ pub struct AccelLabel {
 
 impl Layout for AccelLabel {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let rules = size_handle.text_bound(&self.text, TextClass::Label, axis);
+        let rules = size_handle.text_bound(self.text.get(false), TextClass::Label, axis);
         if axis.is_horizontal() {
             self.core.rect.size.0 = rules.ideal_size();
         } else {
@@ -106,8 +106,9 @@ impl Layout for AccelLabel {
         self.core.rect = rect;
     }
 
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        draw_handle.text(self.core.rect, &self.text, TextClass::Label, self.align);
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, _: bool) {
+        let text = self.text.get(mgr.show_accel_labels());
+        draw_handle.text(self.core.rect, text, TextClass::Label, self.align);
     }
 }
 
@@ -129,7 +130,7 @@ impl AccelLabel {
 
 impl HasText for AccelLabel {
     fn get_text(&self) -> &str {
-        &self.text
+        self.text.get(false)
     }
 
     fn set_cow_string(&mut self, text: CowString) -> TkAction {

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -18,7 +18,7 @@ pub struct Label {
     core: CoreData,
     align: (Align, Align),
     reserve: Option<&'static str>,
-    text: CowString,
+    text: LabelString,
 }
 
 impl Layout for Label {
@@ -48,7 +48,7 @@ impl Layout for Label {
 
 impl Label {
     /// Construct a new, empty instance
-    pub fn new<T: Into<CowString>>(text: T) -> Self {
+    pub fn new<T: Into<LabelString>>(text: T) -> Self {
         Label {
             core: Default::default(),
             align: Default::default(),
@@ -84,7 +84,7 @@ pub struct AccelLabel {
     #[widget_core]
     core: CoreData,
     align: (Align, Align),
-    text: CowString,
+    text: AccelString,
 }
 
 impl Layout for AccelLabel {
@@ -113,7 +113,7 @@ impl Layout for AccelLabel {
 
 impl AccelLabel {
     /// Construct a new, empty instance
-    pub fn new<T: Into<CowString>>(text: T) -> Self {
+    pub fn new<T: Into<AccelString>>(text: T) -> Self {
         AccelLabel {
             core: Default::default(),
             align: Default::default(),

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -42,7 +42,7 @@ impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
         let size = size_handle.menu_frame();
         self.label_off = size.into();
         let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, Margins::ZERO);
-        let text_rules = size_handle.text_bound(&self.label, TextClass::Label, axis);
+        let text_rules = size_handle.text_bound(self.label.get(false), TextClass::Label, axis);
         text_rules.surrounded_by(frame_rules, true)
     }
 
@@ -52,8 +52,9 @@ impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
             pos: self.core.rect.pos + self.label_off,
             size: self.core.rect.size - self.label_off.into(),
         };
+        let text = self.label.get(mgr.show_accel_labels());
         let align = (Align::Begin, Align::Centre);
-        draw_handle.text(rect, &self.label, TextClass::Label, align);
+        draw_handle.text(rect, text, TextClass::Label, align);
     }
 }
 
@@ -80,7 +81,7 @@ impl<M: Clone + Debug + 'static> MenuEntry<M> {
 
 impl<M: Clone + Debug + 'static> HasText for MenuEntry<M> {
     fn get_text(&self) -> &str {
-        &self.label
+        self.label.get(false)
     }
 
     fn set_cow_string(&mut self, text: CowString) -> TkAction {

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -16,7 +16,7 @@ use kas::prelude::*;
 use kas::widget::{AccelLabel, CheckBoxBare};
 
 /// A standard menu entry
-#[widget(config(key_nav = true))]
+#[widget(config=noauto)]
 #[handler(handle=noauto)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct MenuEntry<M: Clone + Debug + 'static> {
@@ -25,6 +25,16 @@ pub struct MenuEntry<M: Clone + Debug + 'static> {
     label: AccelString,
     label_off: Coord,
     msg: M,
+}
+
+impl<M: Clone + Debug + 'static> WidgetConfig for MenuEntry<M> {
+    fn configure(&mut self, mgr: &mut Manager) {
+        mgr.add_accel_keys(self.id(), self.label.keys());
+    }
+
+    fn key_nav(&self) -> bool {
+        true
+    }
 }
 
 impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -13,7 +13,7 @@ use kas::draw::{DrawHandle, SizeHandle, TextClass};
 use kas::event::{Event, Manager, Response, VoidMsg};
 use kas::layout::{AxisInfo, Margins, RulesSetter, RulesSolver, SizeRules};
 use kas::prelude::*;
-use kas::widget::{CheckBoxBare, Label};
+use kas::widget::{AccelLabel, CheckBoxBare};
 
 /// A standard menu entry
 #[widget(config(key_nav = true))]
@@ -102,7 +102,7 @@ pub struct MenuToggle<M: 'static> {
     #[widget]
     checkbox: CheckBoxBare<M>,
     #[widget]
-    label: Label,
+    label: AccelLabel,
 }
 
 impl<M: 'static> Debug for MenuToggle<M> {
@@ -130,7 +130,7 @@ impl<M: 'static> MenuToggle<M> {
             core: Default::default(),
             layout_data: Default::default(),
             checkbox: CheckBoxBare::new_on(f),
-            label: Label::new(label),
+            label: AccelLabel::new(label),
         }
     }
 
@@ -150,7 +150,7 @@ impl MenuToggle<VoidMsg> {
             core: Default::default(),
             layout_data: Default::default(),
             checkbox: CheckBoxBare::new(),
-            label: Label::new(label),
+            label: AccelLabel::new(label),
         }
     }
 

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -22,7 +22,7 @@ use kas::widget::{AccelLabel, CheckBoxBare};
 pub struct MenuEntry<M: Clone + Debug + 'static> {
     #[widget_core]
     core: kas::CoreData,
-    label: CowString,
+    label: AccelString,
     label_off: Coord,
     msg: M,
 }
@@ -53,7 +53,7 @@ impl<M: Clone + Debug + 'static> MenuEntry<M> {
     /// The message `msg` is emitted on activation. Any
     /// type supporting `Clone` is valid, though it is recommended to use a
     /// simple `Copy` type (e.g. an enum).
-    pub fn new<S: Into<CowString>>(label: S, msg: M) -> Self {
+    pub fn new<S: Into<AccelString>>(label: S, msg: M) -> Self {
         MenuEntry {
             core: Default::default(),
             label: label.into(),
@@ -74,7 +74,7 @@ impl<M: Clone + Debug + 'static> HasText for MenuEntry<M> {
     }
 
     fn set_cow_string(&mut self, text: CowString) -> TkAction {
-        self.label = text;
+        self.label = text.into();
         TkAction::Redraw
     }
 }
@@ -122,7 +122,7 @@ impl<M: 'static> MenuToggle<M> {
     /// The closure `f` is called with the new state of the checkbox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn new_on<T: Into<CowString>, F>(f: F, label: T) -> Self
+    pub fn new_on<T: Into<AccelString>, F>(f: F, label: T) -> Self
     where
         F: Fn(bool) -> M + 'static,
     {
@@ -145,7 +145,7 @@ impl<M: 'static> MenuToggle<M> {
 impl MenuToggle<VoidMsg> {
     /// Construct a togglable menu entry with a given `label`
     #[inline]
-    pub fn new<T: Into<CowString>>(label: T) -> Self {
+    pub fn new<T: Into<AccelString>>(label: T) -> Self {
         MenuToggle {
             core: Default::default(),
             layout_data: Default::default(),

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -105,6 +105,7 @@ impl<M: Clone + Debug> Menu for MenuEntry<M> {}
 
 /// A menu entry which can be toggled
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
+#[widget(config=noauto)]
 #[derive(Clone, Default, Widget)]
 pub struct MenuToggle<M: 'static> {
     #[widget_core]
@@ -183,7 +184,13 @@ impl MenuToggle<VoidMsg> {
     }
 }
 
-impl<M: 'static> kas::Layout for MenuToggle<M> {
+impl<M: 'static> WidgetConfig for MenuToggle<M> {
+    fn configure(&mut self, mgr: &mut Manager) {
+        mgr.add_accel_keys(self.checkbox.id(), self.label.keys());
+    }
+}
+
+impl<M: 'static> Layout for MenuToggle<M> {
     // NOTE: This code is mostly copied from the macro expansion.
     // Only draw() is significantly different.
     fn size_rules(

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -22,7 +22,7 @@ pub struct SubMenu<D: Directional, W: Menu> {
     #[widget_core]
     core: CoreData,
     direction: D,
-    label: CowString,
+    label: AccelString,
     label_off: Coord,
     #[widget]
     pub list: MenuFrame<Column<W>>,
@@ -32,7 +32,7 @@ pub struct SubMenu<D: Directional, W: Menu> {
 impl<D: Directional + Default, W: Menu> SubMenu<D, W> {
     /// Construct a sub-menu
     #[inline]
-    pub fn new<S: Into<CowString>>(label: S, list: Vec<W>) -> Self {
+    pub fn new<S: Into<AccelString>>(label: S, list: Vec<W>) -> Self {
         SubMenu::new_with_direction(Default::default(), label, list)
     }
 }
@@ -43,7 +43,7 @@ impl<W: Menu> SubMenu<kas::Right, W> {
     // Consider only accepting an enum of special menu widgets?
     // Then we can pass type information.
     #[inline]
-    pub fn right<S: Into<CowString>>(label: S, list: Vec<W>) -> Self {
+    pub fn right<S: Into<AccelString>>(label: S, list: Vec<W>) -> Self {
         SubMenu::new(label, list)
     }
 }
@@ -51,7 +51,7 @@ impl<W: Menu> SubMenu<kas::Right, W> {
 impl<W: Menu> SubMenu<kas::Down, W> {
     /// Construct a sub-menu, opening downwards
     #[inline]
-    pub fn down<S: Into<CowString>>(label: S, list: Vec<W>) -> Self {
+    pub fn down<S: Into<AccelString>>(label: S, list: Vec<W>) -> Self {
         SubMenu::new(label, list)
     }
 }
@@ -59,7 +59,7 @@ impl<W: Menu> SubMenu<kas::Down, W> {
 impl<D: Directional, W: Menu> SubMenu<D, W> {
     /// Construct a sub-menu
     #[inline]
-    pub fn new_with_direction<S: Into<CowString>>(direction: D, label: S, list: Vec<W>) -> Self {
+    pub fn new_with_direction<S: Into<AccelString>>(direction: D, label: S, list: Vec<W>) -> Self {
         SubMenu {
             core: Default::default(),
             direction,
@@ -247,7 +247,7 @@ impl<D: Directional, W: Menu> HasText for SubMenu<D, W> {
     }
 
     fn set_cow_string(&mut self, text: CowString) -> TkAction {
-        self.label = text;
+        self.label = text.into();
         TkAction::Redraw
     }
 }

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -8,7 +8,7 @@
 use super::{Menu, MenuFrame};
 use kas::class::HasText;
 use kas::draw::{DrawHandle, SizeHandle, TextClass};
-use kas::event::{Event, Manager, NavKey, Response};
+use kas::event::{ConfigureManager, Event, Manager, NavKey, Response};
 use kas::layout::{AxisInfo, Margins, SizeRules};
 use kas::prelude::*;
 use kas::widget::Column;
@@ -89,7 +89,12 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
 }
 
 impl<D: Directional, W: Menu> WidgetConfig for SubMenu<D, W> {
-    fn configure(&mut self, mgr: &mut Manager) {
+    fn configure_recurse<'a, 'b>(&mut self, mut cmgr: ConfigureManager<'a, 'b>) {
+        cmgr.mgr().push_accel_layer();
+        self.list.configure_recurse(cmgr.child());
+        self.core_data_mut().id = cmgr.next_id(self.id());
+        let mgr = cmgr.mgr();
+        mgr.pop_accel_layer(self.id());
         mgr.add_accel_keys(self.id(), self.label.keys());
     }
 

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -108,7 +108,7 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
         let size = size_handle.menu_frame();
         self.label_off = size.into();
         let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, Margins::ZERO);
-        let text_rules = size_handle.text_bound(&self.label, TextClass::Label, axis);
+        let text_rules = size_handle.text_bound(self.label.get(false), TextClass::Label, axis);
         text_rules.surrounded_by(frame_rules, true)
     }
 
@@ -125,8 +125,9 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
             pos: self.core.rect.pos + self.label_off,
             size: self.core.rect.size - self.label_off.into(),
         };
+        let text = self.label.get(mgr.show_accel_labels());
         let align = (Align::Begin, Align::Centre);
-        draw_handle.text(rect, &self.label, TextClass::Label, align);
+        draw_handle.text(rect, text, TextClass::Label, align);
     }
 }
 
@@ -258,7 +259,7 @@ impl<D: Directional, W: Menu> Menu for SubMenu<D, W> {
 
 impl<D: Directional, W: Menu> HasText for SubMenu<D, W> {
     fn get_text(&self) -> &str {
-        &self.label
+        self.label.get(false)
     }
 
     fn set_cow_string(&mut self, text: CowString) -> TkAction {

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -15,7 +15,7 @@ use kas::widget::Column;
 use kas::WindowId;
 
 /// A sub-menu
-#[widget(config(key_nav = true))]
+#[widget(config=noauto)]
 #[handler(noauto)]
 #[derive(Clone, Debug, Widget)]
 pub struct SubMenu<D: Directional, W: Menu> {
@@ -85,6 +85,16 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
         if let Some(id) = self.popup_id {
             mgr.close_window(id);
         }
+    }
+}
+
+impl<D: Directional, W: Menu> WidgetConfig for SubMenu<D, W> {
+    fn configure(&mut self, mgr: &mut Manager) {
+        mgr.add_accel_keys(self.id(), self.label.keys());
+    }
+
+    fn key_nav(&self) -> bool {
+        true
     }
 }
 

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -90,7 +90,7 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
 
 impl<D: Directional, W: Menu> WidgetConfig for SubMenu<D, W> {
     fn configure_recurse<'a, 'b>(&mut self, mut cmgr: ConfigureManager<'a, 'b>) {
-        cmgr.mgr().push_accel_layer();
+        cmgr.mgr().push_accel_layer(true);
         self.list.configure_recurse(cmgr.child());
         self.core_data_mut().id = cmgr.next_id(self.id());
         let mgr = cmgr.mgr();

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -36,7 +36,7 @@ pub use drag::DragHandle;
 pub use editbox::{EditBox, EditBoxVoid, EditGuard};
 pub use filler::Filler;
 pub use frame::Frame;
-pub use label::Label;
+pub use label::{AccelLabel, Label};
 pub use list::*;
 pub use menu::*;
 pub use radiobox::{RadioBox, RadioBoxBare};

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -216,7 +216,7 @@ impl<M: 'static> RadioBox<M> {
     /// The closure `f` is called with the new state of the radiobox when
     /// toggled, and the result of `f` is returned from the event handler.
     #[inline]
-    pub fn new_on<T: Into<CowString>, F>(f: F, handle: UpdateHandle, label: T) -> Self
+    pub fn new_on<T: Into<AccelString>, F>(f: F, handle: UpdateHandle, label: T) -> Self
     where
         F: Fn(WidgetId) -> M + 'static,
     {
@@ -238,7 +238,7 @@ impl RadioBox<VoidMsg> {
     /// RadioBox labels are optional; if no label is desired, use an empty
     /// string.
     #[inline]
-    pub fn new<T: Into<CowString>>(handle: UpdateHandle, label: T) -> Self {
+    pub fn new<T: Into<AccelString>>(handle: UpdateHandle, label: T) -> Self {
         RadioBox {
             core: Default::default(),
             layout_data: Default::default(),

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 use std::fmt::{self, Debug};
 use std::rc::Rc;
 
-use super::Label;
+use super::AccelLabel;
 use kas::class::HasBool;
 use kas::draw::{DrawHandle, SizeHandle};
 use kas::event::{Event, Manager, Response, UpdateHandle, VoidMsg};
@@ -192,7 +192,7 @@ pub struct RadioBox<M: 'static> {
     #[widget]
     radiobox: RadioBoxBare<M>,
     #[widget]
-    label: Label,
+    label: AccelLabel,
 }
 
 impl<M: 'static> Debug for RadioBox<M> {
@@ -224,7 +224,7 @@ impl<M: 'static> RadioBox<M> {
             core: Default::default(),
             layout_data: Default::default(),
             radiobox: RadioBoxBare::new_on(f, handle),
-            label: Label::new(label),
+            label: AccelLabel::new(label),
         }
     }
 }
@@ -243,7 +243,7 @@ impl RadioBox<VoidMsg> {
             core: Default::default(),
             layout_data: Default::default(),
             radiobox: RadioBoxBare::new(handle),
-            label: Label::new(label),
+            label: AccelLabel::new(label),
         }
     }
 

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -183,6 +183,7 @@ impl<M: 'static> HasBool for RadioBoxBare<M> {
 /// A radiobox with optional label
 #[layout(row, area=radiobox)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
+#[widget(config=noauto)]
 #[derive(Clone, Widget)]
 pub struct RadioBox<M: 'static> {
     #[widget_core]
@@ -271,6 +272,12 @@ impl<M: 'static> RadioBox<M> {
     pub fn state(mut self, state: bool) -> Self {
         self.radiobox = self.radiobox.state(state);
         self
+    }
+}
+
+impl<M: 'static> WidgetConfig for RadioBox<M> {
+    fn configure(&mut self, mgr: &mut Manager) {
+        mgr.add_accel_keys(self.radiobox.id(), self.label.keys());
     }
 }
 


### PR DESCRIPTION
This adjusts how keyboard bindings work:

- bindings can be inferred from labels (e.g. "&File" binds `F`)
- bindings are separated into multiple layers, thus e.g. key-bindings from menu items are only accessible when that menu is open
- bindings are visible and active when Alt is held
- if "alt_bypass" is enabled, bindings are also active without Alt

To do this, `LabelString` and `AccelString` types are introduced (in the new `kas::string` module). These types parse labels with `&` bindings.