### PR TITLE
Fixes for selection and ScrollRegion<Label>

### DIFF
--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -194,8 +194,11 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
             SizeRules::new(min, ideal, margins, policy)
         } else {
             let min = match class {
+                TextClass::Label => required.1 as u32,
+                TextClass::LabelSingle | TextClass::Button | TextClass::Edit => {
+                    self.dims.line_height
+                }
                 TextClass::EditMulti => self.dims.line_height * 3,
-                _ => self.dims.line_height,
             };
             let ideal = (required.1 as u32).max(min);
             let stretch = match class {

--- a/kas-wgpu/examples/markdown.rs
+++ b/kas-wgpu/examples/markdown.rs
@@ -9,7 +9,7 @@ use kas::class::HasStr;
 use kas::event::{Manager, Response, VoidMsg};
 use kas::macros::make_widget;
 use kas::text::format::Markdown;
-use kas::widget::{EditBox, EditBoxVoid, Label, TextButton, Window};
+use kas::widget::{EditBox, EditBoxVoid, Label, ScrollRegion, TextButton, Window};
 
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
@@ -44,13 +44,14 @@ It also supports lists:
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget(row=0, col=0, rspan=2)] editor: EditBoxVoid = EditBox::new(doc).multi_line(true),
-                #[widget(row=0, col=1)] label: Label<Markdown> = Label::new(Markdown::new(doc)),
+                #[widget(row=0, col=1)] label: ScrollRegion<Label<Markdown>> = ScrollRegion::new(Label::new(Markdown::new(doc))).with_bars(false, true),
                 #[widget(row=1, col=1, handler=update)] _ = TextButton::new("&Update", ()),
             }
             impl {
                 fn update(&mut self, mgr: &mut Manager, _: ()) -> Response<VoidMsg> {
                     let text = Markdown::new(self.editor.get_str());
-                    *mgr += self.label.set_text(text);
+                    // TODO: this should update the size requirements of the inner area
+                    *mgr += self.label.inner_mut().set_text(text);
                     Response::None
                 }
             }

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -49,6 +49,9 @@ pub struct InputState {
     /// "Character focus" implies this widget is ready to receive text input
     /// (e.g. typing into an input field).
     pub char_focus: bool,
+    /// "Selection focus" allows things such as text to be selected. Selection
+    /// focus implies that the widget also has character focus.
+    pub sel_focus: bool,
 }
 
 impl std::ops::BitOr for InputState {
@@ -62,6 +65,7 @@ impl std::ops::BitOr for InputState {
             depress: self.depress || rhs.depress,
             nav_focus: self.nav_focus || rhs.nav_focus,
             char_focus: self.char_focus || rhs.char_focus,
+            sel_focus: self.sel_focus || rhs.sel_focus,
         }
     }
 }

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -42,6 +42,11 @@ pub enum Event {
     Control(ControlKey),
     /// Widget lost keyboard input focus
     LostCharFocus,
+    /// Widget lost selection focus
+    ///
+    /// Selection focus implies character focus, so this event implies that the
+    /// widget has already received [`Event::LostCharFocus`].
+    LostSelFocus,
     /// Widget receives a character of text input
     ReceivedCharacter(char),
     /// A mouse or touchpad scroll event

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -32,13 +32,23 @@ impl ManagerState {
     /// This is a fast check.
     #[inline]
     pub fn show_accel_labels(&self) -> bool {
-        self.modifiers.alt() && self.char_focus.is_none()
+        self.modifiers.alt() && !self.char_focus
     }
 
-    /// Get whether this widget has a grab on character input
+    /// Get whether this widget has `(char_focus, sel_focus)`
+    ///
+    /// -   `char_focus`: implies this widget receives keyboard input
+    /// -   `sel_focus`: implies this widget is allowed to select things
+    ///
+    /// Note that `char_focus` implies `sel_focus`.
     #[inline]
-    pub fn char_focus(&self, w_id: WidgetId) -> bool {
-        self.char_focus == Some(w_id)
+    pub fn char_focus(&self, w_id: WidgetId) -> (bool, bool) {
+        if let Some(id) = self.sel_focus {
+            if id == w_id {
+                return (self.char_focus, true);
+            }
+        }
+        (false, false)
     }
 
     /// Get whether this widget has keyboard focus
@@ -461,7 +471,7 @@ impl<'a> Manager<'a> {
             }
         }
 
-        if self.mgr.char_focus != Some(id) {
+        if self.mgr.char_focus && self.mgr.sel_focus != Some(id) {
             self.set_char_focus(None);
         }
         self.redraw(start_id);

--- a/src/text.rs
+++ b/src/text.rs
@@ -7,6 +7,9 @@
 
 pub use kas_text::*;
 
+mod selection;
+pub use selection::SelectionHelper;
+
 mod string;
 pub use string::AccelString;
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -16,30 +16,26 @@ pub mod util {
 
     /// Set the text and prepare
     ///
-    /// This is a convenience function to (1) set the text, (2) call prepare
-    /// and (3) return `TkAction` to trigger a redraw.
-    ///
-    /// This calls [`Text::prepare`] internally, then returns
-    /// [`TkAction::Redraw`]. (This does not force a resize.)
+    /// This is a convenience function to (1) set the text, (2) call
+    /// [`Text::prepare`] internally and (3) return [`TkAction::Resize`] to
+    /// trigger a resize.
     pub fn set_text_and_prepare<T: format::FormattableText>(text: &mut Text<T>, s: T) -> TkAction {
         text.set_text(s);
         text.prepare();
-        TkAction::Redraw
+        TkAction::Resize
     }
 
     /// Set the text from a string and prepare
     ///
-    /// This is a convenience function to (1) set the text, (2) call prepare
-    /// and (3) return `TkAction` to trigger a redraw.
-    ///
-    /// This calls [`Text::prepare`] internally, then returns
-    /// [`TkAction::Redraw`]. (This does not force a resize.)
+    /// This is a convenience function to (1) set the text, (2) call
+    /// [`Text::prepare`] internally and (3) return [`TkAction::Resize`] to
+    /// trigger a resize.
     pub fn set_string_and_prepare<T: format::EditableText>(
         text: &mut Text<T>,
         s: String,
     ) -> TkAction {
         text.set_string(s);
         text.prepare();
-        TkAction::Redraw
+        TkAction::Resize
     }
 }

--- a/src/text/selection.rs
+++ b/src/text/selection.rs
@@ -1,0 +1,137 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Tools for text selection
+
+use super::{TextApi, TextApiExt};
+use std::ops::Range;
+use unicode_segmentation::UnicodeSegmentation;
+
+/// Text-selection logic
+///
+/// This struct holds an "edit pos" and a "selection pos", which together form
+/// a range. There is no requirement on the order of these two positions. Each
+/// may be adjusted independently.
+#[derive(Clone, Debug, Default)]
+pub struct SelectionHelper {
+    edit_pos: usize,
+    sel_pos: usize,
+    anchor_pos: usize,
+}
+
+impl SelectionHelper {
+    /// Construct from `(edit, selection)` positions
+    ///
+    /// The anchor position is set to the selection position.
+    pub fn new(edit_pos: usize, sel_pos: usize) -> Self {
+        let anchor_pos = sel_pos;
+        SelectionHelper {
+            edit_pos,
+            sel_pos,
+            anchor_pos,
+        }
+    }
+
+    /// True if the edit pos equals the selection pos
+    pub fn is_empty(&self) -> bool {
+        self.edit_pos == self.sel_pos
+    }
+    /// Set the selection pos to the edit pos
+    pub fn set_empty(&mut self) {
+        self.sel_pos = self.edit_pos;
+    }
+
+    /// Set both edit and selection positions to this value
+    pub fn set_pos(&mut self, pos: usize) {
+        self.edit_pos = pos;
+        self.sel_pos = pos;
+    }
+
+    /// Get the edit pos
+    pub fn edit_pos(&self) -> usize {
+        self.edit_pos
+    }
+    /// Set the edit pos without adjusting the selection pos
+    pub fn set_edit_pos(&mut self, pos: usize) {
+        self.edit_pos = pos;
+    }
+
+    /// Get the selection pos
+    pub fn sel_pos(&self) -> usize {
+        self.sel_pos
+    }
+    /// Set the selection pos without adjusting the edit pos
+    pub fn set_sel_pos(&mut self, pos: usize) {
+        self.sel_pos = pos;
+    }
+
+    /// Construct a range from the edit pos and selection pos
+    ///
+    /// The range is from the minimum of (edit pos, selection pos) to the
+    /// maximum of the two.
+    pub fn range(&self) -> Range<usize> {
+        let mut range = self.edit_pos..self.sel_pos;
+        if range.start > range.end {
+            std::mem::swap(&mut range.start, &mut range.end);
+        }
+        range
+    }
+
+    /// Set the anchor position from the selection position
+    pub fn set_anchor(&mut self) {
+        self.anchor_pos = self.sel_pos;
+    }
+
+    /// Expand the selection from the range between edit pos and anchor pos
+    ///
+    /// This moves both edit pos and sel pos. To obtain repeatable behaviour,
+    /// first use [`SelectionHelper::set_anchor`] to set the anchor position,
+    /// then before each time this method is called set the edit position.
+    ///
+    /// If `repeats <= 2`, the selection is expanded by words, otherwise it is
+    /// expanded by lines.
+    pub fn expand<T: TextApi>(&mut self, text: &T, repeats: u32) {
+        let string = text.as_str();
+        let mut range = self.edit_pos..self.anchor_pos;
+        if range.start > range.end {
+            std::mem::swap(&mut range.start, &mut range.end);
+        }
+        let (mut start, mut end);
+        if repeats <= 2 {
+            end = string[range.start..]
+                .char_indices()
+                .skip(1)
+                .next()
+                .map(|(i, _)| range.start + i)
+                .unwrap_or(string.len());
+            start = string[0..end]
+                .split_word_bound_indices()
+                .next_back()
+                .map(|(index, _)| index)
+                .unwrap_or(0);
+            end = 'a: loop {
+                for (index, _) in string[start..].split_word_bound_indices() {
+                    let pos = start + index;
+                    if pos >= range.end {
+                        break 'a pos;
+                    }
+                }
+                break 'a string.len();
+            };
+        } else {
+            start = text.find_line(range.start).map(|r| r.1.start).unwrap_or(0);
+            end = text
+                .find_line(range.end)
+                .map(|r| r.1.end)
+                .unwrap_or(string.len());
+        }
+
+        if self.edit_pos < self.sel_pos {
+            std::mem::swap(&mut start, &mut end);
+        }
+        self.sel_pos = start;
+        self.edit_pos = end;
+    }
+}

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -124,13 +124,15 @@ pub trait WidgetCore: Any + fmt::Debug {
     /// this.
     fn input_state(&self, mgr: &ManagerState, disabled: bool) -> InputState {
         let id = self.core_data().id;
+        let (char_focus, sel_focus) = mgr.char_focus(id);
         InputState {
             disabled: self.core_data().disabled || disabled,
             error: false,
             hover: mgr.is_hovered(id),
             depress: mgr.is_depressed(id),
             nav_focus: mgr.nav_focus(id),
-            char_focus: mgr.char_focus(id),
+            char_focus,
+            sel_focus,
         }
     }
 }

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -14,6 +14,7 @@ use kas::draw::TextClass;
 use kas::event::{self, ControlKey, GrabMode, PressSource, ScrollDelta};
 use kas::geom::Vec2;
 use kas::prelude::*;
+use kas::text::SelectionHelper;
 
 #[derive(Clone, Debug, PartialEq)]
 enum LastEdit {
@@ -161,9 +162,7 @@ pub struct EditBox<G: 'static> {
     multi_line: bool,
     text: Text<String>,
     required: Vec2,
-    edit_pos: usize,
-    sel_pos: usize,
-    anchor_pos: usize,
+    selection: SelectionHelper,
     edit_x_coord: Option<f32>,
     old_state: Option<(String, usize, usize)>,
     last_edit: LastEdit,
@@ -253,7 +252,7 @@ impl<G: 'static> Layout for EditBox<G> {
         input_state.error = self.error_state;
         draw_handle.edit_box(self.core.rect, input_state);
         let bounds = self.text.env().bounds.into();
-        if self.sel_pos == self.edit_pos {
+        if self.selection.is_empty() {
             draw_handle.text_offset(
                 self.text_pos,
                 bounds,
@@ -270,7 +269,7 @@ impl<G: 'static> Layout for EditBox<G> {
                 bounds,
                 self.view_offset,
                 &self.text,
-                self.selection(),
+                self.selection.range(),
                 class,
             );
         }
@@ -281,7 +280,7 @@ impl<G: 'static> Layout for EditBox<G> {
                 self.view_offset,
                 self.text.as_ref(),
                 class,
-                self.edit_pos,
+                self.selection.edit_pos(),
             );
         }
     }
@@ -291,7 +290,7 @@ impl EditBox<EditVoid> {
     /// Construct an `EditBox` with the given inital `text`.
     pub fn new<S: ToString>(text: S) -> Self {
         let text = text.to_string();
-        let edit_pos = text.len();
+        let len = text.len();
         EditBox {
             core: Default::default(),
             frame_offset: Default::default(),
@@ -302,9 +301,7 @@ impl EditBox<EditVoid> {
             multi_line: false,
             text: Text::new(Default::default(), text.into()),
             required: Vec2::ZERO,
-            edit_pos,
-            sel_pos: edit_pos,
-            anchor_pos: edit_pos,
+            selection: SelectionHelper::new(len, len),
             edit_x_coord: None,
             old_state: None,
             last_edit: LastEdit::None,
@@ -332,9 +329,7 @@ impl EditBox<EditVoid> {
             multi_line: self.multi_line,
             text: self.text,
             required: self.required,
-            edit_pos: self.edit_pos,
-            sel_pos: self.sel_pos,
-            anchor_pos: self.anchor_pos,
+            selection: self.selection,
             edit_x_coord: self.edit_x_coord,
             old_state: self.old_state,
             last_edit: self.last_edit,
@@ -422,36 +417,27 @@ impl<G> EditBox<G> {
         self.error_state = error_state;
     }
 
-    fn selection(&self) -> Range<usize> {
-        let mut range = self.edit_pos..self.sel_pos;
-        if range.start > range.end {
-            std::mem::swap(&mut range.start, &mut range.end);
-        }
-        range
-    }
-
     fn received_char(&mut self, mgr: &mut Manager, c: char) -> EditAction {
         if !self.editable {
             return EditAction::Unhandled;
         }
 
-        let pos = self.edit_pos;
-        let selection = self.selection();
+        let pos = self.selection.edit_pos();
+        let selection = self.selection.range();
         let have_sel = selection.start < selection.end;
         if self.last_edit != LastEdit::Insert || have_sel {
-            self.old_state = Some((self.text.clone_string(), pos, self.sel_pos));
+            self.old_state = Some((self.text.clone_string(), pos, self.selection.sel_pos()));
             self.last_edit = LastEdit::Insert;
         }
         if have_sel {
             let mut buf = [0u8; 4];
             let s = c.encode_utf8(&mut buf);
             let _ = self.text.replace_range(selection.clone(), s);
-            self.edit_pos = selection.start + s.len();
+            self.selection.set_pos(selection.start + s.len());
         } else {
             let _ = self.text.insert_char(pos, c);
-            self.edit_pos = pos + c.len_utf8();
+            self.selection.set_pos(pos + c.len_utf8());
         }
-        self.sel_pos = self.edit_pos;
         self.edit_x_coord = None;
         self.text.prepare();
         self.set_view_offset_from_edit_pos();
@@ -465,8 +451,8 @@ impl<G> EditBox<G> {
         }
 
         let mut buf = [0u8; 4];
-        let pos = self.edit_pos;
-        let selection = self.selection();
+        let pos = self.selection.edit_pos();
+        let selection = self.selection.range();
         let have_sel = selection.end > selection.start;
         let ctrl = mgr.modifiers().ctrl();
         let mut shift = mgr.modifiers().shift();
@@ -484,8 +470,8 @@ impl<G> EditBox<G> {
 
         let action = match key {
             ControlKey::Escape => {
-                if self.sel_pos != self.edit_pos {
-                    self.sel_pos = self.edit_pos;
+                if !self.selection.is_empty() {
+                    self.selection.set_empty();
                     mgr.redraw(self.id());
                     Action::None
                 } else {
@@ -651,12 +637,12 @@ impl<G> EditBox<G> {
                 }
             }
             ControlKey::Deselect => {
-                self.sel_pos = pos;
+                self.selection.set_sel_pos(pos);
                 mgr.redraw(self.id());
                 Action::None
             }
             ControlKey::SelectAll => {
-                self.sel_pos = 0;
+                self.selection.set_sel_pos(0);
                 shift = true; // hack
                 Action::Move(self.text.str_len(), None)
             }
@@ -694,9 +680,11 @@ impl<G> EditBox<G> {
                 // NOTE: undo *and* redo shortcuts map to this control char
                 if let Some((state, pos2, sel_pos)) = self.old_state.as_mut() {
                     self.text.swap_string(state);
-                    self.edit_pos = *pos2;
+                    self.selection.set_edit_pos(*pos2);
                     *pos2 = pos;
-                    std::mem::swap(sel_pos, &mut self.sel_pos);
+                    let pos = *sel_pos;
+                    *sel_pos = self.selection.sel_pos();
+                    self.selection.set_sel_pos(pos);
                     self.edit_x_coord = None;
                     self.last_edit = LastEdit::None;
                 }
@@ -713,40 +701,41 @@ impl<G> EditBox<G> {
             Action::Insert(s, edit) => {
                 let mut pos = pos;
                 if have_sel {
-                    self.old_state = Some((self.text.clone_string(), pos, self.sel_pos));
+                    self.old_state =
+                        Some((self.text.clone_string(), pos, self.selection.sel_pos()));
                     self.last_edit = edit;
 
                     self.text.replace_range(selection.clone(), s);
                     pos = selection.start;
                 } else {
                     if self.last_edit != edit {
-                        self.old_state = Some((self.text.clone_string(), pos, self.sel_pos));
+                        self.old_state =
+                            Some((self.text.clone_string(), pos, self.selection.sel_pos()));
                         self.last_edit = edit;
                     }
 
                     self.text.replace_range(pos..pos, s);
                 }
-                self.edit_pos = pos + s.len();
-                self.sel_pos = self.edit_pos;
+                self.selection.set_pos(pos + s.len());
                 self.edit_x_coord = None;
                 EditAction::Edit
             }
             Action::Delete(sel) => {
                 if self.last_edit != LastEdit::Delete {
-                    self.old_state = Some((self.text.clone_string(), pos, self.sel_pos));
+                    self.old_state =
+                        Some((self.text.clone_string(), pos, self.selection.sel_pos()));
                     self.last_edit = LastEdit::Delete;
                 }
 
                 self.text.replace_range(sel.clone(), "");
-                self.edit_pos = sel.start;
-                self.sel_pos = sel.start;
+                self.selection.set_pos(sel.start);
                 self.edit_x_coord = None;
                 EditAction::Edit
             }
             Action::Move(pos, x_coord) => {
-                self.edit_pos = pos;
+                self.selection.set_edit_pos(pos);
                 if !shift {
-                    self.sel_pos = self.edit_pos;
+                    self.selection.set_empty();
                 }
                 self.edit_x_coord = x_coord;
                 mgr.redraw(self.id());
@@ -754,7 +743,7 @@ impl<G> EditBox<G> {
             }
         };
 
-        let mut set_offset = self.edit_pos != pos;
+        let mut set_offset = self.selection.edit_pos() != pos;
         if !self.text.required_action().is_ready() {
             self.text.prepare();
             set_offset = true;
@@ -769,7 +758,8 @@ impl<G> EditBox<G> {
 
     fn set_edit_pos_from_coord(&mut self, mgr: &mut Manager, coord: Coord) {
         let rel_pos = (coord - self.text_pos + self.view_offset).into();
-        self.edit_pos = self.text.text_index_nearest(rel_pos);
+        self.selection
+            .set_edit_pos(self.text.text_index_nearest(rel_pos));
         self.set_view_offset_from_edit_pos();
         self.edit_x_coord = None;
         mgr.redraw(self.id());
@@ -793,7 +783,8 @@ impl<G> EditBox<G> {
     ///
     /// A redraw is assumed since edit_pos moved.
     fn set_view_offset_from_edit_pos(&mut self) {
-        if let Some(marker) = self.text.text_glyph_pos(self.edit_pos).next_back() {
+        let edit_pos = self.selection.edit_pos();
+        if let Some(marker) = self.text.text_glyph_pos(edit_pos).next_back() {
             let bounds = Vec2::from(self.text.env().bounds);
             let min_x = (marker.pos.0 - bounds.0).ceil();
             let min_y = (marker.pos.1 - marker.descent - bounds.1).ceil();
@@ -808,53 +799,6 @@ impl<G> EditBox<G> {
 
             self.view_offset = self.view_offset.max(min).min(max);
         }
-    }
-
-    fn expand_selection(&mut self, repeats: u32) {
-        let mut range = self.edit_pos..self.anchor_pos;
-        if range.start > range.end {
-            std::mem::swap(&mut range.start, &mut range.end);
-        }
-        let (mut start, mut end);
-        if repeats <= 2 {
-            end = self.text.text()[range.start..]
-                .char_indices()
-                .skip(1)
-                .next()
-                .map(|(i, _)| range.start + i)
-                .unwrap_or(self.text.str_len());
-            start = self.text.text()[0..end]
-                .split_word_bound_indices()
-                .next_back()
-                .map(|(index, _)| index)
-                .unwrap_or(0);
-            end = 'a: loop {
-                for (index, _) in self.text.text()[start..].split_word_bound_indices() {
-                    let pos = start + index;
-                    if pos >= range.end {
-                        break 'a pos;
-                    }
-                }
-                break 'a self.text.str_len();
-            };
-        } else {
-            start = self
-                .text
-                .find_line(range.start)
-                .map(|r| r.1.start)
-                .unwrap_or(0);
-            end = self
-                .text
-                .find_line(range.end)
-                .map(|r| r.1.end)
-                .unwrap_or(self.text.str_len());
-        }
-
-        if self.edit_pos < self.sel_pos {
-            std::mem::swap(&mut start, &mut end);
-        }
-        self.sel_pos = start;
-        self.edit_pos = end;
     }
 }
 
@@ -885,7 +829,7 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                 .map(|msg| msg.into())
                 .unwrap_or(Response::None),
             Event::LostSelFocus => {
-                self.sel_pos = self.edit_pos; // clear selection
+                self.selection.set_empty();
                 mgr.redraw(self.id());
                 Response::None
             }
@@ -913,11 +857,11 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                         // (non-standard, but seems to work well)!
                         self.set_edit_pos_from_coord(mgr, coord);
                         if !mgr.modifiers().shift() {
-                            self.sel_pos = self.edit_pos;
+                            self.selection.set_empty();
                         }
-                        self.anchor_pos = self.sel_pos;
+                        self.selection.set_anchor();
                         if repeats > 1 {
-                            self.expand_selection(repeats);
+                            self.selection.expand(&self.text, repeats);
                         }
                     }
                 }
@@ -954,7 +898,7 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                 } else {
                     self.set_edit_pos_from_coord(mgr, coord);
                     if sel_mode > 1 {
-                        self.expand_selection(sel_mode);
+                        self.selection.expand(&self.text, sel_mode);
                     }
                 }
                 Response::None
@@ -965,7 +909,7 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                         if !mgr.modifiers().ctrl() {
                             self.set_edit_pos_from_coord(mgr, coord);
                             if !mgr.modifiers().shift() {
-                                self.sel_pos = self.edit_pos;
+                                self.selection.set_empty();
                             }
                         }
                         self.touch_phase = TouchPhase::None;
@@ -1002,7 +946,7 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                         if !mgr.modifiers().ctrl() {
                             self.set_edit_pos_from_coord(mgr, coord);
                             if !mgr.modifiers().shift() {
-                                self.sel_pos = self.edit_pos;
+                                self.selection.set_empty();
                             }
                         }
                         self.touch_phase = TouchPhase::Cursor(touch_id);

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -881,10 +881,13 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                 mgr.request_char_focus(self.id());
                 Response::None
             }
-            Event::LostCharFocus => {
-                let r = G::focus_lost(self);
+            Event::LostCharFocus => G::focus_lost(self)
+                .map(|msg| msg.into())
+                .unwrap_or(Response::None),
+            Event::LostSelFocus => {
                 self.sel_pos = self.edit_pos; // clear selection
-                r.map(|msg| msg.into()).unwrap_or(Response::None)
+                mgr.redraw(self.id());
+                Response::None
             }
             Event::Control(key) => match self.control_key(mgr, key) {
                 EditAction::None => Response::None,


### PR DESCRIPTION
New `LostSelFocus` event: widgets may now keep a selection when losing nav focus, but this event is fired when a new widget supporting selection receives focus to prevent multiple selections.

New `SelectionHelper` struct to abstract out some of the selection logic in `EditBox`. This abstraction is chiefly for #138 (which may not land), but may as well be merged.