### PR TITLE
ScrollBars wrapper, filter-list with large numbers of entries

### DIFF
--- a/kas-macros/src/layout.rs
+++ b/kas-macros/src/layout.rs
@@ -199,14 +199,15 @@ pub(crate) fn derive(
             );
         });
 
+        set_rect.append_all(quote! { let mut align2 = align; });
         if let Some(toks) = args.halign_toks()? {
-            set_rect.append_all(quote! { align.horiz = Some(#toks); });
+            set_rect.append_all(quote! { align2.horiz = Some(#toks); });
         }
         if let Some(toks) = args.valign_toks()? {
-            set_rect.append_all(quote! { align.vert = Some(#toks); });
+            set_rect.append_all(quote! { align2.vert = Some(#toks); });
         }
         set_rect.append_all(quote! {
-            self.#ident.set_rect(_sh, setter.child_rect(&mut #data, #child_info), align);
+            self.#ident.set_rect(_sh, setter.child_rect(&mut #data, #child_info), align2);
         });
 
         draw.append_all(quote! {
@@ -261,7 +262,7 @@ pub(crate) fn derive(
             &mut self,
             _sh: &mut dyn kas::draw::SizeHandle,
             rect: kas::geom::Rect,
-            mut align: kas::AlignHints
+            align: kas::AlignHints
         ) {
             use kas::{WidgetCore, Widget};
             use kas::layout::{Margins, RulesSetter};

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -27,6 +27,9 @@ stack_dst = ["kas-theme/stack_dst"]
 # Use kas-theme's unsize feature (nightly-only)
 unsize = ["kas-theme/unsize"]
 
+# See filter-list example
+generator = []
+
 [dependencies]
 kas = { path = "..", version = "0.6.0", features = ["winit"] }
 kas-theme = { path = "../kas-theme", version = "0.6.0" }

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -140,8 +140,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget] _ = Label::new("Contents of selected entry:"),
                 #[widget] display: StringLabel = Label::from("Entry #0"),
                 #[widget] _ = Separator::new(),
-                #[widget(handler = set_radio)] list: ScrollRegion<Column<ListEntry>> =
-                    ScrollRegion::new(Column::new(entries)).with_bars(false, true),
+                #[widget(handler = set_radio)] list: ScrollBarRegion<Column<ListEntry>> =
+                    ScrollBarRegion::new2(Column::new(entries)).with_bars(false, true),
                 #[widget] _ = Filler::maximize(),
                 active: usize = 0,
             }

--- a/kas-wgpu/examples/filter-list.rs
+++ b/kas-wgpu/examples/filter-list.rs
@@ -7,7 +7,7 @@
 
 use kas::prelude::*;
 use kas::widget::view::{FilterAccessor, ListView, SharedConst};
-use kas::widget::{EditBox, Window};
+use kas::widget::{EditBox, ScrollBars, Window};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -50,7 +50,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     mgr.trigger_update(update, 0);
                     None
                 }),
-                #[widget] list = ListView::<kas::Down, FA>::new(data),
+                #[widget] list = ScrollBars::new(ListView::<kas::Down, FA>::new(data)),
             }
         },
     );

--- a/kas-wgpu/examples/filter-list.rs
+++ b/kas-wgpu/examples/filter-list.rs
@@ -6,33 +6,85 @@
 //! Filter list example
 
 use kas::prelude::*;
-use kas::widget::view::{FilterAccessor, ListView, SharedConst};
+use kas::widget::view::{Accessor, ListView};
 use kas::widget::{EditBox, ScrollBars, Window};
-use std::cell::RefCell;
-use std::rc::Rc;
 
-const MONTHS: &[&str] = &[
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-];
+#[cfg(not(feature = "generator"))]
+mod data {
+    use kas::widget::view::{FilterAccessor, SharedConst};
+    use std::{cell::RefCell, rc::Rc};
+
+    type SC = &'static SharedConst<[&'static str]>;
+    pub type Shared = Rc<RefCell<FilterAccessor<usize, SC>>>;
+
+    const MONTHS: &[&str] = &[
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ];
+
+    pub fn get() -> Shared {
+        Rc::new(RefCell::new(FilterAccessor::new_visible(MONTHS.into())))
+    }
+}
+
+// Implementation which generates dates, allowing testing with large numbers of entries
+// Since entries are generated on demand there is no penalty to having very large
+// numbers, *except* that this filter is O(n) in both memory usage and update time.
+#[cfg(feature = "generator")]
+mod data {
+    use chrono::{DateTime, Duration, Local};
+    use kas::widget::view::{Accessor, FilterAccessor};
+    use std::{cell::RefCell, rc::Rc};
+
+    // pub type Shared = Rc<RefCell<DateGenerator>>;
+    pub type Shared = Rc<RefCell<FilterAccessor<usize, DateGenerator>>>;
+
+    #[derive(Debug)]
+    pub struct DateGenerator {
+        start: DateTime<Local>,
+        end: DateTime<Local>,
+        step: Duration,
+    }
+
+    impl Accessor<usize> for DateGenerator {
+        type Item = String;
+        fn len(&self) -> usize {
+            let dur = self.end - self.start;
+            let secs = dur.num_seconds();
+            let step_secs = self.step.num_seconds();
+            1 + ((secs - 1) / step_secs) as usize
+        }
+
+        fn get(&self, index: usize) -> Self::Item {
+            let date = self.start + self.step * index as i32;
+            date.format("%A %e %B %Y, %T").to_string()
+        }
+    }
+
+    pub fn get() -> Shared {
+        Rc::new(RefCell::new(FilterAccessor::new_visible(DateGenerator {
+            start: Local::now(),
+            end: Local::now() + Duration::days(365),
+            step: Duration::seconds(999),
+        })))
+    }
+}
 
 fn main() -> Result<(), kas_wgpu::Error> {
     env_logger::init();
 
-    type SC = &'static SharedConst<[&'static str]>;
-    type FA = Rc<RefCell<FilterAccessor<usize, SC>>>;
-    let data: SC = MONTHS.into();
-    let data = Rc::new(RefCell::new(FilterAccessor::new_visible(data)));
+    let data = data::get();
+    println!("filter-list: {} entries", data.borrow().len());
     let data2 = data.clone();
     let window = Window::new(
         "Filter-list",
@@ -50,7 +102,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     mgr.trigger_update(update, 0);
                     None
                 }),
-                #[widget] list = ScrollBars::new(ListView::<kas::Down, FA>::new(data)),
+                #[widget] list = ScrollBars::new(ListView::<kas::Down, data::Shared>::new(data)),
             }
         },
     );

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -215,8 +215,8 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget(handler = menu)] _ = menubar,
                 #[widget(halign = centre)] _ = Frame::new(Label::new("Widget Gallery")),
                 #[widget(handler = activations)] gallery:
-                    for<W: Widget<Msg = Item>> ScrollRegion<W> =
-                    ScrollRegion::new(widgets).with_auto_bars(true),
+                    for<W: Widget<Msg = Item>> ScrollBarRegion<W> =
+                        ScrollBarRegion::new2(widgets),
             }
             impl {
                 fn menu(&mut self, mgr: &mut Manager, msg: Menu) -> VoidResponse {

--- a/kas-wgpu/examples/markdown.rs
+++ b/kas-wgpu/examples/markdown.rs
@@ -9,7 +9,7 @@ use kas::class::HasStr;
 use kas::event::{Manager, Response, VoidMsg};
 use kas::macros::make_widget;
 use kas::text::format::Markdown;
-use kas::widget::{EditBox, Label, ScrollRegion, TextButton, Window};
+use kas::widget::{EditBox, Label, ScrollBarRegion, TextButton, Window};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -43,8 +43,10 @@ It also supports lists:
             #[layout(grid)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget(row=0, col=0, rspan=2)] editor: EditBox = EditBox::new(doc).multi_line(true),
-                #[widget(row=0, col=1)] label: ScrollRegion<Label<Markdown>> = ScrollRegion::new(Label::new(Markdown::new(doc)?)).with_bars(false, true),
+                #[widget(row=0, col=0, rspan=2)] editor: EditBox =
+                    EditBox::new(doc).multi_line(true),
+                #[widget(row=0, col=1)] label: ScrollBarRegion<Label<Markdown>> =
+                    ScrollBarRegion::new2(Label::new(Markdown::new(doc)?)),
                 #[widget(row=1, col=1, handler=update)] _ = TextButton::new("&Update", ()),
             }
             impl {

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -508,7 +508,7 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
 }
 
 #[cfg(feature = "stack_dst")]
-impl<S> SizeHandle for stack_dst::ValueA<dyn SizeHandle, S>
+impl<'a, S> SizeHandle for stack_dst::ValueA<dyn SizeHandle + 'a, S>
 where
     S: Default + Copy + AsRef<[usize]> + AsMut<[usize]>,
 {
@@ -664,7 +664,7 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
 }
 
 #[cfg(feature = "stack_dst")]
-impl<S> DrawHandle for stack_dst::ValueA<dyn DrawHandle, S>
+impl<'a, S> DrawHandle for stack_dst::ValueA<dyn DrawHandle + 'a, S>
 where
     S: Default + Copy + AsRef<[usize]> + AsMut<[usize]>,
 {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -91,7 +91,7 @@ pub use progress::ProgressBar;
 pub use radiobox::{RadioBox, RadioBoxBare};
 pub use reserve::{Reserve, ReserveP};
 pub use scroll::{ScrollComponent, ScrollRegion};
-pub use scrollbar::{ScrollBar, ScrollBars, ScrollWidget};
+pub use scrollbar::{ScrollBar, ScrollBarRegion, ScrollBars, ScrollWidget};
 pub use separator::Separator;
 pub use slider::{Slider, SliderType};
 pub use splitter::*;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -91,7 +91,7 @@ pub use progress::ProgressBar;
 pub use radiobox::{RadioBox, RadioBoxBare};
 pub use reserve::{Reserve, ReserveP};
 pub use scroll::{ScrollComponent, ScrollRegion};
-pub use scrollbar::ScrollBar;
+pub use scrollbar::{ScrollBar, ScrollBars, ScrollWidget};
 pub use separator::Separator;
 pub use slider::{Slider, SliderType};
 pub use splitter::*;

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -290,8 +290,8 @@ impl<W: Widget> ScrollWidget for ScrollRegion<W> {
     }
 
     #[inline]
-    fn set_scroll_offset(&mut self, offset: Coord) -> TkAction {
-        self.scroll.set_offset(offset)
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) {
+        *mgr += self.scroll.set_offset(offset);
     }
 }
 

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -5,20 +5,18 @@
 
 //! Scroll region
 
-use std::fmt::Debug;
-
-use super::ScrollBar;
+use super::ScrollWidget;
 use kas::draw::{ClipRegion, TextClass};
 use kas::event::ScrollDelta::{LineDelta, PixelDelta};
 use kas::event::{self, ControlKey, PressSource};
 use kas::prelude::*;
+use std::fmt::Debug;
 
 /// Logic for a scroll region
 ///
 /// This struct handles some scroll logic. It does not provide scrollbars.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ScrollComponent {
-    window_size: Size,
     // TODO: offsets should be a vector, not a coord. This affects a number of conversions.
     max_offset: Coord,
     offset: Coord,
@@ -29,7 +27,6 @@ impl Default for ScrollComponent {
     #[inline]
     fn default() -> Self {
         ScrollComponent {
-            window_size: Size::ZERO,
             max_offset: Coord::ZERO,
             offset: Coord::ZERO,
             scroll_rate: 30.0,
@@ -55,15 +52,6 @@ impl ScrollComponent {
         self.offset
     }
 
-    /// Get the window size
-    ///
-    /// This is the size on the outside: the "window" through which the scrolled
-    /// region is viewed (not the application window).
-    #[inline]
-    pub fn window_size(&self) -> Size {
-        self.window_size
-    }
-
     /// Set sizes:
     ///
     /// -   `window_size`: size of scroll region on the outside
@@ -73,7 +61,6 @@ impl ScrollComponent {
     /// change in offset. In practice the caller will likely be performing all
     /// required updates regardless and the return value can be safely ignored.
     pub fn set_sizes(&mut self, window_size: Size, content_size: Size) -> TkAction {
-        self.window_size = window_size;
         self.max_offset = Coord::from(content_size) - Coord::from(window_size);
         self.set_offset(self.offset)
     }
@@ -126,16 +113,19 @@ impl ScrollComponent {
     /// Inputs and outputs:
     ///
     /// -   `rect`: the focus rect
-    /// -   `pos`: the coordinate of the top-left of the scroll area (`rect` is relative to this)
+    /// -   `window_rect`: the rect of the scroll window
     /// -   returned `Rect`: the focus rect, adjusted for scroll offset; normally this should be
     ///     returned via another [`Response::Focus`]
     /// -   returned `TkAction`: action to pass to the event manager
     #[inline]
-    pub fn focus_rect(&mut self, rect: Rect, pos: Coord) -> (Rect, TkAction) {
+    pub fn focus_rect(&mut self, rect: Rect, window_rect: Rect) -> (Rect, TkAction) {
         // TODO: we want vectors here, not coords (points) and sizes!
-        let rel_pos = Coord(rect.pos.0 - pos.0, rect.pos.1 - pos.1);
+        let rel_pos = Coord(
+            rect.pos.0 - window_rect.pos.0,
+            rect.pos.1 - window_rect.pos.1,
+        );
         let mut offset = self.offset;
-        offset = offset.max(rel_pos + rect.size - self.window_size);
+        offset = offset.max(rel_pos + rect.size - window_rect.size);
         offset = offset.min(rel_pos);
         let action = self.set_offset(offset);
         (rect - self.offset, action)
@@ -158,7 +148,8 @@ impl ScrollComponent {
     /// )
     ///     -> Response<Msg>
     /// {
-    ///     let (action, response) = scroll.scroll_by_event(event, |source, _, coord| {
+    ///     let window_size = Size(100, 80);
+    ///     let (action, response) = scroll.scroll_by_event(event, window_size, |source, _, coord| {
     ///         if source.is_primary() {
     ///             let icon = Some(kas::event::CursorIcon::Grabbing);
     ///             mgr.request_grab(id, source, coord, kas::event::GrabMode::Grab, icon);
@@ -169,12 +160,15 @@ impl ScrollComponent {
     /// }
     /// ```
     ///
+    /// If the returned [`TkAction`] is `None`, the scroll offset has not changed and
+    /// the returned [`Response`] is either `None` or `Unhandled(..)`.
     /// If the returned [`TkAction`] is not `None`, the scroll offset has been
-    /// updated. The returned [`Response`] is either `None` or `Unhandled(..)`.
+    /// updated and the second return value is `Response::None`.
     #[inline]
     pub fn scroll_by_event<PS: FnMut(PressSource, WidgetId, Coord)>(
         &mut self,
         event: Event,
+        window_size: Size,
         mut on_press_start: PS,
     ) -> (TkAction, Response<VoidMsg>) {
         let mut action = TkAction::None;
@@ -193,8 +187,8 @@ impl ScrollComponent {
                     ControlKey::Right => LineDelta(1.0, 0.0),
                     ControlKey::Up => LineDelta(0.0, 1.0),
                     ControlKey::Down => LineDelta(0.0, -1.0),
-                    ControlKey::PageUp => PixelDelta(Coord(0, self.window_size.1 as i32 / 2)),
-                    ControlKey::PageDown => PixelDelta(Coord(0, -(self.window_size.1 as i32 / 2))),
+                    ControlKey::PageUp => PixelDelta(Coord(0, window_size.1 as i32 / 2)),
+                    ControlKey::PageDown => PixelDelta(Coord(0, -(window_size.1 as i32 / 2))),
                     key => return (action, Response::Unhandled(Event::Control(key))),
                 };
 
@@ -240,8 +234,6 @@ impl ScrollComponent {
 /// A scrollable region
 ///
 /// This region supports scrolling via mouse wheel and click/touch drag.
-/// Optionally, it can have scroll bars (see [`ScrollRegion::show_bars`] and
-/// [`ScrollRegion::with_bars`]).
 #[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
 #[derive(Clone, Debug, Default, Widget)]
@@ -250,12 +242,6 @@ pub struct ScrollRegion<W: Widget> {
     core: CoreData,
     min_child_size: Size,
     scroll: ScrollComponent,
-    auto_bars: bool,
-    show_bars: (bool, bool),
-    #[widget]
-    horiz_bar: ScrollBar<kas::Right>,
-    #[widget]
-    vert_bar: ScrollBar<kas::Down>,
     #[widget]
     inner: W,
 }
@@ -268,38 +254,8 @@ impl<W: Widget> ScrollRegion<W> {
             core: Default::default(),
             min_child_size: Size::ZERO,
             scroll: Default::default(),
-            auto_bars: false,
-            show_bars: (false, false),
-            horiz_bar: ScrollBar::new(),
-            vert_bar: ScrollBar::new(),
             inner,
         }
-    }
-
-    /// Auto-enable bars
-    ///
-    /// If enabled, this automatically enables/disables scroll bars when
-    /// resized.
-    ///
-    /// This has the side-effect of reserving enough space for scroll bars even
-    /// when not required.
-    #[inline]
-    pub fn with_auto_bars(mut self, enable: bool) -> Self {
-        self.auto_bars = enable;
-        self
-    }
-
-    /// Set which scroll bars are visible
-    #[inline]
-    pub fn with_bars(mut self, horiz: bool, vert: bool) -> Self {
-        self.show_bars = (horiz, vert);
-        self
-    }
-
-    /// Set which scroll bars are visible
-    #[inline]
-    pub fn show_bars(&mut self, horiz: bool, vert: bool) {
-        self.show_bars = (horiz, vert);
     }
 
     /// Access inner widget directly
@@ -313,34 +269,28 @@ impl<W: Widget> ScrollRegion<W> {
     pub fn inner_mut(&mut self) -> &mut W {
         &mut self.inner
     }
+}
 
-    /// Get the maximum scroll offset
-    ///
-    /// Note: the minimum scroll offset is always zero.
+impl<W: Widget> ScrollWidget for ScrollRegion<W> {
+    fn scroll_axes(&self, size: Size) -> (bool, bool) {
+        (
+            self.min_child_size.0 > size.0,
+            self.min_child_size.1 > size.1,
+        )
+    }
+
     #[inline]
-    pub fn max_scroll_offset(&self) -> Coord {
+    fn max_scroll_offset(&self) -> Coord {
         self.scroll.max_offset()
     }
 
-    /// Get the current scroll offset
-    ///
-    /// Contents of the scroll region are translated by this offset (to convert
-    /// coordinates from the outer region to the scroll region, add this offset).
-    ///
-    /// The offset is restricted between [`Coord::ZERO`] and
-    /// [`ScrollRegion::max_scroll_offset`].
     #[inline]
-    pub fn scroll_offset(&self) -> Coord {
+    fn scroll_offset(&self) -> Coord {
         self.scroll.offset()
     }
 
-    /// Set the scroll offset
-    ///
-    /// The offset is clamped to the available scroll range.
-    /// Returns [`TkAction::None`] if the offset is identical to the old offset,
-    /// or a greater action if not identical.
     #[inline]
-    pub fn set_scroll_offset(&mut self, offset: Coord) -> TkAction {
+    fn set_scroll_offset(&mut self, offset: Coord) -> TkAction {
         self.scroll.set_offset(offset)
     }
 }
@@ -362,59 +312,15 @@ impl<W: Widget> Layout for ScrollRegion<W> {
         let line_height = size_handle.line_height(TextClass::Label);
         self.scroll.set_scroll_rate(3.0 * line_height as f32);
         rules.reduce_min_to(line_height);
-
-        if axis.is_horizontal() && (self.auto_bars || self.show_bars.1) {
-            rules.append(self.vert_bar.size_rules(size_handle, axis));
-        } else if axis.is_vertical() && (self.auto_bars || self.show_bars.0) {
-            rules.append(self.horiz_bar.size_rules(size_handle, axis));
-        }
         rules
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, _: AlignHints) {
+    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        // We use simplified layout code here
-        let pos = rect.pos;
-        let mut window_size = rect.size;
-
-        let bar_width = (size_handle.scrollbar().0).1;
-        if self.auto_bars {
-            self.show_bars = (
-                self.min_child_size.0 + bar_width > rect.size.0,
-                self.min_child_size.1 + bar_width > rect.size.1,
-            );
-        }
-        if self.show_bars.0 {
-            window_size.1 -= bar_width;
-        }
-        if self.show_bars.1 {
-            window_size.0 -= bar_width;
-        }
-
-        let child_size = window_size.max(self.min_child_size);
-        let child_rect = Rect::new(pos, child_size);
-        self.inner
-            .set_rect(size_handle, child_rect, AlignHints::NONE);
-        let _ = self.scroll.set_sizes(window_size, child_size);
-
-        if self.show_bars.0 {
-            let pos = Coord(pos.0, pos.1 + window_size.1 as i32);
-            let size = Size(window_size.0, bar_width);
-            self.horiz_bar
-                .set_rect(size_handle, Rect { pos, size }, AlignHints::NONE);
-            let _ = self
-                .horiz_bar
-                .set_limits(self.max_scroll_offset().0 as u32, rect.size.0);
-        }
-        if self.show_bars.1 {
-            let pos = Coord(pos.0 + window_size.0 as i32, pos.1);
-            let size = Size(bar_width, self.core.rect.size.1);
-            self.vert_bar
-                .set_rect(size_handle, Rect { pos, size }, AlignHints::NONE);
-            let _ = self
-                .vert_bar
-                .set_limits(self.max_scroll_offset().1 as u32, rect.size.1);
-        }
+        let child_size = rect.size.max(self.min_child_size);
+        let child_rect = Rect::new(rect.pos, child_size);
+        self.inner.set_rect(size_handle, child_rect, align);
+        let _ = self.scroll.set_sizes(rect.size, child_size);
     }
 
     #[inline]
@@ -430,27 +336,15 @@ impl<W: Widget> Layout for ScrollRegion<W> {
             return None;
         }
 
-        self.horiz_bar
-            .find_id(coord)
-            .or_else(|| self.vert_bar.find_id(coord))
-            .or_else(|| self.inner.find_id(coord + self.scroll_offset()))
+        self.inner
+            .find_id(coord + self.scroll_offset())
             .or(Some(self.id()))
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         let disabled = disabled || self.is_disabled();
-        if self.show_bars.0 {
-            self.horiz_bar.draw(draw_handle, mgr, disabled);
-        }
-        if self.show_bars.1 {
-            self.vert_bar.draw(draw_handle, mgr, disabled);
-        }
-        let rect = Rect {
-            pos: self.core.rect.pos,
-            size: self.scroll.window_size(),
-        };
         draw_handle.clip_region(
-            rect,
+            self.core.rect,
             self.scroll_offset(),
             ClipRegion::Scroll,
             &mut |handle| self.inner.draw(handle, mgr, disabled),
@@ -464,54 +358,37 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
             return Response::Unhandled(event);
         }
 
-        let event = if id <= self.horiz_bar.id() {
-            match Response::<Self::Msg>::try_from(self.horiz_bar.send(mgr, id, event)) {
-                Ok(Response::Unhandled(event)) => event,
-                Ok(r) => return r,
-                Err(msg) => {
-                    *mgr += self.set_scroll_offset(Coord(msg as i32, self.scroll_offset().1));
-                    return Response::None;
-                }
-            }
-        } else if id <= self.vert_bar.id() {
-            match Response::<Self::Msg>::try_from(self.vert_bar.send(mgr, id, event)) {
-                Ok(Response::Unhandled(event)) => event,
-                Ok(r) => return r,
-                Err(msg) => {
-                    *mgr += self.set_scroll_offset(Coord(self.scroll_offset().0, msg as i32));
-                    return Response::None;
-                }
-            }
-        } else if id <= self.inner.id() {
+        let event = if id <= self.inner.id() {
             let event = self.scroll.offset_event(event);
             match self.inner.send(mgr, id, event) {
                 Response::Unhandled(event) => event,
                 Response::Focus(rect) => {
-                    let (rect, action) = self.scroll.focus_rect(rect, self.core.rect.pos);
-                    *mgr += action
-                        + self.horiz_bar.set_value(self.scroll_offset().0 as u32)
-                        + self.vert_bar.set_value(self.scroll_offset().1 as u32);
+                    let (rect, action) = self.scroll.focus_rect(rect, self.core.rect);
+                    *mgr += action;
                     return Response::Focus(rect);
                 }
                 r => return r,
             }
         } else {
+            debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
             event
         };
 
         let id = self.id();
-        let (action, response) = self.scroll.scroll_by_event(event, |source, _, coord| {
-            if source.is_primary() {
-                let icon = Some(event::CursorIcon::Grabbing);
-                mgr.request_grab(id, source, coord, event::GrabMode::Grab, icon);
-            }
-        });
+        let (action, response) =
+            self.scroll
+                .scroll_by_event(event, self.core.rect.size, |source, _, coord| {
+                    if source.is_primary() {
+                        let icon = Some(event::CursorIcon::Grabbing);
+                        mgr.request_grab(id, source, coord, event::GrabMode::Grab, icon);
+                    }
+                });
         if action != TkAction::None {
-            *mgr += action
-                + self.horiz_bar.set_value(self.scroll_offset().0 as u32)
-                + self.vert_bar.set_value(self.scroll_offset().1 as u32);
+            *mgr += action;
+            Response::Focus(self.core.rect)
+        } else {
+            response.void_into()
         }
-        response.void_into()
     }
 }
 

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -284,9 +284,7 @@ pub trait ScrollWidget: Widget {
     /// Set the scroll offset
     ///
     /// The offset is clamped to the available scroll range.
-    /// Returns [`TkAction::None`] if the offset is identical to the old offset,
-    /// or a greater action if not identical.
-    fn set_scroll_offset(&mut self, offset: Coord) -> TkAction;
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord);
 }
 
 /// A scrollable region with bars
@@ -490,7 +488,7 @@ impl<W: ScrollWidget> event::SendEvent for ScrollBars<W> {
                 .try_into()
                 .unwrap_or_else(|msg| {
                     let offset = Coord(msg as i32, self.inner.scroll_offset().1);
-                    *mgr += self.inner.set_scroll_offset(offset);
+                    self.inner.set_scroll_offset(mgr, offset);
                     Response::None
                 })
         } else if id <= self.vert_bar.id() {
@@ -499,7 +497,7 @@ impl<W: ScrollWidget> event::SendEvent for ScrollBars<W> {
                 .try_into()
                 .unwrap_or_else(|msg| {
                     let offset = Coord(self.inner.scroll_offset().0, msg as i32);
-                    *mgr += self.inner.set_scroll_offset(offset);
+                    self.inner.set_scroll_offset(mgr, offset);
                     Response::None
                 })
         } else if id <= self.inner.id() {

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Debug;
 
-use super::DragHandle;
+use super::{DragHandle, ScrollRegion};
 use kas::{event, prelude::*};
 
 /// A scroll bar
@@ -289,6 +289,11 @@ pub trait ScrollWidget: Widget {
     fn set_scroll_offset(&mut self, offset: Coord) -> TkAction;
 }
 
+/// A scrollable region with bars
+///
+/// This is merely a typedef
+pub type ScrollBarRegion<W> = ScrollBars<ScrollRegion<W>>;
+
 /// Scrollbar controls
 ///
 /// This is a wrapper adding scrollbar controls around a child. Note that this
@@ -310,16 +315,26 @@ pub struct ScrollBars<W: ScrollWidget> {
     inner: W,
 }
 
+impl<W: Widget> ScrollBars<ScrollRegion<W>> {
+    /// Construct a `ScrollBars<ScrollRegion<W>>`
+    ///
+    /// This is a convenience constructor.
+    #[inline]
+    pub fn new2(inner: W) -> Self {
+        ScrollBars::new(ScrollRegion::new(inner))
+    }
+}
+
 impl<W: ScrollWidget> ScrollBars<W> {
     /// Construct
     ///
-    /// By default only the vertical scrollbar is enabled. See [`ScrollBars::with_bars`]
-    /// and [`ScrollBars::with_auto_bars`].
+    /// By default scrollbars are automatically enabled based on requirements.
+    /// See [`ScrollBars::with_auto_bars`] and [`ScrollBars::with_bars`].
     #[inline]
     pub fn new(inner: W) -> Self {
         ScrollBars {
             core: Default::default(),
-            auto_bars: false,
+            auto_bars: true,
             show_bars: (false, false),
             horiz_bar: ScrollBar::new(),
             vert_bar: ScrollBar::new(),
@@ -329,8 +344,8 @@ impl<W: ScrollWidget> ScrollBars<W> {
 
     /// Auto-enable bars
     ///
-    /// If enabled, this automatically enables/disables scroll bars as required
-    /// when resized.
+    /// If enabled (default), this automatically enables/disables scroll bars
+    /// as required when resized.
     ///
     /// This has the side-effect of reserving enough space for scroll bars even
     /// when not required.
@@ -341,15 +356,21 @@ impl<W: ScrollWidget> ScrollBars<W> {
     }
 
     /// Set which scroll bars are visible
+    ///
+    /// Calling this method also disables automatic scroll bars.
     #[inline]
     pub fn with_bars(mut self, horiz: bool, vert: bool) -> Self {
+        self.auto_bars = false;
         self.show_bars = (horiz, vert);
         self
     }
 
     /// Set which scroll bars are visible
+    ///
+    /// Calling this method also disables automatic scroll bars.
     #[inline]
     pub fn set_bars(&mut self, horiz: bool, vert: bool) {
+        self.auto_bars = false;
         self.show_bars = (horiz, vert);
     }
 

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -259,3 +259,256 @@ impl<D: Directional> event::SendEvent for ScrollBar<D> {
         }
     }
 }
+
+/// Additional functionality on scrollable widgets
+///
+/// This may be used to add controls via the [`ScrollBars`] wrapper.
+pub trait ScrollWidget: Widget {
+    /// Given size `size`, returns whether `(horiz, vert)` scrolling is required
+    fn scroll_axes(&self, size: Size) -> (bool, bool);
+
+    /// Get the maximum scroll offset
+    ///
+    /// Note: the minimum scroll offset is always zero.
+    fn max_scroll_offset(&self) -> Coord;
+
+    /// Get the current scroll offset
+    ///
+    /// Contents of the scroll region are translated by this offset (to convert
+    /// coordinates from the outer region to the scroll region, add this offset).
+    ///
+    /// The offset is restricted between [`Coord::ZERO`] and
+    /// [`ScrollRegion::max_scroll_offset`].
+    fn scroll_offset(&self) -> Coord;
+
+    /// Set the scroll offset
+    ///
+    /// The offset is clamped to the available scroll range.
+    /// Returns [`TkAction::None`] if the offset is identical to the old offset,
+    /// or a greater action if not identical.
+    fn set_scroll_offset(&mut self, offset: Coord) -> TkAction;
+}
+
+/// Scrollbar controls
+///
+/// This is a wrapper adding scrollbar controls around a child. Note that this
+/// widget does not enable scrolling; see [`ScrollRegion`] for that.
+/// This region supports scrolling via mouse wheel and click/touch drag.
+#[widget(config=noauto)]
+#[handler(send=noauto, msg = <W as event::Handler>::Msg)]
+#[derive(Clone, Debug, Default, Widget)]
+pub struct ScrollBars<W: ScrollWidget> {
+    #[widget_core]
+    core: CoreData,
+    auto_bars: bool,
+    show_bars: (bool, bool),
+    #[widget]
+    horiz_bar: ScrollBar<kas::Right>,
+    #[widget]
+    vert_bar: ScrollBar<kas::Down>,
+    #[widget]
+    inner: W,
+}
+
+impl<W: ScrollWidget> ScrollBars<W> {
+    /// Construct
+    ///
+    /// By default only the vertical scrollbar is enabled. See [`ScrollBars::with_bars`]
+    /// and [`ScrollBars::with_auto_bars`].
+    #[inline]
+    pub fn new(inner: W) -> Self {
+        ScrollBars {
+            core: Default::default(),
+            auto_bars: false,
+            show_bars: (false, false),
+            horiz_bar: ScrollBar::new(),
+            vert_bar: ScrollBar::new(),
+            inner,
+        }
+    }
+
+    /// Auto-enable bars
+    ///
+    /// If enabled, this automatically enables/disables scroll bars as required
+    /// when resized.
+    ///
+    /// This has the side-effect of reserving enough space for scroll bars even
+    /// when not required.
+    #[inline]
+    pub fn with_auto_bars(mut self, enable: bool) -> Self {
+        self.auto_bars = enable;
+        self
+    }
+
+    /// Set which scroll bars are visible
+    #[inline]
+    pub fn with_bars(mut self, horiz: bool, vert: bool) -> Self {
+        self.show_bars = (horiz, vert);
+        self
+    }
+
+    /// Set which scroll bars are visible
+    #[inline]
+    pub fn set_bars(&mut self, horiz: bool, vert: bool) {
+        self.show_bars = (horiz, vert);
+    }
+
+    /// Query which scroll bars are visible
+    ///
+    /// Returns `(horiz, vert)` tuple.
+    #[inline]
+    pub fn bars(&self) -> (bool, bool) {
+        self.show_bars
+    }
+
+    /// Access inner widget directly
+    #[inline]
+    pub fn inner(&self) -> &W {
+        &self.inner
+    }
+
+    /// Access inner widget directly
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+}
+
+impl<W: ScrollWidget> WidgetConfig for ScrollBars<W> {
+    fn configure(&mut self, mgr: &mut Manager) {
+        mgr.register_nav_fallback(self.id());
+    }
+}
+
+impl<W: ScrollWidget> Layout for ScrollBars<W> {
+    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        let mut rules = self.inner.size_rules(size_handle, axis);
+        if axis.is_horizontal() && (self.auto_bars || self.show_bars.1) {
+            rules.append(self.vert_bar.size_rules(size_handle, axis));
+        } else if axis.is_vertical() && (self.auto_bars || self.show_bars.0) {
+            rules.append(self.horiz_bar.size_rules(size_handle, axis));
+        }
+        rules
+    }
+
+    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+        self.core.rect = rect;
+        let pos = rect.pos;
+        let mut child_size = rect.size;
+
+        let bar_width = (size_handle.scrollbar().0).1;
+        if self.auto_bars {
+            child_size -= Size(bar_width, bar_width);
+            self.show_bars = self.inner.scroll_axes(child_size);
+        } else {
+            if self.show_bars.0 {
+                child_size.1 -= bar_width;
+            }
+            if self.show_bars.1 {
+                child_size.0 -= bar_width;
+            }
+        }
+
+        let child_rect = Rect::new(pos, child_size);
+        self.inner.set_rect(size_handle, child_rect, align);
+        let max_scroll_offset = self.inner.max_scroll_offset();
+
+        if self.show_bars.0 {
+            let pos = Coord(pos.0, pos.1 + child_size.1 as i32);
+            let size = Size(child_size.0, bar_width);
+            self.horiz_bar
+                .set_rect(size_handle, Rect { pos, size }, AlignHints::NONE);
+            let _ = self
+                .horiz_bar
+                .set_limits(max_scroll_offset.0 as u32, rect.size.0);
+        }
+        if self.show_bars.1 {
+            let pos = Coord(pos.0 + child_size.0 as i32, pos.1);
+            let size = Size(bar_width, self.core.rect.size.1);
+            self.vert_bar
+                .set_rect(size_handle, Rect { pos, size }, AlignHints::NONE);
+            let _ = self
+                .vert_bar
+                .set_limits(max_scroll_offset.1 as u32, rect.size.1);
+        }
+    }
+
+    fn find_id(&self, coord: Coord) -> Option<WidgetId> {
+        if !self.rect().contains(coord) {
+            return None;
+        }
+
+        self.horiz_bar
+            .find_id(coord)
+            .or_else(|| self.vert_bar.find_id(coord))
+            .or_else(|| self.inner.find_id(coord))
+            .or(Some(self.id()))
+    }
+
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
+        let disabled = disabled || self.is_disabled();
+        if self.show_bars.0 {
+            self.horiz_bar.draw(draw_handle, mgr, disabled);
+        }
+        if self.show_bars.1 {
+            self.vert_bar.draw(draw_handle, mgr, disabled);
+        }
+        self.inner.draw(draw_handle, mgr, disabled);
+    }
+}
+
+impl<W: ScrollWidget> event::SendEvent for ScrollBars<W> {
+    fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
+        if self.is_disabled() {
+            return Response::Unhandled(event);
+        }
+
+        if id <= self.horiz_bar.id() {
+            self.horiz_bar
+                .send(mgr, id, event)
+                .try_into()
+                .unwrap_or_else(|msg| {
+                    let offset = Coord(msg as i32, self.inner.scroll_offset().1);
+                    *mgr += self.inner.set_scroll_offset(offset);
+                    Response::None
+                })
+        } else if id <= self.vert_bar.id() {
+            self.vert_bar
+                .send(mgr, id, event)
+                .try_into()
+                .unwrap_or_else(|msg| {
+                    let offset = Coord(self.inner.scroll_offset().0, msg as i32);
+                    *mgr += self.inner.set_scroll_offset(offset);
+                    Response::None
+                })
+        } else if id <= self.inner.id() {
+            match self.inner.send(mgr, id, event) {
+                Response::Focus(rect) => {
+                    // We assume that the scrollable inner already updated its
+                    // offset; we just update the bar positions
+                    let offset = self.inner.scroll_offset();
+                    *mgr += self.horiz_bar.set_value(offset.0 as u32)
+                        + self.vert_bar.set_value(offset.1 as u32);
+                    Response::Focus(rect)
+                }
+                r => r,
+            }
+        } else {
+            debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
+            self.handle(mgr, event)
+        }
+    }
+}
+
+impl<W: ScrollWidget> std::ops::Deref for ScrollBars<W> {
+    type Target = W;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<W: ScrollWidget> std::ops::DerefMut for ScrollBars<W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -372,7 +372,7 @@ where
             match response {
                 Response::Unhandled(event) => event,
                 Response::Focus(rect) => {
-                    let (rect, mut action) = self.scroll.focus_rect(rect, self.core.rect.pos);
+                    let (rect, mut action) = self.scroll.focus_rect(rect, self.core.rect);
                     action += mgr.size_handle(|h| self.update_widgets(h));
                     *mgr += action;
                     return Response::Focus(rect);
@@ -390,12 +390,14 @@ where
         };
 
         let id = self.id();
-        let (mut action, response) = self.scroll.scroll_by_event(event, |source, _, coord| {
-            if source.is_primary() {
-                let icon = Some(CursorIcon::Grabbing);
-                mgr.request_grab(id, source, coord, GrabMode::Grab, icon);
-            }
-        });
+        let (mut action, response) =
+            self.scroll
+                .scroll_by_event(event, self.core.rect.size, |source, _, coord| {
+                    if source.is_primary() {
+                        let icon = Some(CursorIcon::Grabbing);
+                        mgr.request_grab(id, source, coord, GrabMode::Grab, icon);
+                    }
+                });
         if action != TkAction::None {
             action += mgr.size_handle(|h| self.update_widgets(h));
             *mgr += action;

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -199,8 +199,10 @@ where
     }
 
     #[inline]
-    fn set_scroll_offset(&mut self, offset: Coord) -> TkAction {
-        self.scroll.set_offset(offset)
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) {
+        let mut action = self.scroll.set_offset(offset);
+        action += mgr.size_handle(|h| self.update_widgets(h));
+        *mgr += action;
     }
 }
 


### PR DESCRIPTION
Tested with 31567568 entries (much more than that and the `u32` type used for pixel sizes becomes a problem).

Also fix (or work around) https://github.com/rust-lang/rust/issues/78113