### PR TITLE
Introduce view widgets

### DIFF
--- a/kas-macros/src/layout.rs
+++ b/kas-macros/src/layout.rs
@@ -199,7 +199,6 @@ pub(crate) fn derive(
             );
         });
 
-        set_rect.append_all(quote! { let mut align = kas::AlignHints::NONE; });
         if let Some(toks) = args.halign_toks()? {
             set_rect.append_all(quote! { align.horiz = Some(#toks); });
         }
@@ -262,7 +261,7 @@ pub(crate) fn derive(
             solver.finish(&mut #data)
         }
 
-        fn set_rect(&mut self, rect: kas::geom::Rect, align: kas::AlignHints) {
+        fn set_rect(&mut self, rect: kas::geom::Rect, mut align: kas::AlignHints) {
             use kas::{WidgetCore, Widget};
             use kas::layout::{Margins, RulesSetter};
             self.core.rect = rect;

--- a/kas-wgpu/examples/filter-list.rs
+++ b/kas-wgpu/examples/filter-list.rs
@@ -1,0 +1,32 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Filter list example
+
+use kas::widget::{view::ListView, Window};
+
+const MONTHS: [&'static str; 12] = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
+
+fn main() -> Result<(), kas_wgpu::Error> {
+    env_logger::init();
+
+    let window = Window::new("Filter-list", ListView::<kas::Down, _>::new(&MONTHS[..]));
+
+    let theme = kas_theme::ShadedTheme::new();
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
+}

--- a/kas-wgpu/examples/filter-list.rs
+++ b/kas-wgpu/examples/filter-list.rs
@@ -5,9 +5,10 @@
 
 //! Filter list example
 
-use kas::widget::{view::ListView, Window};
+use kas::widget::view::{ListView, SharedConst};
+use kas::widget::Window;
 
-const MONTHS: [&'static str; 12] = [
+const MONTHS: &[&str] = &[
     "January",
     "February",
     "March",
@@ -25,7 +26,8 @@ const MONTHS: [&'static str; 12] = [
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
-    let window = Window::new("Filter-list", ListView::<kas::Down, _>::new(&MONTHS[..]));
+    let data: &SharedConst<[&str]> = MONTHS.into();
+    let window = Window::new("Filter-list", ListView::<kas::Down, _>::new(data));
 
     let theme = kas_theme::ShadedTheme::new();
     kas_wgpu::Toolkit::new(theme)?.with(window)?.run()

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -48,7 +48,7 @@ struct TextEditPopup {
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,
     #[widget(cspan = 3)]
-    edit: EditBoxVoid,
+    edit: EditBox,
     #[widget(row = 1, col = 0)]
     fill: Filler,
     #[widget(row=1, col=1, handler = close)]

--- a/kas-wgpu/examples/markdown.rs
+++ b/kas-wgpu/examples/markdown.rs
@@ -9,7 +9,7 @@ use kas::class::HasStr;
 use kas::event::{Manager, Response, VoidMsg};
 use kas::macros::make_widget;
 use kas::text::format::Markdown;
-use kas::widget::{EditBox, EditBoxVoid, Label, ScrollRegion, TextButton, Window};
+use kas::widget::{EditBox, Label, ScrollRegion, TextButton, Window};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -43,7 +43,7 @@ It also supports lists:
             #[layout(grid)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget(row=0, col=0, rspan=2)] editor: EditBoxVoid = EditBox::new(doc).multi_line(true),
+                #[widget(row=0, col=0, rspan=2)] editor: EditBox = EditBox::new(doc).multi_line(true),
                 #[widget(row=0, col=1)] label: ScrollRegion<Label<Markdown>> = ScrollRegion::new(Label::new(Markdown::new(doc)?)).with_bars(false, true),
                 #[widget(row=1, col=1, handler=update)] _ = TextButton::new("&Update", ()),
             }

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             struct {
                 // SingleView embeds a shared value, here default-constructed to 0
                 #[widget(halign=centre)] counter:
-                    SingleView<i32, SharedRc<i32>, Label<String>> = SingleView::default(),
+                    SingleView<SharedRc<i32>, Label<String>> = SingleView::default(),
                 #[widget(handler = handle_button)] buttons -> Message = buttons,
             }
             impl {

--- a/kas-wgpu/examples/sync-counter.rs
+++ b/kas-wgpu/examples/sync-counter.rs
@@ -5,14 +5,10 @@
 
 //! A counter synchronised between multiple windows
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
-use kas::class::HasString;
-use kas::event::{Event, Handler, Manager, Response, UpdateHandle, VoidMsg};
+use kas::event::{Manager, Response, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
+use kas::widget::view::{SharedRc, SingleView};
 use kas::widget::{Label, TextButton, Window};
-use kas::{WidgetConfig, WidgetCore};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Message {
@@ -33,47 +29,26 @@ fn main() -> Result<(), kas_wgpu::Error> {
         }
     };
 
-    // We create one window, then clone it. The `handle` is copied (we want the
-    // same one for each window) and the `counter` is shared (due to Rc<..>).
     let window = Window::new(
         "Counter",
         make_widget! {
             #[layout(column)]
-            #[widget(config=noauto)]
             #[derive(Clone)]
+            #[handler(msg = VoidMsg)]
             struct {
-                #[widget(halign=centre)] display: Label<String> = Label::from("0"),
+                // SingleView embeds a shared value, here default-constructed to 0
+                #[widget(halign=centre)] counter:
+                    SingleView<i32, SharedRc<i32>, Label<String>> = SingleView::default(),
                 #[widget(handler = handle_button)] buttons -> Message = buttons,
-                handle: UpdateHandle = UpdateHandle::new(),
-                counter: Rc<RefCell<i32>> = Rc::new(RefCell::new(0)),
-            }
-            impl WidgetConfig {
-                fn configure(&mut self, mgr: &mut Manager) {
-                    mgr.update_on_handle(self.handle, self.id());
-                }
-            }
-            impl Handler {
-                type Msg = VoidMsg;
-                fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<VoidMsg> {
-                    match event {
-                        Event::HandleUpdate { .. } => {
-                            let s = self.counter.borrow().to_string();
-                            *mgr += self.display.set_string(s);
-                            Response::None
-                        }
-                        event => Response::Unhandled(event),
-                    }
-                }
             }
             impl {
                 fn handle_button(&mut self, mgr: &mut Manager, msg: Message)
                     -> Response<VoidMsg>
                 {
-                    *self.counter.borrow_mut() += match msg {
+                    self.counter.update_value(mgr, |v| v + match msg {
                         Message::Decr => -1,
                         Message::Incr => 1,
-                    };
-                    mgr.trigger_update(self.handle, 0);
+                    });
                     Response::None
                 }
             }

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -255,6 +255,7 @@ impl<'a> Manager<'a> {
     /// windows, will receive an update.
     #[inline]
     pub fn trigger_update(&mut self, handle: UpdateHandle, payload: u64) {
+        debug!("trigger_update: handle={:?}, payload={}", handle, payload);
         self.shell.trigger_update(handle, payload);
     }
 

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -627,7 +627,7 @@ impl<'a> Manager<'a> {
                     true
                 }
             }};
-        };
+        }
 
         // Progresses to the next (or previous) sibling, otherwise pops to the
         // parent. Returns true if a sibling is found.
@@ -676,7 +676,7 @@ impl<'a> Manager<'a> {
                 }
                 have_sibling
             }};
-        };
+        }
 
         macro_rules! try_set_focus {
             ($self:ident, $widget:ident) => {

--- a/src/event/update.rs
+++ b/src/event/update.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 /// Update handles are used to trigger an update event on all widgets which are
 /// subscribed to the same handle.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[must_use]
 pub struct UpdateHandle(NonZeroU32);
 
 impl UpdateHandle {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -78,7 +78,7 @@ pub use checkbox::{CheckBox, CheckBoxBare};
 pub use combobox::ComboBox;
 pub use dialog::MessageBox;
 pub use drag::DragHandle;
-pub use editbox::{EditBox, EditBoxVoid, EditGuard};
+pub use editbox::{EditBox, EditGuard};
 pub use filler::Filler;
 pub use frame::Frame;
 pub use label::{AccelLabel, Label, StrLabel, StringLabel};

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -73,6 +73,8 @@ mod splitter;
 mod stack;
 mod window;
 
+pub mod view;
+
 pub use button::TextButton;
 pub use checkbox::{CheckBox, CheckBoxBare};
 pub use combobox::ComboBox;

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -1,0 +1,204 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! List view widget
+
+use super::{Accessor, DefaultView, ViewWidget};
+use kas::prelude::*;
+
+/// List view widget
+#[handler(send=noauto, msg=<W as Handler>::Msg)]
+#[widget(children=noauto)]
+#[derive(Clone, Default, Debug, Widget)]
+pub struct ListView<
+    D: Directional,
+    A: Accessor<usize>,
+    W: ViewWidget<A::Item> = <<A as Accessor<usize>>::Item as DefaultView>::Widget,
+> {
+    first_id: WidgetId,
+    #[widget_core]
+    core: CoreData,
+    data: A,
+    widgets: Vec<W>,
+    direction: D,
+    child_size_min: u32,
+    child_size_ideal: u32,
+    child_inter_margin: i32,
+}
+
+impl<D: Directional + Default, A: Accessor<usize>, W: ViewWidget<A::Item>> ListView<D, A, W> {
+    /// Construct a new instance
+    ///
+    /// This constructor is available where the direction is determined by the
+    /// type: for `D: Directional + Default`. In other cases, use
+    /// [`List::new_with_direction`].
+    pub fn new(data: A) -> Self {
+        ListView {
+            first_id: Default::default(),
+            core: Default::default(),
+            data,
+            widgets: Default::default(),
+            direction: Default::default(),
+            child_size_min: 0,
+            child_size_ideal: 0,
+            child_inter_margin: 0,
+        }
+    }
+}
+impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> ListView<D, A, W> {
+    /// Construct a new instance with explicit direction
+    pub fn new_with_direction(direction: D, data: A) -> Self {
+        ListView {
+            first_id: Default::default(),
+            core: Default::default(),
+            data,
+            widgets: Default::default(),
+            direction,
+            child_size_min: 0,
+            child_size_ideal: 0,
+            child_inter_margin: 0,
+        }
+    }
+
+    /// Get the direction of contents
+    pub fn direction(&self) -> Direction {
+        self.direction.as_direction()
+    }
+
+    fn allocate(&mut self, number: usize) {
+        self.widgets.reserve(number);
+        let len = self.data.len();
+        for i in self.widgets.len()..number {
+            self.widgets.push(if i < len {
+                W::new(self.data.get(i))
+            } else {
+                W::default()
+            });
+        }
+    }
+}
+
+impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> WidgetChildren
+    for ListView<D, A, W>
+{
+    #[inline]
+    fn first_id(&self) -> WidgetId {
+        self.first_id
+    }
+    fn record_first_id(&mut self, id: WidgetId) {
+        self.first_id = id;
+    }
+    #[inline]
+    fn len(&self) -> usize {
+        self.widgets.len()
+    }
+    #[inline]
+    fn get(&self, index: usize) -> Option<&dyn WidgetConfig> {
+        self.widgets.get(index).map(|w| w.as_widget())
+    }
+    #[inline]
+    fn get_mut(&mut self, index: usize) -> Option<&mut dyn WidgetConfig> {
+        self.widgets.get_mut(index).map(|w| w.as_widget_mut())
+    }
+}
+
+impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> Layout for ListView<D, A, W> {
+    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        // TODO: when and how to allocate children?
+        if self.widgets.len() < 1 {
+            self.allocate(1);
+        }
+        let mut rules = self.widgets[0].size_rules(size_handle, axis);
+        if axis.is_vertical() == self.direction.is_vertical() {
+            self.child_size_min = rules.min_size();
+            self.child_size_ideal = rules.ideal_size();
+            self.child_inter_margin = rules.margins().0 as i32 + rules.margins().1 as i32;
+            rules = SizeRules::new(
+                rules.min_size(),
+                rules.appended(rules).appended(rules).ideal_size(),
+                rules.margins(),
+                rules.stretch().max(StretchPolicy::HighUtility),
+            );
+        }
+        rules
+    }
+
+    fn set_rect(&mut self, rect: Rect, mut align: AlignHints) {
+        self.core.rect = rect;
+
+        let mut pos = rect.pos;
+        let mut child_size = rect.size;
+        let mut skip;
+        if self.direction.is_horizontal() {
+            if child_size.0 >= 3 * self.child_size_ideal {
+                child_size.0 = self.child_size_ideal;
+            } else {
+                child_size.0 = self.child_size_min;
+            }
+            skip = Coord(child_size.0 as i32 + self.child_inter_margin, 0);
+            align.horiz = None;
+        } else {
+            if child_size.1 >= 3 * self.child_size_ideal {
+                child_size.1 = self.child_size_ideal;
+            } else {
+                child_size.1 = self.child_size_min;
+            }
+            skip = Coord(0, child_size.0 as i32 + self.child_inter_margin);
+            align.vert = None;
+        }
+
+        if self.direction.is_reversed() {
+            pos += rect.size - skip.into();
+            skip = Coord::ZERO - skip;
+        }
+
+        for child in self.widgets.iter_mut() {
+            child.set_rect(Rect::new(pos, child_size), align);
+            pos += skip;
+        }
+    }
+
+    fn spatial_range(&self) -> (usize, usize) {
+        let last = WidgetChildren::len(self).wrapping_sub(1);
+        match self.direction.is_reversed() {
+            false => (0, last),
+            true => (last, 0),
+        }
+    }
+
+    fn find_id(&self, coord: Coord) -> Option<WidgetId> {
+        if !self.rect().contains(coord) {
+            return None;
+        }
+
+        // FIXME: find child
+        Some(self.id())
+    }
+
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
+        let disabled = disabled || self.is_disabled();
+        // FIXME: cull invisible children and restrict draw region
+        for child in self.widgets.iter() {
+            child.draw(draw_handle, mgr, disabled)
+        }
+    }
+}
+
+impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> SendEvent for ListView<D, A, W> {
+    fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
+        if !self.is_disabled() {
+            if id == self.id() {
+                return self.handle(mgr, event);
+            }
+            for child in &mut self.widgets {
+                if id <= child.id() {
+                    return child.send(mgr, id, event);
+                }
+            }
+        }
+
+        Response::Unhandled(event)
+    }
+}

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -40,7 +40,7 @@ where
     ///
     /// This constructor is available where the direction is determined by the
     /// type: for `D: Directional + Default`. In other cases, use
-    /// [`List::new_with_direction`].
+    /// [`ListView::new_with_direction`].
     pub fn new(data: A) -> Self {
         ListView {
             first_id: Default::default(),

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -8,6 +8,8 @@
 use super::{Accessor, DefaultView, ViewWidget};
 use kas::prelude::*;
 
+// TODO: do we need to keep the A::Item: Default bound used by allocate?
+
 /// List view widget
 #[handler(send=noauto, msg=<W as Handler>::Msg)]
 #[widget(children=noauto)]
@@ -16,7 +18,9 @@ pub struct ListView<
     D: Directional,
     A: Accessor<usize>,
     W: ViewWidget<A::Item> = <<A as Accessor<usize>>::Item as DefaultView>::Widget,
-> {
+> where
+    A::Item: Default,
+{
     first_id: WidgetId,
     #[widget_core]
     core: CoreData,
@@ -28,7 +32,10 @@ pub struct ListView<
     child_inter_margin: i32,
 }
 
-impl<D: Directional + Default, A: Accessor<usize>, W: ViewWidget<A::Item>> ListView<D, A, W> {
+impl<D: Directional + Default, A: Accessor<usize>, W: ViewWidget<A::Item>> ListView<D, A, W>
+where
+    A::Item: Default,
+{
     /// Construct a new instance
     ///
     /// This constructor is available where the direction is determined by the
@@ -47,7 +54,10 @@ impl<D: Directional + Default, A: Accessor<usize>, W: ViewWidget<A::Item>> ListV
         }
     }
 }
-impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> ListView<D, A, W> {
+impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> ListView<D, A, W>
+where
+    A::Item: Default,
+{
     /// Construct a new instance with explicit direction
     pub fn new_with_direction(direction: D, data: A) -> Self {
         ListView {
@@ -82,6 +92,8 @@ impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> ListView<D, A, 
 
 impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> WidgetChildren
     for ListView<D, A, W>
+where
+    A::Item: Default,
 {
     #[inline]
     fn first_id(&self) -> WidgetId {
@@ -104,7 +116,10 @@ impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> WidgetChildren
     }
 }
 
-impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> Layout for ListView<D, A, W> {
+impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> Layout for ListView<D, A, W>
+where
+    A::Item: Default,
+{
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         // TODO: when and how to allocate children?
         if self.widgets.len() < 1 {
@@ -186,7 +201,10 @@ impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> Layout for List
     }
 }
 
-impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> SendEvent for ListView<D, A, W> {
+impl<D: Directional, A: Accessor<usize>, W: ViewWidget<A::Item>> SendEvent for ListView<D, A, W>
+where
+    A::Item: Default,
+{
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         if !self.is_disabled() {
             if id == self.id() {

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -14,7 +14,9 @@ use super::Label;
 use kas::event::UpdateHandle;
 use kas::prelude::*;
 use kas::text::format::FormattableText;
+use std::cell::RefCell;
 use std::fmt::Debug;
+use std::rc::Rc;
 
 // mod list;
 mod single;
@@ -30,7 +32,7 @@ pub trait ViewWidget<T>: Widget {
     /// Construct a default instance (with no data)
     fn default() -> Self;
     /// Construct an instance from a data value
-    fn new(data: &T) -> Self;
+    fn new(data: T) -> Self;
     /// Set the viewed data
     fn set(&mut self, data: &T) -> TkAction;
 }
@@ -39,7 +41,7 @@ impl<T: Clone + Default + FormattableText + 'static> ViewWidget<T> for Label<T> 
     fn default() -> Self {
         Default::default()
     }
-    fn new(data: &T) -> Self {
+    fn new(data: T) -> Self {
         Self::new(data.clone())
     }
     fn set(&mut self, data: &T) -> TkAction {
@@ -59,37 +61,88 @@ impl<T: Clone + Default + FormattableText + 'static> DefaultView for T {
     type Widget = Label<T>;
 }
 
+/// Base trait required by view widgets
 // Note: we require Debug + 'static to allow widgets using this to implement
 // WidgetCore, which requires Debug + Any.
 // Note: since there can be at most one impl for any (T, Self), it would make
 // sense for I to be an associated type; BUT this would make our generic impls
 // conflict (e.g. downstream *could* write `impl AsRef<S> for [S] { .. }`).
 pub trait Accessor<I, T: ?Sized>: Debug + 'static {
+    /// Size descriptor
+    ///
+    /// Note: for `I == ()` we consider `()` a valid index; in other cases we
+    /// usually expect `index < accessor.len()` (for each component).
     fn len(&self) -> I;
-    fn get(&self, index: I) -> &T;
+
+    /// Access data by index
+    fn get(&self, index: I) -> T;
+
+    /// Get an update handle, if any is used
+    ///
+    /// Widgets may use this `handle` to call `mgr.update_on_handle(handle, self.id())`.
     fn update_handle(&self) -> Option<UpdateHandle> {
         None
     }
 }
 
-pub trait AccessorMut<I, T: ?Sized>: Accessor<I, T> {
+/// Extension trait for shared data for view widgets
+pub trait AccessorShared<I, T: ?Sized>: Accessor<I, T> {
+    /// Set data at the given index
+    ///
+    /// The caller is expected to arrange synchronisation as necessary, likely
+    /// using [`Accessor::update_handle`].
     fn set(&mut self, index: I, value: T);
 }
 
-impl<T: Debug + 'static> Accessor<usize, T> for [T] {
+impl<T: Clone + Debug + 'static> Accessor<usize, T> for [T] {
     fn len(&self) -> usize {
         self.len()
     }
-    fn get(&self, index: usize) -> &T {
-        &self[index]
+    fn get(&self, index: usize) -> T {
+        self[index].clone()
     }
 }
 
-impl<T: ?Sized, R: AsRef<T> + Debug + ?Sized + 'static> Accessor<(), T> for R {
+impl<T: Clone + Debug + 'static> Accessor<(), T> for T {
     fn len(&self) -> () {
         ()
     }
-    fn get(&self, _: ()) -> &T {
-        self.as_ref()
+    fn get(&self, _: ()) -> T {
+        self.clone()
+    }
+}
+
+/// Wrapper for single-thread shared data
+#[derive(Clone, Debug)]
+pub struct SharedRc<T: Clone + Debug + 'static> {
+    handle: UpdateHandle,
+    data: Rc<RefCell<T>>,
+}
+
+impl<T: Clone + Debug + 'static> SharedRc<T> {
+    /// Construct with given data
+    pub fn new(data: T) -> Self {
+        SharedRc {
+            handle: UpdateHandle::new(),
+            data: Rc::new(RefCell::new(data)),
+        }
+    }
+}
+
+impl<T: Clone + Debug + 'static> Accessor<(), T> for SharedRc<T> {
+    fn len(&self) -> () {
+        ()
+    }
+    fn get(&self, _: ()) -> T {
+        self.data.borrow().to_owned()
+    }
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        Some(self.handle)
+    }
+}
+
+impl<T: Clone + Debug + 'static> AccessorShared<(), T> for SharedRc<T> {
+    fn set(&mut self, _: (), value: T) {
+        *self.data.borrow_mut() = value;
     }
 }

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! View widgets
+//!
+//! View widgets exist as a view over some shared data.
+
+// TODO: how do we notify widgets holding an Accessor when an update is required?
+// TODO: how do we allow fine-grained updates when a subset of data changes?
+
+use super::Label;
+use kas::prelude::*;
+use kas::text::format::FormattableText;
+use std::fmt::Debug;
+
+mod list;
+
+pub use list::ListView;
+
+/// View widgets
+///
+/// Implementors are able to view data of type `T`.
+pub trait ViewWidget<T>: Widget {
+    /// Construct a default instance (with no data)
+    fn default() -> Self;
+    /// Construct an instance from a data value
+    fn new(data: T) -> Self;
+    /// Set the viewed data
+    fn set(&mut self, data: T) -> TkAction;
+}
+
+impl<T: Default + FormattableText + 'static> ViewWidget<T> for Label<T> {
+    fn default() -> Self {
+        Default::default()
+    }
+    fn new(data: T) -> Self {
+        Self::new(data)
+    }
+    fn set(&mut self, data: T) -> TkAction {
+        self.set_text(data)
+    }
+}
+
+/// Default view assignments
+///
+/// This trait may be implemented to assign a default view widget to a specific
+/// data type.
+pub trait DefaultView: Sized {
+    type Widget: ViewWidget<Self>;
+}
+
+impl DefaultView for &'static str {
+    type Widget = Label<&'static str>;
+}
+impl DefaultView for String {
+    type Widget = Label<String>;
+}
+
+// Note: we require Debug + 'static to allow widgets using this to implement
+// WidgetCore, which requires Debug + Any.
+pub trait Accessor<Index: Copy>: Debug + 'static {
+    type Item;
+    fn len(&self) -> Index;
+    fn get(&self, index: Index) -> Self::Item;
+}
+
+impl<T: Clone + Debug + 'static> Accessor<usize> for [T] {
+    type Item = T;
+    fn len(&self) -> usize {
+        self.len()
+    }
+    fn get(&self, index: usize) -> T {
+        self[index].clone()
+    }
+}
+
+impl<Index: Copy, A: Accessor<Index> + ?Sized> Accessor<Index> for &'static A {
+    type Item = A::Item;
+    fn len(&self) -> Index {
+        (*self).len()
+    }
+    fn get(&self, index: Index) -> Self::Item {
+        (*self).get(index)
+    }
+}

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -10,11 +10,11 @@
 use super::Label;
 use kas::prelude::*;
 
-// mod list;
+mod list;
 mod shared;
 mod single;
 
-// pub use list::ListView;
+pub use list::ListView;
 pub use shared::{Accessor, AccessorShared, SharedConst, SharedRc};
 pub use single::SingleView;
 

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -8,18 +8,14 @@
 //! View widgets exist as a view over some shared data.
 
 use super::Label;
-#[allow(unused)]
-use kas::event::Manager;
-use kas::event::UpdateHandle;
 use kas::prelude::*;
-use std::cell::RefCell;
-use std::fmt::Debug;
-use std::rc::Rc;
 
 // mod list;
+mod shared;
 mod single;
 
 // pub use list::ListView;
+pub use shared::{Accessor, AccessorShared, SharedConst, SharedRc};
 pub use single::SingleView;
 
 /// View widgets
@@ -84,117 +80,4 @@ impl DefaultView for String {
 }
 impl<'a> DefaultView for &'a str {
     type Widget = Label<String>;
-}
-
-/// Base trait required by view widgets
-// Note: we require Debug + 'static to allow widgets using this to implement
-// WidgetCore, which requires Debug + Any.
-pub trait Accessor<I>: Debug + 'static {
-    type Item;
-
-    /// Size descriptor
-    ///
-    /// Note: for `I == ()` we consider `()` a valid index; in other cases we
-    /// usually expect `index < accessor.len()` (for each component).
-    fn len(&self) -> I;
-
-    /// Access data by index
-    fn get(&self, index: I) -> Self::Item;
-
-    /// Get an update handle, if any is used
-    ///
-    /// Widgets may use this `handle` to call `mgr.update_on_handle(handle, self.id())`.
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        None
-    }
-}
-
-/// Extension trait for shared data for view widgets
-pub trait AccessorShared<I>: Accessor<I> {
-    /// Set data at the given index
-    ///
-    /// The caller should call [`Manager::trigger_update`] using the returned
-    /// update handle, using an appropriate transformation of the index for the
-    /// payload (the transformation defined by implementing view widgets).
-    /// Calling `trigger_update` is unnecessary before the UI has been started.
-    fn set(&self, index: I, value: Self::Item) -> UpdateHandle;
-}
-
-/// Wrapper for shared constant data
-///
-/// This may be useful with static data, e.g. `[&'static str]`.
-#[derive(Clone, Debug, Default)]
-pub struct SharedConst<T: Debug + 'static + ?Sized>(T);
-
-impl<T: Clone + Debug + 'static + ?Sized> SharedConst<T> {
-    /// Construct with given data
-    pub fn new(data: T) -> Self {
-        SharedConst(data)
-    }
-}
-
-impl<T: Clone + Debug + 'static> Accessor<()> for SharedConst<T> {
-    type Item = T;
-    fn len(&self) -> () {
-        ()
-    }
-    fn get(&self, _: ()) -> T {
-        self.0.clone()
-    }
-}
-
-impl<T: Clone + Debug + 'static + ?Sized> Accessor<usize> for SharedConst<[T]> {
-    type Item = T;
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-    fn get(&self, index: usize) -> T {
-        self.0[index].to_owned()
-    }
-}
-
-/// Wrapper for single-thread shared data
-#[derive(Clone, Debug)]
-pub struct SharedRc<T: Clone + Debug + 'static> {
-    handle: UpdateHandle,
-    data: Rc<RefCell<T>>,
-}
-
-impl<T: Default + Clone + Debug + 'static> Default for SharedRc<T> {
-    fn default() -> Self {
-        SharedRc {
-            handle: UpdateHandle::new(),
-            data: Default::default(),
-        }
-    }
-}
-
-impl<T: Clone + Debug + 'static> SharedRc<T> {
-    /// Construct with given data
-    pub fn new(data: T) -> Self {
-        SharedRc {
-            handle: UpdateHandle::new(),
-            data: Rc::new(RefCell::new(data)),
-        }
-    }
-}
-
-impl<T: Clone + Debug + 'static> Accessor<()> for SharedRc<T> {
-    type Item = T;
-    fn len(&self) -> () {
-        ()
-    }
-    fn get(&self, _: ()) -> T {
-        self.data.borrow().to_owned()
-    }
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        Some(self.handle)
-    }
-}
-
-impl<T: Clone + Debug + 'static> AccessorShared<()> for SharedRc<T> {
-    fn set(&self, _: (), value: T) -> UpdateHandle {
-        *self.data.borrow_mut() = value;
-        self.handle
-    }
 }

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -15,9 +15,11 @@ use kas::prelude::*;
 use kas::text::format::FormattableText;
 use std::fmt::Debug;
 
-mod list;
+// mod list;
+mod single;
 
-pub use list::ListView;
+// pub use list::ListView;
+pub use single::SingleView;
 
 /// View widgets
 ///

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -11,6 +11,7 @@
 // TODO: how do we allow fine-grained updates when a subset of data changes?
 
 use super::Label;
+use kas::event::UpdateHandle;
 use kas::prelude::*;
 use kas::text::format::FormattableText;
 use std::fmt::Debug;
@@ -66,6 +67,13 @@ impl<T: Clone + Default + FormattableText + 'static> DefaultView for T {
 pub trait Accessor<I, T: ?Sized>: Debug + 'static {
     fn len(&self) -> I;
     fn get(&self, index: I) -> &T;
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        None
+    }
+}
+
+pub trait AccessorMut<I, T: ?Sized>: Accessor<I, T> {
+    fn set(&mut self, index: I, value: T);
 }
 
 impl<T: Debug + 'static> Accessor<usize, T> for [T] {

--- a/src/widget/view/shared.rs
+++ b/src/widget/view/shared.rs
@@ -1,0 +1,126 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Shared data for view widgets
+
+#[allow(unused)]
+use kas::event::Manager;
+use kas::event::UpdateHandle;
+use std::cell::RefCell;
+use std::fmt::Debug;
+use std::rc::Rc;
+
+/// Base trait required by view widgets
+// Note: we require Debug + 'static to allow widgets using this to implement
+// WidgetCore, which requires Debug + Any.
+pub trait Accessor<I>: Debug + 'static {
+    type Item;
+
+    /// Size descriptor
+    ///
+    /// Note: for `I == ()` we consider `()` a valid index; in other cases we
+    /// usually expect `index < accessor.len()` (for each component).
+    fn len(&self) -> I;
+
+    /// Access data by index
+    fn get(&self, index: I) -> Self::Item;
+
+    /// Get an update handle, if any is used
+    ///
+    /// Widgets may use this `handle` to call `mgr.update_on_handle(handle, self.id())`.
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        None
+    }
+}
+
+/// Extension trait for shared data for view widgets
+pub trait AccessorShared<I>: Accessor<I> {
+    /// Set data at the given index
+    ///
+    /// The caller should call [`Manager::trigger_update`] using the returned
+    /// update handle, using an appropriate transformation of the index for the
+    /// payload (the transformation defined by implementing view widgets).
+    /// Calling `trigger_update` is unnecessary before the UI has been started.
+    fn set(&self, index: I, value: Self::Item) -> UpdateHandle;
+}
+
+/// Wrapper for shared constant data
+///
+/// This may be useful with static data, e.g. `[&'static str]`.
+#[derive(Clone, Debug, Default)]
+pub struct SharedConst<T: Debug + 'static + ?Sized>(T);
+
+impl<T: Clone + Debug + 'static + ?Sized> SharedConst<T> {
+    /// Construct with given data
+    pub fn new(data: T) -> Self {
+        SharedConst(data)
+    }
+}
+
+impl<T: Clone + Debug + 'static> Accessor<()> for SharedConst<T> {
+    type Item = T;
+    fn len(&self) -> () {
+        ()
+    }
+    fn get(&self, _: ()) -> T {
+        self.0.clone()
+    }
+}
+
+impl<T: Clone + Debug + 'static + ?Sized> Accessor<usize> for SharedConst<[T]> {
+    type Item = T;
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+    fn get(&self, index: usize) -> T {
+        self.0[index].to_owned()
+    }
+}
+
+/// Wrapper for single-thread shared data
+#[derive(Clone, Debug)]
+pub struct SharedRc<T: Clone + Debug + 'static> {
+    handle: UpdateHandle,
+    data: Rc<RefCell<T>>,
+}
+
+impl<T: Default + Clone + Debug + 'static> Default for SharedRc<T> {
+    fn default() -> Self {
+        SharedRc {
+            handle: UpdateHandle::new(),
+            data: Default::default(),
+        }
+    }
+}
+
+impl<T: Clone + Debug + 'static> SharedRc<T> {
+    /// Construct with given data
+    pub fn new(data: T) -> Self {
+        SharedRc {
+            handle: UpdateHandle::new(),
+            data: Rc::new(RefCell::new(data)),
+        }
+    }
+}
+
+impl<T: Clone + Debug + 'static> Accessor<()> for SharedRc<T> {
+    type Item = T;
+    fn len(&self) -> () {
+        ()
+    }
+    fn get(&self, _: ()) -> T {
+        self.data.borrow().to_owned()
+    }
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        Some(self.handle)
+    }
+}
+
+impl<T: Clone + Debug + 'static> AccessorShared<()> for SharedRc<T> {
+    fn set(&self, _: (), value: T) -> UpdateHandle {
+        *self.data.borrow_mut() = value;
+        self.handle
+    }
+}

--- a/src/widget/view/single.rs
+++ b/src/widget/view/single.rs
@@ -1,0 +1,38 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Single view widget
+
+use super::{Accessor, DefaultView, ViewWidget};
+use kas::prelude::*;
+
+/// Single view widget
+#[derive(Clone, Default, Debug, Widget)]
+#[layout(single)]
+#[handler(msg=<W as Handler>::Msg)]
+pub struct SingleView<
+    A: Accessor<()>,
+    W: ViewWidget<A::Item> = <<A as Accessor<()>>::Item as DefaultView>::Widget,
+> {
+    first_id: WidgetId,
+    #[widget_core]
+    core: CoreData,
+    data: A,
+    #[widget]
+    child: W,
+}
+
+impl<A: Accessor<()>, W: ViewWidget<A::Item>> SingleView<A, W> {
+    /// Construct a new instance
+    pub fn new(data: A) -> Self {
+        let value = data.get(());
+        SingleView {
+            first_id: Default::default(),
+            core: Default::default(),
+            data,
+            child: W::new(value),
+        }
+    }
+}

--- a/src/widget/view/single.rs
+++ b/src/widget/view/single.rs
@@ -5,7 +5,7 @@
 
 //! Single view widget
 
-use super::{Accessor, AccessorMut, DefaultView, ViewWidget};
+use super::{Accessor, AccessorShared, DefaultView, ViewWidget};
 use kas::prelude::*;
 use std::fmt;
 use std::marker::PhantomData;
@@ -38,7 +38,10 @@ impl<T: 'static, A: Accessor<(), T>, W: ViewWidget<T>> SingleView<T, A, W> {
     }
 }
 
-impl<T: 'static, A: AccessorMut<(), T>, W: ViewWidget<T>> SingleView<T, A, W> {
+impl<T: 'static, A: AccessorShared<(), T>, W: ViewWidget<T>> SingleView<T, A, W> {
+    /// Update data
+    ///
+    /// Other widgets with a view of this data are notified of the update.
     pub fn update(&mut self, mgr: &mut Manager, data: T) {
         self.accessor.set((), data);
         if let Some(handle) = self.accessor.update_handle() {

--- a/src/widget/view/single.rs
+++ b/src/widget/view/single.rs
@@ -7,32 +7,42 @@
 
 use super::{Accessor, DefaultView, ViewWidget};
 use kas::prelude::*;
+use std::fmt;
+use std::marker::PhantomData;
 
 /// Single view widget
-#[derive(Clone, Default, Debug, Widget)]
+#[derive(Clone, Default, Widget)]
 #[layout(single)]
 #[handler(msg=<W as Handler>::Msg)]
-pub struct SingleView<
-    A: Accessor<()>,
-    W: ViewWidget<A::Item> = <<A as Accessor<()>>::Item as DefaultView>::Widget,
-> {
-    first_id: WidgetId,
+pub struct SingleView<T: 'static, A: Accessor<(), T>, W: ViewWidget<T> = <T as DefaultView>::Widget>
+{
     #[widget_core]
     core: CoreData,
+    _t: PhantomData<T>,
     data: A,
     #[widget]
     child: W,
 }
 
-impl<A: Accessor<()>, W: ViewWidget<A::Item>> SingleView<A, W> {
+impl<T: 'static, A: Accessor<(), T>, W: ViewWidget<T>> SingleView<T, A, W> {
     /// Construct a new instance
     pub fn new(data: A) -> Self {
-        let value = data.get(());
+        let child = W::new(data.get(()));
         SingleView {
-            first_id: Default::default(),
             core: Default::default(),
+            _t: Default::default(),
             data,
-            child: W::new(value),
+            child,
         }
+    }
+}
+
+impl<T: 'static, A: Accessor<(), T>, W: ViewWidget<T>> fmt::Debug for SingleView<T, A, W> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "SingleView {{ core: {:?}, data: {:?}, child: {:?} }}",
+            self.core, self.data, self.child,
+        )
     }
 }


### PR DESCRIPTION
This `Accessor` and `ViewWidget` framework is supposed to be KAS's answer for widgets which do not own or directly access their data (shared and filtered data).

This design takes a little inspiration from Druid's lens system, but ultimately works quite differently since KAS widgets have *many* more methods than Druid widgets (thus directly passing data everywhere is quite impractical), and our existing design (storing data in widgets) already works well for many cases (constant and unshared data).

Status

- implemented for single (unindexed) data, making the sync-counter significantly simpler for the same functionality
- very early work for list data
- *hopefully* the design will extend nicely to deal with `Vec<T>` (where length is not constant) and to multi-dimensional types