### PR TITLE
Detect double-click; theme code reuse

### DIFF
--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -46,12 +46,12 @@ const DIMS: DimensionsParams = DimensionsParams {
 };
 
 pub struct DrawHandle<'a, D: Draw> {
-    draw: &'a mut D,
-    window: &'a mut DimensionsWindow,
-    cols: &'a ThemeColours,
-    rect: Rect,
-    offset: Coord,
-    pass: Pass,
+    pub(crate) draw: &'a mut D,
+    pub(crate) window: &'a mut DimensionsWindow,
+    pub(crate) cols: &'a ThemeColours,
+    pub(crate) rect: Rect,
+    pub(crate) offset: Coord,
+    pub(crate) pass: Pass,
 }
 
 impl<D: DrawShared + DrawTextShared + 'static> Theme<D> for FlatTheme

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -64,7 +64,8 @@ where
 
         let mut size_handle = unsafe { theme_window.size_handle(&mut draw) };
         let solve_cache = SolveCache::find_constraints(widget.as_widget_mut(), &mut size_handle);
-        let ideal = solve_cache.ideal(true);
+        // Opening a zero-size window causes a crash, so force at least 1x1:
+        let ideal = solve_cache.ideal(true).max(Size(1, 1));
         drop(size_handle);
 
         let mut builder = WindowBuilder::new().with_inner_size(ideal);

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -38,7 +38,7 @@ impl From<f32> for PxScale {
 /// first font loaded by the (first) theme.
 ///
 /// Other than this, users should treat this type as an opaque handle.
-/// An instance may be obtained by [`DrawTextShared::load_font`].
+/// An instance may be obtained from [`DrawTextShared`]'s methods.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct FontId(pub usize);
 

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -271,7 +271,18 @@ impl ControlKey {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PressSource {
     /// A mouse click
-    Mouse(MouseButton),
+    ///
+    /// Arguments: `button, repeats`.
+    ///
+    /// The `repeats` argument is used for double-clicks and similar. For a
+    /// single-click, `repeats == 1`; for a double-click it is 2, for a
+    /// triple-click it is 3, and so on (without upper limit).
+    ///
+    /// For `PressMove` and `PressEnd` events delivered with a mouse-grab,
+    /// both arguments are copied from the initiating `PressStart` event.
+    /// For a `PressMove` delivered without a grab (only possible with pop-ups)
+    /// a fake `button` value is used and `repeats == 0`.
+    Mouse(MouseButton, u32),
     /// A touch event (with given `id`)
     Touch(u64),
 }
@@ -281,8 +292,20 @@ impl PressSource {
     #[inline]
     pub fn is_primary(self) -> bool {
         match self {
-            PressSource::Mouse(button) => button == MouseButton::Left,
+            PressSource::Mouse(button, _) => button == MouseButton::Left,
             PressSource::Touch(_) => true,
+        }
+    }
+
+    /// The `repetitions` value
+    ///
+    /// This is 1 for a single-click and all touch events, 2 for a double-click,
+    /// 3 for a triple-click, etc. For `PressMove` without a grab this is 0.
+    #[inline]
+    pub fn repetitions(self) -> u32 {
+        match self {
+            PressSource::Mouse(_, repetitions) => repetitions,
+            PressSource::Touch(_) => 1,
         }
     }
 }

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -41,6 +41,7 @@ pub enum GrabMode {
 #[derive(Clone, Debug)]
 struct MouseGrab {
     button: MouseButton,
+    repetitions: u32,
     start_id: WidgetId,
     depress: Option<WidgetId>,
     mode: GrabMode,
@@ -101,6 +102,9 @@ pub struct ManagerState {
     hover_icon: CursorIcon,
     key_depress: SmallVec<[(u32, WidgetId); 10]>,
     last_mouse_coord: Coord,
+    last_click_button: MouseButton,
+    last_click_repetitions: u32,
+    last_click_timeout: Instant,
     mouse_grab: Option<MouseGrab>,
     touch_grab: SmallVec<[TouchGrab; 10]>,
     pan_grab: SmallVec<[PanGrab; 4]>,

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -413,7 +413,7 @@ impl<'a> Manager<'a> {
         let start_id = id;
         let mut pan_grab = (u16::MAX, 0);
         match source {
-            PressSource::Mouse(button) => {
+            PressSource::Mouse(button, repetitions) => {
                 if self.mgr.mouse_grab.is_some() {
                     return false;
                 }
@@ -422,9 +422,10 @@ impl<'a> Manager<'a> {
                 }
                 trace!("Manager: start mouse grab by {}", start_id);
                 self.mgr.mouse_grab = Some(MouseGrab {
+                    button,
+                    repetitions,
                     start_id,
                     depress: Some(id),
-                    button,
                     mode,
                     pan_grab,
                 });
@@ -470,7 +471,7 @@ impl<'a> Manager<'a> {
     /// to activate a widget (for the duration of the key-press).
     pub fn set_grab_depress(&mut self, source: PressSource, target: Option<WidgetId>) {
         match source {
-            PressSource::Mouse(_) => {
+            PressSource::Mouse(_, _) => {
                 if let Some(grab) = self.mgr.mouse_grab.as_mut() {
                     grab.depress = target;
                 }

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -126,7 +126,7 @@ impl<F: Fn(&str) -> Option<M>, M> EditGuard for EditEdit<F, M> {
 /// This widget is intended for use with short input strings. Internally it
 /// uses a [`String`], for which edits have `O(n)` cost.
 ///
-/// Currently, this widget has a [`Widget::multi_line`] mode, with some
+/// Currently, this widget has a [`EditBox::multi_line`] mode, with some
 /// limitations (incorrect positioning of the edit cursor at line end,
 /// non-functional up/down keys, lack of scrolling). Later this will be replaced
 /// by a dedicated multi-line widget, probably using the `ropey` crate.


### PR DESCRIPTION
Some minor stuff:

- Force minimum window size of 1x1 since 0-sized windows crashes (on X11)
- Allow `ShadedTheme` to re-use code from `FlatTheme`
- Add detection for double-click, triple-click etc. (currently unused)