### PR TITLE
Span distributions and Mandlebrot

### DIFF
--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -523,7 +523,8 @@ struct MandlebrotWindow {
     iters: Label<String>,
     #[widget(row=2, handler = iter)]
     slider: Slider<i32, kas::Up>,
-    #[widget(col=1, row=1, rspan=2, handler = mbrot)]
+    // extra col span allows use of Label's margin
+    #[widget(col=1, cspan=2, row=1, rspan=2, handler = mbrot)]
     mbrot: Mandlebrot,
 }
 impl MandlebrotWindow {

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -185,7 +185,7 @@ pub trait SizeHandle {
     /// Returns:
     ///
     /// -   `size`: minimum size of handle in horizontal orientation;
-    ///     `size.1` is also the dimension of the scrollbar
+    ///     `size.1` is also the width of the scrollbar
     /// -   `min_len`: minimum length for the whole bar
     ///
     /// Required bound: `min_len >= size.0`.
@@ -196,7 +196,7 @@ pub trait SizeHandle {
     /// Returns:
     ///
     /// -   `size`: minimum size of handle in horizontal orientation;
-    ///     `size.1` is also the dimension of the slider
+    ///     `size.1` is also the width of the slider
     /// -   `min_len`: minimum length for the whole bar
     ///
     /// Required bound: `min_len >= size.0`.

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -249,6 +249,12 @@ impl SizeRules {
         self.m
     }
 
+    /// Get the stretch policy
+    #[inline]
+    pub fn stretch(self) -> StretchPolicy {
+        self.stretch
+    }
+
     /// Set margins to max of own margins and given margins
     pub fn include_margins(&mut self, margins: (u16, u16)) {
         self.m.0 = self.m.0.max(margins.0);
@@ -673,6 +679,24 @@ impl SizeRules {
 
                 largest -= step;
                 num_equal += num_add;
+            }
+        }
+    }
+
+    /// Ensure at least one of `rules` has stretch policy at least as high as self
+    ///
+    /// The stretch policies are increased according to the heighest `scores`.
+    /// Required: `rules.len() == scores.len()`.
+    pub(crate) fn distribute_stretch_over_by(self, rules: &mut [Self], scores: &[u32]) {
+        assert_eq!(rules.len(), scores.len());
+        if rules.iter().any(|r| r.stretch >= self.stretch) {
+            return;
+        }
+
+        let highest = scores.iter().cloned().max().unwrap_or(0);
+        for i in 0..rules.len() {
+            if scores[i] == highest {
+                rules[i].stretch = self.stretch;
             }
         }
     }

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -55,7 +55,7 @@ impl DragHandle {
         self.set_offset(offset).1
     }
 
-    /// Get the current tract `Rect`
+    /// Get the current track `Rect`
     #[inline]
     pub fn track(&self) -> Rect {
         self.track

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -226,7 +226,12 @@ impl<T: SliderType, D: Directional> Layout for Slider<T, D> {
     fn set_rect(&mut self, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         self.handle.set_rect(rect, align);
-        let size = self.handle_size.min(rect.size);
+        let mut size = rect.size;
+        if self.direction.is_horizontal() {
+            size.0 = self.handle_size.0.min(rect.size.0);
+        } else {
+            size.1 = self.handle_size.1.min(rect.size.1);
+        }
         let _ = self.handle.set_size_and_offset(size, self.offset());
     }
 


### PR DESCRIPTION
"Fixes" space distribution within grid spans (well, one bug fix + one improvement; this isn't perfection).

Fixes size of a slider handle when the slider's thickness is larger than required. Graphics are still poor in this case.

The Mandlebrot example now occupies the right margin with its main widget.