### PR TITLE
Double/triple click selection, kas-text 0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,9 @@ version = "0.4.0"
 path = "kas-macros"
 
 [dependencies.kas-text]
-git = "https://github.com/kas-gui/kas-text"
-rev = "78e8a71e38bed637975d007ba3e9142c8cc2cf97"
+version = "0.1"
+# git = "https://github.com/kas-gui/kas-text"
+# rev = ""
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -282,9 +282,9 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
     }
 
     fn edit_marker(&mut self, pos: Coord, text: &PreparedText, class: TextClass, byte: usize) {
-        let col = self.cols.text_class(class);
+        let mut col = self.cols.text_class(class);
         let pos = Vec2::from(pos + self.offset);
-        for m in text.text_glyph_pos(byte) {
+        for m in text.text_glyph_pos(byte).rev() {
             let mut p1 = pos + Vec2::from(m.pos);
             let mut p2 = p1;
             p1.1 -= m.ascent;
@@ -292,6 +292,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             p2.0 += self.window.dims.font_marker_width;
             let quad = Quad::with_coords(p1, p2);
             self.draw.rect(self.pass, quad, col);
+            col = self.cols.button_disabled; // hack to make secondary marker grey
         }
     }
 


### PR DESCRIPTION
This implements support for double- and triple-click selection (word and line), including drag mode.

When multiple edit cursors are displayed, the secondary one is shown in grey (piggy-backing the `button_disabled` colour for now).

We also update to the first release version of kas-text.