### PR TITLE
Update glyph_brush, movable edit marker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ab_glyph = "0.2.1"
 smallvec = "1.4"
 stack_dst = { version = "0.6", optional = true }
 bitflags = "1" # only used without winit
+unicode-segmentation = "1.6"
 
 [dependencies.kas-macros]
 version = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ internal_doc = []
 
 [dependencies]
 log = "0.4"
-rusttype = "0.8"
+ab_glyph = "0.2.1"
 smallvec = "1.4"
 stack_dst = { version = "0.6", optional = true }
 bitflags = "1" # only used without winit

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -37,6 +37,7 @@ pub struct DimensionsParams {
 pub struct Dimensions {
     pub font_id: FontId,
     pub font_scale: f32,
+    pub font_marker_width: f32,
     pub scale_factor: f32,
     pub line_height: u32,
     pub min_line_length: u32,
@@ -63,6 +64,7 @@ impl Dimensions {
         Dimensions {
             font_id,
             font_scale,
+            font_marker_width: (2.0 * scale_factor).round(),
             scale_factor,
             line_height,
             // We appear to average about 2 characters per line_height
@@ -76,6 +78,10 @@ impl Dimensions {
             scrollbar: Size::from(params.scrollbar_size * scale_factor),
             slider: Size::from(params.slider_size * scale_factor),
         }
+    }
+
+    pub fn edit_marker_size(&self) -> Vec2 {
+        Vec2(self.font_marker_width, self.font_scale)
     }
 }
 

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -236,7 +236,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
         let props = TextProperties {
             font: self.window.dims.font_id,
-            scale: self.window.dims.font_scale,
+            scale: self.window.dims.font_scale.into(),
             col: match class {
                 TextClass::Label => self.cols.label_text,
                 TextClass::Button => self.cols.button_text,

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -131,6 +131,23 @@ impl ThemeApi for ShadedTheme {
 }
 
 impl<'a, D: Draw + DrawRounded + DrawShaded> DrawHandle<'a, D> {
+    fn text_props(&self, class: TextClass, align: (Align, Align)) -> TextProperties {
+        TextProperties {
+            font: self.window.dims.font_id,
+            scale: self.window.dims.font_scale.into(),
+            col: match class {
+                TextClass::Label => self.cols.label_text,
+                TextClass::Button => self.cols.button_text,
+                TextClass::Edit | TextClass::EditMulti => self.cols.text,
+            },
+            align,
+            line_wrap: match class {
+                TextClass::Label | TextClass::EditMulti => true,
+                TextClass::Button | TextClass::Edit => false,
+            },
+        }
+    }
+
     /// Draw an edit box with optional navigation highlight.
     /// Return the inner rect.
     ///
@@ -239,21 +256,25 @@ where
     }
 
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
-        let props = TextProperties {
-            font: self.window.dims.font_id,
-            scale: self.window.dims.font_scale.into(),
-            col: match class {
-                TextClass::Label => self.cols.label_text,
-                TextClass::Button => self.cols.button_text,
-                TextClass::Edit | TextClass::EditMulti => self.cols.text,
-            },
-            align,
-            line_wrap: match class {
-                TextClass::Label | TextClass::EditMulti => true,
-                TextClass::Button | TextClass::Edit => false,
-            },
-        };
+        let props = self.text_props(class, align);
         self.draw.text(self.pass, rect + self.offset, text, props);
+    }
+
+    fn edit_marker(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        class: TextClass,
+        align: (Align, Align),
+        byte: usize,
+    ) {
+        let props = self.text_props(class, align);
+        let pos = self
+            .draw
+            .text_glyph_pos(rect + self.offset, text, props, byte);
+        let size = self.window.dims.edit_marker_size();
+        let quad = Quad::with_pos_and_size(pos, size);
+        self.draw.rect(self.pass, quad, props.col);
     }
 
     fn menu_entry(&mut self, rect: Rect, state: InputState) {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -241,7 +241,7 @@ where
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
         let props = TextProperties {
             font: self.window.dims.font_id,
-            scale: self.window.dims.font_scale,
+            scale: self.window.dims.font_scale.into(),
             col: match class {
                 TextClass::Label => self.cols.label_text,
                 TextClass::Button => self.cols.button_text,

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -32,7 +32,7 @@ log = "0.4"
 shaderc = "0.6.1"
 smallvec = "1.1"
 wgpu = "0.5.0"
-wgpu_glyph = "0.8.0"
+wgpu_glyph = "0.9.0"
 winit = "0.22.0"
 
 [dependencies.clipboard]

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -100,7 +100,7 @@ impl Layout for Clock {
         line_seg(a_sec, 0.0, half * 0.9, half * 0.005, col_secs);
 
         let props = TextProperties {
-            scale: self.font_scale,
+            scale: self.font_scale.into(),
             col: col_text,
             align: (Align::Centre, Align::Centre),
             ..TextProperties::default()

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -13,7 +13,7 @@ use wgpu::{Buffer, ShaderModule};
 
 use kas::class::HasText;
 use kas::draw::Pass;
-use kas::event::NavKey;
+use kas::event::ControlKey;
 use kas::geom::{DVec2, Vec2, Vec3};
 use kas::prelude::*;
 use kas::widget::{Label, Slider, Window};
@@ -491,18 +491,18 @@ impl event::Handler for Mandlebrot {
 
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         match event {
-            Event::NavKey(key) => {
+            Event::Control(key) => {
                 match key {
-                    NavKey::Home | NavKey::End => self.reset_view(),
-                    NavKey::PageUp => self.alpha = self.alpha / 2f64.sqrt(),
-                    NavKey::PageDown => self.alpha = self.alpha * 2f64.sqrt(),
+                    ControlKey::Home | ControlKey::End => self.reset_view(),
+                    ControlKey::PageUp => self.alpha = self.alpha / 2f64.sqrt(),
+                    ControlKey::PageDown => self.alpha = self.alpha * 2f64.sqrt(),
                     key => {
                         let d = 0.2;
                         let delta = match key {
-                            NavKey::Up => DVec2(0.0, -d),
-                            NavKey::Down => DVec2(0.0, d),
-                            NavKey::Left => DVec2(-d, 0.0),
-                            NavKey::Right => DVec2(d, 0.0),
+                            ControlKey::Up => DVec2(0.0, -d),
+                            ControlKey::Down => DVec2(0.0, d),
+                            ControlKey::Left => DVec2(-d, 0.0),
+                            ControlKey::Right => DVec2(d, 0.0),
                             _ => return Response::None,
                         };
                         self.delta = self.delta + self.alpha.complex_mul(delta);

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -15,7 +15,7 @@ mod shaded_round;
 mod shaded_square;
 mod shaders;
 
-use kas::draw::Font;
+use kas::draw::FontArc;
 use kas::geom::Rect;
 use wgpu::{CompareFunction, DepthStencilStateDescriptor, TextureFormat};
 use wgpu_glyph::GlyphBrush;
@@ -62,7 +62,7 @@ impl From<kas::draw::Colour> for Rgb {
 
 /// Shared pipeline data
 pub struct DrawPipe<C> {
-    fonts: Vec<Font<'static>>,
+    fonts: Vec<FontArc>,
     shaded_square: shaded_square::Pipeline,
     shaded_round: shaded_round::Pipeline,
     flat_round: flat_round::Pipeline,
@@ -77,5 +77,5 @@ pub struct DrawWindow<CW: CustomWindow> {
     shaded_round: shaded_round::Window,
     flat_round: flat_round::Window,
     custom: CW,
-    glyph_brush: GlyphBrush<'static, DepthStencilStateDescriptor>, // TODO: should be in DrawPipe
+    glyph_brush: GlyphBrush<DepthStencilStateDescriptor>, // TODO: should be in DrawPipe
 }

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -238,6 +238,16 @@ pub trait DrawHandle {
     /// The dimensions required for this text may be queried with [`SizeHandle::text_bound`].
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align));
 
+    /// Draw an edit marker at the given `byte` index on this `text`
+    fn edit_marker(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        class: TextClass,
+        align: (Align, Align),
+        byte: usize,
+    );
+
     /// Draw the background of a menu entry
     fn menu_entry(&mut self, rect: Rect, state: InputState);
 
@@ -400,6 +410,16 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
         self.deref_mut().text(rect, text, class, align)
     }
+    fn edit_marker(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        class: TextClass,
+        align: (Align, Align),
+        byte: usize,
+    ) {
+        self.deref_mut().edit_marker(rect, text, class, align, byte)
+    }
     fn menu_entry(&mut self, rect: Rect, state: InputState) {
         self.deref_mut().menu_entry(rect, state)
     }
@@ -454,6 +474,16 @@ where
     }
     fn text(&mut self, rect: Rect, text: &str, class: TextClass, align: (Align, Align)) {
         self.deref_mut().text(rect, text, class, align)
+    }
+    fn edit_marker(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        class: TextClass,
+        align: (Align, Align),
+        byte: usize,
+    ) {
+        self.deref_mut().edit_marker(rect, text, class, align, byte)
     }
     fn menu_entry(&mut self, rect: Rect, state: InputState) {
         self.deref_mut().menu_entry(rect, state)

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -47,7 +47,7 @@ use crate::geom::{Quad, Rect, Vec2};
 
 pub use colour::Colour;
 pub use handle::{ClipRegion, DrawHandle, InputState, SizeHandle, TextClass};
-pub use text::{DrawText, DrawTextShared, Font, FontId, TextProperties};
+pub use text::{DrawText, DrawTextShared, FontArc, FontId, TextProperties};
 
 /// Pass identifier
 ///

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -5,7 +5,7 @@
 
 //! Text-drawing API
 
-pub use ab_glyph::FontArc;
+pub use ab_glyph::{FontArc, PxScale};
 
 use super::{Colour, Draw, DrawShared, Pass};
 use crate::geom::Rect;
@@ -22,19 +22,31 @@ use crate::Align;
 pub struct FontId(pub usize);
 
 /// Text properties for use by [`DrawText::text`]
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct TextProperties {
     /// The font
     pub font: FontId,
-    /// Font scale (approximately the pixel-height of a line of text or double
-    /// the "pt" size; currently not formally specified)
-    pub scale: f32,
+    /// Font scale
+    ///
+    /// This is approximately the pixel-height of a line of text or double the
+    /// "pt" size. Usually you want to use the same scale for both components,
+    /// e.g. `PxScale::from(18.0)`.
+    pub scale: PxScale,
     /// Font colour
     pub col: Colour,
     /// Text alignment in horizontal and vertical directions
     pub align: (Align, Align),
     /// True if text should automatically be line-wrapped
     pub line_wrap: bool,
+}
+
+impl Default for TextProperties {
+    fn default() -> Self {
+        TextProperties {
+            scale: 18.0.into(),
+            ..Default::default()
+        }
+    }
 }
 
 /// Abstraction over type shared by [`DrawText`] implementations

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -8,7 +8,7 @@
 pub use ab_glyph::{FontArc, PxScale};
 
 use super::{Colour, Draw, DrawShared, Pass};
-use crate::geom::Rect;
+use crate::geom::{Rect, Vec2};
 use crate::Align;
 
 /// Font identifier
@@ -86,4 +86,15 @@ pub trait DrawText: Draw {
         bounds: (f32, f32),
         line_wrap: bool,
     ) -> (f32, f32);
+
+    /// Find the starting position (top-left) of the glyph at the given index
+    ///
+    /// May panic on invalid byte index.
+    fn text_glyph_pos(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        props: TextProperties,
+        byte: usize,
+    ) -> Vec2;
 }

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -5,7 +5,7 @@
 
 //! Text-drawing API
 
-pub use rusttype::Font;
+pub use ab_glyph::FontArc;
 
 use super::{Colour, Draw, DrawShared, Pass};
 use crate::geom::Rect;
@@ -40,7 +40,7 @@ pub struct TextProperties {
 /// Abstraction over type shared by [`DrawText`] implementations
 pub trait DrawTextShared: DrawShared {
     /// Load a font
-    fn load_font(&mut self, font: Font<'static>) -> FontId;
+    fn load_font(&mut self, font: FontArc) -> FontId;
 }
 
 /// Abstraction over text rendering

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -277,20 +277,20 @@ impl<'a> Manager<'a> {
                 if let Some(nav_id) = self.mgr.nav_focus {
                     if vkey == VK::Space || vkey == VK::Return || vkey == VK::NumpadEnter {
                         id_action = Some((nav_id, Event::Activate));
-                    } else if let Some(nav_key) = NavKey::new(vkey) {
-                        id_action = Some((nav_id, Event::NavKey(nav_key)));
+                    } else if let Some(nav_key) = ControlKey::new(vkey) {
+                        id_action = Some((nav_id, Event::Control(nav_key)));
                     }
                 }
 
                 if id_action.is_none() {
                     // Next priority goes to pop-up widget
                     if let Some(popup) = self.mgr.popups.last() {
-                        if let Some(key) = NavKey::new(vkey) {
-                            id_action = Some((popup.1.parent, Event::NavKey(key)));
+                        if let Some(key) = ControlKey::new(vkey) {
+                            id_action = Some((popup.1.parent, Event::Control(key)));
                         }
                     } else if let Some(id) = self.mgr.nav_fallback {
-                        if let Some(key) = NavKey::new(vkey) {
-                            id_action = Some((id, Event::NavKey(key)));
+                        if let Some(key) = ControlKey::new(vkey) {
+                            id_action = Some((id, Event::Control(key)));
                         }
                     }
                 }

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -247,10 +247,11 @@ impl<'a> Manager<'a> {
         W: Widget<Msg = VoidMsg> + ?Sized,
     {
         use VirtualKeyCode as VK;
-        if self.mgr.char_focus.is_some() {
-            match vkey {
-                VK::Escape => self.set_char_focus(None),
-                _ => (),
+        if let Some(id) = self.mgr.char_focus {
+            if vkey == VK::Escape {
+                self.set_char_focus(None);
+            } else if let Some(key) = ControlKey::new(vkey) {
+                self.send_event(widget, id, Event::Control(key));
             }
             return;
         }

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -253,11 +253,11 @@ impl<'a> Manager<'a> {
 
 /// Public API (around event manager state)
 impl<'a> Manager<'a> {
-    /// Attempts to set a fallback to receive [`Event::NavKey`]
+    /// Attempts to set a fallback to receive [`Event::Control`]
     ///
-    /// In case a navigation key is pressed (see [`NavKey`]) but no widget has
+    /// In case a navigation key is pressed (see [`ControlKey`]) but no widget has
     /// navigation focus, then, if a fallback has been set, that widget will
-    /// receive the key via [`Event::NavKey`]. (This does not include
+    /// receive the key via [`Event::Control`]. (This does not include
     /// [`Event::Activate`].)
     ///
     /// Only one widget can be a fallback, and the *first* to set itself wins.
@@ -478,6 +478,8 @@ impl<'a> Manager<'a> {
     }
 
     /// Get the current keyboard navigation focus, if any
+    ///
+    /// This is the widget selected by navigating the UI with the Tab key.
     pub fn nav_focus(&self) -> Option<WidgetId> {
         self.mgr.nav_focus
     }

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -115,3 +115,12 @@ impl<M> From<M> for Response<M> {
         Response::Msg(msg)
     }
 }
+
+impl<M> From<Option<M>> for Response<M> {
+    fn from(msg: Option<M>) -> Self {
+        match msg {
+            Some(msg) => Response::Msg(msg),
+            None => Response::None,
+        }
+    }
+}

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -21,6 +21,21 @@ pub struct Quad {
 }
 
 impl Quad {
+    /// Construct with two coords
+    #[inline]
+    pub fn with_coords(a: Vec2, b: Vec2) -> Self {
+        Quad { a, b }
+    }
+
+    /// Construct with position and size
+    #[inline]
+    pub fn with_pos_and_size(pos: Vec2, size: Vec2) -> Self {
+        Quad {
+            a: pos,
+            b: pos + size,
+        }
+    }
+
     /// Get the size
     #[inline]
     pub fn size(&self) -> Vec2 {

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -11,7 +11,7 @@ use std::iter::FromIterator;
 use super::{Column, MenuEntry, MenuFrame};
 use kas::class::HasText;
 use kas::draw::TextClass;
-use kas::event::{GrabMode, NavKey};
+use kas::event::{ControlKey, GrabMode};
 use kas::prelude::*;
 use kas::WindowId;
 
@@ -198,7 +198,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
         match r {
             Response::None => Response::None,
             Response::Unhandled(ev) => match ev {
-                Event::NavKey(key) => {
+                Event::Control(key) => {
                     let next = |mgr: &mut Manager, s, clr, rev| {
                         if clr {
                             mgr.clear_nav_focus();
@@ -207,11 +207,11 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
                         Response::None
                     };
                     match key {
-                        NavKey::Up => next(mgr, self, false, true),
-                        NavKey::Down => next(mgr, self, false, false),
-                        NavKey::Home => next(mgr, self, true, false),
-                        NavKey::End => next(mgr, self, true, true),
-                        key => Response::Unhandled(Event::NavKey(key)),
+                        ControlKey::Up => next(mgr, self, false, true),
+                        ControlKey::Down => next(mgr, self, false, false),
+                        ControlKey::Home => next(mgr, self, true, false),
+                        ControlKey::End => next(mgr, self, true, true),
+                        key => Response::Unhandled(Event::Control(key)),
                     }
                 }
                 ev => Response::Unhandled(ev),

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -369,8 +369,8 @@ impl<G> EditBox<G> {
                         // ignore them (preventing line-breaks and ignoring any
                         // actions such as recursive-paste).
                         let mut end = content.len();
-                        for (i, b) in content.as_bytes().iter().cloned().enumerate() {
-                            if b < 0x20 || (b >= 0x7f && b <= 0x9f) {
+                        for (i, c) in content.char_indices() {
+                            if c < '\u{20}' || (c >= '\u{7f}' && c <= '\u{9f}') {
                                 end = i;
                                 break;
                             }

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -205,14 +205,11 @@ impl<G: 'static> Layout for EditBox<G> {
         input_state.error = self.error_state;
         draw_handle.edit_box(self.core.rect, input_state);
         let align = (Align::Begin, Align::Begin);
-        let mut text = &self.text;
-        let mut _string;
+        draw_handle.text(self.text_rect, &self.text, class, align);
         if input_state.char_focus {
-            _string = self.text.clone();
-            _string.push('|');
-            text = &_string;
+            let byte = self.text.len(); // FIXME
+            draw_handle.edit_marker(self.text_rect, &self.text, class, align, byte);
         }
-        draw_handle.text(self.text_rect, text, class, align);
     }
 }
 

--- a/src/widget/menu/menubar.rs
+++ b/src/widget/menu/menubar.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use super::{Menu, SubMenu};
-use kas::event::{GrabMode, NavKey};
+use kas::event::{ControlKey, GrabMode};
 use kas::prelude::*;
 use kas::widget::List;
 
@@ -163,16 +163,16 @@ impl<D: Directional, W: Menu<Msg = M>, M> event::Handler for MenuBar<D, W> {
                     self.menu_path(mgr, None);
                 }
             }
-            Event::NavKey(key) => {
+            Event::Control(key) => {
                 // Arrow keys can switch to the next / previous menu.
                 let is_vert = self.bar.direction().is_vertical();
                 let reverse = self.bar.direction().is_reversed()
                     ^ match key {
-                        NavKey::Left if !is_vert => true,
-                        NavKey::Right if !is_vert => false,
-                        NavKey::Up if is_vert => true,
-                        NavKey::Down if is_vert => false,
-                        key => return Response::Unhandled(Event::NavKey(key)),
+                        ControlKey::Left if !is_vert => true,
+                        ControlKey::Right if !is_vert => false,
+                        ControlKey::Up if is_vert => true,
+                        ControlKey::Down if is_vert => false,
+                        key => return Response::Unhandled(Event::Control(key)),
                     };
 
                 for i in 0..self.bar.len() {

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -8,7 +8,7 @@
 use super::{Menu, MenuFrame};
 use kas::class::HasText;
 use kas::draw::TextClass;
-use kas::event::{ConfigureManager, NavKey};
+use kas::event::{ConfigureManager, ControlKey};
 use kas::prelude::*;
 use kas::widget::Column;
 use kas::WindowId;
@@ -149,12 +149,12 @@ impl<D: Directional, M, W: Menu<Msg = M>> event::Handler for SubMenu<D, W> {
                 debug_assert_eq!(Some(id), self.popup_id);
                 self.popup_id = None;
             }
-            Event::NavKey(key) => match (self.direction.as_direction(), key) {
-                (Direction::Left, NavKey::Left) => self.open_menu(mgr),
-                (Direction::Right, NavKey::Right) => self.open_menu(mgr),
-                (Direction::Up, NavKey::Up) => self.open_menu(mgr),
-                (Direction::Down, NavKey::Down) => self.open_menu(mgr),
-                (_, key) => return Response::Unhandled(Event::NavKey(key)),
+            Event::Control(key) => match (self.direction.as_direction(), key) {
+                (Direction::Left, ControlKey::Left) => self.open_menu(mgr),
+                (Direction::Right, ControlKey::Right) => self.open_menu(mgr),
+                (Direction::Up, ControlKey::Up) => self.open_menu(mgr),
+                (Direction::Down, ControlKey::Down) => self.open_menu(mgr),
+                (_, key) => return Response::Unhandled(Event::Control(key)),
             },
             event => return Response::Unhandled(event),
         }
@@ -184,7 +184,7 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
 
             match r {
                 Response::Unhandled(ev) => match ev {
-                    Event::NavKey(key) if self.popup_id.is_some() => {
+                    Event::Control(key) if self.popup_id.is_some() => {
                         if self.popup_id.is_some() {
                             let dir = self.direction.as_direction();
                             let inner_vert = self.list.inner.direction().is_vertical();
@@ -197,17 +197,17 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
                             let rev = self.list.inner.direction().is_reversed();
                             use Direction::*;
                             match key {
-                                NavKey::Left if !inner_vert => next(mgr, self, false, !rev),
-                                NavKey::Right if !inner_vert => next(mgr, self, false, rev),
-                                NavKey::Up if inner_vert => next(mgr, self, false, !rev),
-                                NavKey::Down if inner_vert => next(mgr, self, false, rev),
-                                NavKey::Home => next(mgr, self, true, false),
-                                NavKey::End => next(mgr, self, true, true),
-                                NavKey::Left if dir == Right => self.close_menu(mgr),
-                                NavKey::Right if dir == Left => self.close_menu(mgr),
-                                NavKey::Up if dir == Down => self.close_menu(mgr),
-                                NavKey::Down if dir == Up => self.close_menu(mgr),
-                                key => return Response::Unhandled(Event::NavKey(key)),
+                                ControlKey::Left if !inner_vert => next(mgr, self, false, !rev),
+                                ControlKey::Right if !inner_vert => next(mgr, self, false, rev),
+                                ControlKey::Up if inner_vert => next(mgr, self, false, !rev),
+                                ControlKey::Down if inner_vert => next(mgr, self, false, rev),
+                                ControlKey::Home => next(mgr, self, true, false),
+                                ControlKey::End => next(mgr, self, true, true),
+                                ControlKey::Left if dir == Right => self.close_menu(mgr),
+                                ControlKey::Right if dir == Left => self.close_menu(mgr),
+                                ControlKey::Up if dir == Down => self.close_menu(mgr),
+                                ControlKey::Down if dir == Up => self.close_menu(mgr),
+                                key => return Response::Unhandled(Event::Control(key)),
                             }
                         }
                         Response::None

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 
 use super::ScrollBar;
 use kas::draw::{ClipRegion, TextClass};
-use kas::event::NavKey;
+use kas::event::ControlKey;
 use kas::event::ScrollDelta::{LineDelta, PixelDelta};
 use kas::prelude::*;
 
@@ -329,15 +329,15 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
         };
 
         match event {
-            Event::NavKey(key) => {
+            Event::Control(key) => {
                 let delta = match key {
-                    NavKey::Left => LineDelta(-1.0, 0.0),
-                    NavKey::Right => LineDelta(1.0, 0.0),
-                    NavKey::Up => LineDelta(0.0, 1.0),
-                    NavKey::Down => LineDelta(0.0, -1.0),
-                    NavKey::Home | NavKey::End => {
+                    ControlKey::Left => LineDelta(-1.0, 0.0),
+                    ControlKey::Right => LineDelta(1.0, 0.0),
+                    ControlKey::Up => LineDelta(0.0, 1.0),
+                    ControlKey::Down => LineDelta(0.0, -1.0),
+                    ControlKey::Home | ControlKey::End => {
                         let action = self.set_offset(match key {
-                            NavKey::Home => Coord::ZERO,
+                            ControlKey::Home => Coord::ZERO,
                             _ => self.max_offset,
                         });
                         if action != TkAction::None {
@@ -347,8 +347,11 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
                         }
                         return Response::None;
                     }
-                    NavKey::PageUp => PixelDelta(Coord(0, self.core.rect.size.1 as i32 / 2)),
-                    NavKey::PageDown => PixelDelta(Coord(0, -(self.core.rect.size.1 as i32 / 2))),
+                    ControlKey::PageUp => PixelDelta(Coord(0, self.core.rect.size.1 as i32 / 2)),
+                    ControlKey::PageDown => {
+                        PixelDelta(Coord(0, -(self.core.rect.size.1 as i32 / 2)))
+                    }
+                    key => return Response::Unhandled(Event::Control(key)),
                 };
                 scroll(self, mgr, delta)
             }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -10,7 +10,7 @@ use std::ops::{Add, Sub};
 use std::time::Duration;
 
 use super::DragHandle;
-use kas::event::NavKey;
+use kas::event::ControlKey;
 use kas::prelude::*;
 
 /// Requirements on type used by [`Slider`]
@@ -249,31 +249,31 @@ impl<T: SliderType, D: Directional> event::SendEvent for Slider<T, D> {
             }
         } else {
             match event {
-                Event::NavKey(key) => {
+                Event::Control(key) => {
                     let rev = self.direction.is_reversed();
                     let v = match key {
-                        NavKey::Left | NavKey::Up => match rev {
+                        ControlKey::Left | ControlKey::Up => match rev {
                             false => self.value - self.step,
                             true => self.value + self.step,
                         },
-                        NavKey::Right | NavKey::Down => match rev {
+                        ControlKey::Right | ControlKey::Down => match rev {
                             false => self.value + self.step,
                             true => self.value - self.step,
                         },
-                        NavKey::PageUp | NavKey::PageDown => {
+                        ControlKey::PageUp | ControlKey::PageDown => {
                             // Generics makes this easier than constructing a literal and multiplying!
                             let mut x = self.step + self.step;
                             x = x + x;
                             x = x + x;
                             x = x + x;
-                            match rev == (key == NavKey::PageDown) {
+                            match rev == (key == ControlKey::PageDown) {
                                 false => self.value + x,
                                 true => self.value - x,
                             }
                         }
-                        NavKey::Home => self.range.0,
-                        NavKey::End => self.range.1,
-                        // _ => return Response::Unhandled(event),
+                        ControlKey::Home => self.range.0,
+                        ControlKey::End => self.range.1,
+                        key => return Response::Unhandled(Event::Control(key)),
                     };
                     let action = self.set_value(v);
                     return if action == TkAction::None {


### PR DESCRIPTION
This PR updates to `glyph_brush` 0.7, which allows reliably translating a string index to a glyph position (https://github.com/alexheretic/glyph-brush/issues/80).

- draw a real edit position marker

The PR adds a dependency on [unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation), allowing the edit cursor to advance by a grapheme clustor.

Finally, it renames `NavKey` → `ControlKey`, extends it, avoids sending this simultaneously with `ReceivedCharacter`, and sends `ControlKey` with char focus.

- `EditBox` can respond to nav keys to move the edit marker

This is part of #13, but still has a lot missing (mouse-position to string index, text selection, multi-line editing).