### PR TITLE
Terminology: replace 'toolkit' with 'shell' where appropriate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ gat = ["kas-text/gat"]
 # Use min_specialization (enables accelerator underlining for AccelLabel)
 min_spec = []
 
-# Enables documentation of APIs for toolkits and internal use.
+# Enables documentation of APIs for shells and internal usage.
 # This API is not intended for use by end-user applications and
 # thus is omitted from built documentation by default.
 # This flag does not change the API, only built documentation.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ KAS GUI
 [![Docs](https://docs.rs/kas/badge.svg)](https://docs.rs/kas)
 ![Minimum rustc version](https://img.shields.io/badge/rustc-1.45+-lightgray.svg)
 
-KAS, the *toolKit Abstraction System*, is a general-purpose GUI toolkit.
+KAS, (historically the *toolKit Abstraction System*), is a general-purpose GUI toolkit.
 KAS's design provides:
 
 -   retained mode (library stores state), inspired by Qt (classic)

--- a/kas-wgpu/README.md
+++ b/kas-wgpu/README.md
@@ -1,7 +1,10 @@
 KAS WGPU
 ======
 
-Toolkit rendering over the [wgpu](https://crates.io/crates/wgpu) lib.
+KAS shell interface over [winit] and [wgpu].
+
+[winit]: https://github.com/rust-windowing/winit/
+[wgpu]: https://github.com/gfx-rs/wgpu-rs
 
 
 Compiling shaders

--- a/kas-wgpu/src/options.rs
+++ b/kas-wgpu/src/options.rs
@@ -9,7 +9,7 @@ use log::warn;
 use std::env::var;
 pub use wgpu::{BackendBit, PowerPreference};
 
-/// Toolkit options
+/// Shell options
 #[derive(Clone, PartialEq, Hash)]
 pub struct Options {
     /// Adapter power preference. Default value: low power.

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -437,7 +437,7 @@ where
     }
 }
 
-impl<'a, C, T> kas::TkWindow for TkWindow<'a, C, T>
+impl<'a, C, T> kas::ShellWindow for TkWindow<'a, C, T>
 where
     C: CustomPipe,
     T: Theme<DrawPipe<C>>,

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -101,11 +101,12 @@ impl Default for TextClass {
     }
 }
 
-/// Handle passed to objects during draw and sizing operations
+/// Handle passed to objects during sizing operations
 ///
-/// This handle is provided by the toolkit (usually via a theme implementation)
-/// in order to provide sizing information of the elements drawn by
-/// [`DrawHandle`].
+/// Themes must implement both [`SizeHandle`] and [`DrawHandle`].
+///
+/// The toolkit provides a `&dyn SizeHandle` value when resizing widgets. The
+/// handle may also be accessed via [`kas::event::Manager::size_handle`].
 pub trait SizeHandle {
     /// Get the scale (DPI) factor
     ///
@@ -214,11 +215,13 @@ pub trait SizeHandle {
     fn progress_bar(&self) -> Size;
 }
 
-/// Handle passed to objects during draw and sizing operations
+/// Handle passed to objects during draw operations
 ///
-/// This handle is provided by the toolkit (usually via a theme implementation)
-/// as a high-level drawing interface. See also the extension trait,
-/// [`DrawHandleExt`], and the companion trait, [`SizeHandle`].
+/// Themes must implement both [`SizeHandle`] and [`DrawHandle`].
+///
+/// The toolkit provides a `&mut dyn DrawHandle` value when drawing widgets.
+/// The extension trait [`DrawHandleExt`] provides some additional methods on
+/// draw handles.
 pub trait DrawHandle {
     /// Access a [`SizeHandle`] (object-safe version)
     ///

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -22,9 +22,9 @@
 //!
 //! The [`Draw`] trait itself contains very little; extension traits
 //! [`DrawRounded`], [`DrawShaded`] and [`DrawText`] provide additional draw
-//! routines. Toolkits are required to implement only the base [`Draw`] trait,
-//! and may provide their own extension traits. For this reason, themes are
-//! parameterised over an object `D: Draw + ...` (with specified trait bounds).
+//! routines. Shells are only required to implement the base [`Draw`] trait,
+//! and may also provide their own extension traits. Themes may specify their
+//! own requirements, e.g. `D: Draw + DrawRounded + DrawText`.
 //!
 //! The medium-level API will be extended in the future to support texturing
 //! (not yet supported) and potentially a more comprehensive path-based API
@@ -33,7 +33,7 @@
 //! ### Low-level interface
 //!
 //! There is no universal graphics API, hence none is provided by this crate.
-//! Instead, toolkits may provide their own extensions allowing direct access
+//! Instead, shells may provide their own extensions allowing direct access
 //! to the host graphics API, for example
 //! [`kas-wgpu::draw::CustomPipe`](https://docs.rs/kas-wgpu/*/kas_wgpu/draw/trait.CustomPipe.html).
 
@@ -105,7 +105,7 @@ pub trait Draw: Any {
     /// Cast self to [`std::any::Any`] reference.
     ///
     /// A downcast on this value may be used to obtain a reference to a
-    /// toolkit-specific API.
+    /// shell-specific API.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
     /// Add a clip region

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -19,10 +19,10 @@ use super::*;
 use crate::geom::Coord;
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
-use crate::{TkAction, TkWindow, Widget, WidgetId, WindowId};
+use crate::{ShellWindow, TkAction, Widget, WidgetId, WindowId};
 
 mod mgr_pub;
-mod mgr_tk;
+mod mgr_shell;
 
 /// Controls the types of events delivered by [`Manager::request_grab`]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -84,8 +84,11 @@ enum Pending {
 ///
 /// Besides event handling, this struct also configures widgets.
 ///
-/// Some methods are intended only for toolkit usage and are hidden from
-/// documentation unless the `internal_doc` feature is enabled.
+/// Some methods are intended only for usage by KAS shells and are hidden from
+/// documentation unless the `internal_doc` feature is enabled. Only [winit]
+/// events are currently supported; changes will be required to generalise this.
+///
+/// [winit]: https://github.com/rust-windowing/winit
 //
 // Note that the most frequent usage of fields is to check highlighting states
 // for each widget during drawing. Most fields contain only a few values, hence
@@ -212,17 +215,17 @@ impl ManagerState {
 
 /// Manager of event-handling and toolkit actions
 ///
-/// A `Manager` is in fact a handle around [`ManagerState`] and [`TkWindow`]
+/// A `Manager` is in fact a handle around [`ManagerState`] and [`ShellWindow`]
 /// in order to provide a convenient user-interface during event processing.
 ///
 /// It exposes two interfaces: one aimed at users implementing widgets and UIs
-/// and one aimed at toolkit "frontends". The latter is hidden
+/// and one aimed at shells. The latter is hidden
 /// from documentation unless the `internal_doc` feature is enabled.
 #[must_use]
 pub struct Manager<'a> {
     read_only: bool,
     mgr: &'a mut ManagerState,
-    tkw: &'a mut dyn TkWindow,
+    tkw: &'a mut dyn ShellWindow,
     action: TkAction,
 }
 

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -83,7 +83,7 @@ impl ManagerState {
     }
 }
 
-/// Public API (around toolkit functionality)
+/// Public API (around toolkit and shell functionality)
 impl<'a> Manager<'a> {
     /// Get the current modifier state
     #[inline]
@@ -285,7 +285,7 @@ impl<'a> Manager<'a> {
         self.tkw.size_handle(&mut |size_handle| {
             result = Some(f(size_handle));
         });
-        result.expect("TkWindow::size_handle_dyn impl failed to call function argument")
+        result.expect("ShellWindow::size_handle impl failed to call function argument")
     }
 }
 

--- a/src/event/manager/mgr_shell.rs
+++ b/src/event/manager/mgr_shell.rs
@@ -3,7 +3,7 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! Event manager — toolkit API
+//! Event manager — shell API
 
 use log::*;
 use smallvec::SmallVec;
@@ -15,14 +15,14 @@ use super::*;
 use crate::geom::{Coord, DVec2};
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
-use crate::{TkAction, TkWindow, Widget, WidgetId};
+use crate::{ShellWindow, TkAction, Widget, WidgetId};
 
 // TODO: this should be configurable or derived from the system
 const DOUBLE_CLICK_TIMEOUT: Duration = Duration::from_secs(1);
 
 const FAKE_MOUSE_BUTTON: MouseButton = MouseButton::Other(0);
 
-/// Toolkit API
+/// Shell API
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 impl ManagerState {
     /// Construct an event manager per-window data struct
@@ -69,7 +69,7 @@ impl ManagerState {
     /// [`WidgetId`] identifiers and call widgets' [`WidgetConfig::configure`]
     /// method. Additionally, it updates the [`ManagerState`] to account for
     /// renamed and removed widgets.
-    pub fn configure<W>(&mut self, tkw: &mut dyn TkWindow, widget: &mut W)
+    pub fn configure<W>(&mut self, tkw: &mut dyn ShellWindow, widget: &mut W)
     where
         W: Widget<Msg = VoidMsg> + ?Sized,
     {
@@ -219,7 +219,7 @@ impl ManagerState {
     }
 
     /// Update the widgets under the cursor and touch events
-    pub fn region_moved<W: Widget + ?Sized>(&mut self, tkw: &mut dyn TkWindow, widget: &mut W) {
+    pub fn region_moved<W: Widget + ?Sized>(&mut self, tkw: &mut dyn ShellWindow, widget: &mut W) {
         trace!("Manager::region_moved");
         // Note: redraw is already implied.
 
@@ -266,7 +266,7 @@ impl ManagerState {
     ///
     /// Invokes the given closure on this [`Manager`].
     #[inline]
-    pub fn with<F>(&mut self, tkw: &mut dyn TkWindow, f: F)
+    pub fn with<F>(&mut self, tkw: &mut dyn ShellWindow, f: F)
     where
         F: FnOnce(&mut Manager),
     {
@@ -283,7 +283,7 @@ impl ManagerState {
 
     /// Update, after receiving all events
     #[inline]
-    pub fn update<W>(&mut self, tkw: &mut dyn TkWindow, widget: &mut W) -> TkAction
+    pub fn update<W>(&mut self, tkw: &mut dyn ShellWindow, widget: &mut W) -> TkAction
     where
         W: Widget<Msg = VoidMsg> + ?Sized,
     {
@@ -372,7 +372,7 @@ impl ManagerState {
     }
 }
 
-/// Toolkit API
+/// Shell API
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 impl<'a> Manager<'a> {
     /// Update widgets due to timer
@@ -410,8 +410,8 @@ impl<'a> Manager<'a> {
 
     /// Handle a winit `WindowEvent`.
     ///
-    /// Note that some event types are not *does not* handled, since for these
-    /// events the toolkit must take direct action anyway:
+    /// Note that some event types are not handled, since for these
+    /// events the shell must take direct action anyway:
     /// `Resized(size)`, `RedrawRequested`, `HiDpiFactorChanged(factor)`.
     #[cfg(feature = "winit")]
     pub fn handle_winit<W>(&mut self, widget: &mut W, event: winit::event::WindowEvent)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! KAS, the toolKit Abstraction Library
+//! KAS GUI Toolkit
 //!
 //! KAS is a GUI library. This crate provides the following:
 //!

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,7 +32,7 @@ pub use kas::text::{EditableTextApi, Text, TextApi, TextApiExt};
 #[doc(no_inline)]
 pub use kas::{Align, AlignHints, Direction, Directional, WidgetId};
 #[doc(no_inline)]
-pub use kas::{Boxed, TkAction, TkWindow};
+pub use kas::{Boxed, TkAction};
 #[doc(no_inline)]
 pub use kas::{CoreData, LayoutData};
 #[doc(no_inline)]

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -5,14 +5,12 @@
 
 //! Toolkit interface
 //!
-//! In KAS, the "toolkit" is an external library handling system interfaces
-//! (windowing and event translation) plus rendering. This allows KAS's core
-//! to remain system-neutral.
-//!
-//! Note: although the choice of windowing library is left to the toolkit, for
-//! convenience KAS is able to use several [winit] types.
-//!
-//! [winit]: https://github.com/rust-windowing/winit
+//! This module provides the primary interface between the KAS toolkit and a
+//! KAS shell, though it is not the only interface. A KAS shell connects to the
+//! operating system (or further abstraction layers) by implementing
+//! [`ShellWindow`], the family of draw traits in [`kas::draw`], and
+//! constructing and using an event manager ([`kas::event::ManagerState`]).
+//! The shell also provides the entrypoint, a type named `Toolkit`.
 
 use std::num::NonZeroU32;
 
@@ -28,7 +26,7 @@ pub struct WindowId(NonZeroU32);
 impl WindowId {
     /// Construct a [`WindowId`]
     ///
-    /// Only for toolkit use!
+    /// Only for use by the shell!
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     pub fn new(n: NonZeroU32) -> WindowId {
         WindowId(n)
@@ -105,11 +103,11 @@ impl std::ops::AddAssign for TkAction {
     }
 }
 
-/// Toolkit-specific window management and style interface.
+/// Shell-specific window management and style interface.
 ///
-/// This is implemented by a KAS toolkit on a window handle.
+/// This is implemented by a KAS shell, per window.
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-pub trait TkWindow {
+pub trait ShellWindow {
     /// Add a pop-up
     ///
     /// A pop-up may be presented as an overlay layer in the current window or
@@ -124,8 +122,8 @@ pub trait TkWindow {
     /// Toolkits typically allow windows to be added directly, before start of
     /// the event loop (e.g. `kas_wgpu::Toolkit::add`).
     ///
-    /// This method is an alternative allowing a window to be added via event
-    /// processing, albeit without error handling.
+    /// This method is an alternative allowing a window to be added from an
+    /// event handler, albeit without error handling.
     fn add_window(&mut self, widget: Box<dyn kas::Window>) -> WindowId;
 
     /// Close a window


### PR DESCRIPTION
Previously, our usage of the word 'toolkit' was in some instances non-standard. This PR uses 'shell' instead, matching the usage in other toolkits such as Druid and Iced.

The word `Toolkit` is retained where appropriate, e.g. the `Toolkit` type provided by the `kas-wgpu` shell. (Here it may also be surprising that the toolkit type is provided by the shell, but the name is appropriate to this usage. Although it seems appropriate to move this type to `kas` this would require another abstraction trait and there is very little reason to do so in practice, thus we [Keep It Simple, Stupid!](https://en.wikipedia.org/wiki/KISS_principle))