### PR TITLE
Update kas-text (navigation)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "b9e19c2105d9734ba396841d4d0e64ae688584b0"
+rev = "79d2f680f5b11f8d56c2dba2caaad09ba2fa9902"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -177,7 +177,11 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         });
         let bounds = text.required_size();
 
-        let margins = (self.dims.inner_margin as u16, self.dims.inner_margin as u16);
+        let margin = match class {
+            TextClass::Label | TextClass::LabelSingle => self.dims.outer_margin,
+            TextClass::Button | TextClass::Edit | TextClass::EditMulti => self.dims.inner_margin,
+        } as u16;
+        let margins = (margin, margin);
         if axis.is_horizontal() {
             let bound = bounds.0 as u32;
             let min = self.dims.min_line_length;

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -270,7 +270,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
 
     fn edit_marker(&mut self, pos: Coord, text: &PreparedText, class: TextClass, byte: usize) {
         let col = self.cols.text_class(class);
-        if let Some((mut p1, ascent, descent)) = text.text_glyph_pos(pos + self.offset, byte) {
+        for (mut p1, ascent, descent) in text.text_glyph_pos(pos + self.offset, byte) {
             let mut p2 = p1;
             p1.1 -= ascent;
             p2.1 -= descent;

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -39,8 +39,8 @@ impl FlatTheme {
 }
 
 const DIMS: DimensionsParams = DimensionsParams {
-    outer_margin: 4.0,
-    inner_margin: 2.0,
+    outer_margin: 8.0,
+    inner_margin: 1.0,
     frame_size: 4.0,
     button_frame: 6.0,
     scrollbar_size: Vec2::splat(8.0),

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -37,8 +37,8 @@ impl ShadedTheme {
 }
 
 const DIMS: DimensionsParams = DimensionsParams {
-    outer_margin: 3.0,
-    inner_margin: 2.0,
+    outer_margin: 6.0,
+    inner_margin: 1.0,
     frame_size: 5.0,
     button_frame: 5.0,
     scrollbar_size: Vec2::splat(8.0),

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             struct {
                 #[widget(row=0, col=1)] _ = Label::new("Layout demo"),
                 #[widget(row=1, col=0, cspan=3)] _ = Label::new(lipsum),
-                #[widget(row=2, col=0, halign=centre)] _ = Label::new("Text"),
+                #[widget(row=2, col=0, halign=centre)] _ = Label::new("abc אבג def"),
                 #[widget(row=2, col=1, cspan=2, rspan=2, halign=stretch)] _ = Label::new(crasit),
                 #[widget(row=3, col=0)] _ = EditBox::new("A small\nsample\nof text").multi_line(true),
                 #[widget(row=0, col=2)] _ = CheckBoxBare::new(),

--- a/src/text.rs
+++ b/src/text.rs
@@ -118,24 +118,6 @@ impl PreparedText {
         self.0.line_range(line)
     }
 
-    /// Find the next glyph index to the left of the given glyph
-    ///
-    /// Warning: this counts *glyphs*, which makes the result dependent on
-    /// text shaping. Combining diacritics *may* count as discrete glyphs.
-    /// Ligatures will count as a single glyph.
-    pub fn nav_left(&self, index: usize) -> usize {
-        self.0.nav_left(index)
-    }
-
-    /// Find the next glyph index to the right of the given glyph
-    ///
-    /// Warning: this counts *glyphs*, which makes the result dependent on
-    /// text shaping. Combining diacritics *may* count as discrete glyphs.
-    /// Ligatures will count as a single glyph.
-    pub fn nav_right(&self, index: usize) -> usize {
-        self.0.nav_right(index)
-    }
-
     /// Find the starting position (top-left) of the glyph at the given index
     ///
     /// Returns `Some(pos, ascent, descent)` on success, where `pos.1 - ascent`
@@ -148,20 +130,28 @@ impl PreparedText {
     ///
     /// Note: if the text's bounding rect does not start at the origin, then
     /// the coordinates of the top-left corner should be added to this result.
-    pub fn text_glyph_pos(&self, pos: Coord, index: usize) -> Option<(Vec2, f32, f32)> {
+    pub fn text_glyph_pos(
+        &self,
+        pos: Coord,
+        index: usize,
+    ) -> impl DoubleEndedIterator<Item = (Vec2, f32, f32)> {
+        let x = Vec2::from(pos);
         self.0
             .text_glyph_pos(index)
-            .map(|result| (Vec2::from(pos) + Vec2::from(result.0), result.1, result.2))
+            .map(move |item| (x + Vec2::from(item.pos), item.ascent, item.descent))
     }
 
     /// Find the starting position (top-left) of the glyph at the given index
     ///
     /// This differs from [`PreparedText::text_glyph_pos`] in that it does not
     /// offset the result by a coordinate `pos`.
-    pub fn text_glyph_rel_pos(&self, index: usize) -> Option<(Vec2, f32, f32)> {
+    pub fn text_glyph_rel_pos(
+        &self,
+        index: usize,
+    ) -> impl DoubleEndedIterator<Item = (Vec2, f32, f32)> {
         self.0
             .text_glyph_pos(index)
-            .map(|result| (Vec2::from(result.0), result.1, result.2))
+            .map(|item| (Vec2::from(item.pos), item.ascent, item.descent))
     }
 
     /// Find the text index for the glyph nearest the given `coord`, relative to `pos`

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -487,6 +487,7 @@ impl<G> EditBox<G> {
                     None => self
                         .prepared
                         .text_glyph_rel_pos(pos)
+                        .next_back()
                         .map(|r| (r.0).0)
                         .unwrap_or(0.0),
                 };


### PR DESCRIPTION
Multi-line text editing now works fairly well, even with bidirectional content!

There are still several major limitations:

-   the design doesn't scale to large documents (noticeable when editing a couple hundred lines)
-   there is no implicit support for scrolling when texts don't fit in the edit box
-   short-cuts aren't handled aside from a few already mapped to control-codes by the OS (so e.g. Ctrl+V works on KDE/Linux but not Ctrl+A)
-   the undo buffer is limited to a single action and handled directly by `EditBox`
-   text formatting / highlighting (other than background) isn't started yet