### PR TITLE
Misc changes [breaking]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ nightly = []
 internal_doc = []
 
 [dependencies]
-conv = "0.3"
 log = "0.4"
 rusttype = "0.8"
 smallvec = "1.4"

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -40,7 +40,7 @@ pub struct Dimensions {
     pub scale_factor: f32,
     pub line_height: u32,
     pub min_line_length: u32,
-    pub max_line_length: u32,
+    pub ideal_line_length: u32,
     pub margin: u32,
     pub frame: u32,
     pub button_frame: u32,
@@ -65,8 +65,10 @@ impl Dimensions {
             font_scale,
             scale_factor,
             line_height,
-            min_line_length: line_height * 8,
-            max_line_length: line_height * 24,
+            // We appear to average about 2 characters per line_height
+            // TODO: better to specify in terms of font's 'n' size?
+            min_line_length: line_height * 6,
+            ideal_line_length: line_height * 15,
             margin,
             frame,
             button_frame: (params.button_frame * scale_factor).round() as u32,
@@ -171,7 +173,7 @@ impl<'a, Draw: DrawText> draw::SizeHandle for SizeHandle<'a, Draw> {
         if axis.is_horizontal() {
             let bound = bounds.0 as u32;
             let min = self.dims.min_line_length;
-            let ideal = self.dims.max_line_length;
+            let ideal = self.dims.ideal_line_length;
             let (min, ideal) = match class {
                 TextClass::Edit | TextClass::EditMulti => (min, ideal),
                 _ => (bound.min(min), bound.min(ideal)),

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -8,7 +8,7 @@
 
 use kas::event::VoidMsg;
 use kas::macros::make_widget;
-use kas::widget::{CheckBox, EditBox, Label, Window};
+use kas::widget::{CheckBoxBare, EditBox, Label, Window};
 
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
@@ -24,7 +24,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             struct {
                 #[widget(row=0, col=2)] _ = Label::new("Layout demo"),
                 #[widget(row=1, col=1, cspan=3)] _ = Label::new(lipsum),
-                #[widget(row=1, col=4)] _ = CheckBox::new(""),
+                #[widget(row=1, col=4)] _ = CheckBoxBare::new(),
                 #[widget(row=2, col=0)] _ = Label::new("Text"),
                 #[widget(row=2, col=2, cspan=2, rspan=2)] _ = Label::new(crasit),
                 #[widget(row=3, col=1)] _ = EditBox::new("edit"),

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -90,6 +90,7 @@ enum Pending {
 // `SmallVec` is used to keep contents in local memory.
 #[derive(Debug)]
 pub struct ManagerState {
+    end_id: WidgetId,
     dpi_factor: f64,
     modifiers: ModifiersState,
     char_focus: Option<WidgetId>,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,14 +13,25 @@
 //! This prelude may be more useful when implementing widgets than when simply
 //! using widgets in a GUI.
 
+#[doc(no_inline)]
 pub use kas::draw::{DrawHandle, SizeHandle};
+#[doc(no_inline)]
 pub use kas::event::{Event, Handler, Manager, ManagerState, Response, SendEvent, VoidMsg};
+#[doc(no_inline)]
 pub use kas::geom::{Coord, Rect, Size};
+#[doc(no_inline)]
 pub use kas::layout::{AxisInfo, Margins, SizeRules, StretchPolicy};
+#[doc(no_inline)]
 pub use kas::macros::*;
+#[doc(no_inline)]
 pub use kas::string::{AccelString, CowString, CowStringL, LabelString};
+#[doc(no_inline)]
 pub use kas::{class, draw, event, geom, layout, widget};
+#[doc(no_inline)]
 pub use kas::{Align, AlignHints, Direction, Directional, WidgetId};
+#[doc(no_inline)]
 pub use kas::{Boxed, TkAction, TkWindow};
+#[doc(no_inline)]
 pub use kas::{CloneTo, Layout, ThemeApi, Widget, WidgetChildren, WidgetConfig, WidgetCore};
+#[doc(no_inline)]
 pub use kas::{CoreData, LayoutData};

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -74,8 +74,8 @@ pub enum TkAction {
     Popup,
     /// Whole window requires reconfiguring
     ///
-    /// *Configuring* widgets assigns [`WidgetId`] identifiers, updates
-    /// [`event::Manager`] state and resizes all widgets.
+    /// *Configuring* widgets assigns [`WidgetId`] identifiers and calls
+    /// [`kas::WidgetConfig::configure`].
     ///
     /// [`WidgetId`]: crate::WidgetId
     /// [`event::Manager`]: crate::event::Manager

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -279,6 +279,11 @@ pub trait WidgetConfig: Layout {
     /// a [`WidgetId`] has been assigned to self, and after `configure` has
     /// been called on each child.
     ///
+    /// It is not advised to perform any action requiring a reconfigure (e.g.
+    /// adding a child widget) during configure due to the possibility of
+    /// getting stuck in a reconfigure-loop. See issue kas#91 for more on this.
+    /// KAS has a crude mechanism to detect this and panic.
+    ///
     /// The default implementation of this method does nothing.
     fn configure(&mut self, _: &mut Manager) {}
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -87,7 +87,7 @@ pub use radiobox::{RadioBox, RadioBoxBare};
 pub use scroll::ScrollRegion;
 pub use scrollbar::ScrollBar;
 pub use separator::Separator;
-pub use slider::Slider;
+pub use slider::{Slider, SliderType};
 pub use splitter::*;
 pub use stack::{BoxStack, RefStack, Stack};
 pub use window::Window;


### PR DESCRIPTION
This includes breaking changes, so probably there won't be another 0.4.x release.

The `Slider`'s value type bounds changed to support `std::time::Duration`.

We also pull in a change from the `view` branch: protection against getting stuck in a loop due to sending `TkAction::Reconfigure` from `WidgetConfig::configure`.