### PR TITLE
Update kas-text; restore accel labels; O(1) is_ancestor_of

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,4 +62,4 @@ jobs:
       - name: test (kas-wgpu)
         run: |
           # note: gat is broken
-          cargo test --manifest-path kas-wgpu/Cargo.toml --features stack_dst,unsize
+          cargo test --manifest-path kas-wgpu/Cargo.toml --features nightly,shaping

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,13 @@ exclude = ["/screenshots"]
 
 [features]
 # Enables usage of unstable Rust features
-nightly = []
+nightly = ["min_spec"]
 
-# Use Generic Associated Types (experimental)
+# Use Generic Associated Types (this is too unstable to include in nightly!)
 gat = ["kas-text/gat"]
+
+# Use min_specialization (enables accelerator underlining for AccelLabel)
+min_spec = []
 
 # Enables documentation of APIs for toolkits and internal use.
 # This API is not intended for use by end-user applications and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ exclude = ["/screenshots"]
 # Enables usage of unstable Rust features
 nightly = []
 
+# Use Generic Associated Types (experimental)
+gat = ["kas-text/gat"]
+
 # Enables documentation of APIs for toolkits and internal use.
 # This API is not intended for use by end-user applications and
 # thus is omitted from built documentation by default.
@@ -44,7 +47,7 @@ path = "kas-macros"
 [dependencies.kas-text]
 version = "0.1.2"
 git = "https://github.com/kas-gui/kas-text"
-rev = "a3d4e426d05f7c728a10d89b56d3b9462767ba78"
+rev = "ce08a05df11081de0a638b8e6efa52afafe145d9"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/kas-theme/Cargo.toml
+++ b/kas-theme/Cargo.toml
@@ -16,7 +16,7 @@ default = ["stack_dst"]
 
 # Use Generic Associated Types (experimental)
 # Currently (Feb 2020) compiler support is poor.
-gat = ["unsize"]
+gat = ["unsize", "kas/gat"]
 
 # Use stack_dst crate for sized unsized types
 stack_dst = ["kas/stack_dst", "stack_dst_"]

--- a/kas-theme/Cargo.toml
+++ b/kas-theme/Cargo.toml
@@ -13,9 +13,9 @@ documentation = "https://docs.rs/kas-theme/"
 
 [features]
 default = ["stack_dst"]
+nightly = ["unsize", "kas/nightly"]
 
-# Use Generic Associated Types (experimental)
-# Currently (Feb 2020) compiler support is poor.
+# Use Generic Associated Types (this is too unstable to include in nightly!)
 gat = ["unsize", "kas/gat"]
 
 # Use stack_dst crate for sized unsized types

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -247,16 +247,24 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             .rounded_frame(self.pass, outer, inner, 0.5, self.cols.frame);
     }
 
-    fn text_offset(&mut self, pos: Coord, offset: Coord, text: &TextDisplay, class: TextClass) {
+    fn text_offset(
+        &mut self,
+        pos: Coord,
+        bounds: Vec2,
+        offset: Coord,
+        text: &TextDisplay,
+        class: TextClass,
+    ) {
         let pos = pos + self.offset;
         let col = self.cols.text_class(class);
         self.draw
-            .text(self.pass, pos.into(), offset.into(), col, text);
+            .text(self.pass, pos.into(), bounds, offset.into(), col, text);
     }
 
     fn text_selected_range(
         &mut self,
         pos: Coord,
+        bounds: Vec2,
         offset: Coord,
         text: &TextDisplay,
         range: Range<usize>,
@@ -264,7 +272,6 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
     ) {
         let pos = Vec2::from(pos + self.offset);
         let offset = Vec2::from(offset);
-        let bounds = Vec2::from(text.env().bounds);
         let col = self.cols.text_class(class);
 
         // Draw background:
@@ -299,12 +306,13 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             },
         ];
         self.draw
-            .text_with_effects(self.pass, pos, offset, text, &effects);
+            .text_with_effects(self.pass, pos, bounds, offset, text, &effects);
     }
 
     fn edit_marker(
         &mut self,
         pos: Coord,
+        mut bounds: Vec2,
         offset: Coord,
         text: &TextDisplay,
         class: TextClass,
@@ -312,9 +320,8 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
     ) {
         let width = self.window.dims.font_marker_width;
         let p = Vec2::from(pos + self.offset);
-        let mut size: Vec2 = text.env().bounds.into();
-        size.0 += width;
-        let bounds = Quad::with_pos_and_size(p, size);
+        bounds.0 += width;
+        let bounds = Quad::with_pos_and_size(p, bounds);
         let pos = Vec2::from(pos - offset + self.offset);
 
         let mut col = self.cols.text_class(class);

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -14,7 +14,7 @@ use kas::draw::{
     Pass, SizeHandle, TextClass,
 };
 use kas::geom::*;
-use kas::text::TextDisplay;
+use kas::text::{AccelString, Text, TextDisplay};
 use kas::{Direction, Directional, ThemeAction, ThemeApi};
 
 /// A theme using simple shading to give apparent depth to elements
@@ -277,6 +277,10 @@ where
         class: TextClass,
     ) {
         self.as_flat().text_offset(pos, bounds, offset, text, class);
+    }
+
+    fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
+        self.as_flat().text_accel(pos, text, state, class);
     }
 
     fn text_selected_range(

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -268,31 +268,41 @@ where
             .shaded_round_frame(self.pass, outer, inner, norm, col);
     }
 
-    fn text_offset(&mut self, pos: Coord, offset: Coord, text: &TextDisplay, class: TextClass) {
-        self.as_flat().text_offset(pos, offset, text, class);
+    fn text_offset(
+        &mut self,
+        pos: Coord,
+        bounds: Vec2,
+        offset: Coord,
+        text: &TextDisplay,
+        class: TextClass,
+    ) {
+        self.as_flat().text_offset(pos, bounds, offset, text, class);
     }
 
     fn text_selected_range(
         &mut self,
         pos: Coord,
+        bounds: Vec2,
         offset: Coord,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
     ) {
         self.as_flat()
-            .text_selected_range(pos, offset, text, range, class);
+            .text_selected_range(pos, bounds, offset, text, range, class);
     }
 
     fn edit_marker(
         &mut self,
         pos: Coord,
+        bounds: Vec2,
         offset: Coord,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,
     ) {
-        self.as_flat().edit_marker(pos, offset, text, class, byte);
+        self.as_flat()
+            .edit_marker(pos, bounds, offset, text, class, byte);
     }
 
     fn menu_entry(&mut self, rect: Rect, state: InputState) {

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -13,8 +13,9 @@ documentation = "https://docs.rs/kas-wgpu/"
 
 [features]
 default = ["clipboard", "stack_dst"]
+nightly = ["unsize", "kas/nightly", "kas-theme/nightly"]
 
-# Use Generic Associated Types (experimental)
+# Use Generic Associated Types (this is too unstable to include in nightly!)
 gat = ["kas-theme/gat"]
 
 # Enables text shaping

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -106,10 +106,12 @@ impl Layout for Clock {
         line_seg(a_min, 0.0, half * 0.8, half * 0.015, col_hands);
         line_seg(a_sec, 0.0, half * 0.9, half * 0.005, col_secs);
 
-        let date_pos = (self.date_pos + offset).into();
-        let time_pos = (self.time_pos + offset).into();
-        draw.text(pass, date_pos, Vec2::ZERO, col_text, self.date.as_ref());
-        draw.text(pass, time_pos, Vec2::ZERO, col_text, self.time.as_ref());
+        let pos = (self.date_pos + offset).into();
+        let bounds = self.date.env().bounds.into();
+        draw.text(pass, pos, bounds, Vec2::ZERO, col_text, self.date.as_ref());
+        let pos = (self.time_pos + offset).into();
+        let bounds = self.time.env().bounds.into();
+        draw.text(pass, pos, bounds, Vec2::ZERO, col_text, self.time.as_ref());
     }
 }
 
@@ -144,8 +146,7 @@ impl Handler for Clock {
 impl Clock {
     fn new() -> Self {
         let env = kas::text::Environment {
-            halign: Align::Centre,
-            valign: Align::Centre,
+            align: (Align::Centre, Align::Centre),
             ..Default::default()
         };
         let date = Text::new(env.clone(), "0000-00-00".into());

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -38,7 +38,15 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
         }
     }
 
-    fn text(&mut self, pass: Pass, pos: Vec2, offset: Vec2, col: Colour, text: &TextDisplay) {
+    fn text(
+        &mut self,
+        pass: Pass,
+        pos: Vec2,
+        bounds: Vec2,
+        offset: Vec2,
+        col: Colour,
+        text: &TextDisplay,
+    ) {
         let time = std::time::Instant::now();
         let ab_pos = to_point(pos);
         let ab_offset = ab_pos - to_point(offset);
@@ -59,7 +67,7 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
         text.glyphs(for_glyph);
 
         let min = ab_pos;
-        let max = ab_pos + ktv_to_point(text.env().bounds);
+        let max = ab_pos + to_point(bounds);
         let bounds = ab_glyph::Rect { min, max };
 
         let extra = vec![Extra {
@@ -75,6 +83,7 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
         &mut self,
         pass: Pass,
         pos: Vec2,
+        bounds: Vec2,
         offset: Vec2,
         text: &TextDisplay,
         effects: &[Effect<Colour>],
@@ -109,7 +118,7 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
         text.glyphs_with_effects(effects, for_glyph, for_rect);
 
         let min = ab_pos;
-        let max = ab_pos + ktv_to_point(text.env().bounds);
+        let max = ab_pos + to_point(bounds);
         let bounds = ab_glyph::Rect { min, max };
 
         let extra = effects

--- a/src/data.rs
+++ b/src/data.rs
@@ -192,6 +192,7 @@ impl AlignHints {
 /// Provides alignment information on both axes along with ideal size
 ///
 /// Note that the `ideal` size detail is only used for non-stretch alignment.
+#[derive(Copy, Clone, Debug)]
 pub struct CompleteAlignment {
     halign: Align,
     valign: Align,
@@ -221,6 +222,11 @@ impl CompleteAlignment {
             size.1 = ideal.1;
         }
         Rect { pos, size }
+    }
+
+    /// Get `Align` members
+    pub fn align(&self) -> (Align, Align) {
+        (self.halign, self.valign)
     }
 }
 

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -720,7 +720,8 @@ mod test {
         let _size = draw_handle.size_handle(|h| h.frame());
 
         let zero = Coord::ZERO;
+        let bounds = Vec2(100.0, 30.0);
         let text = kas::text::Text::new_single("sample");
-        draw_handle.text_selected(zero, zero, &text, .., TextClass::Label)
+        draw_handle.text_selected(zero, bounds, zero, &text, .., TextClass::Label)
     }
 }

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -11,7 +11,7 @@ use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use kas::draw::{Draw, Pass};
 use kas::geom::{Coord, Rect, Size, Vec2};
 use kas::layout::{AxisInfo, Margins, SizeRules};
-use kas::text::{format::FormattableText, TextApi, TextDisplay};
+use kas::text::{format::FormattableText, AccelString, TextApi, TextDisplay};
 use kas::Direction;
 
 // for doc use
@@ -287,6 +287,13 @@ pub trait DrawHandle {
         class: TextClass,
     );
 
+    /// Draw an `AccelString` text
+    ///
+    /// The `text` is drawn within the rect from `pos` to `text.env().bounds`.
+    ///
+    /// The dimensions required for this text may be queried with [`SizeHandle::text_bound`].
+    fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass);
+
     /// Method used to implement [`DrawHandleExt::text_selected`]
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     fn text_selected_range(
@@ -559,6 +566,9 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         self.deref_mut()
             .text_offset(pos, bounds, offset, text, class)
     }
+    fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
+        self.deref_mut().text_accel(pos, text, state, class);
+    }
     fn text_selected_range(
         &mut self,
         pos: Coord,
@@ -648,6 +658,9 @@ where
     ) {
         self.deref_mut()
             .text_offset(pos, bounds, offset, text, class)
+    }
+    fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
+        self.deref_mut().text_accel(pos, text, state, class);
     }
     fn text_selected_range(
         &mut self,

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -220,13 +220,21 @@ pub trait DrawText {
     fn prepare_fonts(&mut self);
 
     /// Draw text
-    fn text(&mut self, pass: Pass, pos: Vec2, offset: Vec2, col: Colour, text: &TextDisplay) {
+    fn text(
+        &mut self,
+        pass: Pass,
+        pos: Vec2,
+        bounds: Vec2,
+        offset: Vec2,
+        col: Colour,
+        text: &TextDisplay,
+    ) {
         let effects = [Effect {
             start: 0,
             flags: Default::default(),
             aux: col,
         }];
-        self.text_with_effects(pass, pos, offset, text, &effects);
+        self.text_with_effects(pass, pos, bounds, offset, text, &effects);
     }
 
     /// Draw text with effects
@@ -238,6 +246,7 @@ pub trait DrawText {
         &mut self,
         pass: Pass,
         pos: Vec2,
+        bounds: Vec2,
         offset: Vec2,
         text: &TextDisplay,
         effects: &[Effect<Colour>],

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -502,6 +502,11 @@ impl<'a: 'b, 'b> ConfigureManager<'a, 'b> {
         }
     }
 
+    /// Get the next [`WidgetId`], without advancing the counter
+    pub fn peek_next(&self) -> WidgetId {
+        *self.id
+    }
+
     /// Get a new [`WidgetId`] for the widget
     ///
     /// Pass the old ID (`self.id()`), even if not yet configured.

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -222,7 +222,10 @@ impl<'a> Manager<'a> {
             }
         }
 
+        // For popups, we need to update mouse/keyboard focus.
+        // (For windows, focus gained/lost events do this job.)
         self.mgr.send_action(TkAction::RegionMoved);
+
         self.tkw.close_window(id);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 //! [examples](https://github.com/kas-gui/kas/tree/master/kas-wgpu/examples)
 //! provide a starting point.
 
+#![cfg_attr(feature = "gat", feature(generic_associated_types))]
+
 #[cfg(not(feature = "winit"))]
 #[macro_use]
 extern crate bitflags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! provide a starting point.
 
 #![cfg_attr(feature = "gat", feature(generic_associated_types))]
+#![cfg_attr(feature = "min_spec", feature(min_specialization))]
 
 #[cfg(not(feature = "winit"))]
 #[macro_use]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -28,7 +28,7 @@ pub use kas::macros::*;
 #[doc(no_inline)]
 pub use kas::text::AccelString;
 #[doc(no_inline)]
-pub use kas::text::Text;
+pub use kas::text::{EditableTextApi, Text, TextApi, TextApiExt};
 #[doc(no_inline)]
 pub use kas::{Align, AlignHints, Direction, Directional, WidgetId};
 #[doc(no_inline)]

--- a/src/text.rs
+++ b/src/text.rs
@@ -11,7 +11,7 @@ mod string;
 pub use string::AccelString;
 
 pub mod util {
-    use super::{format, Text};
+    use super::{format, EditableTextApi, Text, TextApi};
     use kas::TkAction;
 
     /// Set the text and prepare
@@ -22,12 +22,9 @@ pub mod util {
     /// This calls [`Text::prepare`] internally, then returns
     /// [`TkAction::Redraw`]. (This does not force a resize.)
     pub fn set_text_and_prepare<T: format::FormattableText>(text: &mut Text<T>, s: T) -> TkAction {
-        if text.set_text(s).prepare() {
-            text.prepare();
-            TkAction::Redraw
-        } else {
-            TkAction::None
-        }
+        text.set_text(s);
+        text.prepare();
+        TkAction::Redraw
     }
 
     /// Set the text from a string and prepare
@@ -41,11 +38,8 @@ pub mod util {
         text: &mut Text<T>,
         s: String,
     ) -> TkAction {
-        if text.set_string(s).prepare() {
-            text.prepare();
-            TkAction::Redraw
-        } else {
-            TkAction::None
-        }
+        text.set_string(s);
+        text.prepare();
+        TkAction::Redraw
     }
 }

--- a/src/text/string.rs
+++ b/src/text/string.rs
@@ -12,8 +12,10 @@
 use smallvec::{smallvec, SmallVec};
 
 use kas::event::{VirtualKeyCode as VK, VirtualKeyCodes};
+use kas::text::fonts::FontId;
 use kas::text::format::{FontToken, FormattableText};
-use kas::text::{fonts::FontId, Environment};
+#[cfg(not(feature = "gat"))]
+use kas::text::OwningVecIter;
 
 /// An accelerator key string
 ///
@@ -104,19 +106,24 @@ impl AccelString {
 }
 
 impl FormattableText for AccelString {
-    #[inline]
-    fn clone_boxed(&self) -> Box<dyn FormattableText> {
-        Box::new(self.clone())
-    }
+    #[cfg(feature = "gat")]
+    type FontTokenIterator<'a> = UlinesIter<'a>;
 
     #[inline]
     fn as_str(&self) -> &str {
         &self.label
     }
 
+    #[cfg(feature = "gat")]
     #[inline]
-    fn font_tokens<'a>(&'a self, env: &'a Environment) -> Box<dyn Iterator<Item = FontToken> + 'a> {
-        Box::new(UlinesIter::new(&self.ulines, env))
+    fn font_tokens<'a>(&'a self, dpp: f32, pt_size: f32) -> Self::FontTokenIterator<'a> {
+        UlinesIter::new(&self.ulines, dpp * pt_size)
+    }
+    #[cfg(not(feature = "gat"))]
+    #[inline]
+    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken> {
+        let iter = UlinesIter::new(&self.ulines, dpp * pt_size);
+        OwningVecIter::new(iter.collect())
     }
 }
 
@@ -127,11 +134,11 @@ pub struct UlinesIter<'a> {
 }
 
 impl<'a> UlinesIter<'a> {
-    fn new(ulines: &'a [u32], env: &Environment) -> Self {
+    fn new(ulines: &'a [u32], dpem: f32) -> Self {
         UlinesIter {
             index: 0,
             ulines,
-            dpem: env.dpp * env.pt_size,
+            dpem,
         }
     }
 }

--- a/src/text/string.rs
+++ b/src/text/string.rs
@@ -95,13 +95,12 @@ impl AccelString {
         &self.label
     }
 
-    /// Get the glyph to be underlined
-    pub fn underline(&self) -> usize {
-        // TODO: this is not the intended way to pass on this information!
-        self.ulines
-            .get(0)
-            .map(|pos| *pos as usize)
-            .unwrap_or(usize::MAX)
+    /// Get the underline sequence
+    ///
+    /// Even entries (from 0) are positions to start underlining, odd entries
+    /// are positions to end underlines.
+    pub fn underlines(&self) -> &[u32] {
+        &self.ulines
     }
 }
 

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -65,10 +65,9 @@ pub enum TkAction {
     Redraw,
     /// Some widgets within a region moved
     ///
-    /// This action should be emitted when e.g. a scroll-region is moved or
-    /// widget layout is adjusted to allow for the fact that coordinates
-    /// (e.g. mouse position) have changed relative to widgets.
-    // NOTE: one could specify a Rect here, but there's not much advantage
+    /// Used when a pop-up is closed or a region adjusted (e.g. scroll or switch
+    /// tab) to update which widget is under the mouse cursor / touch events.
+    /// Identifier is that of the parent widget/window encapsulating the region.
     RegionMoved,
     /// A pop-up opened/closed/needs resizing
     Popup,

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -40,6 +40,12 @@ impl<M: 'static> WidgetCore for Box<dyn Widget<Msg = M>> {
 }
 
 impl<M: 'static> WidgetChildren for Box<dyn Widget<Msg = M>> {
+    fn first_id(&self) -> WidgetId {
+        self.as_ref().first_id()
+    }
+    fn record_first_id(&mut self, id: WidgetId) {
+        self.as_mut().record_first_id(id)
+    }
     fn len(&self) -> usize {
         self.as_ref().len()
     }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -60,8 +60,8 @@ impl<M: Clone + Debug + 'static> Layout for TextButton<M> {
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         draw_handle.button(self.core.rect, self.input_state(mgr, disabled));
-        // TODO: draw state is mgr.show_accel_labels()
-        draw_handle.text(self.core.rect.pos, &self.label, TextClass::Button);
+        let state = mgr.show_accel_labels();
+        draw_handle.text_accel(self.core.rect.pos, &self.label, state, TextClass::Button);
     }
 }
 

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -89,6 +89,7 @@ pub type RefList<'a, D, M> = List<D, &'a mut dyn Widget<Msg = M>>;
 #[widget(children=noauto)]
 #[derive(Clone, Default, Debug, Widget)]
 pub struct List<D: Directional, W: Widget> {
+    first_id: WidgetId,
     #[widget_core]
     core: CoreData,
     widgets: Vec<W>,
@@ -97,6 +98,13 @@ pub struct List<D: Directional, W: Widget> {
 }
 
 impl<D: Directional, W: Widget> WidgetChildren for List<D, W> {
+    #[inline]
+    fn first_id(&self) -> WidgetId {
+        self.first_id
+    }
+    fn record_first_id(&mut self, id: WidgetId) {
+        self.first_id = id;
+    }
     #[inline]
     fn len(&self) -> usize {
         self.widgets.len()
@@ -186,6 +194,7 @@ impl<D: Directional + Default, W: Widget> List<D, W> {
     /// [`List::new_with_direction`].
     pub fn new(widgets: Vec<W>) -> Self {
         List {
+            first_id: Default::default(),
             core: Default::default(),
             widgets,
             data: Default::default(),
@@ -198,6 +207,7 @@ impl<D: Directional, W: Widget> List<D, W> {
     /// Construct a new instance with explicit direction
     pub fn new_with_direction(direction: D, widgets: Vec<W>) -> Self {
         List {
+            first_id: Default::default(),
             core: Default::default(),
             widgets,
             data: Default::default(),

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -66,6 +66,12 @@ impl<M: 'static> WidgetCore for Box<dyn Menu<Msg = M>> {
 }
 
 impl<M: 'static> WidgetChildren for Box<dyn Menu<Msg = M>> {
+    fn first_id(&self) -> WidgetId {
+        self.as_ref().first_id()
+    }
+    fn record_first_id(&mut self, id: WidgetId) {
+        self.as_mut().record_first_id(id)
+    }
     fn len(&self) -> usize {
         self.as_ref().len()
     }

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -56,8 +56,7 @@ impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         draw_handle.menu_entry(self.core.rect, self.input_state(mgr, disabled));
         let pos = self.core.rect.pos + self.label_off;
-        // TODO: draw state is mgr.show_accel_labels()
-        draw_handle.text(pos, &self.label, TextClass::LabelSingle);
+        draw_handle.text_accel(pos, &self.label, mgr.show_accel_labels(), TextClass::Label);
     }
 }
 

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -128,8 +128,7 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
         state.depress = state.depress || self.popup_id.is_some();
         draw_handle.menu_entry(self.core.rect, state);
         let pos = self.core.rect.pos + self.label_off;
-        // TODO: draw state is mgr.show_accel_labels()
-        draw_handle.text(pos, &self.label, TextClass::Label);
+        draw_handle.text_accel(pos, &self.label, mgr.show_accel_labels(), TextClass::Label);
     }
 }
 

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -73,6 +73,7 @@ pub type RefSplitter<'a, D, M> = Splitter<D, &'a mut dyn Widget<Msg = M>>;
 #[widget(children=noauto)]
 #[derive(Clone, Default, Debug, Widget)]
 pub struct Splitter<D: Directional, W: Widget> {
+    first_id: WidgetId,
     #[widget_core]
     core: CoreData,
     widgets: Vec<W>,
@@ -83,6 +84,13 @@ pub struct Splitter<D: Directional, W: Widget> {
 }
 
 impl<D: Directional, W: Widget> WidgetChildren for Splitter<D, W> {
+    #[inline]
+    fn first_id(&self) -> WidgetId {
+        self.first_id
+    }
+    fn record_first_id(&mut self, id: WidgetId) {
+        self.first_id = id;
+    }
     #[inline]
     fn len(&self) -> usize {
         self.widgets.len() + self.handles.len()
@@ -268,6 +276,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         let mut handles = Vec::new();
         handles.resize_with(widgets.len().saturating_sub(1), || DragHandle::new());
         Splitter {
+            first_id: Default::default(),
             core: Default::default(),
             widgets,
             handles,

--- a/src/widget/stack.rs
+++ b/src/widget/stack.rs
@@ -34,6 +34,7 @@ pub type RefStack<'a, M> = Stack<&'a mut dyn Widget<Msg = M>>;
 #[widget(children=noauto)]
 #[derive(Clone, Default, Debug, Widget)]
 pub struct Stack<W: Widget> {
+    first_id: WidgetId,
     #[widget_core]
     core: CoreData,
     widgets: Vec<W>,
@@ -41,6 +42,13 @@ pub struct Stack<W: Widget> {
 }
 
 impl<W: Widget> WidgetChildren for Stack<W> {
+    #[inline]
+    fn first_id(&self) -> WidgetId {
+        self.first_id
+    }
+    fn record_first_id(&mut self, id: WidgetId) {
+        self.first_id = id;
+    }
     #[inline]
     fn len(&self) -> usize {
         self.widgets.len()
@@ -113,6 +121,7 @@ impl<W: Widget> Stack<W> {
     /// visible; otherwise, no widget will be visible.
     pub fn new(widgets: Vec<W>, active: usize) -> Self {
         Stack {
+            first_id: Default::default(),
             core: Default::default(),
             widgets,
             active,


### PR DESCRIPTION
This addresses part of #91: storing the identifier range start for parent widgets in order to allow O(1) `is_ancestor_of` check.

Then we update corresponding to https://github.com/kas-gui/kas-text/pull/33 and add support for extracting underlining data from `AccelString` text when drawing.

Finally, we add a `min_spec` feature (`min_specialization`) and add it to the `nightly` feature target (also adding `unsize` and using `nightly` transitively through KAS crates).