### PR TITLE
Shaping + Text-navigation; Rust 1.45 update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "d4a32ac8995c2f122ccb4ffb92a6d17aeecdfa2b"
+rev = "b9e19c2105d9734ba396841d4d0e64ae688584b0"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ nightly = []
 # This flag does not change the API, only built documentation.
 internal_doc = []
 
+# Enables text shaping via HarfBuzz
+# Shaping is part of Complex Text Layout, used for ligatures and where form
+# depends on position and context (especially important for Arabic).
+shaping = ["kas-text/shaping"]
+
 [dependencies]
 log = "0.4"
 smallvec = "1.4"
@@ -35,7 +40,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "77b9a3fa35e4c661830ade18bfcd8a841e0c259a"
+rev = "d4a32ac8995c2f122ccb4ffb92a6d17aeecdfa2b"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "06a2668a749b6ef4f20d5de451442f02629d749a"
+rev = "77b9a3fa35e4c661830ade18bfcd8a841e0c259a"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ KAS is compatible with **stable rustc**. Using nightly Rust is advantageous:
 
 -   Proceedural macros emit better diagnostics. In some cases, diagnostics are
     missed without nightly rustc, hence **nightly is recommended for development**.
--   The `make_widget!` macro will require nightly Rust until the
-    `proc_macro_hygiene` feature is complete.
-    Usage of this macro is optional; most examples do so for convenience.
 -   A few other minor features are nightly-only. See *feature flags*
     documentation below and in other crates' READMEs.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -189,9 +189,6 @@ features, though not all of these issues have a clear solution:
 
 -   #25 lists existing (optional) usage of Rust nightly features; all of these
     would be great to have in stable Rust but must are not essential
--   `proc_macro_hygiene` is used to enable the `make_widget!` macro; this is not
-    an *essential* part of KAS but is *extremely useful*; `proc-macro-hack`
-    provides a workaround (with significant limitations)
 -   #15 documents a major limitation of `make_widget!`; Rust's RFC 2524 provides
     a solution but has not been accepted or implemented
 -   #11 documents one example of a bad error message; another case of bad error

--- a/kas-macros/README.md
+++ b/kas-macros/README.md
@@ -16,7 +16,6 @@ has some benefits:
 
 -   More macro diagnostics are emitted, resulting in better error messages
     (without this, some errors may not even be reported)
--   With `#![feature(proc_macro_hygiene)]`, the `make_widget!` macro may be used
 
 
 Copyright and Licence

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -309,8 +309,6 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// Macro to create a widget with anonymous type
 ///
 /// See the [`kas::macros`](../kas/macros/index.html) module documentation.
-///
-/// Currently usage of this macro requires `#![feature(proc_macro_hygiene)]`.
 #[proc_macro]
 pub fn make_widget(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut find_handler_ty_buf: Vec<(Ident, Type)> = vec![];

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -150,10 +150,6 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         self.dims.line_height
     }
 
-    fn prepare(&mut self, text: &mut PreparedText, _class: TextClass) {
-        text.prepare(Vec2::INFINITY, self.dims.dpp, self.dims.pt_size);
-    }
-
     fn text_bound(
         &mut self,
         text: &mut PreparedText,
@@ -163,11 +159,17 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         let line_height = self.dims.line_height;
         let mut bounds = Vec2::INFINITY;
         if let Some(size) = axis.size_other_if_fixed(false) {
+            bounds.0 = text.env().bounds.0;
             bounds.1 = size as f32;
         } else if let Some(size) = axis.size_other_if_fixed(true) {
             bounds.0 = size as f32;
+            bounds.1 = text.env().bounds.1;
         }
-        text.prepare(bounds, self.dims.dpp, self.dims.pt_size);
+        text.update_env(|env| {
+            env.set_bounds(bounds.into());
+            env.set_dpp(self.dims.dpp);
+            env.set_pt_size(self.dims.pt_size);
+        });
         let bounds = text.required_size();
 
         let margins = (self.dims.margin as u16, self.dims.margin as u16);

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -36,10 +36,11 @@ pub struct DimensionsParams {
 /// Dimensions available within [`DimensionsWindow`]
 #[derive(Clone, Debug)]
 pub struct Dimensions {
-    pub font_id: FontId,
-    pub font_scale: f32,
-    pub font_marker_width: f32,
     pub scale_factor: f32,
+    pub dpp: f32,
+    pub font_id: FontId,
+    pub pt_size: f32,
+    pub font_marker_width: f32,
     pub line_height: u32,
     pub min_line_length: u32,
     pub ideal_line_length: u32,
@@ -52,37 +53,29 @@ pub struct Dimensions {
 }
 
 impl Dimensions {
-    pub fn new(
-        params: DimensionsParams,
-        font_id: FontId,
-        font_size: f32,
-        scale_factor: f32,
-    ) -> Self {
-        let font_scale = font_size * scale_factor;
-        let line_height = font_scale.round() as u32;
+    pub fn new(params: DimensionsParams, font_id: FontId, pt_size: f32, scale_factor: f32) -> Self {
+        let dpp = scale_factor * (96.0 / 72.0);
+        let dpem = dpp * pt_size;
+        let line_height = kas::text::fonts().get(font_id).line_height(dpem).ceil() as u32;
+
         let margin = (params.margin * scale_factor).round() as u32;
         let frame = (params.frame_size * scale_factor).round() as u32;
         Dimensions {
-            font_id,
-            font_scale,
-            font_marker_width: (font_size * (1.0 / 9.0)).round().max(1.0),
             scale_factor,
+            dpp,
+            font_id,
+            pt_size,
+            font_marker_width: (1.6 * scale_factor).round().max(1.0),
             line_height,
-            // We appear to average about 2 characters per line_height
-            // TODO: better to specify in terms of font's 'n' size?
-            min_line_length: line_height * 6,
-            ideal_line_length: line_height * 15,
+            min_line_length: (12.0 * dpem).round() as u32,
+            ideal_line_length: (30.0 * dpem).round() as u32,
             margin,
             frame,
             button_frame: (params.button_frame * scale_factor).round() as u32,
-            checkbox: (font_scale * 0.7).round() as u32 + 2 * (margin + frame),
+            checkbox: (9.0 * dpp).round() as u32 + 2 * (margin + frame),
             scrollbar: Size::from(params.scrollbar_size * scale_factor),
             slider: Size::from(params.slider_size * scale_factor),
         }
-    }
-
-    pub fn edit_marker_size(&self) -> Vec2 {
-        Vec2(self.font_marker_width, self.font_scale)
     }
 }
 
@@ -158,7 +151,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
     }
 
     fn prepare(&mut self, text: &mut PreparedText, _class: TextClass) {
-        text.prepare(Vec2::INFINITY, self.dims.font_scale.into());
+        text.prepare(Vec2::INFINITY, self.dims.dpp, self.dims.pt_size);
     }
 
     fn text_bound(
@@ -174,7 +167,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         } else if let Some(size) = axis.size_other_if_fixed(true) {
             bounds.0 = size as f32;
         }
-        text.prepare(bounds, self.dims.font_scale.into());
+        text.prepare(bounds, self.dims.dpp, self.dims.pt_size);
         let bounds = text.required_size();
 
         let margins = (self.dims.margin as u16, self.dims.margin as u16);

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -32,7 +32,7 @@ impl FlatTheme {
     pub fn new() -> Self {
         FlatTheme {
             font_id: Default::default(),
-            font_size: 18.0,
+            font_size: 12.0,
             cols: ThemeColours::new(),
         }
     }
@@ -273,7 +273,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             let mut p2 = p1;
             p1.1 -= ascent;
             p2.1 -= descent;
-            p2.0 += self.window.dims.edit_marker_size().0;
+            p2.0 += self.window.dims.font_marker_width;
             let quad = Quad::with_coords(p1, p2);
             self.draw.rect(self.pass, quad, col);
         }

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -30,7 +30,7 @@ impl ShadedTheme {
     pub fn new() -> Self {
         ShadedTheme {
             font_id: Default::default(),
-            font_size: 18.0,
+            font_size: 12.0,
             cols: ThemeColours::new(),
         }
     }

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -17,6 +17,9 @@ default = ["clipboard", "stack_dst"]
 # Use Generic Associated Types (experimental)
 gat = ["kas-theme/gat"]
 
+# Enables text shaping
+shaping = ["kas/shaping"]
+
 # Use stack_dst crate for sized unsized types
 stack_dst = ["kas-theme/stack_dst"]
 

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -4,7 +4,6 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 //! Simple calculator example (lots of buttons, grid layout)
-#![feature(proc_macro_hygiene)]
 
 use std::num::ParseFloatError;
 use std::str::FromStr;

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -47,13 +47,19 @@ impl Layout for Clock {
         let pos = rect.pos + (excess * 0.5);
         self.core.rect = Rect { pos, size };
 
-        let font_scale = (size.1 as f32 * 0.125).into();
-        self.date.prepare(Vec2::INFINITY, font_scale);
-        self.time.prepare(Vec2::INFINITY, font_scale);
-
+        // Note: font size is calculated as dpp * pt_size with units pixels/em.
+        // We leave dpp at its default 96/72 and set pt_size based on pixels.
+        // Dimensions are still dependent on fonts.
+        let pt_size = (size.1 as f32 * 0.09).into();
         let half_size = Size(size.0, size.1 / 2);
-        self.date.update_env(|env| env.set_bounds(half_size.into()));
-        self.time.update_env(|env| env.set_bounds(half_size.into()));
+        self.date.update_env(|env| {
+            env.set_pt_size(pt_size);
+            env.set_bounds(half_size.into());
+        });
+        self.time.update_env(|env| {
+            env.set_pt_size(pt_size);
+            env.set_bounds(half_size.into());
+        });
         self.date_pos = pos + Size(0, size.1 - half_size.1);
         self.time_pos = pos;
     }

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -4,7 +4,6 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 //! Counter example (simple button)
-#![feature(proc_macro_hygiene)]
 
 use kas::class::SetText;
 use kas::event::{Manager, VoidMsg, VoidResponse};

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -4,7 +4,6 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 //! Custom theme demo
-#![feature(proc_macro_hygiene)]
 #![cfg_attr(feature = "gat", feature(generic_associated_types))]
 
 use std::cell::Cell;

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -16,7 +16,6 @@
 //! -   hundreds of thousands of widgets has some issues (slow creation,
 //!     very slow activation of a RadioBox in a chain hundreds-of-thousands
 //!     long), but in many ways still performs well in release mode
-#![feature(proc_macro_hygiene)]
 
 use kas::class::{HasString, SetText};
 use kas::event::UpdateHandle;

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -7,7 +7,6 @@
 //!
 //! This is a test-bed to demonstrate most toolkit functionality
 //! (excepting custom graphics).
-#![feature(proc_macro_hygiene)]
 
 use kas::class::HasString;
 use kas::event::{UpdateHandle, VoidResponse};

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -4,7 +4,6 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 //! Gallery of all widgets
-#![feature(proc_macro_hygiene)]
 
 use kas::event::VoidMsg;
 use kas::macros::make_widget;

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -491,7 +491,7 @@ impl event::Handler for Mandlebrot {
 
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         match event {
-            Event::Control(key, _) => {
+            Event::Control(key) => {
                 match key {
                     ControlKey::Home | ControlKey::End => self.reset_view(),
                     ControlKey::PageUp => self.alpha = self.alpha / 2f64.sqrt(),

--- a/kas-wgpu/examples/splitter.rs
+++ b/kas-wgpu/examples/splitter.rs
@@ -4,7 +4,6 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 //! Counter example (simple button)
-#![feature(proc_macro_hygiene)]
 
 use kas::event::{Manager, VoidMsg, VoidResponse};
 use kas::macros::{make_widget, VoidMsg};

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -4,7 +4,6 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 //! Counter example (simple button)
-#![feature(proc_macro_hygiene)]
 
 use std::time::{Duration, Instant};
 

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -4,7 +4,6 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 //! A counter synchronised between multiple windows
-#![feature(proc_macro_hygiene)]
 
 use std::cell::RefCell;
 

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -86,7 +86,8 @@ impl<C: CustomPipe> DrawPipe<C> {
         let flat_round = self.flat_round.new_window(device, size);
         let custom = self.custom.new_window(device, size);
 
-        let glyph_brush = GlyphBrushBuilder::using_fonts(kas::text::fonts().fonts_vec())
+        let fonts = kas::text::fonts().ab_glyph_fonts_vec();
+        let glyph_brush = GlyphBrushBuilder::using_fonts(fonts)
             .depth_stencil_state(super::GLPYH_DEPTH_DESC)
             .build(device, TEX_FORMAT);
 

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -5,7 +5,7 @@
 
 //! Text drawing API for `kas_wgpu`
 
-use wgpu_glyph::{ab_glyph, Extra, SectionGlyph};
+use wgpu_glyph::{ab_glyph, Extra, SectionGlyph, FontId};
 
 use super::{CustomWindow, DrawWindow};
 use kas::draw::{Colour, DrawText, Pass};
@@ -28,7 +28,7 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
                 scale,
                 position: pos + glyph.position.into(),
             },
-            font_id: font_id.into(),
+            font_id: FontId(font_id.get()),
         });
         let extra = vec![Extra {
             color: col.into(),

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -5,7 +5,7 @@
 
 //! Text drawing API for `kas_wgpu`
 
-use wgpu_glyph::{ab_glyph, Extra, SectionGlyph, FontId};
+use wgpu_glyph::{ab_glyph, Extra, FontId, SectionGlyph};
 
 use super::{CustomWindow, DrawWindow};
 use kas::draw::{Colour, DrawText, Pass};

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -17,6 +17,7 @@ mod shaders;
 
 use kas::geom::Rect;
 use wgpu::{CompareFunction, DepthStencilStateDescriptor, TextureFormat};
+use wgpu_glyph::ab_glyph::FontRef;
 
 pub(crate) use shaders::ShaderManager;
 
@@ -66,7 +67,7 @@ pub struct DrawPipe<C> {
     custom: C,
 }
 
-type GlyphBrush = wgpu_glyph::GlyphBrush<DepthStencilStateDescriptor, kas::text::Font>;
+type GlyphBrush = wgpu_glyph::GlyphBrush<DepthStencilStateDescriptor, &'static FontRef<'static>>;
 
 /// Per-window pipeline data
 pub struct DrawWindow<CW: CustomWindow> {

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -358,7 +358,7 @@ pub trait DrawHandleExt: DrawHandle {
         let end = match range.end_bound() {
             Bound::Included(n) => *n + 1,
             Bound::Excluded(n) => *n,
-            Bound::Unbounded => text.raw_text_len(),
+            Bound::Unbounded => text.text_len(),
         };
         let range = Range { start, end };
         self.text_selected_range(pos, text, range, class);

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -136,16 +136,15 @@ pub trait SizeHandle {
     /// The height of a line of text
     fn line_height(&self, class: TextClass) -> u32;
 
-    /// Prepare a text
+    /// Update a [`PreparedText`] and get a size bound
     ///
-    /// This must be done before drawing to avoid a "not ready" error.
-    fn prepare(&mut self, text: &mut PreparedText, class: TextClass);
-
-    /// Get a text label size bound
+    /// First, this method updates the text's [`Environment`]: `bounds`, `dpp`
+    /// and `pt_size` are set. Second, the text is prepared (which is necessary
+    /// to calculate size requirements). Finally, this converts the requirements
+    /// to a [`SizeRules`] value and returns it.
     ///
-    /// This also prepares the text.
-    ///
-    /// Sizing requirements of [`DrawHandle::text`].
+    /// Usually this method is used in [`Layout::size_rules`], then
+    /// [`PreparedText::update_env`] is used in [`Layout::set_rect`].
     fn text_bound(
         &mut self,
         text: &mut PreparedText,
@@ -388,9 +387,6 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
     fn line_height(&self, class: TextClass) -> u32 {
         self.deref().line_height(class)
     }
-    fn prepare(&mut self, text: &mut PreparedText, class: TextClass) {
-        self.deref_mut().prepare(text, class)
-    }
     fn text_bound(
         &mut self,
         text: &mut PreparedText,
@@ -445,9 +441,6 @@ where
 
     fn line_height(&self, class: TextClass) -> u32 {
         self.deref().line_height(class)
-    }
-    fn prepare(&mut self, text: &mut PreparedText, class: TextClass) {
-        self.deref_mut().prepare(text, class)
     }
     fn text_bound(
         &mut self,

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -7,7 +7,7 @@
 
 #[allow(unused)]
 use super::{GrabMode, Manager, Response}; // for doc-links
-use super::{ModifiersState, MouseButton, UpdateHandle, VirtualKeyCode};
+use super::{MouseButton, UpdateHandle, VirtualKeyCode};
 
 use crate::geom::{Coord, DVec2};
 use crate::{WidgetId, WindowId};
@@ -39,7 +39,7 @@ pub enum Event {
     /// [`ControlKey::Return`]. Without char focus, both Space and Return keys
     /// send [`Event::Activate`] to the widget with nav focus (if any, otherwise
     /// to the nav fallback, if any).
-    Control(ControlKey, ModifiersState),
+    Control(ControlKey),
     /// Widget lost keyboard input focus
     LostCharFocus,
     /// Widget receives a character of text input

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -255,7 +255,7 @@ impl<'a> Manager<'a> {
             if vkey == VK::Escape {
                 self.set_char_focus(None);
             } else if let Some(key) = ControlKey::new(vkey) {
-                self.send_event(widget, id, Event::Control(key, self.mgr.modifiers));
+                self.send_event(widget, id, Event::Control(key));
             }
             return;
         }
@@ -283,7 +283,7 @@ impl<'a> Manager<'a> {
                     if vkey == VK::Space || vkey == VK::Return || vkey == VK::NumpadEnter {
                         id_action = Some((nav_id, Event::Activate));
                     } else if let Some(nav_key) = ControlKey::new(vkey) {
-                        id_action = Some((nav_id, Event::Control(nav_key, self.mgr.modifiers)));
+                        id_action = Some((nav_id, Event::Control(nav_key)));
                     }
                 }
 
@@ -291,12 +291,12 @@ impl<'a> Manager<'a> {
                     // Next priority goes to pop-up widget
                     if let Some(popup) = self.mgr.popups.last() {
                         if let Some(key) = ControlKey::new(vkey) {
-                            let ev = Event::Control(key, self.mgr.modifiers);
+                            let ev = Event::Control(key);
                             id_action = Some((popup.1.parent, ev));
                         }
                     } else if let Some(id) = self.mgr.nav_fallback {
                         if let Some(key) = ControlKey::new(vkey) {
-                            id_action = Some((id, Event::Control(key, self.mgr.modifiers)));
+                            id_action = Some((id, Event::Control(key)));
                         }
                     }
                 }

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -75,6 +75,12 @@ impl ManagerState {
 
 /// Public API (around toolkit functionality)
 impl<'a> Manager<'a> {
+    /// Get the current modifier state
+    #[inline]
+    pub fn modifiers(&self) -> ModifiersState {
+        self.mgr.modifiers
+    }
+
     /// Schedule an update
     ///
     /// Widgets requiring animation should schedule an update; as a result,

--- a/src/event/manager/mgr_tk.rs
+++ b/src/event/manager/mgr_tk.rs
@@ -396,7 +396,7 @@ impl<'a> Manager<'a> {
                             '\u{1A}' => ControlKey::Undo, // also redo; we can't differentiate
                             _ => return,
                         };
-                        let event = Event::Control(key, self.mgr.modifiers);
+                        let event = Event::Control(key);
                         self.send_event(widget, id, event);
                     } else {
                         let event = Event::ReceivedCharacter(c);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -298,19 +298,14 @@
 //! Its usage is convenient (and widespread in the examples) but not required.
 //!
 //! But first, a **warning**: this macro is complex (especially with regards to
-//! elided types) and very dependent on **nightly rustc**. It would be much
+//! elided types) and tends to produce terrible error messages. Accessing fields
+//! of the generated widgets from outside code is complicated. It would be much
 //! improved with [RFC 2524](https://github.com/rust-lang/rfcs/pull/2524)
-//! (essentially, anonymous types). And it requires the user enable the
-//! following feature:
-//! ```
-//! #![feature(proc_macro_hygiene)]
-//! ```
+//! (essentially, anonymous types). And it requires Rust 1.45.0 (or nightly).
 //!
 //! Lets start with some examples:
 //!
 //! ```
-//! #![feature(proc_macro_hygiene)]
-//!
 //! use kas::prelude::*;
 //! use kas::widget::{Label, TextButton, Window};
 //!

--- a/src/text.rs
+++ b/src/text.rs
@@ -64,21 +64,6 @@ impl PreparedText {
         self.0.text_len()
     }
 
-    /// Layout text
-    ///
-    /// The given bounds are used to influence line-wrapping (if enabled).
-    /// [`Vec2::INFINITY`] may be used where no bounds are required.
-    ///
-    /// The `dpp` (pixels/point) and `pt_size` (points/em) values set font size.
-    pub fn prepare(&mut self, bounds: Vec2, dpp: f32, pt_size: f32) {
-        self.0.update_env(|env| {
-            env.set_bounds(bounds.into());
-            env.set_dpp(dpp);
-            env.set_pt_size(pt_size);
-        });
-        self.0.prepare();
-    }
-
     /// Set the text
     ///
     /// Returns [`TkAction::Resize`] when it is necessary to call [`PreparedText::prepare`].
@@ -96,12 +81,9 @@ impl PreparedText {
         self.0.env()
     }
 
-    /// Update the environment
-    ///
-    /// This calls [`PreparedText::prepare`] internally.
+    /// Update the environment and prepare for drawing
     pub fn update_env<F: FnOnce(&mut UpdateEnv)>(&mut self, f: F) {
         self.0.update_env(f);
-        self.0.prepare();
     }
 
     pub fn positioned_glyphs<G, F: Fn(&str, FontId, PxScale, Glyph) -> G>(&self, f: F) -> Vec<G> {

--- a/src/text.rs
+++ b/src/text.rs
@@ -29,14 +29,18 @@ impl PreparedText {
     /// This struct must be made ready for use before
     /// To do so, call [`PreparedText::prepare`].
     pub fn new(text: rich::Text) -> Self {
-        Self::new_with_env(Environment::new(), text)
+        // Note: wrap is on by default for Environment, but here it makes more
+        // sense to turn it off in the default constructor.
+        let mut env = Environment::new();
+        env.wrap = false;
+        Self::new_with_env(env, text)
     }
 
     /// New multi-line text
     ///
     /// This differs from [`PreparedText::new`] only in that it enables line wrapping.
     pub fn new_wrap(text: rich::Text) -> Self {
-        Self::new_with_env(Environment::new_wrap(), text)
+        Self::new_with_env(Environment::new(), text)
     }
 
     /// New multi-line text
@@ -65,11 +69,12 @@ impl PreparedText {
     /// The given bounds are used to influence line-wrapping (if enabled).
     /// [`Vec2::INFINITY`] may be used where no bounds are required.
     ///
-    /// The `scale` is used to set the base scale: rich text may adjust this.
-    pub fn prepare(&mut self, bounds: Vec2, scale: FontScale) {
+    /// The `dpp` (pixels/point) and `pt_size` (points/em) values set font size.
+    pub fn prepare(&mut self, bounds: Vec2, dpp: f32, pt_size: f32) {
         self.0.update_env(|env| {
             env.set_bounds(bounds.into());
-            env.set_font_scale(scale);
+            env.set_dpp(dpp);
+            env.set_pt_size(pt_size);
         });
         self.0.prepare();
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -54,10 +54,10 @@ impl PreparedText {
 
     /// Length of raw text
     ///
-    /// It is valid to reference text within the range `0..raw_text_len()`,
+    /// It is valid to reference text within the range `0..text_len()`,
     /// even if not all text within this range will be displayed (due to runs).
-    pub fn raw_text_len(&self) -> usize {
-        self.0.raw_text_len()
+    pub fn text_len(&self) -> usize {
+        self.0.text_len()
     }
 
     /// Layout text
@@ -110,6 +110,45 @@ impl PreparedText {
         self.0.required_size().into()
     }
 
+    /// Get the number of lines
+    pub fn num_lines(&self) -> usize {
+        self.0.num_lines()
+    }
+
+    /// Find the line containing text `index`
+    ///
+    /// Returns the line number and the text-range of the line.
+    ///
+    /// Returns `None` in case `index` does not line on or at the end of a line
+    /// (which means either that `index` is beyond the end of the text or that
+    /// `index` is within a mult-byte line break).
+    pub fn find_line(&self, index: usize) -> Option<(usize, std::ops::Range<usize>)> {
+        self.0.find_line(index)
+    }
+
+    /// Get the range of a line, by line number
+    pub fn line_range(&self, line: usize) -> Option<std::ops::Range<usize>> {
+        self.0.line_range(line)
+    }
+
+    /// Find the next glyph index to the left of the given glyph
+    ///
+    /// Warning: this counts *glyphs*, which makes the result dependent on
+    /// text shaping. Combining diacritics *may* count as discrete glyphs.
+    /// Ligatures will count as a single glyph.
+    pub fn nav_left(&self, index: usize) -> usize {
+        self.0.nav_left(index)
+    }
+
+    /// Find the next glyph index to the right of the given glyph
+    ///
+    /// Warning: this counts *glyphs*, which makes the result dependent on
+    /// text shaping. Combining diacritics *may* count as discrete glyphs.
+    /// Ligatures will count as a single glyph.
+    pub fn nav_right(&self, index: usize) -> usize {
+        self.0.nav_right(index)
+    }
+
     /// Find the starting position (top-left) of the glyph at the given index
     ///
     /// Returns `Some(pos, ascent, descent)` on success, where `pos.1 - ascent`
@@ -126,6 +165,32 @@ impl PreparedText {
         self.0
             .text_glyph_pos(index)
             .map(|result| (Vec2::from(pos) + Vec2::from(result.0), result.1, result.2))
+    }
+
+    /// Find the starting position (top-left) of the glyph at the given index
+    ///
+    /// This differs from [`PreparedText::text_glyph_pos`] in that it does not
+    /// offset the result by a coordinate `pos`.
+    pub fn text_glyph_rel_pos(&self, index: usize) -> Option<(Vec2, f32, f32)> {
+        self.0
+            .text_glyph_pos(index)
+            .map(|result| (Vec2::from(result.0), result.1, result.2))
+    }
+
+    /// Find the text index for the glyph nearest the given `coord`, relative to `pos`
+    ///
+    /// This includes the index immediately after the last glyph, thus
+    /// `result ≤ text.len()`.
+    pub fn text_index_nearest(&self, pos: Coord, coord: Coord) -> usize {
+        self.0.text_index_nearest((coord - pos).into())
+    }
+
+    /// Find the text index nearest horizontal-coordinate `x` on `line`
+    ///
+    /// Unlike [`PreparedText::text_index_nearest`], this does not offset `x`.
+    /// It also allows the line to be specified explicitly.
+    pub fn line_index_nearest(&self, line: usize, x: f32) -> Option<usize> {
+        self.0.line_index_nearest(line, x)
     }
 
     /// Yield a sequence of rectangles to highlight a given range, by lines
@@ -168,13 +233,5 @@ impl PreparedText {
             .iter()
             .map(|(p1, p2)| Quad::with_coords(pos + Vec2::from(*p1), pos + Vec2::from(*p2)))
             .collect()
-    }
-
-    /// Find the text index for the glyph nearest the given `coord`, relative to `pos`
-    ///
-    /// This includes the index immediately after the last glyph, thus
-    /// `result ≤ text.len()`.
-    pub fn text_index_nearest(&self, pos: Coord, coord: Coord) -> usize {
-        self.0.text_index_nearest((coord - pos).into())
     }
 }

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -200,7 +200,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
         match r {
             Response::None => Response::None,
             Response::Unhandled(ev) => match ev {
-                Event::Control(key, modifiers) => {
+                Event::Control(key) => {
                     let next = |mgr: &mut Manager, s, clr, rev| {
                         if clr {
                             mgr.clear_nav_focus();
@@ -213,7 +213,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
                         ControlKey::Down => next(mgr, self, false, false),
                         ControlKey::Home => next(mgr, self, true, false),
                         ControlKey::End => next(mgr, self, true, true),
-                        key => Response::Unhandled(Event::Control(key, modifiers)),
+                        key => Response::Unhandled(Event::Control(key)),
                     }
                 }
                 ev => Response::Unhandled(ev),

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -11,7 +11,7 @@ use unicode_segmentation::GraphemeCursor;
 
 use kas::class::HasString;
 use kas::draw::{DrawHandleExt, TextClass};
-use kas::event::{ControlKey, GrabMode, ModifiersState};
+use kas::event::{ControlKey, GrabMode};
 use kas::prelude::*;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -400,12 +400,7 @@ impl<G> EditBox<G> {
         EditAction::Edit
     }
 
-    fn control_key(
-        &mut self,
-        mgr: &mut Manager,
-        key: ControlKey,
-        modifiers: ModifiersState,
-    ) -> EditAction {
+    fn control_key(&mut self, mgr: &mut Manager, key: ControlKey) -> EditAction {
         if !self.editable {
             return EditAction::None;
         }
@@ -415,7 +410,7 @@ impl<G> EditBox<G> {
         let pos = self.edit_pos;
         let selection = self.selection();
         let have_sel = selection.end > selection.start;
-        let shift = modifiers.shift();
+        let shift = mgr.modifiers().shift();
         let string;
 
         enum Action<'a> {
@@ -641,7 +636,7 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                 let r = G::focus_lost(self);
                 r.map(|msg| msg.into()).unwrap_or(Response::None)
             }
-            Event::Control(key, modifiers) => match self.control_key(mgr, key, modifiers) {
+            Event::Control(key) => match self.control_key(mgr, key) {
                 EditAction::None => Response::None,
                 EditAction::Activate => G::activate(self).into(),
                 EditAction::Edit => G::edit(self).into(),

--- a/src/widget/menu/menubar.rs
+++ b/src/widget/menu/menubar.rs
@@ -163,7 +163,7 @@ impl<D: Directional, W: Menu<Msg = M>, M> event::Handler for MenuBar<D, W> {
                     self.menu_path(mgr, None);
                 }
             }
-            Event::Control(key, modifiers) => {
+            Event::Control(key) => {
                 // Arrow keys can switch to the next / previous menu.
                 let is_vert = self.bar.direction().is_vertical();
                 let reverse = self.bar.direction().is_reversed()
@@ -172,7 +172,7 @@ impl<D: Directional, W: Menu<Msg = M>, M> event::Handler for MenuBar<D, W> {
                         ControlKey::Right if !is_vert => false,
                         ControlKey::Up if is_vert => true,
                         ControlKey::Down if is_vert => false,
-                        key => return Response::Unhandled(Event::Control(key, modifiers)),
+                        key => return Response::Unhandled(Event::Control(key)),
                     };
 
                 for i in 0..self.bar.len() {

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -158,12 +158,12 @@ impl<D: Directional, M, W: Menu<Msg = M>> event::Handler for SubMenu<D, W> {
                 debug_assert_eq!(Some(id), self.popup_id);
                 self.popup_id = None;
             }
-            Event::Control(key, modifiers) => match (self.direction.as_direction(), key) {
+            Event::Control(key) => match (self.direction.as_direction(), key) {
                 (Direction::Left, ControlKey::Left) => self.open_menu(mgr),
                 (Direction::Right, ControlKey::Right) => self.open_menu(mgr),
                 (Direction::Up, ControlKey::Up) => self.open_menu(mgr),
                 (Direction::Down, ControlKey::Down) => self.open_menu(mgr),
-                (_, key) => return Response::Unhandled(Event::Control(key, modifiers)),
+                (_, key) => return Response::Unhandled(Event::Control(key)),
             },
             event => return Response::Unhandled(event),
         }
@@ -193,7 +193,7 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
 
             match r {
                 Response::Unhandled(ev) => match ev {
-                    Event::Control(key, modifiers) if self.popup_id.is_some() => {
+                    Event::Control(key) if self.popup_id.is_some() => {
                         if self.popup_id.is_some() {
                             let dir = self.direction.as_direction();
                             let inner_vert = self.list.inner.direction().is_vertical();
@@ -216,7 +216,7 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
                                 ControlKey::Right if dir == Left => self.close_menu(mgr),
                                 ControlKey::Up if dir == Down => self.close_menu(mgr),
                                 ControlKey::Down if dir == Up => self.close_menu(mgr),
-                                key => return Response::Unhandled(Event::Control(key, modifiers)),
+                                key => return Response::Unhandled(Event::Control(key)),
                             }
                         }
                         Response::None

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -329,7 +329,7 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
         };
 
         match event {
-            Event::Control(key, modifiers) => {
+            Event::Control(key) => {
                 let delta = match key {
                     ControlKey::Left => LineDelta(-1.0, 0.0),
                     ControlKey::Right => LineDelta(1.0, 0.0),
@@ -351,7 +351,7 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
                     ControlKey::PageDown => {
                         PixelDelta(Coord(0, -(self.core.rect.size.1 as i32 / 2)))
                     }
-                    key => return Response::Unhandled(Event::Control(key, modifiers)),
+                    key => return Response::Unhandled(Event::Control(key)),
                 };
                 scroll(self, mgr, delta)
             }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -249,7 +249,7 @@ impl<T: SliderType, D: Directional> event::SendEvent for Slider<T, D> {
             }
         } else {
             match event {
-                Event::Control(key, modifiers) => {
+                Event::Control(key) => {
                     let rev = self.direction.is_reversed();
                     let v = match key {
                         ControlKey::Left | ControlKey::Up => match rev {
@@ -273,7 +273,7 @@ impl<T: SliderType, D: Directional> event::SendEvent for Slider<T, D> {
                         }
                         ControlKey::Home => self.range.0,
                         ControlKey::End => self.range.1,
-                        key => return Response::Unhandled(Event::Control(key, modifiers)),
+                        key => return Response::Unhandled(Event::Control(key)),
                     };
                     let action = self.set_value(v);
                     return if action == TkAction::None {


### PR DESCRIPTION
KAS-text update: implement most text navigation (Home, Ctrl+Home, Ctrl+Left, Up, PageDown, etc.)
The Ctrl+Left/Right part isn't quite right, but left/right navigation needs re-writing when we get to bidirectional text support anyway.

Additionally: with the Rust 1.45 release we no longer require proc_macro_hygiene!

Depends on: https://github.com/kas-gui/kas-text/pull/6