### PR TITLE
kas-text: use re-implemented breaking and shaping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "8565f29f324f08232277cf9d9f782e568ce9b509"
+rev = "f9dbee591613f6b0b57ad722a67fe63b3c0bccd6"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "f9dbee591613f6b0b57ad722a67fe63b3c0bccd6"
+rev = "b2bddd4797e66901f673f0ff1988e3cd6ea1d0bf"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "1d428e413aa08d0a452e0b2409f12873a8c45729"
+rev = "06a2668a749b6ef4f20d5de451442f02629d749a"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "b2bddd4797e66901f673f0ff1988e3cd6ea1d0bf"
+rev = "1d428e413aa08d0a452e0b2409f12873a8c45729"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/kas-macros/src/args.rs
+++ b/kas-macros/src/args.rs
@@ -238,30 +238,33 @@ impl WidgetAttrArgs {
         ))
     }
 
-    fn match_align(ident: &Ident) -> Result<TokenStream> {
+    fn match_align(ident: &Ident, horiz: bool) -> Result<TokenStream> {
         Ok(match ident {
-            ident if ident == "begin" => quote! { kas::Align::Begin },
+            ident if ident == "default" => quote! { kas::Align::Default },
+            ident if horiz && ident == "left" => quote! { kas::Align::TL },
+            ident if !horiz && ident == "top" => quote! { kas::Align::TL },
             ident if ident == "centre" || ident == "center" => quote! { kas::Align::Centre },
-            ident if ident == "end" => quote! { kas::Align::End },
+            ident if horiz && ident == "right" => quote! { kas::Align::BR },
+            ident if !horiz && ident == "bottom" => quote! { kas::Align::BR },
             ident if ident == "stretch" => quote! { kas::Align::Stretch },
             ident => {
                 return Err(Error::new(
                     ident.span(),
-                    "expected one of `begin`, `centre`, `center`, `end`, `stretch`",
+                    "expected one of `default`, `centre`, `stretch`, `top` or `bottom` (if vertical), `left` or `right` (if horizontal)",
                 ));
             }
         })
     }
     pub fn halign_toks(&self) -> Result<Option<TokenStream>> {
         if let Some(ref ident) = self.halign {
-            Ok(Some(Self::match_align(ident)?))
+            Ok(Some(Self::match_align(ident, true)?))
         } else {
             Ok(None)
         }
     }
     pub fn valign_toks(&self) -> Result<Option<TokenStream>> {
         if let Some(ref ident) = self.valign {
-            Ok(Some(Self::match_align(ident)?))
+            Ok(Some(Self::match_align(ident, false)?))
         } else {
             Ok(None)
         }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -259,14 +259,8 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         let col = self.cols.text_class(class);
 
         // Draw background:
-        // TODO: this should retrieve a list of rects!
-        let r1 = text.text_glyph_pos(pos, range.start);
-        let r2 = text.text_glyph_pos(pos, range.end);
-        if let (Some((mut p1, ascent, descent)), Some((mut p2, _, _))) = (r1, r2) {
-            p1.1 -= ascent;
-            p2.1 -= descent;
-            let quad = Quad::with_coords(p1, p2);
-            self.draw.rect(self.pass, quad, self.cols.text_sel_bg);
+        for quad in &text.highlight_lines(pos, range) {
+            self.draw.rect(self.pass, *quad, self.cols.text_sel_bg);
         }
 
         // TODO: which should use self.cols.text_sel for the selected range!

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -52,8 +52,8 @@ impl Layout for Clock {
         self.time.prepare(Vec2::INFINITY, font_scale);
 
         let half_size = Size(size.0, size.1 / 2);
-        self.date.set_size(half_size);
-        self.time.set_size(half_size);
+        self.date.update_env(|env| env.set_bounds(half_size.into()));
+        self.time.update_env(|env| env.set_bounds(half_size.into()));
         self.date_pos = pos + Size(0, size.1 - half_size.1);
         self.time_pos = pos;
     }
@@ -133,10 +133,13 @@ impl Handler for Clock {
 
 impl Clock {
     fn new() -> Self {
-        let mut date = PreparedText::new("0000-00-00".into(), false);
-        let mut time = PreparedText::new("00:00:00".into(), false);
-        date.set_alignment(Align::Centre, Align::Centre);
-        time.set_alignment(Align::Centre, Align::Centre);
+        let env = kas::text::Environment {
+            halign: Align::Centre,
+            valign: Align::Centre,
+            ..Default::default()
+        };
+        let date = PreparedText::new_with_env(env.clone(), "0000-00-00".into());
+        let time = PreparedText::new_with_env(env, "00:00:00".into());
         Clock {
             core: Default::default(),
             date_pos: Coord::ZERO,

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget(row=1, col=1, cspan=3)] _ = Label::new(lipsum),
                 #[widget(row=1, col=4)] _ = CheckBoxBare::new(),
                 #[widget(row=2, col=0)] _ = Label::new("Text"),
-                #[widget(row=2, col=2, cspan=2, rspan=2)] _ = Label::new(crasit),
+                #[widget(row=2, col=2, cspan=2, rspan=2, halign=stretch)] _ = Label::new(crasit),
                 #[widget(row=3, col=1)] _ = EditBox::new("A small\nsample\nof text").multi_line(true),
                 #[widget(row=0, col=3)] _ = Label::new("<->"),
             }

--- a/src/data.rs
+++ b/src/data.rs
@@ -114,7 +114,7 @@ pub struct CoreData {
 ///     .apply(rect);
 /// // self.core.rect = rect;
 /// ```
-#[derive(Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct AlignHints {
     pub horiz: Option<Align>,
     pub vert: Option<Align>,
@@ -127,6 +127,11 @@ impl AlignHints {
     /// Construct with optional horiz. and vert. alignment
     pub const fn new(horiz: Option<Align>, vert: Option<Align>) -> Self {
         Self { horiz, vert }
+    }
+
+    /// Unwrap type's alignments or substitute parameters
+    pub fn unwrap_or(self, horiz: Align, vert: Align) -> (Align, Align) {
+        (self.horiz.unwrap_or(horiz), self.vert.unwrap_or(vert))
     }
 
     /// Complete via defaults and ideal size information

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -628,7 +628,7 @@ mod test {
         let _size = draw_handle.size_handle(|h| h.frame());
 
         let pos = Coord::ZERO;
-        let text = PreparedText::new("sample".into(), false);
+        let text = PreparedText::new("sample".into());
         draw_handle.text_selected(pos, &text, .., TextClass::Label)
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -130,8 +130,8 @@
 //! is greater than the child's ideal size. These parameters are used to
 //! construct an [`AlignHints`] which is passed into [`Layout::set_rect`].
 //!
-//! -   `halign = ...` — one of `begin`, `centre`, `end`, `stretch`
-//! -   `valign = ...` — one of `begin`, `centre`, `end`, `stretch`
+//! -   `halign = ...` — one of `default`, `left`, `centre`, `center`, `right`, `stretch`
+//! -   `valign = ...` — one of `default`, `top`, `centre`, `center`, `bottom`, `stretch`
 //!
 //! **Layout data storage**
 //!

--- a/src/text.rs
+++ b/src/text.rs
@@ -112,12 +112,20 @@ impl PreparedText {
 
     /// Find the starting position (top-left) of the glyph at the given index
     ///
-    /// May panic on invalid byte index.
+    /// Returns `Some(pos, ascent, descent)` on success, where `pos.1 - ascent`
+    /// and `pos.1 - descent` are the top and bottom of the glyph position.
     ///
-    /// This method is only partially compatible with mult-line text.
-    /// Ideally an external line-breaker should be used.
-    pub fn text_glyph_pos(&self, pos: Coord, index: usize) -> Vec2 {
-        Vec2::from(pos) + Vec2::from(self.0.text_glyph_pos(index))
+    /// Note that this only searches *visible* text sections for a valid index.
+    /// In case the `index` is not within a slice of visible text, this returns
+    /// `None`. So long as `index` is within a visible slice (or at its end),
+    /// it does not need to be on a valid code-point.
+    ///
+    /// Note: if the text's bounding rect does not start at the origin, then
+    /// the coordinates of the top-left corner should be added to this result.
+    pub fn text_glyph_pos(&self, pos: Coord, index: usize) -> Option<(Vec2, f32, f32)> {
+        self.0
+            .text_glyph_pos(index)
+            .map(|result| (Vec2::from(pos) + Vec2::from(result.0), result.1, result.2))
     }
 
     /// Find the text index for the glyph nearest the given `coord`, relative to `pos`

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -54,11 +54,10 @@ impl<M: Clone + Debug + 'static> Layout for TextButton<M> {
         // In practice, it sometimes overflows a tiny bit, and looks better if
         // we let it overflow. Since the text is centred this is okay.
         // self.label_rect = ...
-        self.label.set_size(rect.size);
-        self.label.set_alignment(
-            align.horiz.unwrap_or(Align::Centre),
-            align.vert.unwrap_or(Align::Centre),
-        );
+        self.label.update_env(|env| {
+            env.set_bounds(rect.size.into());
+            env.set_align(align.unwrap_or(Align::Centre, Align::Centre));
+        });
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
@@ -77,7 +76,7 @@ impl<M: Clone + Debug + 'static> TextButton<M> {
     /// the parent (or other ancestor).
     pub fn new<S: Into<AccelString>>(label: S, msg: M) -> Self {
         let label = label.into();
-        let text = PreparedText::new(label.get(false).into(), false);
+        let text = PreparedText::new(label.get(false).into());
         let keys2 = label.take_keys();
         TextButton {
             core: Default::default(),

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -43,11 +43,10 @@ impl<M: Clone + Debug + 'static> kas::Layout for ComboBox<M> {
 
     fn set_rect(&mut self, rect: Rect, align: kas::AlignHints) {
         self.core.rect = rect;
-        self.label.set_size(rect.size);
-        self.label.set_alignment(
-            align.horiz.unwrap_or(Align::Centre),
-            align.vert.unwrap_or(Align::Centre),
-        );
+        self.label.update_env(|env| {
+            env.set_bounds(rect.size.into());
+            env.set_align(align.unwrap_or(Align::Centre, Align::Centre));
+        });
     }
 
     fn spatial_range(&self) -> (usize, usize) {
@@ -89,7 +88,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     #[inline]
     fn new_(column: Vec<MenuEntry<u64>>, messages: Vec<M>) -> Self {
         assert!(column.len() > 0, "ComboBox: expected at least one choice");
-        let label = PreparedText::new(column[0].clone_text(), false);
+        let label = PreparedText::new(column[0].clone_text());
         ComboBox {
             core: Default::default(),
             label,

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -206,7 +206,12 @@ impl<G: 'static> Layout for EditBox<G> {
 
         self.core.rect = rect;
         self.text_pos = rect.pos + self.frame_offset;
-        self.prepared.set_size(rect.size - self.frame_size);
+        let size = rect.size - self.frame_size;
+        let multi_line = self.multi_line;
+        self.prepared.update_env(|env| {
+            env.set_bounds(size.into());
+            env.set_wrap(multi_line);
+        });
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
@@ -242,7 +247,7 @@ impl EditBox<EditVoid> {
             editable: true,
             multi_line: false,
             text: text.clone(),
-            prepared: PreparedText::new(text.into(), false),
+            prepared: PreparedText::new(text.into()),
             edit_pos,
             sel_pos: edit_pos,
             old_state: None,
@@ -340,7 +345,6 @@ impl<G> EditBox<G> {
     /// Set whether this `EditBox` shows multiple text lines
     pub fn multi_line(mut self, multi_line: bool) -> Self {
         self.multi_line = multi_line;
-        self.prepared.set_line_wrap(multi_line);
         self
     }
 

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -24,7 +24,7 @@ impl Layout for Label {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let mut prepared;
         let text = if let Some(s) = self.reserve {
-            prepared = PreparedText::new(s.into(), true);
+            prepared = PreparedText::new_wrap(s.into());
             &mut prepared
         } else {
             &mut self.label
@@ -40,11 +40,10 @@ impl Layout for Label {
 
     fn set_rect(&mut self, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        self.label.set_size(rect.size);
-        self.label.set_alignment(
-            align.horiz.unwrap_or(Align::Default),
-            align.vert.unwrap_or(Align::Centre),
-        );
+        self.label.update_env(|env| {
+            env.set_bounds(rect.size.into());
+            env.set_align(align.unwrap_or(Align::Default, Align::Centre));
+        });
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
@@ -58,7 +57,7 @@ impl Label {
         Label {
             core: Default::default(),
             reserve: None,
-            label: PreparedText::new(label.into().deref().into(), true),
+            label: PreparedText::new_wrap(label.into().deref().into()),
         }
     }
 
@@ -110,11 +109,10 @@ impl Layout for AccelLabel {
 
     fn set_rect(&mut self, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        self.label.set_size(rect.size);
-        self.label.set_alignment(
-            align.horiz.unwrap_or(Align::Default),
-            align.vert.unwrap_or(Align::Centre),
-        );
+        self.label.update_env(|env| {
+            env.set_bounds(rect.size.into());
+            env.set_align(align.unwrap_or(Align::Default, Align::Centre));
+        });
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _mgr: &ManagerState, _: bool) {
@@ -127,7 +125,7 @@ impl AccelLabel {
     /// Construct a new, empty instance
     pub fn new<T: Into<AccelString>>(label: T) -> Self {
         let label = label.into();
-        let text = PreparedText::new(label.get(false).into(), false);
+        let text = PreparedText::new(label.get(false).into());
         let keys = label.take_keys();
         AccelLabel {
             core: Default::default(),

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -49,11 +49,10 @@ impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
 
     fn set_rect(&mut self, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        self.label.set_size(rect.size);
-        self.label.set_alignment(
-            align.horiz.unwrap_or(Align::Default),
-            align.vert.unwrap_or(Align::Centre),
-        );
+        self.label.update_env(|env| {
+            env.set_bounds(rect.size.into());
+            env.set_align(align.unwrap_or(Align::Default, Align::Centre));
+        });
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
@@ -72,7 +71,7 @@ impl<M: Clone + Debug + 'static> MenuEntry<M> {
     /// simple `Copy` type (e.g. an enum).
     pub fn new<S: Into<AccelString>>(label: S, msg: M) -> Self {
         let label = label.into();
-        let text = PreparedText::new(label.get(false).into(), false);
+        let text = PreparedText::new(label.get(false).into());
         let keys = label.take_keys();
         MenuEntry {
             core: Default::default(),

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -61,7 +61,7 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
     #[inline]
     pub fn new_with_direction<S: Into<AccelString>>(direction: D, label: S, list: Vec<W>) -> Self {
         let label = label.into();
-        let text = PreparedText::new(label.get(false).into(), false);
+        let text = PreparedText::new(label.get(false).into());
         let keys = label.take_keys();
         SubMenu {
             core: Default::default(),
@@ -118,11 +118,10 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
 
     fn set_rect(&mut self, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        self.label.set_size(rect.size);
-        self.label.set_alignment(
-            align.horiz.unwrap_or(Align::Default),
-            align.vert.unwrap_or(Align::Centre),
-        );
+        self.label.update_env(|env| {
+            env.set_bounds(rect.size.into());
+            env.set_align(align.unwrap_or(Align::Default, Align::Centre));
+        });
     }
 
     fn spatial_range(&self) -> (usize, usize) {


### PR DESCRIPTION
This gets us back to feature parity with the situation prior to kas-text, plus has correct multi-line highlighting.

Corresponding PR: https://github.com/kas-gui/kas-text/pull/5