### PR TITLE
Allow scrolling editable text; remove PreparedText wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "af0afb0cd9e0fceee6ca5c2a35d83aa158cb6f5f"
+rev = "7330daf22fb8c1303e5b90f178522493d870d1bf"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "7af3f054151db987bbe51bdf923fd7876b002cd8"
+rev = "78e8a71e38bed637975d007ba3e9142c8cc2cf97"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ path = "kas-macros"
 
 [dependencies.kas-text]
 git = "https://github.com/kas-gui/kas-text"
-rev = "7330daf22fb8c1303e5b90f178522493d870d1bf"
+rev = "7af3f054151db987bbe51bdf923fd7876b002cd8"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -170,10 +170,15 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
             bounds.0 = size as f32;
             bounds.1 = text.env().bounds.1;
         }
+        let wrap = match class {
+            TextClass::Label | TextClass::EditMulti => true,
+            _ => false,
+        };
         text.update_env(|env| {
             env.set_bounds(bounds.into());
             env.set_dpp(self.dims.dpp);
             env.set_pt_size(self.dims.pt_size);
+            env.set_wrap(wrap);
         });
         let bounds = text.required_size();
 

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -208,6 +208,10 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         }
     }
 
+    fn edit_marker_width(&self) -> f32 {
+        self.dims.font_marker_width
+    }
+
     fn button_surround(&self) -> (Size, Size) {
         let s = Size::uniform(self.dims.button_frame);
         (s, s)

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -243,30 +243,42 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             .rounded_frame(self.pass, outer, inner, 0.5, self.cols.frame);
     }
 
-    fn text(&mut self, pos: Coord, text: &PreparedText, class: TextClass) {
+    fn text_offset(&mut self, pos: Coord, offset: Coord, text: &PreparedText, class: TextClass) {
         let pos = pos + self.offset;
         let col = self.cols.text_class(class);
-        self.draw.text(self.pass, pos.into(), col, text);
+        self.draw
+            .text(self.pass, pos.into(), offset.into(), col, text);
     }
 
     fn text_selected_range(
         &mut self,
         pos: Coord,
+        offset: Coord,
         text: &PreparedText,
         range: Range<usize>,
         class: TextClass,
     ) {
         let pos = Vec2::from(pos + self.offset);
+        let offset = Vec2::from(offset);
+        let bounds = Vec2::from(text.env().bounds);
         let col = self.cols.text_class(class);
 
         // Draw background:
         for (p1, p2) in &text.highlight_lines(range) {
-            let quad = Quad::with_coords(pos + Vec2::from(*p1), pos + Vec2::from(*p2));
+            let mut p1 = Vec2::from(*p1) - offset;
+            let mut p2 = Vec2::from(*p2) - offset;
+            if !p2.gt(Vec2::ZERO) || !p1.lt(bounds) {
+                continue;
+            }
+            p1 = p1.max(Vec2::ZERO);
+            p2 = p2.min(bounds);
+
+            let quad = Quad::with_coords(pos + p1, pos + p2);
             self.draw.rect(self.pass, quad, self.cols.text_sel_bg);
         }
 
         // TODO: which should use self.cols.text_sel for the selected range!
-        self.draw.text(self.pass, pos.into(), col, text);
+        self.draw.text(self.pass, pos, offset, col, text);
     }
 
     fn edit_marker(&mut self, pos: Coord, text: &PreparedText, class: TextClass, byte: usize) {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -264,18 +264,20 @@ where
             .shaded_round_frame(self.pass, outer, inner, norm, col);
     }
 
-    fn text(&mut self, pos: Coord, text: &PreparedText, class: TextClass) {
-        self.as_flat().text(pos, text, class);
+    fn text_offset(&mut self, pos: Coord, offset: Coord, text: &PreparedText, class: TextClass) {
+        self.as_flat().text_offset(pos, offset, text, class);
     }
 
     fn text_selected_range(
         &mut self,
         pos: Coord,
+        offset: Coord,
         text: &PreparedText,
         range: Range<usize>,
         class: TextClass,
     ) {
-        self.as_flat().text_selected_range(pos, text, range, class);
+        self.as_flat()
+            .text_selected_range(pos, offset, text, range, class);
     }
 
     fn edit_marker(&mut self, pos: Coord, text: &PreparedText, class: TextClass, byte: usize) {

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -106,8 +106,10 @@ impl Layout for Clock {
         line_seg(a_min, 0.0, half * 0.8, half * 0.015, col_hands);
         line_seg(a_sec, 0.0, half * 0.9, half * 0.005, col_secs);
 
-        draw.text(pass, (self.date_pos + offset).into(), col_text, &self.date);
-        draw.text(pass, (self.time_pos + offset).into(), col_text, &self.time);
+        let date_pos = (self.date_pos + offset).into();
+        let time_pos = (self.time_pos + offset).into();
+        draw.text(pass, date_pos, Vec2::ZERO, col_text, &self.date);
+        draw.text(pass, time_pos, Vec2::ZERO, col_text, &self.time);
     }
 }
 

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -148,8 +148,8 @@ impl Clock {
             valign: Align::Centre,
             ..Default::default()
         };
-        let date = PreparedText::new_with_env(env.clone(), "0000-00-00".into());
-        let time = PreparedText::new_with_env(env, "00:00:00".into());
+        let date = PreparedText::new(env.clone(), "0000-00-00".into());
+        let time = PreparedText::new(env, "00:00:00".into());
         Clock {
             core: Default::default(),
             date_pos: Coord::ZERO,

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -17,8 +17,9 @@ fn to_point(Vec2(x, y): Vec2) -> ab_glyph::Point {
 }
 
 impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
-    fn text(&mut self, pass: Pass, pos: Vec2, col: Colour, text: &PreparedText) {
+    fn text(&mut self, pass: Pass, pos: Vec2, offset: Vec2, col: Colour, text: &PreparedText) {
         let pos = to_point(pos);
+        let offset = pos - to_point(offset);
         let glyphs = text.positioned_glyphs(|_, font_id, scale, glyph| SectionGlyph {
             // Index fields are not used when drawing
             section_index: 0,
@@ -26,7 +27,7 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
             glyph: ab_glyph::Glyph {
                 id: glyph.id,
                 scale,
-                position: pos + glyph.position.into(),
+                position: offset + glyph.position.into(),
             },
             font_id: FontId(font_id.get()),
         });

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -627,7 +627,7 @@ mod test {
         let _size = draw_handle.size_handle(|h| h.frame());
 
         let pos = Coord::ZERO;
-        let text = PreparedText::new("sample".into());
+        let text = PreparedText::new_single("sample".into());
         draw_handle.text_selected(pos, &text, .., TextClass::Label)
     }
 }

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -217,5 +217,5 @@ pub trait DrawShaded: Draw {
 /// changes are expected to support external font shaping libraries.
 pub trait DrawText {
     /// Draw text
-    fn text(&mut self, pass: Pass, pos: Vec2, col: Colour, text: &PreparedText);
+    fn text(&mut self, pass: Pass, pos: Vec2, offset: Vec2, col: Colour, text: &PreparedText);
 }

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -304,6 +304,15 @@ impl PressSource {
         }
     }
 
+    /// Returns true if this represents a touch event
+    #[inline]
+    pub fn is_touch(self) -> bool {
+        match self {
+            PressSource::Touch(_) => true,
+            _ => false,
+        }
+    }
+
     /// The `repetitions` value
     ///
     /// This is 1 for a single-click and all touch events, 2 for a double-click,

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -151,6 +151,12 @@ macro_rules! impl_vec2 {
                 $T(self.0.abs(), self.1.abs())
             }
 
+            /// Take the ceiling of each component
+            #[inline]
+            pub fn ceil(self) -> Self {
+                $T(self.0.ceil(), self.1.ceil())
+            }
+
             /// For each component, return `±1` with the same sign as `self`.
             #[inline]
             pub fn sign(self) -> Self {

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -133,6 +133,18 @@ macro_rules! impl_vec2 {
                 self.0.min(self.1)
             }
 
+            /// Return the minimum, componentwise
+            #[inline]
+            pub fn min(self, other: Self) -> Self {
+                $T(self.0.min(other.0), self.1.min(other.1))
+            }
+
+            /// Return the maximum, componentwise
+            #[inline]
+            pub fn max(self, other: Self) -> Self {
+                $T(self.0.max(other.0), self.1.max(other.1))
+            }
+
             /// Take the absolute value of each component
             #[inline]
             pub fn abs(self) -> Self {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,7 +26,7 @@ pub use kas::macros::*;
 #[doc(no_inline)]
 pub use kas::string::{AccelString, LabelString};
 #[doc(no_inline)]
-pub use kas::text::{PreparedText, RichText};
+pub use kas::text::{PreparedText, PreparedTextExt, RichText};
 #[doc(no_inline)]
 pub use kas::{class, draw, event, geom, layout, widget};
 #[doc(no_inline)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,7 +14,7 @@
 //! using widgets in a GUI.
 
 #[doc(no_inline)]
-pub use kas::draw::{DrawHandle, SizeHandle};
+pub use kas::draw::{DrawHandle, DrawHandleExt, SizeHandle};
 #[doc(no_inline)]
 pub use kas::event::{Event, Handler, Manager, ManagerState, Response, SendEvent, VoidMsg};
 #[doc(no_inline)]

--- a/src/text.rs
+++ b/src/text.rs
@@ -285,11 +285,7 @@ impl PreparedText {
     /// yields a separate rect for each "run" within this range (where "run" is
     /// is a line or part of a line). Rects are represented by the top-left
     /// vertex and the bottom-right vertex.
-    pub fn highlight_lines<R: Into<std::ops::Range<usize>>>(
-        &self,
-        pos: Coord,
-        range: R,
-    ) -> Vec<Quad> {
+    pub fn highlight_lines(&self, pos: Coord, range: std::ops::Range<usize>) -> Vec<Quad> {
         let pos = Vec2::from(pos);
         self.0
             .highlight_lines(range)
@@ -306,11 +302,7 @@ impl PreparedText {
     /// yields a separate rect for each "run" within this range (where "run" is
     /// is a line or part of a line). Rects are represented by the top-left
     /// vertex and the bottom-right vertex.
-    pub fn highlight_runs<R: Into<std::ops::Range<usize>>>(
-        &self,
-        pos: Coord,
-        range: R,
-    ) -> Vec<Quad> {
+    pub fn highlight_runs(&self, pos: Coord, range: std::ops::Range<usize>) -> Vec<Quad> {
         let pos = Vec2::from(pos);
         self.0
             .highlight_runs(range)

--- a/src/text.rs
+++ b/src/text.rs
@@ -5,309 +5,34 @@
 
 //! Abstractions over `kas-text`
 
-use kas::geom::{Coord, Quad, Vec2};
 use kas::TkAction;
 pub use kas_text::*;
 
 #[doc(no_inline)]
 pub use rich::Text as RichText;
 
-/// Prepare action needed after text object updates
-#[must_use]
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
-pub enum PrepareAction {
-    /// No action needed
-    None,
-    /// Prepare must be called
-    Prepare,
-}
+#[doc(no_inline)]
+pub use prepared::Text as PreparedText;
 
-impl std::ops::Add for PrepareAction {
-    type Output = Self;
+#[doc(no_inline)]
+pub use prepared::Prepare as PrepareAction;
 
-    #[inline]
-    fn add(self, rhs: PrepareAction) -> Self {
-        self.max(rhs)
-    }
-}
-
-impl std::ops::AddAssign for PrepareAction {
-    #[inline]
-    fn add_assign(&mut self, rhs: PrepareAction) {
-        *self = (*self).max(rhs);
-    }
-}
-
-/// Text, prepared for display in a given enviroment
-///
-/// Text is laid out for display in a box with the given size.
-///
-/// The type can be default-constructed with no text.
-#[derive(Clone, Debug, Default)]
-pub struct PreparedText(prepared::Text);
-
-impl PreparedText {
-    /// New single-line text
-    ///
-    /// This method assumes single-line mode and default alignment.
-    /// To adjust, use [`PreparedText::update_env`].
-    ///
-    /// This struct must be made ready for use before
-    /// To do so, call [`PreparedText::prepare`].
-    pub fn new(text: rich::Text) -> Self {
-        // Note: wrap is on by default for Environment, but here it makes more
-        // sense to turn it off in the default constructor.
-        let mut env = Environment::new();
-        env.wrap = false;
-        Self::new_with_env(env, text)
-    }
-
-    /// New multi-line text
-    ///
-    /// This differs from [`PreparedText::new`] only in that it enables line wrapping.
-    pub fn new_wrap(text: rich::Text) -> Self {
-        Self::new_with_env(Environment::new(), text)
-    }
-
-    /// New multi-line text
-    ///
-    /// This differs from [`PreparedText::new`] in that it allows explicit
-    /// setting of [`Environment`] parameters.
-    pub fn new_with_env(env: Environment, text: rich::Text) -> Self {
-        PreparedText(prepared::Text::new(env, text))
-    }
-
-    /// Reconstruct the [`RichText`] defining this `PreparedText`
-    pub fn clone_text(&self) -> RichText {
-        self.0.clone_text()
-    }
-
-    /// Clone the raw string
-    pub fn clone_string(&self) -> String {
-        self.0.text().to_string()
-    }
-
-    /// Length of raw text
-    ///
-    /// It is valid to reference text within the range `0..text_len()`,
-    /// even if not all text within this range will be displayed (due to runs).
-    pub fn text_len(&self) -> usize {
-        self.0.text_len()
-    }
-
-    /// Access to the raw text
-    ///
-    /// This is the contiguous raw text without formatting information.
-    pub fn text(&self) -> &str {
-        self.0.text()
-    }
-
-    /// Insert a char at the given position
-    ///
-    /// This may be used to edit the raw text instead of replacing it.
-    /// One must call [`PreparedText::prepare`] afterwards.
-    ///
-    /// TODO: document how this affects formatting.
-    ///
-    /// Currently this is not significantly more efficent than
-    /// [`PreparedText::set_text`]. This may change in the future (TODO).
-    ///
-    /// Returns [`PrepareAction::Prepare`]: i.e. this does not cause resizing.
-    pub fn insert_char(&mut self, index: usize, c: char) -> PrepareAction {
-        self.0.insert_char(index, c);
-        PrepareAction::Prepare
-    }
-
-    /// Replace a section of text
-    ///
-    /// This may be used to edit the raw text instead of replacing it.
-    /// One must call [`PreparedText::prepare`] afterwards.
-    ///
-    /// TODO: document how this affects formatting.
-    ///
-    /// Currently this is not significantly more efficent than
-    /// [`PreparedText::set_text`]. This may change in the future (TODO).
-    ///
-    /// Returns [`PrepareAction::Prepare`]: i.e. this does not cause resizing.
-    pub fn replace_range<R>(&mut self, range: R, replace_with: &str) -> PrepareAction
-    where
-        R: std::ops::RangeBounds<usize>,
-    {
-        self.0.replace_range(range, replace_with);
-        PrepareAction::Prepare
-    }
-
-    /// Swap the raw text with a `String`
-    ///
-    /// This may be used to edit the raw text instead of replacing it.
-    /// One must call [`PreparedText::prepare`] afterwards.
-    ///
-    /// TODO: document how this affects formatting.
-    ///
-    /// Currently this is not significantly more efficent than
-    /// [`PreparedText::set_text`]. This may change in the future (TODO).
-    ///
-    /// Returns [`PrepareAction::Prepare`]: i.e. this does not cause resizing.
-    pub fn swap_string(&mut self, string: &mut String) -> PrepareAction {
-        self.0.swap_string(string);
-        PrepareAction::Prepare
-    }
-
-    /// Set the text
-    ///
-    /// See also [`PreparedText::set_and_prepare`].
-    pub fn set_text<T: Into<RichText>>(&mut self, text: T) -> PrepareAction {
-        match self.0.set_text(text.into()) {
-            false => PrepareAction::None,
-            true => PrepareAction::Prepare, // set_size calls prepare
-        }
-    }
-
+/// Extension trait over [`prepared::Text`]
+pub trait PreparedTextExt {
     /// Set the text
     ///
     /// This calls [`PreparedText::prepare`] internally, then returns
     /// [`TkAction::Redraw`]. (This does not force a resize.)
-    pub fn set_and_prepare<T: Into<RichText>>(&mut self, text: T) -> TkAction {
-        if self.0.set_text(text.into()) {
-            self.0.prepare();
+    fn set_and_prepare<T: Into<RichText>>(&mut self, text: T) -> TkAction;
+}
+
+impl PreparedTextExt for PreparedText {
+    fn set_and_prepare<T: Into<RichText>>(&mut self, text: T) -> TkAction {
+        if self.set_text(text.into()).prepare() {
+            self.prepare();
             TkAction::Redraw
         } else {
             TkAction::None
         }
-    }
-
-    /// Read the environment
-    pub fn env(&self) -> &Environment {
-        self.0.env()
-    }
-
-    /// Update the environment and prepare for display
-    ///
-    /// This calls [`PreparedText::prepare`] to prepare text for display.
-    pub fn update_env<F: FnOnce(&mut UpdateEnv)>(&mut self, f: F) {
-        self.0.update_env(f);
-    }
-
-    /// Prepare text for display
-    pub fn prepare(&mut self) {
-        self.0.prepare();
-    }
-
-    pub fn positioned_glyphs<G, F: Fn(&str, FontId, PxScale, Glyph) -> G>(&self, f: F) -> Vec<G> {
-        // TODO: Should we cache this result somewhere? Unfortunately we still
-        // don't have the type G here, and the caller (draw_text.rs) does not
-        // have storage directly associated with this PreparedText.
-        self.0.positioned_glyphs(f)
-    }
-
-    pub fn required_size(&self) -> Vec2 {
-        self.0.required_size().into()
-    }
-
-    /// Get the number of lines
-    pub fn num_lines(&self) -> usize {
-        self.0.num_lines()
-    }
-
-    /// Find the line containing text `index`
-    ///
-    /// Returns the line number and the text-range of the line.
-    ///
-    /// Returns `None` in case `index` does not line on or at the end of a line
-    /// (which means either that `index` is beyond the end of the text or that
-    /// `index` is within a mult-byte line break).
-    pub fn find_line(&self, index: usize) -> Option<(usize, std::ops::Range<usize>)> {
-        self.0.find_line(index)
-    }
-
-    /// Get the range of a line, by line number
-    pub fn line_range(&self, line: usize) -> Option<std::ops::Range<usize>> {
-        self.0.line_range(line)
-    }
-
-    /// Find the starting position (top-left) of the glyph at the given index
-    ///
-    /// Returns `Some(pos, ascent, descent)` on success, where `pos.1 - ascent`
-    /// and `pos.1 - descent` are the top and bottom of the glyph position.
-    ///
-    /// Note that this only searches *visible* text sections for a valid index.
-    /// In case the `index` is not within a slice of visible text, this returns
-    /// `None`. So long as `index` is within a visible slice (or at its end),
-    /// it does not need to be on a valid code-point.
-    ///
-    /// Note: if the text's bounding rect does not start at the origin, then
-    /// the coordinates of the top-left corner should be added to this result.
-    pub fn text_glyph_pos(
-        &self,
-        pos: Coord,
-        index: usize,
-    ) -> impl DoubleEndedIterator<Item = (Vec2, f32, f32)> {
-        let x = Vec2::from(pos);
-        self.0
-            .text_glyph_pos(index)
-            .map(move |item| (x + Vec2::from(item.pos), item.ascent, item.descent))
-    }
-
-    /// Find the starting position (top-left) of the glyph at the given index
-    ///
-    /// This differs from [`PreparedText::text_glyph_pos`] in that it does not
-    /// offset the result by a coordinate `pos`.
-    pub fn text_glyph_rel_pos(
-        &self,
-        index: usize,
-    ) -> impl DoubleEndedIterator<Item = (Vec2, f32, f32)> {
-        self.0
-            .text_glyph_pos(index)
-            .map(|item| (Vec2::from(item.pos), item.ascent, item.descent))
-    }
-
-    /// Find the text index for the glyph nearest the given `coord`, relative to `pos`
-    ///
-    /// This includes the index immediately after the last glyph, thus
-    /// `result ≤ text.len()`.
-    pub fn text_index_nearest(&self, pos: Coord, coord: Coord) -> usize {
-        self.0.text_index_nearest((coord - pos).into())
-    }
-
-    /// Find the text index nearest horizontal-coordinate `x` on `line`
-    ///
-    /// Unlike [`PreparedText::text_index_nearest`], this does not offset `x`.
-    /// It also allows the line to be specified explicitly.
-    pub fn line_index_nearest(&self, line: usize, x: f32) -> Option<usize> {
-        self.0.line_index_nearest(line, x)
-    }
-
-    /// Yield a sequence of rectangles to highlight a given range, by lines
-    ///
-    /// Rectangles span to end and beginning of lines when wrapping lines.
-    ///
-    /// This locates the ends of a range as with [`PreparedText::text_glyph_pos`], but
-    /// yields a separate rect for each "run" within this range (where "run" is
-    /// is a line or part of a line). Rects are represented by the top-left
-    /// vertex and the bottom-right vertex.
-    pub fn highlight_lines(&self, pos: Coord, range: std::ops::Range<usize>) -> Vec<Quad> {
-        let pos = Vec2::from(pos);
-        self.0
-            .highlight_lines(range)
-            .iter()
-            .map(|(p1, p2)| Quad::with_coords(pos + Vec2::from(*p1), pos + Vec2::from(*p2)))
-            .collect()
-    }
-
-    /// Yield a sequence of rectangles to highlight a given range, by runs
-    ///
-    /// Rectangles tightly fit each "run" (piece) of text highlighted.
-    ///
-    /// This locates the ends of a range as with [`PreparedText::text_glyph_pos`], but
-    /// yields a separate rect for each "run" within this range (where "run" is
-    /// is a line or part of a line). Rects are represented by the top-left
-    /// vertex and the bottom-right vertex.
-    pub fn highlight_runs(&self, pos: Coord, range: std::ops::Range<usize>) -> Vec<Quad> {
-        let pos = Vec2::from(pos);
-        self.0
-            .highlight_runs(range)
-            .iter()
-            .map(|(p1, p2)| Quad::with_coords(pos + Vec2::from(*p1), pos + Vec2::from(*p2)))
-            .collect()
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -76,7 +76,7 @@ impl<M: Clone + Debug + 'static> TextButton<M> {
     /// the parent (or other ancestor).
     pub fn new<S: Into<AccelString>>(label: S, msg: M) -> Self {
         let label = label.into();
-        let text = PreparedText::new(label.get(false).into());
+        let text = PreparedText::new_single(label.get(false).into());
         let keys2 = label.take_keys();
         TextButton {
             core: Default::default(),

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -88,7 +88,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     #[inline]
     fn new_(column: Vec<MenuEntry<u64>>, messages: Vec<M>) -> Self {
         assert!(column.len() > 0, "ComboBox: expected at least one choice");
-        let label = PreparedText::new(column[0].clone_text());
+        let label = PreparedText::new_single(column[0].clone_text());
         ComboBox {
             core: Default::default(),
             label,

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -145,10 +145,9 @@ impl Default for TouchPhase {
 /// This widget is intended for use with short input strings. Internally it
 /// uses a [`String`], for which edits have `O(n)` cost.
 ///
-/// Currently, this widget has a [`EditBox::multi_line`] mode, with some
-/// limitations (incorrect positioning of the edit cursor at line end,
-/// non-functional up/down keys, lack of scrolling). Later this will be replaced
-/// by a dedicated multi-line widget, probably using the `ropey` crate.
+/// Optionally, [`EditBox::multi_line`] mode can be activated (enabling
+/// line-wrapping and a larger vertical height). This mode is only recommended
+/// for short texts for performance reasons.
 #[widget(config(key_nav = true, cursor_icon = event::CursorIcon::Text))]
 #[handler(handle=noauto, generics = <> where G: EditGuard)]
 #[derive(Clone, Default, Widget)]

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -24,7 +24,7 @@ impl Layout for Label {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let mut prepared;
         let text = if let Some(s) = self.reserve {
-            prepared = PreparedText::new_wrap(s.into());
+            prepared = PreparedText::new_multi(s.into());
             &mut prepared
         } else {
             &mut self.label
@@ -57,7 +57,7 @@ impl Label {
         Label {
             core: Default::default(),
             reserve: None,
-            label: PreparedText::new_wrap(label.into().deref().into()),
+            label: PreparedText::new_multi(label.into().deref().into()),
         }
     }
 
@@ -125,7 +125,7 @@ impl AccelLabel {
     /// Construct a new, empty instance
     pub fn new<T: Into<AccelString>>(label: T) -> Self {
         let label = label.into();
-        let text = PreparedText::new(label.get(false).into());
+        let text = PreparedText::new_single(label.get(false).into());
         let keys = label.take_keys();
         AccelLabel {
             core: Default::default(),

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -71,7 +71,7 @@ impl<M: Clone + Debug + 'static> MenuEntry<M> {
     /// simple `Copy` type (e.g. an enum).
     pub fn new<S: Into<AccelString>>(label: S, msg: M) -> Self {
         let label = label.into();
-        let text = PreparedText::new(label.get(false).into());
+        let text = PreparedText::new_single(label.get(false).into());
         let keys = label.take_keys();
         MenuEntry {
             core: Default::default(),

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -61,7 +61,7 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
     #[inline]
     pub fn new_with_direction<S: Into<AccelString>>(direction: D, label: S, list: Vec<W>) -> Self {
         let label = label.into();
-        let text = PreparedText::new(label.get(false).into());
+        let text = PreparedText::new_single(label.get(false).into());
         let keys = label.take_keys();
         SubMenu {
             core: Default::default(),


### PR DESCRIPTION
This has some API adjustments, but most notably EditBox now supports scrolling its contents:

- by ctrl+mouse drag
- by touch drag (or move cursor after 1sec delay / touch without drag)
- mouse wheel (needs speed adjustment, but possibly elsewhere)