### PR TITLE
Update kas-text, remove CowString

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "a116a5543634201453f55a7ecbdb7d5d78ca54fb"
+rev = "b038fa2fc4d8eeacf8aa50f2d467bab045558c8a"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "b038fa2fc4d8eeacf8aa50f2d467bab045558c8a"
+rev = "8565f29f324f08232277cf9d9f782e568ce9b509"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -12,7 +12,7 @@ use std::marker::Unsize;
 use crate::{StackDst, Theme, ThemeDst, WindowDst};
 use kas::draw::{Colour, DrawHandle, DrawShared};
 use kas::geom::Rect;
-use kas::{string::CowString, ThemeAction, ThemeApi};
+use kas::{ThemeAction, ThemeApi};
 
 #[cfg(feature = "unsize")]
 type DynTheme<Draw> = StackDst<dyn ThemeDst<Draw>>;
@@ -23,7 +23,7 @@ type DynTheme<Draw> = Box<dyn ThemeDst<Draw>>;
 ///
 /// **Feature gated**: this is only available with feature `stack_dst`.
 pub struct MultiTheme<Draw> {
-    names: HashMap<CowString, usize>,
+    names: HashMap<String, usize>,
     themes: Vec<DynTheme<Draw>>,
     active: usize,
 }
@@ -32,7 +32,7 @@ pub struct MultiTheme<Draw> {
 ///
 /// Construct via [`MultiTheme::builder`].
 pub struct MultiThemeBuilder<Draw> {
-    names: HashMap<CowString, usize>,
+    names: HashMap<String, usize>,
     themes: Vec<DynTheme<Draw>>,
 }
 
@@ -52,13 +52,13 @@ impl<Draw> MultiThemeBuilder<Draw> {
     /// Note: the constraints of this method vary depending on the `unsize`
     /// feature.
     #[cfg(feature = "unsize")]
-    pub fn add<S: Into<CowString>, U>(mut self, name: S, theme: U) -> Self
+    pub fn add<S: ToString, U>(mut self, name: S, theme: U) -> Self
     where
         U: Unsize<dyn ThemeDst<Draw>>,
         Box<U>: Unsize<dyn ThemeDst<Draw>>,
     {
         let index = self.themes.len();
-        self.names.insert(name.into(), index);
+        self.names.insert(name.to_string(), index);
         self.themes.push(StackDst::new_or_boxed(theme));
         self
     }
@@ -68,13 +68,13 @@ impl<Draw> MultiThemeBuilder<Draw> {
     /// Note: the constraints of this method vary depending on the `unsize`
     /// feature.
     #[cfg(not(feature = "unsize"))]
-    pub fn add<S: Into<CowString>, T>(mut self, name: S, theme: T) -> Self
+    pub fn add<S: ToString, T>(mut self, name: S, theme: T) -> Self
     where
         Draw: DrawShared,
         T: ThemeDst<Draw> + 'static,
     {
         let index = self.themes.len();
-        self.names.insert(name.into(), index);
+        self.names.insert(name.to_string(), index);
         self.themes.push(Box::new(theme));
         self
     }

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -9,7 +9,7 @@
 use std::num::ParseFloatError;
 use std::str::FromStr;
 
-use kas::class::HasText;
+use kas::class::HasString;
 use kas::event::VirtualKeyCode as VK;
 use kas::event::{Manager, Response, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
@@ -84,14 +84,14 @@ fn main() -> Result<(), kas_wgpu::Error> {
         #[layout(column)]
         #[handler(msg = VoidMsg)]
         struct {
-            #[widget] display: impl HasText = EditBox::new("0").editable(false).multi_line(true),
+            #[widget] display: impl HasString = EditBox::new("0").editable(false).multi_line(true),
             #[widget(handler = handle_button)] buttons -> Key = buttons,
             calc: Calculator = Calculator::new(),
         }
         impl {
             fn handle_button(&mut self, mgr: &mut Manager, msg: Key) -> Response<VoidMsg> {
                 if self.calc.handle(msg) {
-                    *mgr += self.display.set_text(self.calc.display());
+                    *mgr += self.display.set_string(self.calc.display());
                 }
                 Response::None
             }

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -18,7 +18,7 @@
 //!     long), but in many ways still performs well in release mode
 #![feature(proc_macro_hygiene)]
 
-use kas::class::{HasText, SetText};
+use kas::class::{HasString, SetText};
 use kas::event::UpdateHandle;
 use kas::prelude::*;
 use kas::widget::*;
@@ -48,10 +48,7 @@ impl EditGuard for ListEntryGuard {
     type Msg = EntryMsg;
 
     fn edit(entry: &mut EditBox<Self>) -> Option<Self::Msg> {
-        Some(EntryMsg::Update(
-            entry.guard.0,
-            entry.get_text().to_string(),
-        ))
+        Some(EntryMsg::Update(entry.guard.0, entry.get_string()))
     }
 }
 
@@ -103,7 +100,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         #[handler(msg = usize)]
         struct {
             #[widget] _ = Label::new("Number of rows:"),
-            #[widget(handler = activate)] edit: impl SetText = EditBox::new("3")
+            #[widget(handler = activate)] edit: impl HasString = EditBox::new("3")
                 .on_afl(|text| text.parse::<usize>().ok()),
             #[widget(handler = button)] _ = TextButton::new("Set", Control::Set),
             #[widget(handler = button)] _ = TextButton::new("−", Control::Decr),
@@ -121,7 +118,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     Control::Incr => self.n.saturating_add(1),
                     Control::Set => self.n,
                 };
-                *mgr += self.edit.set_text(n.to_string());
+                *mgr += self.edit.set_string(n.to_string());
                 self.n = n;
                 n.into()
             }
@@ -164,7 +161,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     match msg {
                         EntryMsg::Select(n) => {
                             self.active = n;
-                            let text = self.list.inner()[n].entry.get_text().to_string();
+                            let text = self.list.inner()[n].entry.get_string();
                             *mgr += self.display.set_text(text);
                         }
                         EntryMsg::Update(n, text) => {

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -9,7 +9,7 @@
 //! (excepting custom graphics).
 #![feature(proc_macro_hygiene)]
 
-use kas::class::HasText;
+use kas::class::HasString;
 use kas::event::{UpdateHandle, VoidResponse};
 use kas::prelude::*;
 use kas::widget::*;
@@ -32,12 +32,12 @@ impl EditGuard for Guard {
     type Msg = Item;
 
     fn activate(edit: &mut EditBox<Self>) -> Option<Self::Msg> {
-        Some(Item::Edit(edit.get_text().to_string()))
+        Some(Item::Edit(edit.get_string()))
     }
 
     fn edit(edit: &mut EditBox<Self>) -> Option<Self::Msg> {
         // 7a is the colour of *magic*!
-        edit.set_error_state(edit.get_text().len() % (7 + 1) == 0);
+        edit.set_error_state(edit.get_str().len() % (7 + 1) == 0);
         None
     }
 }

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -21,8 +21,9 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
         let glyphs = text
             .positioned_glyphs(pos)
             .map(|sg| SectionGlyph {
-                section_index: sg.section_index,
-                byte_index: sg.byte_index,
+                // Index fields are not used when drawing
+                section_index: 0,
+                byte_index: 0,
                 glyph: sg.glyph,
                 font_id: FontId(sg.font_id.get()),
             })

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -5,7 +5,7 @@
 
 //! Text drawing API for `kas_wgpu`
 
-use wgpu_glyph::{ab_glyph, Extra, FontId, SectionGlyph};
+use wgpu_glyph::{ab_glyph, Extra, SectionGlyph};
 
 use super::{CustomWindow, DrawWindow};
 use kas::draw::{Colour, DrawText, Pass};
@@ -25,15 +25,13 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
                 section_index: 0,
                 byte_index: 0,
                 glyph: sg.glyph,
-                font_id: FontId(sg.font_id.get()),
+                font_id: sg.font_id,
             })
             .collect();
-        let extra = (0..text.num_parts())
-            .map(|_| Extra {
-                color: col.into(),
-                z: pass.depth(),
-            })
-            .collect();
+        let extra = vec![Extra {
+            color: col.into(),
+            z: pass.depth(),
+        }];
         let min = to_point(pos);
         let max = to_point(pos + text.bounds());
         let bounds = ab_glyph::Rect { min, max };

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -5,8 +5,7 @@
 
 //! Text drawing API for `kas_wgpu`
 
-use wgpu_glyph::ab_glyph;
-use wgpu_glyph::Extra;
+use wgpu_glyph::{ab_glyph, Extra, FontId, SectionGlyph};
 
 use super::{CustomWindow, DrawWindow};
 use kas::draw::{Colour, DrawText, Pass};
@@ -19,8 +18,15 @@ fn to_point(Vec2(x, y): Vec2) -> ab_glyph::Point {
 
 impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
     fn text(&mut self, pass: Pass, pos: Vec2, col: Colour, text: &PreparedText) {
-        // TODO: perhaps glyph_brush can accept an offset for all glyphs?
-        let glyphs = text.positioned_glyphs(pos);
+        let glyphs = text
+            .positioned_glyphs(pos)
+            .map(|sg| SectionGlyph {
+                section_index: sg.section_index,
+                byte_index: sg.byte_index,
+                glyph: sg.glyph,
+                font_id: FontId(sg.font_id.get()),
+            })
+            .collect();
         let extra = (0..text.num_parts())
             .map(|_| Extra {
                 color: col.into(),

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -11,7 +11,6 @@ use std::num::NonZeroU32;
 use crate::draw::{CustomPipe, CustomPipeBuilder, DrawPipe, DrawWindow, ShaderManager};
 use crate::{Error, Options, WindowId};
 use kas::event::UpdateHandle;
-use kas::string::{CowString, CowStringL};
 use kas_theme::Theme;
 
 #[cfg(feature = "clipboard")]
@@ -110,16 +109,16 @@ where
 
     #[cfg(not(feature = "clipboard"))]
     #[inline]
-    pub fn get_clipboard(&mut self) -> Option<CowString> {
+    pub fn get_clipboard(&mut self) -> Option<String> {
         None
     }
 
     #[cfg(feature = "clipboard")]
-    pub fn get_clipboard(&mut self) -> Option<CowString> {
+    pub fn get_clipboard(&mut self) -> Option<String> {
         self.clipboard
             .as_mut()
             .and_then(|cb| match cb.get_contents() {
-                Ok(c) => Some(c.into()),
+                Ok(c) => Some(c),
                 Err(e) => {
                     warn!("Failed to get clipboard contents: {:?}", e);
                     None
@@ -129,10 +128,10 @@ where
 
     #[cfg(not(feature = "clipboard"))]
     #[inline]
-    pub fn set_clipboard<'c>(&mut self, content: CowStringL<'c>) {}
+    pub fn set_clipboard<'c>(&mut self, _: std::borrow::Cow<'c, str>) {}
 
     #[cfg(feature = "clipboard")]
-    pub fn set_clipboard<'c>(&mut self, content: CowStringL<'c>) {
+    pub fn set_clipboard<'c>(&mut self, content: std::borrow::Cow<'c, str>) {
         self.clipboard.as_mut().map(|cb| {
             cb.set_contents(content.into())
                 .unwrap_or_else(|e| warn!("Failed to set clipboard contents: {:?}", e))

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -12,7 +12,6 @@ use kas::draw::SizeHandle;
 use kas::event::{CursorIcon, ManagerState, UpdateHandle};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
-use kas::string::{CowString, CowStringL};
 use kas::{ThemeAction, ThemeApi, TkAction, WindowId};
 use kas_theme::Theme;
 use winit::dpi::PhysicalSize;
@@ -448,12 +447,12 @@ where
     }
 
     #[inline]
-    fn get_clipboard(&mut self) -> Option<CowString> {
+    fn get_clipboard(&mut self) -> Option<String> {
         self.shared.get_clipboard()
     }
 
     #[inline]
-    fn set_clipboard<'c>(&mut self, content: CowStringL<'c>) {
+    fn set_clipboard<'c>(&mut self, content: std::borrow::Cow<'c, str>) {
         self.shared.set_clipboard(content);
     }
 

--- a/src/class.rs
+++ b/src/class.rs
@@ -8,7 +8,7 @@
 //! These traits provide generic ways to interact with common widget properties,
 //! e.g. to read the text of a `Label` or set the state of a `CheckBox`.
 
-use crate::{string::CowString, TkAction};
+use crate::TkAction;
 
 /// Read / write a boolean value
 ///
@@ -23,23 +23,18 @@ pub trait HasBool {
 
 /// Write a plain-text value or label
 pub trait SetText {
-    /// Set the widget's text
-    ///
-    /// Depending on the widget, this may set a label or a value.
-    fn set_text<T: Into<CowString>>(&mut self, text: T) -> TkAction
+    /// Set text (unformatted)
+    fn set_text<T: ToString>(&mut self, text: T) -> TkAction
     where
         Self: Sized,
     {
-        self.set_cow_string(text.into())
+        self.set_string(text.to_string())
     }
 
-    /// Set the widget's text ([`CowString`])
+    /// Set text from a `String`
     ///
     /// Depending on the widget, this may set a label or a value.
-    ///
-    /// This method is for implementation. It is recommended to use
-    /// [`HasText::set_text`] instead.
-    fn set_cow_string(&mut self, text: CowString) -> TkAction;
+    fn set_string(&mut self, text: String) -> TkAction;
 }
 
 /// Read a plain-text value / label

--- a/src/class.rs
+++ b/src/class.rs
@@ -46,8 +46,7 @@ pub trait CloneText {
     /// though where an unformatted representation is available internally this
     /// may be used for a more efficient implementation.
     fn clone_string(&self) -> String {
-        todo!()
-        // self.clone_text().to_string()
+        self.clone_text().to_string()
     }
 
     /// Clone text as rich text

--- a/src/class.rs
+++ b/src/class.rs
@@ -8,6 +8,7 @@
 //! These traits provide generic ways to interact with common widget properties,
 //! e.g. to read the text of a `Label` or set the state of a `CheckBox`.
 
+use crate::string::AccelString;
 use crate::TkAction;
 
 /// Read / write a boolean value
@@ -21,37 +22,87 @@ pub trait HasBool {
     fn set_bool(&mut self, state: bool) -> TkAction;
 }
 
-/// Write a plain-text value or label
-pub trait SetText {
-    /// Set text (unformatted)
-    fn set_text<T: ToString>(&mut self, text: T) -> TkAction
-    where
-        Self: Sized,
-    {
-        self.set_string(text.to_string())
+/// Read / write an unformatted `String`
+pub trait HasString {
+    /// Get text by reference
+    fn get_str(&self) -> &str;
+
+    /// Get text as a `String`
+    fn get_string(&self) -> String {
+        self.get_str().to_string()
     }
 
-    /// Set text from a `String`
-    ///
-    /// Depending on the widget, this may set a label or a value.
+    /// Set text from an unformatted string
     fn set_string(&mut self, text: String) -> TkAction;
 }
 
-/// Read a plain-text value / label
-///
-/// This is an extension over [`SetText`] allowing text to be read.
-///
-/// Note that widgets may support setting a plain-text label or value without
-/// supporting reading a plain text value, for example since rich-text labels
-/// are not easily converted to a plain-text representation.
-pub trait HasText: SetText {
-    /// Get the widget's text value (as plain text)
-    fn get_text(&self) -> &str;
+/// Read a (rich) text value
+pub trait CloneText {
+    /// Clone text as a plain `String`
+    ///
+    /// For rich-text representations this strips formatting.
+    ///
+    /// An implementation is provided based on [`CloneText::clone_text`],
+    /// though where an unformatted representation is available internally this
+    /// may be used for a more efficient implementation.
+    fn clone_string(&self) -> String {
+        todo!()
+        // self.clone_text().to_string()
+    }
+
+    /// Clone text as rich text
+    ///
+    /// Can be implemented via `self.clone_string().into()` if there is no
+    /// rich-text representation.
+    fn clone_text(&self) -> kas::text::RichText;
 }
 
-/// Read a rich text value / label
-pub trait HasRichText {
-    // TODO: set_rich_text and auto impls?
-    /// Get the widget's text label as rich text
-    fn clone_rich_text(&self) -> kas::text::RichText;
+// TODO(spec): it would be nice to provide this implementation
+// impl<T: HasString> CloneText for T {
+//     fn clone_string(&self) -> String {
+//         self.get_string().to_string()
+//     }
+//
+//     fn clone_text(&self) -> kas::text::RichText {
+//         self.get_string().into()
+//     }
+// }
+
+/// Set a text value
+///
+/// TODO: add convenience methods for parsing, e.g. `set_html`.
+pub trait SetText: CloneText {
+    /// Set text
+    ///
+    /// This method supports [`kas::text::RichText`] for formatted input and
+    /// `String` and `&str` for unformatted input.
+    fn set_text<T: Into<kas::text::RichText>>(&mut self, text: T) -> TkAction
+    where
+        Self: Sized,
+    {
+        self.set_rich_text(text.into())
+    }
+
+    /// Set rich text
+    fn set_rich_text(&mut self, text: kas::text::RichText) -> TkAction;
+}
+
+/// Set a control label
+///
+/// Control labels do not support rich-text formatting but do support
+/// accelerator keys, identified via a `&` prefix (e.g. `&File`).
+pub trait SetAccel {
+    /// Set text
+    ///
+    /// This method supports [`AccelString`], `String` and `&str` as input.
+    /// The latter are parsed for accel keys identified by `&` prefix.
+    fn set_accel<T: Into<AccelString>>(&mut self, accel: T) -> TkAction
+    where
+        Self: Sized,
+    {
+        self.set_accel_string(accel.into())
+    }
+
+    /// Set accel string
+    fn set_accel_string(&mut self, accel: AccelString) -> TkAction;
 }

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -358,7 +358,7 @@ pub trait DrawHandleExt: DrawHandle {
         let end = match range.end_bound() {
             Bound::Included(n) => *n + 1,
             Bound::Excluded(n) => *n,
-            Bound::Unbounded => text.total_len(),
+            Bound::Unbounded => text.raw_text_len(),
         };
         let range = Range { start, end };
         self.text_selected_range(pos, text, range, class);

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -12,7 +12,6 @@ use std::u16;
 use super::*;
 use crate::draw::SizeHandle;
 use crate::geom::Coord;
-use crate::string::{CowString, CowStringL};
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
 use crate::{ThemeAction, ThemeApi, TkAction, WidgetId, WindowId};
@@ -235,13 +234,13 @@ impl<'a> Manager<'a> {
     /// In case of failure, paste actions will simply fail. The implementation
     /// may wish to log an appropriate warning message.
     #[inline]
-    pub fn get_clipboard(&mut self) -> Option<CowString> {
+    pub fn get_clipboard(&mut self) -> Option<String> {
         self.tkw.get_clipboard()
     }
 
     /// Attempt to set clipboard contents
     #[inline]
-    pub fn set_clipboard<'c>(&mut self, content: CowStringL<'c>) {
+    pub fn set_clipboard<'c>(&mut self, content: std::borrow::Cow<'c, str>) {
         self.tkw.set_clipboard(content)
     }
 

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -141,13 +141,13 @@ macro_rules! impl_void_msg {
             }
         }
     };
-    ($t:ty, $($tt:ty,)*) => {
+    ($t:ty, $($tt:ty),*) => {
         impl_void_msg!($t);
-        impl_void_msg!($($tt,)*);
+        impl_void_msg!($($tt),*);
     };
 }
-impl_void_msg!(bool, char,);
-impl_void_msg!(u8, u16, u32, u64, u128, usize,);
-impl_void_msg!(i8, i16, i32, i64, i128, isize,);
-impl_void_msg!(f32, f64,);
-impl_void_msg!(&'static str, String, kas::string::CowString,);
+impl_void_msg!(bool, char);
+impl_void_msg!(u8, u16, u32, u64, u128, usize);
+impl_void_msg!(i8, i16, i32, i64, i128, isize);
+impl_void_msg!(f32, f64);
+impl_void_msg!(&'static str, String);

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -101,9 +101,9 @@ impl std::ops::Add<Size> for Coord {
     }
 }
 
-impl From<Coord> for kas_text::Size {
-    fn from(pos: Coord) -> kas_text::Size {
-        kas_text::Size(pos.0 as f32, pos.1 as f32)
+impl From<Coord> for kas_text::Vec2 {
+    fn from(pos: Coord) -> kas_text::Vec2 {
+        kas_text::Vec2(pos.0 as f32, pos.1 as f32)
     }
 }
 
@@ -212,9 +212,9 @@ impl From<Size> for winit::dpi::Size {
     }
 }
 
-impl From<Size> for kas_text::Size {
-    fn from(size: Size) -> kas_text::Size {
-        kas_text::Size(size.0 as f32, size.1 as f32)
+impl From<Size> for kas_text::Vec2 {
+    fn from(size: Size) -> kas_text::Vec2 {
+        kas_text::Vec2(size.0 as f32, size.1 as f32)
     }
 }
 

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -319,16 +319,16 @@ macro_rules! impl_vec2 {
             }
         }
 
-        impl From<kas_text::Size> for $T {
+        impl From<kas_text::Vec2> for $T {
             #[inline]
-            fn from(size: kas_text::Size) -> Self {
+            fn from(size: kas_text::Vec2) -> Self {
                 $T(size.0 as $f, size.1 as $f)
             }
         }
 
-        impl From<$T> for kas_text::Size {
-            fn from(size: $T) -> kas_text::Size {
-                kas_text::Size(size.0 as f32, size.1 as f32)
+        impl From<$T> for kas_text::Vec2 {
+            fn from(size: $T) -> kas_text::Vec2 {
+                kas_text::Vec2(size.0 as f32, size.1 as f32)
             }
         }
     };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,7 +26,7 @@ pub use kas::macros::*;
 #[doc(no_inline)]
 pub use kas::string::{AccelString, LabelString};
 #[doc(no_inline)]
-pub use kas::text::PreparedText;
+pub use kas::text::{PreparedText, RichText};
 #[doc(no_inline)]
 pub use kas::{class, draw, event, geom, layout, widget};
 #[doc(no_inline)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -24,7 +24,7 @@ pub use kas::layout::{AxisInfo, Margins, SizeRules, StretchPolicy};
 #[doc(no_inline)]
 pub use kas::macros::*;
 #[doc(no_inline)]
-pub use kas::string::{AccelString, CowString, CowStringL, LabelString};
+pub use kas::string::{AccelString, LabelString};
 #[doc(no_inline)]
 pub use kas::text::PreparedText;
 #[doc(no_inline)]

--- a/src/string.rs
+++ b/src/string.rs
@@ -14,12 +14,6 @@ use std::ops::Deref;
 
 use kas::event::{VirtualKeyCode as VK, VirtualKeyCodes};
 
-/// Convenience definition: `Cow<'a, str>`
-pub type CowStringL<'a> = std::borrow::Cow<'a, str>;
-
-/// Convenience definition: `Cow<'static, str>`
-pub type CowString = CowStringL<'static>;
-
 /// A label string
 ///
 /// This is a label which supports markup.
@@ -27,7 +21,7 @@ pub type CowString = CowStringL<'static>;
 /// Markup: `&&` translates to `&`; `&x` for any `x` translates to `x`.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct LabelString {
-    label: CowString,
+    label: String,
 }
 
 impl LabelString {
@@ -60,8 +54,8 @@ impl LabelString {
     }
 }
 
-impl From<CowString> for LabelString {
-    fn from(input: CowString) -> Self {
+impl From<String> for LabelString {
+    fn from(input: String) -> Self {
         if input.as_bytes().contains(&b'&') {
             Self::parse(&input)
         } else {
@@ -73,13 +67,7 @@ impl From<CowString> for LabelString {
 
 impl From<&'static str> for LabelString {
     fn from(input: &'static str) -> Self {
-        CowString::from(input).into()
-    }
-}
-
-impl From<String> for LabelString {
-    fn from(input: String) -> Self {
-        CowString::from(input).into()
+        input.to_string().into()
     }
 }
 
@@ -99,8 +87,8 @@ impl Deref for LabelString {
 /// may support keyboard access via e.g. `Alt+X`.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AccelString {
-    label: CowString,
-    underlined: CowString,
+    label: String,
+    underlined: String,
     // TODO: is it worth using such a large structure here instead of Option?
     keys: VirtualKeyCodes,
 }
@@ -173,8 +161,8 @@ impl AccelString {
     }
 }
 
-impl From<CowString> for AccelString {
-    fn from(input: CowString) -> Self {
+impl From<String> for AccelString {
+    fn from(input: String) -> Self {
         if input.as_bytes().contains(&b'&') {
             Self::parse(&input)
         } else {
@@ -190,13 +178,7 @@ impl From<CowString> for AccelString {
 
 impl From<&'static str> for AccelString {
     fn from(input: &'static str) -> Self {
-        CowString::from(input).into()
-    }
-}
-
-impl From<String> for AccelString {
-    fn from(input: String) -> Self {
-        CowString::from(input).into()
+        input.to_string().into()
     }
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -8,7 +8,8 @@
 use kas::geom::{Coord, Size, Vec2};
 use kas::{Align, TkAction};
 pub use kas_text::{
-    fonts, Font, FontId, FontScale, PreparedPart, RichText, SectionGlyph, TextPart,
+    fonts, Font, FontId, FontScale, PreparedGlyphIter, PreparedPart, RichText, SectionGlyph,
+    TextPart,
 };
 
 /// Text, prepared for display in a given enviroment
@@ -95,7 +96,7 @@ impl PreparedText {
         self.0.num_parts()
     }
 
-    pub fn positioned_glyphs(&self, pos: Vec2) -> Vec<SectionGlyph> {
+    pub fn positioned_glyphs(&self, pos: Vec2) -> PreparedGlyphIter {
         self.0.positioned_glyphs(pos.into())
     }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -7,10 +7,10 @@
 
 use kas::geom::{Coord, Size, Vec2};
 use kas::{Align, TkAction};
-pub use kas_text::{
-    fonts, Font, FontId, FontScale, PreparedGlyphIter, PreparedPart, RichText, SectionGlyph,
-    TextPart,
-};
+pub use kas_text::*;
+
+#[doc(no_inline)]
+pub use rich::Text as RichText;
 
 /// Text, prepared for display in a given enviroment
 ///
@@ -18,17 +18,17 @@ pub use kas_text::{
 ///
 /// The type can be default-constructed with no text.
 #[derive(Clone, Debug, Default)]
-pub struct PreparedText(kas_text::PreparedText);
+pub struct PreparedText(prepared::Text);
 
 impl PreparedText {
     /// Construct from a text model
     ///
-    /// This method assumes default alignment. To adjust, use [`PreparedText::set_alignment`].
+    /// This method assumes default alignment. To adjust, use [`Text::set_alignment`].
     ///
     /// This struct must be made ready for use before
-    /// To do so, call [`PreparedText::set_environment`].
+    /// To do so, call [`PreparedText::prepare`].
     pub fn new(text: RichText, line_wrap: bool) -> PreparedText {
-        PreparedText(kas_text::PreparedText::new(text, line_wrap))
+        PreparedText(prepared::Text::new(text, line_wrap))
     }
 
     /// Reconstruct the [`RichText`] defining this `PreparedText`
@@ -36,9 +36,12 @@ impl PreparedText {
         self.0.clone_text()
     }
 
-    /// Index at end of text
-    pub fn total_len(&self) -> usize {
-        self.0.total_len()
+    /// Length of raw text
+    ///
+    /// It is valid to reference text within the range `0..raw_text_len()`,
+    /// even if not all text within this range will be displayed (due to runs).
+    pub fn raw_text_len(&self) -> usize {
+        self.0.raw_text_len()
     }
 
     /// Layout text
@@ -54,6 +57,8 @@ impl PreparedText {
     }
 
     /// Set the text
+    ///
+    /// Returns [`TkAction::Resize`] when it is necessary to call [`PreparedText::prepare`].
     pub fn set_text<T: Into<RichText>>(&mut self, text: T) -> TkAction {
         if self.0.set_text(text.into()) {
             // Layout must be re-calculated which currently requires resizing
@@ -92,11 +97,7 @@ impl PreparedText {
         self.0.bounds().into()
     }
 
-    pub fn num_parts(&self) -> usize {
-        self.0.num_parts()
-    }
-
-    pub fn positioned_glyphs(&self, pos: Vec2) -> PreparedGlyphIter {
+    pub fn positioned_glyphs(&self, pos: Vec2) -> prepared::GlyphIter {
         self.0.positioned_glyphs(pos.into())
     }
 

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -17,7 +17,6 @@
 use std::num::NonZeroU32;
 
 use crate::draw::SizeHandle;
-use crate::string::{CowString, CowStringL};
 use crate::{event, ThemeAction, ThemeApi};
 
 /// Identifier for a window or pop-up
@@ -143,10 +142,10 @@ pub trait TkWindow {
     ///
     /// In case of failure, paste actions will simply fail. The implementation
     /// may wish to log an appropriate warning message.
-    fn get_clipboard(&mut self) -> Option<CowString>;
+    fn get_clipboard(&mut self) -> Option<String>;
 
     /// Attempt to set clipboard contents
-    fn set_clipboard<'c>(&mut self, content: CowStringL<'c>);
+    fn set_clipboard<'c>(&mut self, content: std::borrow::Cow<'c, str>);
 
     /// Adjust the theme
     fn adjust_theme(&mut self, f: &mut dyn FnMut(&mut dyn ThemeApi) -> ThemeAction);

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Debug;
 
-use kas::class::{HasRichText, SetText};
+use kas::class::{CloneText, SetAccel};
 use kas::draw::TextClass;
 use kas::event::{VirtualKeyCode, VirtualKeyCodes};
 use kas::prelude::*;
@@ -104,18 +104,17 @@ impl<M: Clone + Debug + 'static> TextButton<M> {
     }
 }
 
-impl<M: Clone + Debug + 'static> SetText for TextButton<M> {
-    fn set_string(&mut self, label: String) -> TkAction {
-        let label = AccelString::from(label);
-        let text = label.get(false).to_string();
-        self.keys2 = label.take_keys();
-        self.label.set_text(text)
+impl<M: Clone + Debug + 'static> CloneText for TextButton<M> {
+    fn clone_text(&self) -> kas::text::RichText {
+        self.label.clone_text()
     }
 }
 
-impl<M: Clone + Debug + 'static> HasRichText for TextButton<M> {
-    fn clone_rich_text(&self) -> kas::text::RichText {
-        self.label.clone_text()
+impl<M: Clone + Debug + 'static> SetAccel for TextButton<M> {
+    fn set_accel_string(&mut self, label: AccelString) -> TkAction {
+        let text = label.get(false).to_string();
+        self.keys2 = label.take_keys();
+        self.label.set_text(text)
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -105,7 +105,7 @@ impl<M: Clone + Debug + 'static> TextButton<M> {
 }
 
 impl<M: Clone + Debug + 'static> SetText for TextButton<M> {
-    fn set_cow_string(&mut self, label: CowString) -> TkAction {
+    fn set_string(&mut self, label: String) -> TkAction {
         let label = AccelString::from(label);
         let text = label.get(false).to_string();
         self.keys2 = label.take_keys();

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 use std::iter::FromIterator;
 
 use super::{Column, MenuEntry, MenuFrame};
-use kas::class::{HasRichText, SetText};
+use kas::class::{CloneText, SetAccel};
 use kas::draw::TextClass;
 use kas::event::{ControlKey, GrabMode};
 use kas::prelude::*;
@@ -89,7 +89,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     #[inline]
     fn new_(column: Vec<MenuEntry<u64>>, messages: Vec<M>) -> Self {
         assert!(column.len() > 0, "ComboBox: expected at least one choice");
-        let label = PreparedText::new(column[0].clone_rich_text(), false);
+        let label = PreparedText::new(column[0].clone_text(), false);
         ComboBox {
             core: Default::default(),
             label,
@@ -121,7 +121,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
         if self.active != index {
             self.active = index;
             self.label
-                .set_text(self.popup.inner.inner[self.active].clone_rich_text())
+                .set_text(self.popup.inner.inner[self.active].clone_text())
         } else {
             TkAction::None
         }
@@ -144,11 +144,11 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     /// Add a choice to the combobox, in last position
     ///
     /// Triggers a [reconfigure action](Manager::send_action).
-    pub fn push<T: ToString>(&mut self, label: T, msg: M) -> TkAction {
+    pub fn push<T: Into<AccelString>>(&mut self, label: T, msg: M) -> TkAction {
         self.messages.push(msg);
         let column = &mut self.popup.inner.inner;
         let len = column.len() as u64;
-        column.push(MenuEntry::new(label.to_string(), len))
+        column.push(MenuEntry::new(label, len))
         // TODO: localised reconfigure
     }
 
@@ -159,11 +159,11 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     /// Panics if `index > len`.
     ///
     /// Triggers a [reconfigure action](Manager::send_action).
-    pub fn insert<T: ToString>(&mut self, index: usize, label: T, msg: M) -> TkAction {
+    pub fn insert<T: Into<AccelString>>(&mut self, index: usize, label: T, msg: M) -> TkAction {
         self.messages.insert(index, msg);
         let column = &mut self.popup.inner.inner;
         let len = column.len() as u64;
-        column.insert(index, MenuEntry::new(label.to_string(), len))
+        column.insert(index, MenuEntry::new(label, len))
         // TODO: localised reconfigure
     }
 
@@ -184,10 +184,15 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     /// Replace the choice at `index`
     ///
     /// Panics if `index` is out of bounds.
-    pub fn replace<T: ToString>(&mut self, index: usize, label: T, msg: M) -> (M, TkAction) {
+    pub fn replace<T: Into<AccelString>>(
+        &mut self,
+        index: usize,
+        label: T,
+        msg: M,
+    ) -> (M, TkAction) {
         let mut m = msg;
         std::mem::swap(&mut m, &mut self.messages[index]);
-        (m, self.popup.inner.inner[index].set_text(label))
+        (m, self.popup.inner.inner[index].set_accel(label))
     }
 }
 

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -144,11 +144,11 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     /// Add a choice to the combobox, in last position
     ///
     /// Triggers a [reconfigure action](Manager::send_action).
-    pub fn push<T: Into<CowString>>(&mut self, label: T, msg: M) -> TkAction {
+    pub fn push<T: ToString>(&mut self, label: T, msg: M) -> TkAction {
         self.messages.push(msg);
         let column = &mut self.popup.inner.inner;
         let len = column.len() as u64;
-        column.push(MenuEntry::new(label.into(), len))
+        column.push(MenuEntry::new(label.to_string(), len))
         // TODO: localised reconfigure
     }
 
@@ -159,11 +159,11 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     /// Panics if `index > len`.
     ///
     /// Triggers a [reconfigure action](Manager::send_action).
-    pub fn insert<T: Into<CowString>>(&mut self, index: usize, label: T, msg: M) -> TkAction {
+    pub fn insert<T: ToString>(&mut self, index: usize, label: T, msg: M) -> TkAction {
         self.messages.insert(index, msg);
         let column = &mut self.popup.inner.inner;
         let len = column.len() as u64;
-        column.insert(index, MenuEntry::new(label.into(), len))
+        column.insert(index, MenuEntry::new(label.to_string(), len))
         // TODO: localised reconfigure
     }
 
@@ -184,7 +184,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     /// Replace the choice at `index`
     ///
     /// Panics if `index` is out of bounds.
-    pub fn replace<T: Into<CowString>>(&mut self, index: usize, label: T, msg: M) -> (M, TkAction) {
+    pub fn replace<T: ToString>(&mut self, index: usize, label: T, msg: M) -> (M, TkAction) {
         let mut m = msg;
         std::mem::swap(&mut m, &mut self.messages[index]);
         (m, self.popup.inner.inner[index].set_text(label))

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -27,7 +27,7 @@ pub struct MessageBox {
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,
-    title: CowString,
+    title: String,
     #[widget]
     label: Label,
     #[widget(handler = handle_button)]
@@ -35,11 +35,11 @@ pub struct MessageBox {
 }
 
 impl MessageBox {
-    pub fn new<T: Into<CowString>, M: Into<LabelString>>(title: T, message: M) -> Self {
+    pub fn new<T: ToString, M: Into<LabelString>>(title: T, message: M) -> Self {
         MessageBox {
             core: Default::default(),
             layout_data: Default::default(),
-            title: title.into(),
+            title: title.to_string(),
             label: Label::new(message),
             button: TextButton::new("Ok", DialogButton::Close).with_keys(&[
                 VirtualKeyCode::Return,

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -352,7 +352,7 @@ impl<G> EditBox<G> {
     /// Set the error state
     ///
     /// When true, the input field's background is drawn red.
-    // TODO: possibly change type to Option<CowString> and display the error
+    // TODO: possibly change type to Option<String> and display the error
     pub fn set_error_state(&mut self, error_state: bool) {
         self.error_state = error_state;
     }
@@ -569,8 +569,8 @@ impl<G> EditBox<G> {
 }
 
 impl<G: EditGuard> SetText for EditBox<G> {
-    fn set_cow_string(&mut self, text: CowString) -> TkAction {
-        self.text = text.to_string();
+    fn set_string(&mut self, text: String) -> TkAction {
+        self.text = text;
         let action = self.prepared.set_text(self.text.clone());
         let _ = G::edit(self);
         action

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Debug};
 use std::ops::Range;
 use unicode_segmentation::GraphemeCursor;
 
-use kas::class::{HasText, SetText};
+use kas::class::HasString;
 use kas::draw::{DrawHandleExt, TextClass};
 use kas::event::{ControlKey, GrabMode, ModifiersState};
 use kas::prelude::*;
@@ -568,18 +568,16 @@ impl<G> EditBox<G> {
     }
 }
 
-impl<G: EditGuard> SetText for EditBox<G> {
+impl<G: EditGuard> HasString for EditBox<G> {
+    fn get_str(&self) -> &str {
+        &self.text
+    }
+
     fn set_string(&mut self, text: String) -> TkAction {
         self.text = text;
         let action = self.prepared.set_text(self.text.clone());
         let _ = G::edit(self);
         action
-    }
-}
-
-impl<G: EditGuard> HasText for EditBox<G> {
-    fn get_text(&self) -> &str {
-        &self.text
     }
 }
 

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -89,8 +89,8 @@ impl<W: HasBool + Widget> HasBool for Frame<W> {
 }
 
 impl<W: SetText + Widget> SetText for Frame<W> {
-    fn set_cow_string(&mut self, text: CowString) -> TkAction {
-        self.child.set_cow_string(text)
+    fn set_string(&mut self, text: String) -> TkAction {
+        self.child.set_string(text)
     }
 }
 

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -88,20 +88,34 @@ impl<W: HasBool + Widget> HasBool for Frame<W> {
     }
 }
 
-impl<W: SetText + Widget> SetText for Frame<W> {
+impl<W: HasString + Widget> HasString for Frame<W> {
+    fn get_str(&self) -> &str {
+        self.child.get_str()
+    }
+
     fn set_string(&mut self, text: String) -> TkAction {
         self.child.set_string(text)
     }
 }
 
-impl<W: HasText + Widget> HasText for Frame<W> {
-    fn get_text(&self) -> &str {
-        self.child.get_text()
+impl<W: CloneText + Widget> CloneText for Frame<W> {
+    fn clone_string(&self) -> String {
+        self.child.clone_string()
+    }
+
+    fn clone_text(&self) -> kas::text::RichText {
+        self.child.clone_text()
     }
 }
 
-impl<W: HasRichText + Widget> HasRichText for Frame<W> {
-    fn clone_rich_text(&self) -> kas::text::RichText {
-        self.child.clone_rich_text()
+impl<W: SetText + Widget> SetText for Frame<W> {
+    fn set_rich_text(&mut self, text: kas::text::RichText) -> TkAction {
+        self.child.set_rich_text(text)
+    }
+}
+
+impl<W: SetAccel + Widget> SetAccel for Frame<W> {
+    fn set_accel_string(&mut self, accel: AccelString) -> TkAction {
+        self.child.set_accel_string(accel)
     }
 }

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -5,7 +5,7 @@
 
 //! Text widgets
 
-use kas::class::{HasRichText, SetText};
+use kas::class::{CloneText, SetAccel, SetText};
 use kas::draw::TextClass;
 use kas::event::VirtualKeyCodes;
 use kas::prelude::*;
@@ -73,15 +73,15 @@ impl Label {
     }
 }
 
-impl SetText for Label {
-    fn set_string(&mut self, text: String) -> TkAction {
-        self.label.set_text(text)
+impl CloneText for Label {
+    fn clone_text(&self) -> kas::text::RichText {
+        self.label.clone_text()
     }
 }
 
-impl HasRichText for Label {
-    fn clone_rich_text(&self) -> kas::text::RichText {
-        self.label.clone_text()
+impl SetText for Label {
+    fn set_rich_text(&mut self, text: kas::text::RichText) -> TkAction {
+        self.label.set_text(text)
     }
 }
 
@@ -142,17 +142,16 @@ impl AccelLabel {
     }
 }
 
-impl SetText for AccelLabel {
-    fn set_string(&mut self, label: String) -> TkAction {
-        let label = AccelString::from(label);
-        let text = label.get(false).to_string();
-        self.keys = label.take_keys();
-        self.label.set_text(text)
+impl CloneText for AccelLabel {
+    fn clone_text(&self) -> kas::text::RichText {
+        self.label.clone_text()
     }
 }
 
-impl HasRichText for AccelLabel {
-    fn clone_rich_text(&self) -> kas::text::RichText {
-        self.label.clone_text()
+impl SetAccel for AccelLabel {
+    fn set_accel_string(&mut self, label: AccelString) -> TkAction {
+        let text = label.get(false).to_string();
+        self.keys = label.take_keys();
+        self.label.set_text(text)
     }
 }

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -74,8 +74,8 @@ impl Label {
 }
 
 impl SetText for Label {
-    fn set_cow_string(&mut self, string: CowString) -> TkAction {
-        self.label.set_text(string.to_string())
+    fn set_string(&mut self, text: String) -> TkAction {
+        self.label.set_text(text)
     }
 }
 
@@ -143,7 +143,7 @@ impl AccelLabel {
 }
 
 impl SetText for AccelLabel {
-    fn set_cow_string(&mut self, label: CowString) -> TkAction {
+    fn set_string(&mut self, label: String) -> TkAction {
         let label = AccelString::from(label);
         let text = label.get(false).to_string();
         self.keys = label.take_keys();

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -90,7 +90,7 @@ impl<M: Clone + Debug + 'static> MenuEntry<M> {
 }
 
 impl<M: Clone + Debug + 'static> SetText for MenuEntry<M> {
-    fn set_cow_string(&mut self, label: CowString) -> TkAction {
+    fn set_string(&mut self, label: String) -> TkAction {
         let label = AccelString::from(label);
         let text = label.get(false).to_string();
         self.keys = label.take_keys();

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 
 use super::Menu;
-use kas::class::{HasBool, HasRichText, SetText};
+use kas::class::{CloneText, HasBool, SetAccel};
 use kas::draw::TextClass;
 use kas::event::VirtualKeyCodes;
 use kas::layout::{RulesSetter, RulesSolver};
@@ -89,18 +89,17 @@ impl<M: Clone + Debug + 'static> MenuEntry<M> {
     }
 }
 
-impl<M: Clone + Debug + 'static> SetText for MenuEntry<M> {
-    fn set_string(&mut self, label: String) -> TkAction {
-        let label = AccelString::from(label);
-        let text = label.get(false).to_string();
-        self.keys = label.take_keys();
-        self.label.set_text(text)
+impl<M: Clone + Debug + 'static> CloneText for MenuEntry<M> {
+    fn clone_text(&self) -> kas::text::RichText {
+        self.label.clone_text()
     }
 }
 
-impl<M: Clone + Debug + 'static> HasRichText for MenuEntry<M> {
-    fn clone_rich_text(&self) -> kas::text::RichText {
-        self.label.clone_text()
+impl<M: Clone + Debug + 'static> SetAccel for MenuEntry<M> {
+    fn set_accel_string(&mut self, label: AccelString) -> TkAction {
+        let text = label.get(false).to_string();
+        self.keys = label.take_keys();
+        self.label.set_text(text)
     }
 }
 

--- a/src/widget/menu/menu_frame.rs
+++ b/src/widget/menu/menu_frame.rs
@@ -85,20 +85,34 @@ impl<W: HasBool + Widget> HasBool for MenuFrame<W> {
     }
 }
 
-impl<W: SetText + Widget> SetText for MenuFrame<W> {
+impl<W: HasString + Widget> HasString for MenuFrame<W> {
+    fn get_str(&self) -> &str {
+        self.inner.get_str()
+    }
+
     fn set_string(&mut self, text: String) -> TkAction {
         self.inner.set_string(text)
     }
 }
 
-impl<W: HasText + Widget> HasText for MenuFrame<W> {
-    fn get_text(&self) -> &str {
-        self.inner.get_text()
+impl<W: CloneText + Widget> CloneText for MenuFrame<W> {
+    fn clone_string(&self) -> String {
+        self.inner.clone_string()
+    }
+
+    fn clone_text(&self) -> kas::text::RichText {
+        self.inner.clone_text()
     }
 }
 
-impl<W: HasRichText + Widget> HasRichText for MenuFrame<W> {
-    fn clone_rich_text(&self) -> kas::text::RichText {
-        self.inner.clone_rich_text()
+impl<W: SetText + Widget> SetText for MenuFrame<W> {
+    fn set_rich_text(&mut self, text: kas::text::RichText) -> TkAction {
+        self.inner.set_rich_text(text)
+    }
+}
+
+impl<W: SetAccel + Widget> SetAccel for MenuFrame<W> {
+    fn set_accel_string(&mut self, accel: AccelString) -> TkAction {
+        self.inner.set_accel_string(accel)
     }
 }

--- a/src/widget/menu/menu_frame.rs
+++ b/src/widget/menu/menu_frame.rs
@@ -86,8 +86,8 @@ impl<W: HasBool + Widget> HasBool for MenuFrame<W> {
 }
 
 impl<W: SetText + Widget> SetText for MenuFrame<W> {
-    fn set_cow_string(&mut self, text: CowString) -> TkAction {
-        self.inner.set_cow_string(text)
+    fn set_string(&mut self, text: String) -> TkAction {
+        self.inner.set_string(text)
     }
 }
 

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -279,7 +279,7 @@ impl<D: Directional, W: Menu> Menu for SubMenu<D, W> {
 }
 
 impl<D: Directional, W: Menu> SetText for SubMenu<D, W> {
-    fn set_cow_string(&mut self, label: CowString) -> TkAction {
+    fn set_string(&mut self, label: String) -> TkAction {
         let label = AccelString::from(label);
         let text = label.get(false).to_string();
         self.keys = label.take_keys();

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -6,7 +6,7 @@
 //! Sub-menu
 
 use super::{Menu, MenuFrame};
-use kas::class::{HasRichText, SetText};
+use kas::class::{CloneText, SetAccel};
 use kas::draw::TextClass;
 use kas::event::{ConfigureManager, ControlKey, VirtualKeyCodes};
 use kas::prelude::*;
@@ -278,17 +278,16 @@ impl<D: Directional, W: Menu> Menu for SubMenu<D, W> {
     }
 }
 
-impl<D: Directional, W: Menu> SetText for SubMenu<D, W> {
-    fn set_string(&mut self, label: String) -> TkAction {
-        let label = AccelString::from(label);
-        let text = label.get(false).to_string();
-        self.keys = label.take_keys();
-        self.label.set_text(text)
+impl<D: Directional, W: Menu> CloneText for SubMenu<D, W> {
+    fn clone_text(&self) -> kas::text::RichText {
+        self.label.clone_text()
     }
 }
 
-impl<D: Directional, W: Menu> HasRichText for SubMenu<D, W> {
-    fn clone_rich_text(&self) -> kas::text::RichText {
-        self.label.clone_text()
+impl<D: Directional, W: Menu> SetAccel for SubMenu<D, W> {
+    fn set_accel_string(&mut self, label: AccelString) -> TkAction {
+        let text = label.get(false).to_string();
+        self.keys = label.take_keys();
+        self.label.set_text(text)
     }
 }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -21,7 +21,7 @@ pub struct Window<W: Widget + 'static> {
     #[widget_core]
     core: CoreData,
     restrict_dimensions: (bool, bool),
-    title: CowString,
+    title: String,
     #[widget]
     w: W,
     popups: SmallVec<[(WindowId, kas::Popup); 16]>,
@@ -61,11 +61,11 @@ impl<W: Widget + Clone> Clone for Window<W> {
 
 impl<W: Widget> Window<W> {
     /// Create
-    pub fn new<T: Into<CowString>>(title: T, w: W) -> Window<W> {
+    pub fn new<T: ToString>(title: T, w: W) -> Window<W> {
         Window {
             core: Default::default(),
             restrict_dimensions: (true, false),
-            title: title.into(),
+            title: title.to_string(),
             w,
             popups: Default::default(),
             fns: Vec::new(),


### PR DESCRIPTION
From the commit removing `CowString`:

> This is a mis-placed optimisation: the only place it helps is with string literals; real apps mostly won't use these anyway due to translation support.