### PR TITLE
Deselect via scroll and focus loss; fix scrolling

### DIFF
--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -503,7 +503,7 @@ impl event::Handler for Mandlebrot {
                             ControlKey::Down => DVec2(0.0, d),
                             ControlKey::Left => DVec2(-d, 0.0),
                             ControlKey::Right => DVec2(d, 0.0),
-                            _ => return Response::None,
+                            _ => return Response::Unhandled(Event::Control(key)),
                         };
                         self.delta = self.delta + self.alpha.complex_mul(delta);
                     }

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -163,9 +163,6 @@ pub enum Event {
 /// nav focus. The codes generated differ slightly depending on which focus
 /// dominates; see notes on [`ControlKey::Return`] and [`ControlKey::Tab`].
 ///
-/// The Escape key is notably absent: it always cancels char or nav focus, thus
-/// is never sent to a widget. The Tab key is only reported with char focus.
-///
 /// In some cases, a widget's response will depend on the state of modifier
 /// keys. This state can be read via the [`Manager::modifiers`] method.
 ///
@@ -177,6 +174,12 @@ pub enum Event {
 /// uniform behaviour with regards to num-pad keys.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ControlKey {
+    /// Escape key
+    ///
+    /// Each press of this key should somehow relax control. It is expected that
+    /// widgets receiving this key repeatedly eventually (soon) have no more
+    /// use for this themselves and return it via [`Response::Unhandled`].
+    Escape,
     /// Line break (return / enter key)
     ///
     /// Note: this is generated *only* when a widget has char focus (see
@@ -247,6 +250,7 @@ impl ControlKey {
         use ControlKey as CK;
         use VirtualKeyCode::*;
         Some(match vkey {
+            Escape => CK::Escape,
             Snapshot => CK::Snapshot,
             Scroll => CK::ScrollLock,
             Pause => CK::Pause,

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -276,10 +276,16 @@ impl<'a> Manager<'a> {
         let opt_control = self.match_shortcuts(vkey);
 
         if let Some(id) = self.mgr.char_focus {
-            if vkey == VK::Escape {
-                self.set_char_focus(None);
-            } else if let Some(key) = opt_control {
-                self.send_event(widget, id, Event::Control(key));
+            if let Some(key) = opt_control {
+                let event = Event::Control(key);
+                trace!("Send to {}: {:?}", id, event);
+                match widget.send(self, id, event) {
+                    Response::Unhandled(Event::Control(key)) => match key {
+                        ControlKey::Escape => self.set_char_focus(None),
+                        _ => (),
+                    },
+                    _ => (),
+                }
             }
             return;
         }

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -402,7 +402,7 @@ impl<'a> Manager<'a> {
     /// (only the first grab is successful).
     ///
     /// This method automatically cancels any active character grab
-    /// and updates keyboard navigation focus.
+    /// on other widgets and updates keyboard navigation focus.
     pub fn request_grab(
         &mut self,
         id: WidgetId,
@@ -458,7 +458,9 @@ impl<'a> Manager<'a> {
             }
         }
 
-        self.set_char_focus(None);
+        if self.mgr.char_focus != Some(id) {
+            self.set_char_focus(None);
+        }
         self.redraw(start_id);
         true
     }

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -822,6 +822,7 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
             }
             Event::LostCharFocus => {
                 let r = G::focus_lost(self);
+                self.sel_pos = self.edit_pos; // clear selection
                 r.map(|msg| msg.into()).unwrap_or(Response::None)
             }
             Event::Control(key) => match self.control_key(mgr, key) {


### PR DESCRIPTION
The middle commit is inspired by https://github.com/linebender/druid/issues/1124. We take the lazy option and deselect on any loss of input focus which is what a number of UI controls do. (If we instead want to only clear on another selection starting, I guess we should add a method like `Manager::report_selection(&mut self, id: WidgetId)`, and send `Deselect` to the last such widget.)