### PR TITLE
Use LinearMap, clear less state in reconfigure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ smallvec = "1.4"
 stack_dst = { version = "0.6", optional = true }
 bitflags = "1" # only used without winit
 unicode-segmentation = "1.6"
+linear-map = "1.2.0"
 
 [dependencies.kas-macros]
 version = "0.5.0"

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -51,7 +51,6 @@ struct MouseGrab {
 
 #[derive(Clone, Debug)]
 struct TouchGrab {
-    touch_id: u64,
     start_id: WidgetId,
     depress: Option<WidgetId>,
     cur_id: Option<WidgetId>,
@@ -109,7 +108,7 @@ pub struct ManagerState {
     last_click_repetitions: u32,
     last_click_timeout: Instant,
     mouse_grab: Option<MouseGrab>,
-    touch_grab: SmallVec<[TouchGrab; 10]>,
+    touch_grab: LinearMap<u64, TouchGrab>,
     pan_grab: SmallVec<[PanGrab; 4]>,
     accel_stack: Vec<(bool, HashMap<VirtualKeyCode, WidgetId>)>,
     accel_layers: HashMap<WidgetId, (bool, HashMap<VirtualKeyCode, WidgetId>)>,
@@ -175,10 +174,10 @@ impl ManagerState {
                 grab.pan_grab.0 = p0 - 1;
             }
         }
-        for grab in &mut self.touch_grab {
-            let p0 = grab.pan_grab.0;
+        for grab in self.touch_grab.iter_mut() {
+            let p0 = grab.1.pan_grab.0;
             if p0 >= index as u16 && p0 != u16::MAX {
-                grab.pan_grab.0 = p0 - 1;
+                grab.1.pan_grab.0 = p0 - 1;
             }
         }
     }
@@ -198,7 +197,8 @@ impl ManagerState {
         }
 
         // Note: the fact that grab.n > 0 implies source is a touch event!
-        for grab in &mut self.touch_grab {
+        for grab in self.touch_grab.iter_mut() {
+            let grab = grab.1;
             if grab.pan_grab.0 == g.0 && grab.pan_grab.1 > g.1 {
                 grab.pan_grab.1 -= 1;
                 if (grab.pan_grab.1 as usize) == MAX_PAN_GRABS - 1 {
@@ -417,27 +417,14 @@ impl<'a> Manager<'a> {
 
     #[inline]
     fn get_touch(&mut self, touch_id: u64) -> Option<&mut TouchGrab> {
-        self.mgr.touch_grab.iter_mut().find_map(|grab| {
-            if grab.touch_id == touch_id {
-                Some(grab)
-            } else {
-                None
-            }
-        })
+        self.mgr.touch_grab.get_mut(&touch_id)
     }
 
     fn remove_touch(&mut self, touch_id: u64) -> Option<TouchGrab> {
-        let len = self.mgr.touch_grab.len();
-        for i in 0..len {
-            if self.mgr.touch_grab[i].touch_id == touch_id {
-                let grab = self.mgr.touch_grab[i].clone();
-                trace!("Manager: end touch grab by {}", grab.start_id);
-                self.mgr.touch_grab.swap(i, len - 1);
-                self.mgr.touch_grab.truncate(len - 1);
-                return Some(grab);
-            }
-        }
-        None
+        self.mgr.touch_grab.remove(&touch_id).map(|grab| {
+            trace!("Manager: end touch grab by {}", grab.start_id);
+            grab
+        })
     }
 
     fn set_char_focus(&mut self, wid: Option<WidgetId>) {

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -74,8 +74,8 @@ impl ManagerState {
         if self.mouse_grab.as_ref().and_then(|grab| grab.depress) == Some(w_id) {
             return true;
         }
-        for touch in &self.touch_grab {
-            if touch.depress == Some(w_id) {
+        for grab in self.touch_grab.values() {
+            if grab.depress == Some(w_id) {
                 return true;
             }
         }
@@ -459,15 +459,17 @@ impl<'a> Manager<'a> {
                     pan_grab = self.mgr.set_pan_on(id, mode, true, coord);
                 }
                 trace!("Manager: start touch grab by {}", start_id);
-                self.mgr.touch_grab.push(TouchGrab {
+                self.mgr.touch_grab.insert(
                     touch_id,
-                    start_id,
-                    depress: Some(id),
-                    cur_id: Some(id),
-                    coord,
-                    mode,
-                    pan_grab,
-                });
+                    TouchGrab {
+                        start_id,
+                        depress: Some(id),
+                        cur_id: Some(id),
+                        coord,
+                        mode,
+                        pan_grab,
+                    },
+                );
             }
         }
 
@@ -497,11 +499,8 @@ impl<'a> Manager<'a> {
                 }
             }
             PressSource::Touch(id) => {
-                for touch in &mut self.mgr.touch_grab {
-                    if touch.touch_id == id {
-                        touch.depress = target;
-                        break;
-                    }
+                if let Some(grab) = self.mgr.touch_grab.get_mut(&id) {
+                    grab.depress = target;
                 }
             }
         }


### PR DESCRIPTION
Add `linear-map` dependency and use for a couple of fields in the event manager (cleaner code). Somehow I missed this lib before.

During reconfigure, attempt to map `WidgetId` data within `time_updates`, `handle_updates` and `pending` fields of `ManagerState`. Previously these fields were cleared, which could cause a few subtle bugs (e.g. cancelling notification of a `Window::on_drop` future).