### PR TITLE
Builder-style methods for Theme and Toolkit; kas-text update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ path = "kas-macros"
 [dependencies.kas-text]
 version = "0.1.2"
 git = "https://github.com/kas-gui/kas-text"
-rev = "088fde383a0f3fab9e29c3cfdb8afe4875a31096"
+rev = "7b698261431c5e5bda9b0a45805e488e3424ac4d"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -89,9 +89,9 @@ pub struct DimensionsWindow {
 }
 
 impl DimensionsWindow {
-    pub fn new(dims: DimensionsParams, font_size: f32, scale_factor: f32) -> Self {
+    pub fn new(dims: DimensionsParams, pt_size: f32, scale_factor: f32) -> Self {
         DimensionsWindow {
-            dims: Dimensions::new(dims, font_size, scale_factor),
+            dims: Dimensions::new(dims, pt_size, scale_factor),
         }
     }
 }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -23,7 +23,7 @@ use kas::{Direction, Directional, ThemeAction, ThemeApi};
 /// A theme with flat (unshaded) rendering
 #[derive(Clone, Debug)]
 pub struct FlatTheme {
-    font_size: f32,
+    pt_size: f32,
     cols: ThemeColours,
 }
 
@@ -31,9 +31,27 @@ impl FlatTheme {
     /// Construct
     pub fn new() -> Self {
         FlatTheme {
-            font_size: 12.0,
+            pt_size: 12.0,
             cols: ThemeColours::new(),
         }
+    }
+
+    /// Set font size
+    ///
+    /// Units: Points per Em (standard unit of font size)
+    pub fn with_font_size(mut self, pt_size: f32) -> Self {
+        self.pt_size = pt_size;
+        self
+    }
+
+    /// Set the colour scheme
+    ///
+    /// If no scheme by this name is found the scheme is left unchanged.
+    pub fn with_colours(mut self, scheme: &str) -> Self {
+        if let Some(scheme) = ThemeColours::open(scheme) {
+            self.cols = scheme;
+        }
+        self
     }
 }
 
@@ -73,11 +91,11 @@ where
     }
 
     fn new_window(&self, _draw: &mut D::Draw, dpi_factor: f32) -> Self::Window {
-        DimensionsWindow::new(DIMS, self.font_size, dpi_factor)
+        DimensionsWindow::new(DIMS, self.pt_size, dpi_factor)
     }
 
     fn update_window(&self, window: &mut Self::Window, dpi_factor: f32) {
-        window.dims = Dimensions::new(DIMS, self.font_size, dpi_factor);
+        window.dims = Dimensions::new(DIMS, self.pt_size, dpi_factor);
     }
 
     #[cfg(not(feature = "gat"))]
@@ -126,7 +144,7 @@ where
 
 impl ThemeApi for FlatTheme {
     fn set_font_size(&mut self, size: f32) -> ThemeAction {
-        self.font_size = size;
+        self.pt_size = size;
         ThemeAction::ThemeResize
     }
 

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -20,7 +20,7 @@ use kas::{Direction, Directional, ThemeAction, ThemeApi};
 /// A theme using simple shading to give apparent depth to elements
 #[derive(Clone, Debug)]
 pub struct ShadedTheme {
-    font_size: f32,
+    pt_size: f32,
     cols: ThemeColours,
 }
 
@@ -28,9 +28,27 @@ impl ShadedTheme {
     /// Construct
     pub fn new() -> Self {
         ShadedTheme {
-            font_size: 12.0,
+            pt_size: 12.0,
             cols: ThemeColours::new(),
         }
+    }
+
+    /// Set font size
+    ///
+    /// Units: Points per Em (standard unit of font size)
+    pub fn with_font_size(mut self, pt_size: f32) -> Self {
+        self.pt_size = pt_size;
+        self
+    }
+
+    /// Set the colour scheme
+    ///
+    /// If no scheme by this name is found the scheme is left unchanged.
+    pub fn with_colours(mut self, scheme: &str) -> Self {
+        if let Some(scheme) = ThemeColours::open(scheme) {
+            self.cols = scheme;
+        }
+        self
     }
 }
 
@@ -70,11 +88,11 @@ where
     }
 
     fn new_window(&self, _draw: &mut D::Draw, dpi_factor: f32) -> Self::Window {
-        DimensionsWindow::new(DIMS, self.font_size, dpi_factor)
+        DimensionsWindow::new(DIMS, self.pt_size, dpi_factor)
     }
 
     fn update_window(&self, window: &mut Self::Window, dpi_factor: f32) {
-        window.dims = Dimensions::new(DIMS, self.font_size, dpi_factor);
+        window.dims = Dimensions::new(DIMS, self.pt_size, dpi_factor);
     }
 
     #[cfg(not(feature = "gat"))]
@@ -123,7 +141,7 @@ where
 
 impl ThemeApi for ShadedTheme {
     fn set_font_size(&mut self, size: f32) -> ThemeAction {
-        self.font_size = size;
+        self.pt_size = size;
         ThemeAction::ThemeResize
     }
 

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -97,9 +97,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new("Calculator", content);
 
     let theme = kas_theme::ShadedTheme::new().with_font_size(16.0);
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -13,7 +13,6 @@ use kas::event::VirtualKeyCode as VK;
 use kas::event::{Manager, Response, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{EditBox, TextButton, Window};
-use kas::ThemeApi;
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Key {
@@ -97,8 +96,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     };
     let window = Window::new("Calculator", content);
 
-    let mut theme = kas_theme::ShadedTheme::new();
-    theme.set_font_size(16.0);
+    let theme = kas_theme::ShadedTheme::new().with_font_size(16.0);
     let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
     toolkit.add(window)?;
     toolkit.run()

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -47,17 +47,16 @@ impl Layout for Clock {
         let pos = rect.pos + (excess * 0.5);
         self.core.rect = Rect { pos, size };
 
-        // Note: font size is calculated as dpp * pt_size with units pixels/em.
-        // We leave dpp at its default 96/72 and set pt_size based on pixels.
-        // Dimensions are still dependent on fonts.
-        let pt_size = (size.1 as f32 * 0.09).into();
+        // Note: font size is calculated as dpem = dpp * pt_size. Instead of
+        // the usual semantics we set dpp=1 (in constructor) and pt_size=dpem.
+        let dpem = (size.1 as f32 * 0.12).into();
         let half_size = Size(size.0, size.1 / 2);
         self.date.update_env(|env| {
-            env.set_pt_size(pt_size);
+            env.set_pt_size(dpem);
             env.set_bounds(half_size.into());
         });
         self.time.update_env(|env| {
-            env.set_pt_size(pt_size);
+            env.set_pt_size(dpem);
             env.set_bounds(half_size.into());
         });
         self.date_pos = pos + Size(0, size.1 - half_size.1);
@@ -147,6 +146,7 @@ impl Clock {
     fn new() -> Self {
         let env = kas::text::Environment {
             align: (Align::Centre, Align::Centre),
+            dpp: 1.0,
             ..Default::default()
         };
         let date = Text::new(env.clone(), "0000-00-00".into());

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -168,7 +168,5 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let window = Window::new("Clock", Clock::new());
 
     let theme = kas_theme::FlatTheme::new();
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -58,7 +58,5 @@ fn main() -> Result<(), kas_wgpu::Error> {
     );
 
     let theme = kas_theme::ShadedTheme::new().with_font_size(24.0);
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -9,7 +9,6 @@ use kas::class::HasString;
 use kas::event::{Manager, VoidMsg, VoidResponse};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{Label, TextButton, Window};
-use kas::ThemeApi;
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Message {
@@ -58,8 +57,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         },
     );
 
-    let mut theme = kas_theme::ShadedTheme::new();
-    theme.set_font_size(24.0);
+    let theme = kas_theme::ShadedTheme::new().with_font_size(24.0);
     let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
     toolkit.add(window)?;
     toolkit.run()

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -154,7 +154,5 @@ fn main() -> Result<(), kas_wgpu::Error> {
         },
     );
 
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -175,7 +175,5 @@ fn main() -> Result<(), kas_wgpu::Error> {
     );
 
     let theme = kas_theme::ShadedTheme::new();
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/kas-wgpu/examples/hello.rs
+++ b/kas-wgpu/examples/hello.rs
@@ -15,7 +15,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let window = MessageBox::new("Message", text);
 
     let theme = kas_theme::FlatTheme::new();
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/kas-wgpu/examples/hello.rs
+++ b/kas-wgpu/examples/hello.rs
@@ -7,11 +7,11 @@
 
 use kas::widget::MessageBox;
 
-fn main() -> Result<(), kas_wgpu::Error> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build widgets.
     // Message is a Window with an "Ok" button and notification status.
     // Each Window::new method creates objects then solves constraints.
-    let text = kas::text::format::Markdown::new("Hello *world*!");
+    let text = kas::text::format::Markdown::new("Hello *world*!")?;
     let window = MessageBox::new("Message", text);
 
     let theme = kas_theme::FlatTheme::new();

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -32,7 +32,5 @@ fn main() -> Result<(), kas_wgpu::Error> {
     );
 
     let theme = kas_theme::FlatTheme::new();
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -558,7 +558,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
 
     let theme = kas_theme::FlatTheme::new().with_colours("dark");
 
-    let mut toolkit = kas_wgpu::Toolkit::new_custom(PipeBuilder, theme, Options::from_env())?;
-    toolkit.add(MandlebrotWindow::new_window())?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new_custom(PipeBuilder, theme, Options::from_env())?
+        .with(MandlebrotWindow::new_window())?
+        .run()
 }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -556,8 +556,7 @@ impl MandlebrotWindow {
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
-    let mut theme = kas_theme::FlatTheme::new();
-    theme.set_colours("dark");
+    let theme = kas_theme::FlatTheme::new().with_colours("dark");
 
     let mut toolkit = kas_wgpu::Toolkit::new_custom(PipeBuilder, theme, Options::from_env())?;
     toolkit.add(MandlebrotWindow::new_window())?;

--- a/kas-wgpu/examples/markdown.rs
+++ b/kas-wgpu/examples/markdown.rs
@@ -65,7 +65,5 @@ It also supports lists:
     );
 
     let theme = kas_theme::FlatTheme::new();
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/kas-wgpu/examples/splitter.rs
+++ b/kas-wgpu/examples/splitter.rs
@@ -60,7 +60,5 @@ fn main() -> Result<(), kas_wgpu::Error> {
     );
 
     let theme = kas_theme::ShadedTheme::new();
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     let theme = kas_theme::ShadedTheme::new()
         .with_colours("dark")
         .with_font_size(18.0);
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add_boxed(make_window())?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?
+        .with_boxed(make_window())?
+        .run()
 }

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -11,7 +11,7 @@ use kas::class::HasString;
 use kas::event::{Event, Handler, Manager, Response, VoidMsg};
 use kas::macros::make_widget;
 use kas::widget::{Frame, Label, TextButton, Window};
-use kas::{ThemeApi, WidgetCore};
+use kas::WidgetCore;
 
 // Unlike most examples, we encapsulate the GUI configuration into a function.
 // There's no reason for this, but it demonstrates usage of Toolkit::add_boxed
@@ -77,8 +77,9 @@ fn make_window() -> Box<dyn kas::Window> {
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
-    let mut theme = kas_theme::ShadedTheme::new();
-    let _ = theme.set_colours("dark");
+    let theme = kas_theme::ShadedTheme::new()
+        .with_colours("dark")
+        .with_font_size(18.0);
     let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
     toolkit.add_boxed(make_window())?;
     toolkit.run()

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -11,7 +11,7 @@ use kas::class::HasString;
 use kas::event::{Event, Handler, Manager, Response, UpdateHandle, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::{Label, TextButton, Window};
-use kas::{ThemeApi, WidgetConfig, WidgetCore};
+use kas::{WidgetConfig, WidgetCore};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Message {
@@ -86,8 +86,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         },
     );
 
-    let mut theme = kas_theme::ShadedTheme::new();
-    theme.set_font_size(24.0);
+    let theme = kas_theme::ShadedTheme::new().with_font_size(24.0);
     let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
     toolkit.add(window.clone())?;
     toolkit.add(window)?;

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -87,8 +87,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
     );
 
     let theme = kas_theme::ShadedTheme::new().with_font_size(24.0);
-    let mut toolkit = kas_wgpu::Toolkit::new(theme)?;
-    toolkit.add(window.clone())?;
-    toolkit.add(window)?;
-    toolkit.run()
+    kas_wgpu::Toolkit::new(theme)?
+        .with(window.clone())?
+        .with(window)?
+        .run()
 }

--- a/kas-wgpu/src/lib.rs
+++ b/kas-wgpu/src/lib.rs
@@ -133,12 +133,30 @@ where
         self.add_boxed(Box::new(window))
     }
 
+    /// Assume ownership of and display a window, inline
+    ///
+    /// This is a convenience wrapper around [`Toolkit::add_boxed`].
+    ///
+    /// Note: typically, one should have `W: Clone`, enabling multiple usage.
+    pub fn with<W: kas::Window + 'static>(mut self, window: W) -> Result<Self, Error> {
+        self.add_boxed(Box::new(window))?;
+        Ok(self)
+    }
+
     /// Add a boxed window directly
     pub fn add_boxed(&mut self, widget: Box<dyn kas::Window>) -> Result<WindowId, Error> {
         let id = self.shared.next_window_id();
         let win = Window::new(&mut self.shared, &self.el, id, widget)?;
         self.windows.push(win);
         Ok(id)
+    }
+
+    /// Add a boxed window directly, inline
+    pub fn with_boxed(mut self, widget: Box<dyn kas::Window>) -> Result<Self, Error> {
+        let id = self.shared.next_window_id();
+        let win = Window::new(&mut self.shared, &self.el, id, widget)?;
+        self.windows.push(win);
+        Ok(self)
     }
 
     /// Create a proxy which can be used to update the UI from another thread

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -135,12 +135,14 @@ pub enum ThemeAction {
 /// is updated via [`Manager::adjust_theme`]. When adjusting a theme before
 /// the UI is started, this return value can be safely ignored.
 pub trait ThemeApi {
-    /// Set font size. Default is 18. Units are unknown.
-    fn set_font_size(&mut self, size: f32) -> ThemeAction;
+    /// Set font size
+    ///
+    /// Units: Points per Em (standard unit of font size)
+    fn set_font_size(&mut self, pt_size: f32) -> ThemeAction;
 
     /// Change the colour scheme
     ///
-    /// If no scheme by this name is found, the scheme is unchanged.
+    /// If no scheme by this name is found the scheme is left unchanged.
     // TODO: revise scheme identification and error handling?
     fn set_colours(&mut self, _scheme: &str) -> ThemeAction;
 


### PR DESCRIPTION
A direct effect of the introduction of MarkdownError in kas-text is that our markdown example can now display errors in the app (without contextual information, but considering the errors are only due to unsupported features this likely isn't a big deal).