### PR TITLE
Roadmap, text_index_nearest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ window size limits, and switchable themes and colour schemes.
 -   Re-added separate `Layout` trait (#42)
 -   Widget configure now happens on init and may run user-defined code (#36)
 -   Widgets can now directly schedule updates on timer (#42)
--   Widgets updates can now be triggerred via an `UpdateHandle` (#46)
+-   Widgets updates can now be triggered via an `UpdateHandle` (#46)
 -   Rename `WidgetCore::get_by_id` → `find` and add `find_mut` (#42)
 -   Add `WidgetCore::find_coord_mut` (#47)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,228 @@
+Roadmap
+======
+
+The past
+--------
+
+First, lets summarise KAS's journey so far.
+For details, see the [CHANGELOG](CHANGELOG.md).
+
+### 0.0.x — Jan 2019
+
+Early releases, built over GTK.
+
+### 0.1.0 — Dec 2019
+
+A restart, replacing GTK with direct widget implementations including rendering
+via the `rgx` crate. Initial theme traits, event-handling revision.
+
+### 0.2.0 — Feb 2020
+
+Lots of small but significant changes, including the introduction of the
+`Manager` handle, user-defined `configure` code, scheduled updates (animation),
+a scrollable region with scrollbars and addition of `ToolkitProxy`.
+
+### 0.3.0 — Feb 2020
+
+Only three weeks later, this delivered two new levels of draw API (portrayed by
+`clock` and `mandlebrot` examples respectively), a "flat" theme, run-time theme
+and colour-scheme switching, widget alignment, `StretchPolicy`, more adjustments
+to event handling (removal of by-coordinate addressing), a `RadioBox` widget,
+and window size limits.
+
+### 0.4.0 — May 2020
+
+This release revised widget traits into an integral family with opt-out
+derivation (thus allowing future extension without breaking all existing
+widgets), separating child-enumeration out of `WidgetCore` and separating
+routing and handling of events.
+
+Secondly, the release improved layout generation and notation, adding proper
+margins, replacing `Horizontal` and `Vertical` with the four principal
+directions, rewriting `solve_seq` to make only required changes (enabling
+manual column resizing), and calculating the ideal window size before creation.
+
+Thirdly (and no less significantly), the release added pop-up menus, including
+fixes for overlapping graphics and robust event handling (including delayed
+opening of sub-menus and navigation via tab and arrow keys).
+
+Fourthly, it added Alt-accelerator keys, including visible labels when Alt is
+depressed and locality to the visible pop-up layer.
+
+Small additions included recursive disabled states for all widgets and an error
+state for `EditBox` (set via a user-defined input guard). Widgets included a
+`Slider`, a resizable `Splitter`, a `ComboBox` and menu widgets.
+
+
+Current work
+-----------
+
+The next release will include proper text-edit handling (positionable edit
+marker, selection), and likely one further item from the list below.
+
+Additionly, it includes a `CONTRIBUTING` guide and this `ROADMAP`.
+
+
+Future work
+-----------
+
+These items are not versioned and appear only roughly in the expected order.
+Each should be a decently sized work item (roughly one release).
+
+### Standard geometry types
+
+KAS has ad-hoc geometry types. *Possibly* it would be useful to use third-party
+types instead. See #95.
+
+### Images and icons
+
+Support display of images in the GUI:
+
+-   fixed-size raster images sized to the pixel count without scaling
+-   scaling of fixed raster images
+-   image display using a target size and multiple rastered versions, with
+    the option of scaling to the target size or using the nearest size
+-   vector images rastered to a target size
+-   buttons with embedded images
+
+Possibly as part of this topic, implement colour management #59.
+
+### Configuration and resource management
+
+Currently KAS has an ad-hoc font loader and fixed colour-schemes.
+This work item includes:
+
+-   discovery of resources (fonts, icons, colour-schemes) from the system and
+    from user-local directories
+-   configuration for e.g. fonts, colour schemes, icon sets
+-   overriding the scale factor
+-   shortcuts (e.g. Ctrl+Z), including configuration and maybe some localisation
+
+### Standard resource sets
+
+Ideally, KAS should provide an identifier for common icons and either map these
+to a system-provided icon set or provide its own, so that apps can use icons
+like "save" or "undo" without having to provide the icon themselves.
+
+Colour schemes and short-cuts are similar in that potentially they can be
+inherited from the desktop, but otherwise KAS should provide them.
+
+### Multiple fonts and text markup
+
+Support at least italic and bold fonts.
+
+Support reading text markup (e.g. Markdown or HTML) and rendering this text
+within e.g. the `Label` widget.
+
+### Text shaping
+
+Current text shaping uses the layout engine provided by `glyph_brush`. We should
+likely replace this with a full text shaping engine, possibly `allsorts` or
+`harfbuzz`.
+
+While doing this, we can probably remove the requirement that `SizeHandle` have
+a reference to per-window `draw` state, and possibly also support justified
+alignment.
+
+*Possibly* also within the same work-set, add a real multi-line text-edit
+widget.
+
+### Widget identifiers
+
+Currently widgets are identified simply by enumerating all widgets. See #91
+
+### View widgets
+
+Viewing a table or spreadsheet should not require a dedicated widget for each
+cell, for scalability reasons (even though KAS can viably use a million
+widgets). This could be extended to viewing only a slice of a remote database.
+
+The [view branch](https://github.com/kas-gui/kas/tree/view) has some initial
+work and notes on this topic.
+
+### Widget library
+
+Although the current widget set covers a good portion of the "full complement"
+mentioned by #2, its primary purpose is to prototype requirements for other APIs
+(including the widget trait family, event handling, draw model).
+
+Once other APIs are more stable, this focus should shift to providing the full
+complement of standard GUI widgets, likely within a dedicated crate.
+
+Additionally, several standard dialog boxes / pop-ups should be added, e.g. a
+colour picker, a date picker, and a file-open dialog.
+
+### Desktop integration
+
+This is less a separate work item than it is a long-term goal, one which will
+require substantial help. KAS should attempt to discover initial configuration
+from the current desktop environment, e.g. the current font and font size, the
+icon set, locale and short-cuts.
+
+Additionally, on Linux it is expected that the desktop environment provide a
+few standard dialog boxes (e.g. file open/save), not only for consistency but
+also security (e.g. a container may not let an app explore the filesystem).
+Such dialogs should automatically use desktop-provided equivalents where
+available.
+
+
+External dependencies
+----------------------
+
+### Rust
+
+KAS currently *does* support stable `rustc`, but with feature limitations.
+Getting everything working well on stable Rust *requires* some new Rust
+features, though not all of these issues have a clear solution:
+
+-   #25 lists existing (optional) usage of Rust nightly features; all of these
+    would be great to have in stable Rust but must are not essential
+-   `proc_macro_hygiene` is used to enable the `make_widget!` macro; this is not
+    an *essential* part of KAS but is *extremely useful*; `proc-macro-hack`
+    provides a workaround (with significant limitations)
+-   #15 documents a major limitation of `make_widget!`; Rust's RFC 2524 provides
+    a solution but has not been accepted or implemented
+-   #11 documents one example of a bad error message; another case of bad error
+    messages is [the sole reason `msg` does not have a default type within `make_widget!`](https://github.com/kas-gui/kas/blob/master/src/macros.rs#L381);
+    it is not clear (to me) how best to solve these issues
+
+### WebGPU and CPU rasterisation
+
+Currently, KAS can only draw via `wgpu`, which currently does not support OpenGL
+or CPU-rendered graphics, making KAS unusable on many older systems.
+
+It seems likely that `wgpu` will support OpenGL in the future.
+
+Additionally, KAS should provide a CPU-based renderer. See #33.
+
+### Clipboard support
+
+The current clipboard dependency is sub-par.
+[window_clipboard](https://github.com/hecrj/window_clipboard) may be the path
+forward, but still needs a lot of work (even copy-to-clipboard support).
+
+This includes support for formats other than plain text, e.g. images and HTML.
+
+This is not a trivial topic, especially considering that platforms have very
+different approaches to this (e.g. both X11 and Wayland expect apps to publish
+a list of available formats by mime type, then send contents in the window's
+event handler, while other platforms usually have more restricted formats and
+expect data to be sent to the clipboard provider in all formats up front).
+
+### (winit) pop-up window support
+
+It has been requested that winit support popup windows for things like menus
+which are not restricted to the parent window; currently it doesn't.
+See https://github.com/rust-windowing/winit/issues/950 (and other issues).
+
+### (winit) drag and drop
+
+Winit *does* have support for this, but only in a very limited fashion. With
+its current event model it is difficult or impossible to determine the widget
+receiving a drop or under a hovered drop.
+See #98 and https://github.com/rust-windowing/winit/issues/1550
+
+### (winit) full key-bindings
+
+Winit's `VirtualKeyCode` enum is rather limited. See #27 (and *several* winit
+issues) on this topic.

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -10,9 +10,10 @@
 use std::any::Any;
 use std::f32;
 
-use kas::draw::{self, DrawText, FontId, TextClass};
-use kas::geom::{Size, Vec2};
+use kas::draw::{self, DrawText, FontId, TextClass, TextProperties};
+use kas::geom::{Rect, Size, Vec2};
 use kas::layout::{AxisInfo, Margins, SizeRules, StretchPolicy};
+use kas::Align;
 
 /// Parameterisation of [`Dimensions`]
 ///
@@ -197,6 +198,30 @@ impl<'a, Draw: DrawText> draw::SizeHandle for SizeHandle<'a, Draw> {
             };
             SizeRules::new(min, ideal, margins, stretch)
         }
+    }
+
+    fn text_index_nearest(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        class: TextClass,
+        align: (Align, Align),
+        pos: Vec2,
+    ) -> usize {
+        let props = TextProperties {
+            font: self.dims.font_id,
+            scale: self.dims.font_scale.into(),
+            align,
+            line_wrap: match class {
+                TextClass::Label | TextClass::EditMulti => true,
+                TextClass::Button | TextClass::Edit => false,
+            },
+            ..Default::default()
+        };
+
+        // Note: we don't add offset here since it was already subtracted from
+        // pos (e.g. via ScrollRegion::send)
+        self.draw.text_index_nearest(rect, text, props, pos)
     }
 
     fn button_surround(&self) -> (Size, Size) {

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -9,10 +9,10 @@
 
 use std::f32;
 
-use crate::{Dimensions, DimensionsParams, DimensionsWindow, Theme, ThemeColours};
+use crate::{Dimensions, DimensionsParams, DimensionsWindow, Theme, ThemeColours, Window};
 use kas::draw::{
     self, ClipRegion, Colour, Draw, DrawRounded, DrawShared, DrawText, DrawTextShared, FontId,
-    InputState, Pass, TextClass, TextProperties,
+    InputState, Pass, SizeHandle, TextClass, TextProperties,
 };
 use kas::geom::*;
 use kas::{Align, Direction, Directional, ThemeAction, ThemeApi};
@@ -192,6 +192,13 @@ impl<'a, D: Draw + DrawRounded> DrawHandle<'a, D> {
 }
 
 impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D> {
+    fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
+        unsafe {
+            let mut size_handle = self.window.size_handle(self.draw);
+            f(&mut size_handle);
+        }
+    }
+
     fn draw_device(&mut self) -> (kas::draw::Pass, Coord, &mut dyn kas::draw::Draw) {
         (self.pass, self.offset, self.draw)
     }

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -7,10 +7,10 @@
 
 use std::f32;
 
-use crate::{Dimensions, DimensionsParams, DimensionsWindow, Theme, ThemeColours};
+use crate::{Dimensions, DimensionsParams, DimensionsWindow, Theme, ThemeColours, Window};
 use kas::draw::{
     self, ClipRegion, Colour, Draw, DrawRounded, DrawShaded, DrawShared, DrawText, DrawTextShared,
-    FontId, InputState, Pass, TextClass, TextProperties,
+    FontId, InputState, Pass, SizeHandle, TextClass, TextProperties,
 };
 use kas::geom::*;
 use kas::{Align, Direction, Directional, ThemeAction, ThemeApi};
@@ -192,6 +192,13 @@ impl<'a, D> draw::DrawHandle for DrawHandle<'a, D>
 where
     D: Draw + DrawRounded + DrawShaded + DrawText + 'static,
 {
+    fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
+        unsafe {
+            let mut size_handle = self.window.size_handle(self.draw);
+            f(&mut size_handle);
+        }
+    }
+
     fn draw_device(&mut self) -> (kas::draw::Pass, Coord, &mut dyn kas::draw::Draw) {
         (self.pass, self.offset, self.draw)
     }

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget(row=1, col=4)] _ = CheckBoxBare::new(),
                 #[widget(row=2, col=0)] _ = Label::new("Text"),
                 #[widget(row=2, col=2, cspan=2, rspan=2)] _ = Label::new(crasit),
-                #[widget(row=3, col=1)] _ = EditBox::new("edit"),
+                #[widget(row=3, col=1)] _ = EditBox::new("A small\nsample\nof text").multi_line(true),
                 #[widget(row=0, col=3)] _ = Label::new("<->"),
             }
         },

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -198,6 +198,7 @@ where
             TkAction::Popup => {
                 let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw) };
                 self.widget.resize_popups(&mut size_handle);
+                drop(size_handle);
 
                 let mut tkw =
                     TkWindow::new(shared, &self.window, &mut self.draw, &mut self.theme_window);
@@ -263,10 +264,9 @@ where
         T: Theme<DrawPipe<C>, Window = TW>,
     {
         let window = &mut *self.widget;
-        let mut size_handle = unsafe { self.theme_window.size_handle(&mut self.draw) };
         let mut tkw = TkWindow::new(shared, &self.window, &mut self.draw, &mut self.theme_window);
         self.mgr.with(&mut tkw, |mut mgr| {
-            kas::Window::add_popup(window, &mut size_handle, &mut mgr, id, popup);
+            kas::Window::add_popup(window, &mut mgr, id, popup);
         });
     }
 

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -8,7 +8,7 @@
 use std::ops::{Deref, DerefMut};
 
 use kas::draw::{Draw, Pass};
-use kas::geom::{Coord, Rect, Size};
+use kas::geom::{Coord, Rect, Size, Vec2};
 use kas::layout::{AxisInfo, Margins, SizeRules};
 use kas::{Align, Direction};
 
@@ -132,6 +132,22 @@ pub trait SizeHandle {
     ///
     /// Sizing requirements of [`DrawHandle::text`].
     fn text_bound(&mut self, text: &str, class: TextClass, axis: AxisInfo) -> SizeRules;
+
+    /// Find the text index nearest to `pos`
+    ///
+    /// Text is assumed to be positioned as in [`DrawHandle::text`], except
+    /// that we do not adjust `rect` by the `clip_region`'s `offset`. Instead it
+    /// is assumed that any `offset` has already been subtracted from `pos`.
+    ///
+    /// The returned `index ≤ text.len()`.
+    fn text_index_nearest(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        class: TextClass,
+        align: (Align, Align),
+        pos: Vec2,
+    ) -> usize;
 
     /// Size of the sides of a button.
     ///
@@ -332,6 +348,17 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
     fn text_bound(&mut self, text: &str, class: TextClass, axis: AxisInfo) -> SizeRules {
         self.deref_mut().text_bound(text, class, axis)
     }
+    fn text_index_nearest(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        class: TextClass,
+        align: (Align, Align),
+        pos: Vec2,
+    ) -> usize {
+        self.deref_mut()
+            .text_index_nearest(rect, text, class, align, pos)
+    }
 
     fn button_surround(&self) -> (Size, Size) {
         self.deref().button_surround()
@@ -381,6 +408,17 @@ where
     }
     fn text_bound(&mut self, text: &str, class: TextClass, axis: AxisInfo) -> SizeRules {
         self.deref_mut().text_bound(text, class, axis)
+    }
+    fn text_index_nearest(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        class: TextClass,
+        align: (Align, Align),
+        pos: Vec2,
+    ) -> usize {
+        self.deref_mut()
+            .text_index_nearest(rect, text, class, align, pos)
     }
 
     fn button_surround(&self) -> (Size, Size) {

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -43,8 +43,11 @@ pub struct TextProperties {
 impl Default for TextProperties {
     fn default() -> Self {
         TextProperties {
+            font: Default::default(),
             scale: 18.0.into(),
-            ..Default::default()
+            col: Default::default(),
+            align: Default::default(),
+            line_wrap: Default::default(),
         }
     }
 }
@@ -97,4 +100,16 @@ pub trait DrawText: Draw {
         props: TextProperties,
         byte: usize,
     ) -> Vec2;
+
+    /// Find the text index for the glyph nearest the given `pos`
+    ///
+    /// This includes the index immediately after the last glyph, thus
+    /// `result ≤ text.len()`.
+    fn text_index_nearest(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        props: TextProperties,
+        pos: Vec2,
+    ) -> usize;
 }

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use std::u16;
 
 use super::*;
+use crate::draw::SizeHandle;
 use crate::geom::Coord;
 use crate::string::{CowString, CowStringL};
 #[allow(unused)]
@@ -248,6 +249,15 @@ impl<'a> Manager<'a> {
     #[inline]
     pub fn adjust_theme<F: FnMut(&mut dyn ThemeApi) -> ThemeAction>(&mut self, mut f: F) {
         self.tkw.adjust_theme(&mut f);
+    }
+
+    /// Access a [`SizeHandle`]
+    pub fn size_handle<F: Fn(&mut dyn SizeHandle) -> T, T>(&mut self, f: F) -> T {
+        let mut result = None;
+        self.tkw.size_handle(&mut |size_handle| {
+            result = Some(f(size_handle));
+        });
+        result.expect("TkWindow::size_handle_dyn impl failed to call function argument")
     }
 }
 

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -252,7 +252,7 @@ impl<'a> Manager<'a> {
     }
 
     /// Access a [`SizeHandle`]
-    pub fn size_handle<F: Fn(&mut dyn SizeHandle) -> T, T>(&mut self, f: F) -> T {
+    pub fn size_handle<F: FnMut(&mut dyn SizeHandle) -> T, T>(&mut self, mut f: F) -> T {
         let mut result = None;
         self.tkw.size_handle(&mut |size_handle| {
             result = Some(f(size_handle));

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -130,6 +130,12 @@ macro_rules! impl_vec2 {
                 self.0.min(self.1)
             }
 
+            /// Take the absolute value of each component
+            #[inline]
+            pub fn abs(self) -> Self {
+                $T(self.0.abs(), self.1.abs())
+            }
+
             /// For each component, return `±1` with the same sign as `self`.
             #[inline]
             pub fn sign(self) -> Self {

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -16,6 +16,7 @@
 
 use std::num::NonZeroU32;
 
+use crate::draw::SizeHandle;
 use crate::string::{CowString, CowStringL};
 use crate::{event, ThemeAction, ThemeApi};
 
@@ -145,6 +146,13 @@ pub trait TkWindow {
 
     /// Adjust the theme
     fn adjust_theme(&mut self, f: &mut dyn FnMut(&mut dyn ThemeApi) -> ThemeAction);
+
+    /// Access a [`SizeHandle`]
+    ///
+    /// Implementations should call the given function argument once; not doing
+    /// so is memory-safe but will cause a panic when `size_handle` is called.
+    /// User-code *must not* depend on `f` being called for memory safety.
+    fn size_handle(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle));
 
     /// Set the mouse cursor
     fn set_cursor_icon(&mut self, icon: event::CursorIcon);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -93,13 +93,7 @@ pub trait Window: Widget<Msg = event::VoidMsg> {
     /// Add a pop-up as a layer in the current window
     ///
     /// Each [`Popup`] is assigned a [`WindowId`]; both are passed.
-    fn add_popup(
-        &mut self,
-        size_handle: &mut dyn SizeHandle,
-        mgr: &mut Manager,
-        id: WindowId,
-        popup: Popup,
-    );
+    fn add_popup(&mut self, mgr: &mut Manager, id: WindowId, popup: Popup);
 
     /// Resize popups
     ///

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -57,11 +57,11 @@ impl<M: 'static> WidgetChildren for Box<dyn Widget<Msg = M>> {
         self.as_mut().find_mut(id)
     }
 
-    fn walk(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {
-        self.as_ref().walk(f);
+    fn walk_dyn(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {
+        self.as_ref().walk_dyn(f);
     }
-    fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn WidgetConfig)) {
-        self.as_mut().walk_mut(f);
+    fn walk_mut_dyn(&mut self, f: &mut dyn FnMut(&mut dyn WidgetConfig)) {
+        self.as_mut().walk_mut_dyn(f);
     }
 }
 

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -230,10 +230,18 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// This walk is iterative (nonconcurrent), depth-first, and always calls
     /// `f` on self *after* walking through all children.
-    fn walk(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {
+    fn walk<F: FnMut(&dyn WidgetConfig)>(&self, mut f: F)
+    where
+        Self: Sized,
+    {
+        self.walk_dyn(&mut f)
+    }
+
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    fn walk_dyn(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {
         for i in 0..self.len() {
             if let Some(w) = self.get(i) {
-                w.walk(f);
+                w.walk_dyn(f);
             }
         }
         f(self.as_widget());
@@ -243,10 +251,18 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// This walk is iterative (nonconcurrent), depth-first, and always calls
     /// `f` on self *after* walking through all children.
-    fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn WidgetConfig)) {
+    fn walk_mut<F: FnMut(&mut dyn WidgetConfig)>(&mut self, mut f: F)
+    where
+        Self: Sized,
+    {
+        self.walk_mut_dyn(&mut f)
+    }
+
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    fn walk_mut_dyn(&mut self, f: &mut dyn FnMut(&mut dyn WidgetConfig)) {
         for i in 0..self.len() {
             if let Some(w) = self.get_mut(i) {
-                w.walk_mut(f);
+                w.walk_mut_dyn(f);
             }
         }
         f(self.as_widget_mut());

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -73,7 +73,7 @@ impl kas::Window for MessageBox {
     }
 
     // do not support overlays (yet?)
-    fn add_popup(&mut self, _: &mut dyn SizeHandle, _: &mut Manager, _: WindowId, _: kas::Popup) {
+    fn add_popup(&mut self, _: &mut Manager, _: WindowId, _: kas::Popup) {
         panic!("MessageBox does not (currently) support pop-ups");
     }
 

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -123,6 +123,14 @@ impl<F: Fn(&str) -> Option<M>, M> EditGuard for EditEdit<F, M> {
 }
 
 /// An editable, single-line text box.
+///
+/// This widget is intended for use with short input strings. Internally it
+/// uses a [`String`], for which edits have `O(n)` cost.
+///
+/// Currently, this widget has a [`Widget::multi_line`] mode, with some
+/// limitations (incorrect positioning of the edit cursor at line end,
+/// non-functional up/down keys, lack of scrolling). Later this will be replaced
+/// by a dedicated multi-line widget, probably using the `ropey` crate.
 #[widget(config(key_nav = true, cursor_icon = event::CursorIcon::Text))]
 #[handler(handle=noauto, generics = <> where G: EditGuard)]
 #[derive(Clone, Default, Widget)]

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -10,7 +10,7 @@ use unicode_segmentation::GraphemeCursor;
 
 use kas::class::{Editable, HasText};
 use kas::draw::TextClass;
-use kas::event::ControlKey;
+use kas::event::{ControlKey, GrabMode};
 use kas::prelude::*;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -460,6 +460,19 @@ impl<G> EditBox<G> {
             _ => EditAction::None,
         }
     }
+
+    fn set_edit_pos_from_coord(&mut self, mgr: &mut Manager, coord: Coord) {
+        let class = if self.multi_line {
+            TextClass::EditMulti
+        } else {
+            TextClass::Edit
+        };
+        let align = (Align::Begin, Align::Begin);
+        self.edit_pos = mgr.size_handle(|h| {
+            h.text_index_nearest(self.text_rect, &self.text, class, align, coord.into())
+        });
+        mgr.redraw(self.id());
+    }
 }
 
 impl<G: EditGuard> HasText for EditBox<G> {
@@ -487,11 +500,6 @@ impl<G: EditGuard> Editable for EditBox<G> {
 impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
     type Msg = G::Msg;
 
-    #[inline]
-    fn activation_via_press(&self) -> bool {
-        true
-    }
-
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         match event {
             Event::Activate => {
@@ -512,6 +520,18 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                 EditAction::Activate => G::activate(self).into(),
                 EditAction::Edit => G::edit(self).into(),
             },
+            Event::PressStart { source, coord, .. } if source.is_primary() => {
+                self.set_edit_pos_from_coord(mgr, coord);
+                mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None);
+                mgr.request_char_focus(self.id());
+                Response::None
+            }
+            Event::PressMove { coord, .. } => {
+                self.set_edit_pos_from_coord(mgr, coord);
+                // TODO: text selection
+                Response::None
+            }
+            Event::PressEnd { .. } => Response::None,
             event => Response::Unhandled(event),
         }
     }

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -83,11 +83,11 @@ impl<M: 'static> WidgetChildren for Box<dyn Menu<Msg = M>> {
         self.as_mut().find_mut(id)
     }
 
-    fn walk(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {
-        self.as_ref().walk(f);
+    fn walk_dyn(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {
+        self.as_ref().walk_dyn(f);
     }
-    fn walk_mut(&mut self, f: &mut dyn FnMut(&mut dyn WidgetConfig)) {
-        self.as_mut().walk_mut(f);
+    fn walk_mut_dyn(&mut self, f: &mut dyn FnMut(&mut dyn WidgetConfig)) {
+        self.as_mut().walk_mut_dyn(f);
     }
 }
 

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -157,16 +157,10 @@ impl<W: Widget<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
         self.restrict_dimensions
     }
 
-    fn add_popup(
-        &mut self,
-        size_handle: &mut dyn SizeHandle,
-        mgr: &mut Manager,
-        id: WindowId,
-        popup: kas::Popup,
-    ) {
+    fn add_popup(&mut self, mgr: &mut Manager, id: WindowId, popup: kas::Popup) {
         let index = self.popups.len();
         self.popups.push((id, popup));
-        self.resize_popup(size_handle, index);
+        mgr.size_handle(|size_handle| self.resize_popup(size_handle, index));
         mgr.send_action(TkAction::Redraw);
     }
 


### PR DESCRIPTION
This PR allows look-up of the text index nearest the mouse cursor. It doesn't work that well for multi-line text, but external line splitting is probably the best approach here so this is not solved for now.

Also, add a roadmap.