### PR TITLE
O(log n) find, DrawHandle::text_effects, tab entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ path = "kas-macros"
 [dependencies.kas-text]
 version = "0.1.2"
 git = "https://github.com/kas-gui/kas-text"
-rev = "15416e9827d1b21575916ebdf9ff8967cd2509c4"
+rev = "088fde383a0f3fab9e29c3cfdb8afe4875a31096"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ path = "kas-macros"
 [dependencies.kas-text]
 version = "0.1.2"
 git = "https://github.com/kas-gui/kas-text"
-rev = "ce08a05df11081de0a638b8e6efa52afafe145d9"
+rev = "c906162da81e9e5b39e8e279dc88578569301180"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ path = "kas-macros"
 [dependencies.kas-text]
 version = "0.1.2"
 git = "https://github.com/kas-gui/kas-text"
-rev = "c906162da81e9e5b39e8e279dc88578569301180"
+rev = "1e344faea785610704207deac187a339b7769c9f"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ path = "kas-macros"
 [dependencies.kas-text]
 version = "0.1.2"
 git = "https://github.com/kas-gui/kas-text"
-rev = "1e344faea785610704207deac187a339b7769c9f"
+rev = "15416e9827d1b21575916ebdf9ff8967cd2509c4"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -262,6 +262,18 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             .text(self.pass, pos.into(), bounds, offset.into(), text, col);
     }
 
+    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass) {
+        self.draw.text_col_effects(
+            self.pass,
+            (pos + self.offset).into(),
+            text.env().bounds.into(),
+            offset.into(),
+            text.display(),
+            self.cols.text_class(class),
+            text.effect_tokens(),
+        );
+    }
+
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
         let pos = Vec2::from(pos + self.offset);
         let offset = Vec2::ZERO;

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -259,23 +259,21 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         let pos = pos + self.offset;
         let col = self.cols.text_class(class);
         self.draw
-            .text(self.pass, pos.into(), bounds, offset.into(), col, text);
+            .text(self.pass, pos.into(), bounds, offset.into(), text, col);
     }
 
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
         let pos = Vec2::from(pos + self.offset);
         let offset = Vec2::ZERO;
         let bounds = text.env().bounds.into();
-        let aux = self.cols.text_class(class);
+        let col = self.cols.text_class(class);
         if state {
-            let effects = text.text().effect_tokens(aux);
-            #[cfg(feature = "gat")]
-            let effects: Vec<_> = effects.collect();
+            let effects = text.text().effect_tokens();
             self.draw
-                .text_with_effects(self.pass, pos, bounds, offset, text.as_ref(), &effects);
+                .text_col_effects(self.pass, pos, bounds, offset, text.as_ref(), col, effects);
         } else {
             self.draw
-                .text(self.pass, pos, bounds, offset, aux, text.as_ref());
+                .text(self.pass, pos, bounds, offset, text.as_ref(), col);
         }
     }
 
@@ -324,7 +322,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             },
         ];
         self.draw
-            .text_with_effects(self.pass, pos, bounds, offset, text, &effects);
+            .text_effects(self.pass, pos, bounds, offset, text, &effects);
     }
 
     fn edit_marker(

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -16,7 +16,8 @@ use kas::draw::{
     SizeHandle, TextClass,
 };
 use kas::geom::*;
-use kas::text::{AccelString, Effect, EffectFlags, Text, TextApi, TextDisplay};
+use kas::text::format::FormattableText;
+use kas::text::{AccelString, Effect, Text, TextApi, TextDisplay};
 use kas::{Direction, Directional, ThemeAction, ThemeApi};
 
 /// A theme with flat (unshaded) rendering
@@ -267,18 +268,9 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         let bounds = text.env().bounds.into();
         let aux = self.cols.text_class(class);
         if state {
-            let ulines = text.text().underlines();
-            let mut effects = Vec::with_capacity(1 + ulines.len());
-            effects.push(Effect {
-                start: 0,
-                flags: Default::default(),
-                aux,
-            });
-            let mut flags = EffectFlags::UNDERLINE;
-            for start in ulines.iter().cloned() {
-                effects.push(Effect { start, flags, aux });
-                flags.toggle(EffectFlags::UNDERLINE);
-            }
+            let effects = text.text().effect_tokens(aux);
+            #[cfg(feature = "gat")]
+            let effects: Vec<_> = effects.collect();
             self.draw
                 .text_with_effects(self.pass, pos, bounds, offset, text.as_ref(), &effects);
         } else {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -14,7 +14,7 @@ use kas::draw::{
     Pass, SizeHandle, TextClass,
 };
 use kas::geom::*;
-use kas::text::{AccelString, Text, TextDisplay};
+use kas::text::{AccelString, Text, TextApi, TextDisplay};
 use kas::{Direction, Directional, ThemeAction, ThemeApi};
 
 /// A theme using simple shading to give apparent depth to elements
@@ -277,6 +277,10 @@ where
         class: TextClass,
     ) {
         self.as_flat().text_offset(pos, bounds, offset, text, class);
+    }
+
+    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass) {
+        self.as_flat().text_effects(pos, offset, text, class);
     }
 
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -108,10 +108,10 @@ impl Layout for Clock {
 
         let pos = (self.date_pos + offset).into();
         let bounds = self.date.env().bounds.into();
-        draw.text(pass, pos, bounds, Vec2::ZERO, col_text, self.date.as_ref());
+        draw.text(pass, pos, bounds, Vec2::ZERO, self.date.as_ref(), col_text);
         let pos = (self.time_pos + offset).into();
         let bounds = self.time.env().bounds.into();
-        draw.text(pass, pos, bounds, Vec2::ZERO, col_text, self.time.as_ref());
+        draw.text(pass, pos, bounds, Vec2::ZERO, self.time.as_ref(), col_text);
     }
 }
 

--- a/kas-wgpu/examples/markdown.rs
+++ b/kas-wgpu/examples/markdown.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
 ================
 
 Markdown supports *italic* and **bold** highlighting, ***both***, even with*in* w**o**rds.
+As an extension, it also supports ~~strikethrough~~.
 
 Inline `code = 2;` is supported. Code blocks are supported:
 ```
@@ -25,6 +26,8 @@ let x = 1;
 let y = x + 1;
 ```
 
+Markdown supports explicit line breaks —  
+via two trailing spaces.  
 It also supports lists:
 
 1.  First item

--- a/kas-wgpu/src/draw/draw_text.rs
+++ b/kas-wgpu/src/draw/draw_text.rs
@@ -38,47 +38,6 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
         }
     }
 
-    fn text(
-        &mut self,
-        pass: Pass,
-        pos: Vec2,
-        bounds: Vec2,
-        offset: Vec2,
-        col: Colour,
-        text: &TextDisplay,
-    ) {
-        let time = std::time::Instant::now();
-        let ab_pos = to_point(pos);
-        let ab_offset = ab_pos - to_point(offset);
-
-        let mut glyphs = Vec::with_capacity(text.num_glyphs());
-        let for_glyph = |font_id: FontId, _, height: f32, glyph: Glyph| {
-            glyphs.push(SectionGlyph {
-                section_index: 0,
-                byte_index: 0, // not used
-                glyph: ab_glyph::Glyph {
-                    id: ab_glyph::GlyphId(glyph.id.0),
-                    scale: height.into(),
-                    position: ab_offset + ktv_to_point(glyph.position),
-                },
-                font_id: wgpu_glyph::FontId(font_id.get()),
-            });
-        };
-        text.glyphs(for_glyph);
-
-        let min = ab_pos;
-        let max = ab_pos + to_point(bounds);
-        let bounds = ab_glyph::Rect { min, max };
-
-        let extra = vec![Extra {
-            color: col.into(),
-            z: pass.depth(),
-        }];
-
-        self.glyph_brush.queue_pre_positioned(glyphs, extra, bounds);
-        self.dur_text += time.elapsed();
-    }
-
     fn text_with_effects(
         &mut self,
         pass: Pass,
@@ -88,34 +47,55 @@ impl<CW: CustomWindow + 'static> DrawText for DrawWindow<CW> {
         text: &TextDisplay,
         effects: &[Effect<Colour>],
     ) {
+        assert!(
+            effects.get(0).map(|e| e.start == 0).unwrap_or(false),
+            "DrawText::text_with_effects: effects list is empty or first item has start > 0"
+        );
+
         let time = std::time::Instant::now();
         let ab_pos = to_point(pos);
         let ab_offset = ab_pos - to_point(offset);
 
         let mut glyphs = Vec::with_capacity(text.num_glyphs());
-        let for_glyph = |font_id: FontId, _, height: f32, glyph: Glyph, i, _| {
-            glyphs.push(SectionGlyph {
-                section_index: i,
-                byte_index: 0, // not used
-                glyph: ab_glyph::Glyph {
-                    id: ab_glyph::GlyphId(glyph.id.0),
-                    scale: height.into(),
-                    position: ab_offset + ktv_to_point(glyph.position),
-                },
-                font_id: wgpu_glyph::FontId(font_id.get()),
-            });
-        };
-        let for_rect = |x1, x2, mut y, h: f32, i: usize, _| {
-            let y2 = y + h;
-            if h < 1.0 {
-                // h too small can make the line invisible due to rounding
-                // In this case we prefer to push the line up (nearer text).
-                y = y2 - 1.0;
-            }
-            let quad = Quad::with_coords(pos + Vec2(x1, y), pos + Vec2(x2, y2));
-            self.rect(pass, quad, effects[i].aux);
-        };
-        text.glyphs_with_effects(effects, for_glyph, for_rect);
+        if effects.len() > 1 {
+            let for_glyph = |font_id: FontId, _, height: f32, glyph: Glyph, i, _| {
+                glyphs.push(SectionGlyph {
+                    section_index: i,
+                    byte_index: 0, // not used
+                    glyph: ab_glyph::Glyph {
+                        id: ab_glyph::GlyphId(glyph.id.0),
+                        scale: height.into(),
+                        position: ab_offset + ktv_to_point(glyph.position),
+                    },
+                    font_id: wgpu_glyph::FontId(font_id.get()),
+                });
+            };
+            let for_rect = |x1, x2, mut y, h: f32, i: usize, _| {
+                let y2 = y + h;
+                if h < 1.0 {
+                    // h too small can make the line invisible due to rounding
+                    // In this case we prefer to push the line up (nearer text).
+                    y = y2 - 1.0;
+                }
+                let quad = Quad::with_coords(pos + Vec2(x1, y), pos + Vec2(x2, y2));
+                self.rect(pass, quad, effects[i].aux);
+            };
+            text.glyphs_with_effects(effects, for_glyph, for_rect);
+        } else {
+            let for_glyph = |font_id: FontId, _, height: f32, glyph: Glyph| {
+                glyphs.push(SectionGlyph {
+                    section_index: 0,
+                    byte_index: 0, // not used
+                    glyph: ab_glyph::Glyph {
+                        id: ab_glyph::GlyphId(glyph.id.0),
+                        scale: height.into(),
+                        position: ab_offset + ktv_to_point(glyph.position),
+                    },
+                    font_id: wgpu_glyph::FontId(font_id.get()),
+                });
+            };
+            text.glyphs(for_glyph);
+        }
 
         let min = ab_pos;
         let max = ab_pos + to_point(bounds);

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -11,12 +11,12 @@ use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use kas::draw::{Draw, Pass};
 use kas::geom::{Coord, Rect, Size, Vec2};
 use kas::layout::{AxisInfo, Margins, SizeRules};
-use kas::text::{format::FormattableText, AccelString, TextApi, TextDisplay};
+use kas::text::{format::FormattableText, AccelString, Text, TextApi, TextDisplay};
 use kas::Direction;
 
 // for doc use
 #[allow(unused)]
-use kas::text::Text;
+use kas::text::TextApiExt;
 
 /// Classification of a clip region
 pub enum ClipRegion {
@@ -151,7 +151,7 @@ pub trait SizeHandle {
     /// to a [`SizeRules`] value and returns it.
     ///
     /// Usually this method is used in [`Layout::size_rules`], then
-    /// [`Text::update_env`] is used in [`Layout::set_rect`].
+    /// [`TextApiExt::update_env`] is used in [`Layout::set_rect`].
     ///
     /// [`Environment`]: kas::text::Environment
     /// [`Layout::set_rect`]: kas::Layout::set_rect

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -287,6 +287,13 @@ pub trait DrawHandle {
         class: TextClass,
     );
 
+    /// Draw text with effects
+    ///
+    /// [`DrawHandle::text_offset`] already supports *font* effects: bold,
+    /// emphasis, text size. In addition, this method supports underline and
+    /// strikethrough effects.
+    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass);
+
     /// Draw an `AccelString` text
     ///
     /// The `text` is drawn within the rect from `pos` to `text.env().bounds`.
@@ -566,6 +573,9 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         self.deref_mut()
             .text_offset(pos, bounds, offset, text, class)
     }
+    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass) {
+        self.deref_mut().text_effects(pos, offset, text, class);
+    }
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
         self.deref_mut().text_accel(pos, text, state, class);
     }
@@ -658,6 +668,9 @@ where
     ) {
         self.deref_mut()
             .text_offset(pos, bounds, offset, text, class)
+    }
+    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass) {
+        self.deref_mut().text_effects(pos, offset, text, class);
     }
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
         self.deref_mut().text_accel(pos, text, state, class);

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -239,9 +239,8 @@ pub trait DrawText {
 
     /// Draw text with effects
     ///
-    /// The `effects` list must have length at least 1 and its first item
-    /// should have `start = 0` and supply the base text colour (otherwise
-    /// black will be used).
+    /// It is required that the `effects` list have length at least 1 and that
+    /// its first item has `start = 0`.
     fn text_with_effects(
         &mut self,
         pass: Pass,

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -239,8 +239,8 @@ pub trait DrawText {
 
     /// Draw text with effects
     ///
-    /// It is required that the `effects` list have length at least 1 and that
-    /// its first item has `start = 0`.
+    /// If the `effects` list is empty or the first entry has `start > 0`, a
+    /// default entity will be assumed.
     fn text_with_effects(
         &mut self,
         pass: Pass,

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -219,29 +219,38 @@ pub trait DrawText {
     /// Load resources needed for the next frame
     fn prepare_fonts(&mut self);
 
-    /// Draw text
+    /// Draw text with a colour
     fn text(
         &mut self,
         pass: Pass,
         pos: Vec2,
         bounds: Vec2,
         offset: Vec2,
-        col: Colour,
         text: &TextDisplay,
-    ) {
-        let effects = [Effect {
-            start: 0,
-            flags: Default::default(),
-            aux: col,
-        }];
-        self.text_with_effects(pass, pos, bounds, offset, text, &effects);
-    }
+        col: Colour,
+    );
+
+    /// Draw text with a colour and effects
+    ///
+    /// The effects list does not contain colour information, but may contain
+    /// underlining/strikethrough information. It may be empty.
+    fn text_col_effects(
+        &mut self,
+        pass: Pass,
+        pos: Vec2,
+        bounds: Vec2,
+        offset: Vec2,
+        text: &TextDisplay,
+        col: Colour,
+        effects: &[Effect<()>],
+    );
 
     /// Draw text with effects
     ///
+    /// The `effects` list provides both underlining and colour information.
     /// If the `effects` list is empty or the first entry has `start > 0`, a
     /// default entity will be assumed.
-    fn text_with_effects(
+    fn text_effects(
         &mut self,
         pass: Pass,
         pos: Vec2,

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -27,12 +27,12 @@ impl<'a> std::ops::AddAssign<TkAction> for Manager<'a> {
 impl ManagerState {
     /// True when accelerator key labels should be shown
     ///
-    /// (True when Alt is held.)
+    /// (True when Alt is held and no widget has character focus.)
     ///
     /// This is a fast check.
     #[inline]
     pub fn show_accel_labels(&self) -> bool {
-        self.modifiers.alt()
+        self.modifiers.alt() && self.char_focus.is_none()
     }
 
     /// Get whether this widget has a grab on character input

--- a/src/text/string.rs
+++ b/src/text/string.rs
@@ -130,19 +130,8 @@ impl FormattableText for AccelString {
         OwningVecIter::new(vec![])
     }
 
-    #[cfg(feature = "gat")]
-    fn effect_tokens<'a, X: Clone>(&'a self, _: X) -> Self::EffectTokenIter<'a, X> {
-        todo!() // untestable with current state of GAT in nightly rustc
-    }
-    #[cfg(not(feature = "gat"))]
-    fn effect_tokens<'a, X: Clone>(&'a self, aux: X) -> Vec<Effect<X>> {
-        // TODO(opt): avoid copy where X=() ?
-        let iter = self.effects.iter().map(|effect| Effect {
-            start: effect.start,
-            flags: effect.flags,
-            aux: aux.clone(),
-        });
-        iter.collect()
+    fn effect_tokens(&self) -> &[Effect<()>] {
+        &self.effects
     }
 }
 

--- a/src/text/string.rs
+++ b/src/text/string.rs
@@ -111,9 +111,6 @@ impl FormattableText for AccelString {
     #[cfg(feature = "gat")]
     type FontTokenIter<'a> = std::iter::Empty<FontToken>;
 
-    #[cfg(feature = "gat")]
-    type EffectTokenIter<'a, X: Clone> = std::iter::Empty<Effect<X>>;
-
     #[inline]
     fn as_str(&self) -> &str {
         &self.label

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -496,6 +496,7 @@ impl<G> EditBox<G> {
             ControlKey::Return if self.multi_line => {
                 Action::Insert('\n'.encode_utf8(&mut buf), LastEdit::Insert)
             }
+            ControlKey::Tab => Action::Insert('\t'.encode_utf8(&mut buf), LastEdit::Insert),
             ControlKey::Home if ctrl => Action::Move(0, None),
             ControlKey::Home => {
                 let pos = self.text.find_line(pos).map(|r| r.1.start).unwrap_or(0);

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -72,11 +72,21 @@ impl<T: FormattableText + 'static> Layout for Label<T> {
 
     #[cfg(feature = "min_spec")]
     default fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        draw_handle.text(self.core.rect.pos, &self.label, TextClass::Label);
+        draw_handle.text_effects(
+            self.core.rect.pos,
+            Coord::ZERO,
+            &self.label,
+            TextClass::Label,
+        );
     }
     #[cfg(not(feature = "min_spec"))]
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        draw_handle.text(self.core.rect.pos, &self.label, TextClass::Label);
+        draw_handle.text_effects(
+            self.core.rect.pos,
+            Coord::ZERO,
+            &self.label,
+            TextClass::Label,
+        );
     }
 }
 
@@ -85,6 +95,20 @@ impl Layout for AccelLabel {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, _: bool) {
         let state = mgr.show_accel_labels();
         draw_handle.text_accel(self.core.rect.pos, &self.label, state, TextClass::Label);
+    }
+}
+
+// Str/String representations have no effects, so use simpler draw call
+#[cfg(feature = "min_spec")]
+impl<'a> Layout for Label<&'a str> {
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
+        draw_handle.text(self.core.rect.pos, &self.label, TextClass::Label);
+    }
+}
+#[cfg(feature = "min_spec")]
+impl Layout for StringLabel {
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
+        draw_handle.text(self.core.rect.pos, &self.label, TextClass::Label);
     }
 }
 


### PR DESCRIPTION
The `WidgetChildren::find` and `find_mut` methods now use binary search to achieve `O(log n)` performance over large numbers of children. This is only really relevant on *large* lists of children and still probably not the most significant cost, but is another step towards #91.

Other changes depend on these changes: https://github.com/kas-gui/kas-text/pull/34

`EditBox` now enters `\t` on the Tab key to allow testing the new tab support. (Should be configurable later, or depend on the use case?)

Added `DrawHandle::text_effects` and revised `DrawText` methods. We can now forward effects like strikethrough from parsed text. We keep `DrawHandle::text_accel` (since behaviour depends on an extra state parameter), but move the effect-list creation up to `AccelString`.