### PR TITLE
make TkAction a bitflags struct; pass mgr to set_rect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@ The most likely changes needed to update 0.3 → 0.4:
 
 -   Replace `Label::from` with `Label::new`
 -   Replace `layout(horizontal)` with `layout(row)`, `layout(vertical)` with `layout(column)`
--   For several methods like `set_text`, replace `w.set_text(mgr, text)` with `*mgr += w.set_text(text)`
+-   For several methods like `set_text`, replace `w.set_text(mgr, text)` with `*mgr |= w.set_text(text)`
 
 ### Widget traits and API
 The `Widget` trait model has seen significant revision (#75, #74, #85):

--- a/kas-macros/src/layout.rs
+++ b/kas-macros/src/layout.rs
@@ -207,7 +207,7 @@ pub(crate) fn derive(
             set_rect.append_all(quote! { align2.vert = Some(#toks); });
         }
         set_rect.append_all(quote! {
-            self.#ident.set_rect(_sh, setter.child_rect(&mut #data, #child_info), align2);
+            self.#ident.set_rect(_mgr, setter.child_rect(&mut #data, #child_info), align2);
         });
 
         draw.append_all(quote! {
@@ -260,7 +260,7 @@ pub(crate) fn derive(
 
         fn set_rect(
             &mut self,
-            _sh: &mut dyn kas::draw::SizeHandle,
+            _mgr: &mut kas::event::Manager,
             rect: kas::geom::Rect,
             align: kas::AlignHints
         ) {

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -88,7 +88,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
         impl {
             fn handle_button(&mut self, mgr: &mut Manager, msg: Key) -> Response<VoidMsg> {
                 if self.calc.handle(msg) {
-                    *mgr += self.display.set_string(self.calc.display());
+                    *mgr |= self.display.set_string(self.calc.display());
                 }
                 Response::None
             }

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -39,7 +39,7 @@ impl Layout for Clock {
     }
 
     #[inline]
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, _align: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, _align: AlignHints) {
         // Force to square
         let size = rect.size.0.min(rect.size.1);
         let size = Size::uniform(size);

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -130,8 +130,8 @@ impl Handler for Clock {
                 self.now = Local::now();
                 let date = self.now.format("%Y-%m-%d").to_string();
                 let time = self.now.format("%H:%M:%S").to_string();
-                *mgr += set_text_and_prepare(&mut self.date, date)
-                    + set_text_and_prepare(&mut self.time, time);
+                *mgr |= set_text_and_prepare(&mut self.date, date)
+                    | set_text_and_prepare(&mut self.time, time);
                 let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
                 info!("Requesting update in {}ns", ns);
                 mgr.update_on_timer(Duration::new(0, ns), self.id());

--- a/kas-wgpu/examples/counter.rs
+++ b/kas-wgpu/examples/counter.rs
@@ -44,11 +44,11 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     match msg {
                         Message::Decr => {
                             self.counter = self.counter.saturating_sub(1);
-                            *mgr += self.display.set_string(self.counter.to_string());
+                            *mgr |= self.display.set_string(self.counter.to_string());
                         }
                         Message::Incr => {
                             self.counter = self.counter.saturating_add(1);
-                            *mgr += self.display.set_string(self.counter.to_string());
+                            *mgr |= self.display.set_string(self.counter.to_string());
                         }
                     };
                     VoidResponse::None

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -116,7 +116,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     Control::Incr => self.n.saturating_add(1),
                     Control::Set => self.n,
                 };
-                *mgr += self.edit.set_string(n.to_string());
+                *mgr |= self.edit.set_string(n.to_string());
                 self.n = n;
                 n.into()
             }
@@ -149,7 +149,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 fn set_len(&mut self, mgr: &mut Manager, len: usize) -> Response<VoidMsg> {
                     let active = self.active;
                     let old_len = self.list.len();
-                    *mgr += self.list.inner_mut().resize_with(len, |n| ListEntry::new(n, n == active));
+                    *mgr |= self.list.inner_mut().resize_with(len, |n| ListEntry::new(n, n == active));
                     if active >= old_len && active < len {
                         let _ = self.set_radio(mgr, EntryMsg::Select(active));
                     }
@@ -160,11 +160,11 @@ fn main() -> Result<(), kas_wgpu::Error> {
                         EntryMsg::Select(n) => {
                             self.active = n;
                             let text = self.list[n].entry.get_string();
-                            *mgr += self.display.set_string(text);
+                            *mgr |= self.display.set_string(text);
                         }
                         EntryMsg::Update(n, text) => {
                             if n == self.active {
-                                *mgr += self.display.set_string(text);
+                                *mgr |= self.display.set_string(text);
                             }
                         }
                     }

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -72,7 +72,7 @@ impl TextEditPopup {
 
     fn close(&mut self, mgr: &mut Manager, commit: bool) -> VoidResponse {
         self.commit = commit;
-        mgr.send_action(TkAction::Close);
+        mgr.send_action(TkAction::CLOSE);
         Response::None
     }
 }
@@ -146,7 +146,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                         if let Some(future) = self.future.take() {
                             let result = future.try_finish().unwrap();
                             if let Some(text) = result {
-                                *mgr += self.label.set_string(text);
+                                *mgr |= self.label.set_string(text);
                             }
                         }
                         Response::None
@@ -200,7 +200,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             }
             fn handle_scroll(&mut self, mgr: &mut Manager, msg: u32) -> Response<Item> {
                 let ratio = msg as f32 / self.sc.max_value() as f32;
-                *mgr += self.pg.set_value(ratio);
+                *mgr |= self.pg.set_value(ratio);
                 Response::Msg(Item::Scroll(msg))
             }
         }
@@ -233,10 +233,10 @@ fn main() -> Result<(), kas_wgpu::Error> {
                             mgr.adjust_theme(|theme| theme.set_colours(name));
                         }
                         Menu::Disabled(state) => {
-                            *mgr += self.gallery.set_disabled(state);
+                            *mgr |= self.gallery.set_disabled(state);
                         }
                         Menu::Quit => {
-                            *mgr += TkAction::CloseAll;
+                            *mgr |= TkAction::EXIT;
                         }
                     }
                     Response::None

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -416,7 +416,7 @@ impl Layout for Mandlebrot {
     }
 
     #[inline]
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, _align: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, _: AlignHints) {
         self.core.rect = rect;
         let size = DVec2::from(rect.size);
         let rel_width = DVec2(size.0 / size.1, 1.0);

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -544,11 +544,11 @@ impl MandlebrotWindow {
 
     fn iter(&mut self, mgr: &mut Manager, iter: i32) -> Response<VoidMsg> {
         self.mbrot.iter = iter;
-        *mgr += self.iters.set_string(format!("{}", iter));
+        *mgr |= self.iters.set_string(format!("{}", iter));
         Response::None
     }
     fn mbrot(&mut self, mgr: &mut Manager, _: ()) -> Response<VoidMsg> {
-        *mgr += self.label.set_string(self.mbrot.loc());
+        *mgr |= self.label.set_string(self.mbrot.loc());
         Response::None
     }
 }

--- a/kas-wgpu/examples/markdown.rs
+++ b/kas-wgpu/examples/markdown.rs
@@ -59,7 +59,7 @@ It also supports lists:
                         }
                     };
                     // TODO: this should update the size requirements of the inner area
-                    *mgr += self.label.set_text(text);
+                    *mgr |= self.label.set_text(text);
                     Response::None
                 }
             }

--- a/kas-wgpu/examples/splitter.rs
+++ b/kas-wgpu/examples/splitter.rs
@@ -46,11 +46,11 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 {
                     match msg {
                         Message::Decr => {
-                            *mgr += self.panes.pop().1;
+                            *mgr |= self.panes.pop().1;
                         }
                         Message::Incr => {
                             let n = self.panes.len() + 1;
-                            *mgr += self.panes.push(StringLabel::new(format!("Pane {}", n)));
+                            *mgr |= self.panes.push(StringLabel::new(format!("Pane {}", n)));
                         }
                     };
                     VoidResponse::None

--- a/kas-wgpu/examples/stopwatch.rs
+++ b/kas-wgpu/examples/stopwatch.rs
@@ -31,7 +31,7 @@ fn make_window() -> Box<dyn kas::Window> {
             fn reset(&mut self, mgr: &mut Manager, _: ()) -> Response<VoidMsg> {
                 self.saved = Duration::default();
                 self.start = None;
-                *mgr += self.display.set_str("0.000");
+                *mgr |= self.display.set_str("0.000");
                 Response::None
             }
             fn start(&mut self, mgr: &mut Manager, _: ()) -> Response<VoidMsg> {
@@ -58,7 +58,7 @@ fn make_window() -> Box<dyn kas::Window> {
                         if let Some(start) = self.start {
                             let dur = self.saved + (Instant::now() - start);
                             let text = format!("{}.{:03}", dur.as_secs(), dur.subsec_millis());
-                            *mgr += self.display.set_string(text);
+                            *mgr |= self.display.set_string(text);
                             mgr.update_on_timer(Duration::new(0, 1), self.id());
                         }
                         Response::None

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -234,7 +234,7 @@ where
                 }
                 PendingAction::ThemeResize => {
                     for (_, window) in self.windows.iter_mut() {
-                        window.theme_resize(&self.shared);
+                        window.theme_resize(&mut self.shared);
                     }
                 }
                 PendingAction::RedrawAll => {

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -76,13 +76,13 @@ where
                 ProxyAction::Close(id) => {
                     if let Some(id) = self.id_map.get(&id) {
                         if let Some(window) = self.windows.get_mut(&id) {
-                            window.send_action(TkAction::Close);
+                            window.send_action(TkAction::CLOSE);
                         }
                     }
                 }
                 ProxyAction::CloseAll => {
                     for window in self.windows.values_mut() {
-                        window.send_action(TkAction::Close);
+                        window.send_action(TkAction::CLOSE);
                     }
                 }
                 ProxyAction::Update(handle, payload) => {
@@ -138,16 +138,10 @@ where
                 let mut to_close = SmallVec::<[ww::WindowId; 4]>::new();
                 for (window_id, window) in self.windows.iter_mut() {
                     let (action, resume) = window.update(&mut self.shared);
-                    match action {
-                        TkAction::None
-                        | TkAction::Redraw
-                        | TkAction::RegionMoved
-                        | TkAction::Popup
-                        | TkAction::SetSize
-                        | TkAction::Resize
-                        | TkAction::Reconfigure => (),
-                        TkAction::Close => to_close.push(*window_id),
-                        TkAction::CloseAll => close_all = true,
+                    if action.contains(TkAction::EXIT) {
+                        close_all = true;
+                    } else if action.contains(TkAction::CLOSE) {
+                        to_close.push(*window_id);
                     }
                     if let Some(instant) = resume {
                         if let Some((i, _)) = self
@@ -166,7 +160,10 @@ where
                 for window_id in &to_close {
                     if let Some(window) = self.windows.remove(window_id) {
                         self.id_map.remove(&window.window_id);
-                        if window.handle_closure(&mut self.shared) == TkAction::CloseAll {
+                        if window
+                            .handle_closure(&mut self.shared)
+                            .contains(TkAction::EXIT)
+                        {
                             close_all = true;
                         }
                         // Wake immediately in order to close remaining windows:

--- a/src/data.rs
+++ b/src/data.rs
@@ -67,7 +67,7 @@ impl<T: 'static> Future<T> {
 /// `Option<WidgetId>` is a free extension (requires no extra memory).
 ///
 /// Identifiers are assigned when configured and when re-configured
-/// (via [`kas::TkAction::Reconfigure`]). Since user-code is not notified of a
+/// (via [`kas::TkAction::RECONFIGURE`]). Since user-code is not notified of a
 /// re-configure, user-code should not store a `WidgetId`.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct WidgetId(NonZeroU32);

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -235,7 +235,7 @@ impl<'a> Manager<'a> {
         if self.state.hover != w_id {
             trace!("Manager: hover = {:?}", w_id);
             self.state.hover = w_id;
-            self.send_action(TkAction::Redraw);
+            self.send_action(TkAction::REDRAW);
 
             if let Some(id) = w_id {
                 let icon = widget

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -216,9 +216,7 @@ impl SolveCache {
             rect.size.0 = width;
             rect.size.1 -= (self.margins.vert.0 + self.margins.vert.1) as u32;
         }
-        mgr.size_handle(|size_handle| {
-            widget.set_rect(size_handle, rect, AlignHints::NONE);
-        });
+        widget.set_rect(mgr, rect, AlignHints::NONE);
 
         trace!(
             "layout::solve_and_set for size={:?} has hierarchy:{}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 #![cfg_attr(feature = "gat", feature(generic_associated_types))]
 #![cfg_attr(feature = "min_spec", feature(min_specialization))]
 
-#[cfg(not(feature = "winit"))]
 #[macro_use]
 extern crate bitflags;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -344,7 +344,7 @@
 //!                 _ => (),
 //!             }
 //!             // Whichever button was pressed, we close the window:
-//!             *mgr += TkAction::Close;
+//!             *mgr |= TkAction::CLOSE;
 //!             Response::None
 //!         }
 //!     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -20,18 +20,18 @@ pub mod util {
     /// Set the text and prepare
     ///
     /// This is a convenience function to (1) set the text, (2) call
-    /// [`Text::prepare`] internally and (3) return [`TkAction::Resize`] to
+    /// [`Text::prepare`] internally and (3) return [`TkAction::RESIZE`] to
     /// trigger a resize.
     pub fn set_text_and_prepare<T: format::FormattableText>(text: &mut Text<T>, s: T) -> TkAction {
         text.set_text(s);
         text.prepare();
-        TkAction::Resize
+        TkAction::RESIZE
     }
 
     /// Set the text from a string and prepare
     ///
     /// This is a convenience function to (1) set the text, (2) call
-    /// [`Text::prepare`] internally and (3) return [`TkAction::Resize`] to
+    /// [`Text::prepare`] internally and (3) return [`TkAction::RESIZE`] to
     /// trigger a resize.
     pub fn set_string_and_prepare<T: format::EditableText>(
         text: &mut Text<T>,
@@ -39,6 +39,6 @@ pub mod util {
     ) -> TkAction {
         text.set_string(s);
         text.prepare();
-        TkAction::Resize
+        TkAction::RESIZE
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,7 +9,6 @@ use std::any::Any;
 use std::fmt;
 use std::ops::DerefMut;
 
-use crate::draw::SizeHandle;
 use crate::event::{self, Manager};
 use crate::{layout, Direction, WidgetId, WindowId};
 
@@ -97,7 +96,7 @@ pub trait Window: Widget<Msg = event::VoidMsg> {
     ///
     /// This is called immediately after [`Layout::set_rect`] to resize
     /// existing pop-ups.
-    fn resize_popups(&mut self, size_handle: &mut dyn SizeHandle);
+    fn resize_popups(&mut self, mgr: &mut Manager);
 
     /// Trigger closure of a pop-up
     ///

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -89,8 +89,8 @@ impl<M: 'static> Layout for Box<dyn Widget<Msg = M>> {
         self.as_mut().size_rules(size_handle, axis)
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
-        self.as_mut().set_rect(size_handle, rect, align);
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
+        self.as_mut().set_rect(mgr, rect, align);
     }
 
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -81,7 +81,7 @@ pub trait WidgetCore: Any + fmt::Debug {
     #[inline]
     fn set_disabled(&mut self, disabled: bool) -> TkAction {
         self.core_data_mut().disabled = disabled;
-        TkAction::Redraw
+        TkAction::REDRAW
     }
 
     /// Set disabled state (chaining)
@@ -146,7 +146,7 @@ pub trait WidgetCore: Any + fmt::Debug {
 /// cannot currently handle fields like `Vec<SomeWidget>`.
 ///
 /// Whenever the number of child widgets changes or child widgets are replaced,
-/// one must send [`TkAction::Reconfigure`].
+/// one must send [`TkAction::RECONFIGURE`].
 /// (TODO: this is slow. Find an option for partial reconfigures. This requires
 /// better widget identifiers; see #91.)
 ///
@@ -312,7 +312,7 @@ pub trait WidgetConfig: Layout {
     /// Configure widget
     ///
     /// Widgets are *configured* on window creation and when
-    /// [`TkAction::Reconfigure`] is sent.
+    /// [`TkAction::RECONFIGURE`] is sent.
     ///
     /// Configure is called before resizing (but after calculation of the
     /// initial window size). This method is called after

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -407,7 +407,8 @@ pub trait Layout: WidgetChildren {
     /// axis with current size information before this method, however
     /// `size_rules` might not be re-called before calling `set_rect` again.
     #[inline]
-    fn set_rect(&mut self, _size_handle: &mut dyn SizeHandle, rect: Rect, _align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
+        let _ = (mgr, align);
         self.core_data_mut().rect = rect;
     }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -45,7 +45,7 @@ impl<M: Clone + Debug + 'static> Layout for TextButton<M> {
         content_rules.surrounded_by(frame_rules, true)
     }
 
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
 
         // In theory, text rendering should be restricted as in EditBox.

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -113,7 +113,7 @@ impl<M: 'static> HasBool for CheckBoxBare<M> {
 
     fn set_bool(&mut self, state: bool) -> TkAction {
         self.state = state;
-        TkAction::Redraw
+        TkAction::REDRAW
     }
 }
 

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -40,7 +40,7 @@ impl<M: 'static> Layout for CheckBoxBare<M> {
         SizeRules::extract_fixed(axis.is_vertical(), size, margins)
     }
 
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         let rect = align
             .complete(Align::Centre, Align::Centre, self.rect().size)
             .apply(rect);

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -121,7 +121,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
             let string = self.popup.inner[self.active].get_string();
             kas::text::util::set_text_and_prepare(&mut self.label, string)
         } else {
-            TkAction::None
+            TkAction::empty()
         }
     }
 
@@ -220,7 +220,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
             Response::Focus(x) => Response::Focus(x),
             Response::Msg(msg) => {
                 let index = msg as usize;
-                *mgr += self.set_active(index);
+                *mgr |= self.set_active(index);
                 if let Some(id) = self.popup_id {
                     mgr.close_window(id);
                 }
@@ -228,7 +228,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
             }
         }
         // NOTE: as part of the Popup API we are expected to trap
-        // TkAction::Close here, but we know our widget doesn't generate
+        // TkAction::CLOSE here, but we know our widget doesn't generate
         // this action.
     }
 }

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -40,7 +40,7 @@ impl<M: Clone + Debug + 'static> kas::Layout for ComboBox<M> {
         content_rules.surrounded_by(frame_rules, true)
     }
 
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, align: kas::AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: kas::AlignHints) {
         self.core.rect = rect;
         self.label.update_env(|env| {
             env.set_bounds(rect.size.into());

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -79,5 +79,5 @@ impl<T: FormattableText + 'static> kas::Window for MessageBox<T> {
     }
 
     fn remove_popup(&mut self, _: &mut Manager, _: WindowId) {}
-    fn resize_popups(&mut self, _: &mut dyn SizeHandle) {}
+    fn resize_popups(&mut self, _: &mut Manager) {}
 }

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -52,7 +52,7 @@ impl<T: FormattableText + 'static> MessageBox<T> {
 
     fn handle_button(&mut self, mgr: &mut Manager, msg: DialogButton) -> Response<VoidMsg> {
         match msg {
-            DialogButton::Close => mgr.send_action(TkAction::Close),
+            DialogButton::Close => mgr.send_action(TkAction::CLOSE),
         };
         Response::None
     }

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -49,7 +49,7 @@ impl DragHandle {
 
     /// Set a new handle size and offset
     ///
-    /// Returns [`TkAction::Redraw`] if a redraw is required.
+    /// Returns [`TkAction::REDRAW`] if a redraw is required.
     pub fn set_size_and_offset(&mut self, size: Size, offset: Coord) -> TkAction {
         self.core.rect.size = size;
         self.set_offset(offset).1
@@ -77,17 +77,17 @@ impl DragHandle {
 
     /// Set a new handle offset
     ///
-    /// Returns the new offset (after clamping input) and an action: `None` if
-    /// the handle hasn't moved; `Redraw` if it has (though this widget is
+    /// Returns the new offset (after clamping input) and an action: empty if
+    /// the handle hasn't moved; `REDRAW` if it has (though this widget is
     /// not directly responsible for drawing, so this may not be accurate).
     pub fn set_offset(&mut self, offset: Coord) -> (Coord, TkAction) {
         let offset = offset.clamp(Coord::ZERO, self.max_offset());
         let handle_pos = self.track.pos + offset;
         if handle_pos != self.core.rect.pos {
             self.core.rect.pos = handle_pos;
-            (offset, TkAction::Redraw)
+            (offset, TkAction::REDRAW)
         } else {
-            (offset, TkAction::None)
+            (offset, TkAction::empty())
         }
     }
 
@@ -112,7 +112,7 @@ impl DragHandle {
 
         // Since the press is not on the handle, we move the bar immediately.
         let (offset, action) = self.set_offset(coord - self.press_offset);
-        debug_assert!(action == TkAction::Redraw);
+        debug_assert!(action == TkAction::REDRAW);
         mgr.send_action(action);
         offset
     }
@@ -166,7 +166,7 @@ impl event::Handler for DragHandle {
             Event::PressMove { source, coord, .. } if Some(source) == self.press_source => {
                 let offset = coord - self.press_offset;
                 let (offset, action) = self.set_offset(offset);
-                if action == TkAction::None {
+                if action.is_empty() {
                     Response::None
                 } else {
                     mgr.send_action(action);

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -142,7 +142,7 @@ impl Layout for DragHandle {
         SizeRules::EMPTY
     }
 
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, _: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, _: AlignHints) {
         self.track = rect;
     }
 

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -228,7 +228,7 @@ impl<G: 'static> Layout for EditBox<G> {
         rules
     }
 
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, mut align: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, mut align: AlignHints) {
         let valign = if self.multi_line {
             Some(Align::Stretch)
         } else {

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -55,11 +55,11 @@ impl<W: Widget> Layout for Frame<W> {
         child_rules.surrounded_by(frame_rules, true)
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, mut rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, mut rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         rect.pos += self.m0;
         rect.size -= self.m0 + self.m1;
-        self.inner.set_rect(size_handle, rect, align);
+        self.inner.set_rect(mgr, rect, align);
     }
 
     #[inline]

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -26,7 +26,7 @@ impl<T: FormattableText + 'static> Layout for Label<T> {
         size_handle.text_bound(&mut self.label, TextClass::Label, axis)
     }
 
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         self.label.update_env(|env| {
             env.set_bounds(rect.size.into());

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -131,14 +131,14 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
         solver.finish(&mut self.data)
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         let dim = (self.direction, self.widgets.len());
         let mut setter = layout::RowSetter::<D, Vec<u32>, _>::new(rect, dim, align, &mut self.data);
 
         for (n, child) in self.widgets.iter_mut().enumerate() {
             let align = AlignHints::default();
-            child.set_rect(size_handle, setter.child_rect(&mut self.data, n), align);
+            child.set_rect(mgr, setter.child_rect(&mut self.data, n), align);
         }
     }
 

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -247,8 +247,8 @@ impl<D: Directional, W: Widget> List<D, W> {
     /// removed.
     pub fn clear(&mut self) -> TkAction {
         let action = match self.widgets.is_empty() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         };
         self.widgets.clear();
         action
@@ -259,7 +259,7 @@ impl<D: Directional, W: Widget> List<D, W> {
     /// Triggers a [reconfigure action](Manager::send_action).
     pub fn push(&mut self, widget: W) -> TkAction {
         self.widgets.push(widget);
-        TkAction::Reconfigure
+        TkAction::RECONFIGURE
     }
 
     /// Remove the last child widget
@@ -271,8 +271,8 @@ impl<D: Directional, W: Widget> List<D, W> {
     /// removed.
     pub fn pop(&mut self) -> (Option<W>, TkAction) {
         let action = match self.widgets.is_empty() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         };
         (self.widgets.pop(), action)
     }
@@ -284,7 +284,7 @@ impl<D: Directional, W: Widget> List<D, W> {
     /// Triggers a [reconfigure action](Manager::send_action).
     pub fn insert(&mut self, index: usize, widget: W) -> TkAction {
         self.widgets.insert(index, widget);
-        TkAction::Reconfigure
+        TkAction::RECONFIGURE
     }
 
     /// Removes the child widget at position `index`
@@ -294,7 +294,7 @@ impl<D: Directional, W: Widget> List<D, W> {
     /// Triggers a [reconfigure action](Manager::send_action).
     pub fn remove(&mut self, index: usize) -> (W, TkAction) {
         let r = self.widgets.remove(index);
-        (r, TkAction::Reconfigure)
+        (r, TkAction::RECONFIGURE)
     }
 
     /// Replace the child at `index`
@@ -307,7 +307,7 @@ impl<D: Directional, W: Widget> List<D, W> {
     // we somehow test "has compatible size"?
     pub fn replace(&mut self, index: usize, mut widget: W) -> (W, TkAction) {
         std::mem::swap(&mut widget, &mut self.widgets[index]);
-        (widget, TkAction::Reconfigure)
+        (widget, TkAction::RECONFIGURE)
     }
 
     /// Append child widgets from an iterator
@@ -318,8 +318,8 @@ impl<D: Directional, W: Widget> List<D, W> {
         let len = self.widgets.len();
         self.widgets.extend(iter);
         match len == self.widgets.len() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         }
     }
 
@@ -329,7 +329,7 @@ impl<D: Directional, W: Widget> List<D, W> {
     pub fn resize_with<F: Fn(usize) -> W>(&mut self, len: usize, f: F) -> TkAction {
         let l0 = self.widgets.len();
         if l0 == len {
-            return TkAction::None;
+            return TkAction::empty();
         } else if l0 > len {
             self.widgets.truncate(len);
         } else {
@@ -338,7 +338,7 @@ impl<D: Directional, W: Widget> List<D, W> {
                 self.widgets.push(f(i));
             }
         }
-        TkAction::Reconfigure
+        TkAction::RECONFIGURE
     }
 
     /// Retain only widgets satisfying predicate `f`
@@ -351,8 +351,8 @@ impl<D: Directional, W: Widget> List<D, W> {
         let len = self.widgets.len();
         self.widgets.retain(f);
         match len == self.widgets.len() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         }
     }
 

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -115,8 +115,8 @@ impl<M: 'static> Layout for Box<dyn Menu<Msg = M>> {
         self.as_mut().size_rules(size_handle, axis)
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
-        self.as_mut().set_rect(size_handle, rect, align);
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
+        self.as_mut().set_rect(mgr, rect, align);
     }
 
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -45,7 +45,7 @@ impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
         text_rules.surrounded_by(frame_rules, true)
     }
 
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         self.label.update_env(|env| {
             env.set_bounds(rect.size.into());
@@ -213,7 +213,7 @@ impl<M: 'static> Layout for MenuToggle<M> {
         solver.finish(&mut self.layout_data)
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         let mut setter = layout::RowSetter::<_, [u32; 2], _>::new(
             rect,
@@ -223,12 +223,9 @@ impl<M: 'static> Layout for MenuToggle<M> {
         );
         let align = kas::AlignHints::NONE;
         let cb_rect = setter.child_rect(&mut self.layout_data, 0usize);
-        self.checkbox.set_rect(size_handle, cb_rect, align.clone());
-        self.label.set_rect(
-            size_handle,
-            setter.child_rect(&mut self.layout_data, 1usize),
-            align,
-        );
+        self.checkbox.set_rect(mgr, cb_rect, align.clone());
+        self.label
+            .set_rect(mgr, setter.child_rect(&mut self.layout_data, 1usize), align);
     }
 
     fn find_id(&self, coord: Coord) -> Option<WidgetId> {

--- a/src/widget/menu/menu_frame.rs
+++ b/src/widget/menu/menu_frame.rs
@@ -52,11 +52,11 @@ impl<W: Widget> Layout for MenuFrame<W> {
         child_rules.surrounded_by(frame_rules, true)
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, mut rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, mut rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         rect.pos += self.m0;
         rect.size -= self.m0 + self.m1;
-        self.inner.set_rect(size_handle, rect, align);
+        self.inner.set_rect(mgr, rect, align);
     }
 
     #[inline]

--- a/src/widget/menu/menubar.rs
+++ b/src/widget/menu/menubar.rs
@@ -55,10 +55,10 @@ impl<D: Directional, W: Menu> Layout for MenuBar<D, W> {
         self.bar.size_rules(size_handle, axis)
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, _: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, _: AlignHints) {
         self.core_data_mut().rect = rect;
         let align = AlignHints::new(Some(Align::Default), Some(Align::Default));
-        self.bar.set_rect(size_handle, rect, align);
+        self.bar.set_rect(mgr, rect, align);
     }
 
     #[inline]

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -176,7 +176,7 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
             // The pop-up API expects us to check actions here
             // But NOTE: we don't actually use this. Should we remove from API?
             match mgr.pop_action() {
-                TkAction::Close => {
+                TkAction::CLOSE => {
                     if let Some(id) = self.popup_id {
                         mgr.close_window(id);
                     }

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -110,7 +110,7 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
         text_rules.surrounded_by(frame_rules, true)
     }
 
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         self.label.update_env(|env| {
             env.set_bounds(rect.size.into());

--- a/src/widget/progress.rs
+++ b/src/widget/progress.rs
@@ -58,14 +58,14 @@ impl<D: Directional> ProgressBar<D> {
 
     /// Set the value
     ///
-    /// Returns [`TkAction::Redraw`] if a redraw is required.
+    /// Returns [`TkAction::REDRAW`] if a redraw is required.
     pub fn set_value(&mut self, value: f32) -> TkAction {
         let value = value.max(0.0).min(1.0);
         if value == self.value {
-            TkAction::None
+            TkAction::empty()
         } else {
             self.value = value;
-            TkAction::Redraw
+            TkAction::REDRAW
         }
     }
 }

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -93,7 +93,7 @@ impl<M: 'static> Layout for RadioBoxBare<M> {
         SizeRules::extract_fixed(axis.is_vertical(), size, margins)
     }
 
-    fn set_rect(&mut self, _: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         let rect = align
             .complete(Align::Centre, Align::Centre, self.rect().size)
             .apply(rect);

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -176,7 +176,7 @@ impl<M: 'static> HasBool for RadioBoxBare<M> {
 
     fn set_bool(&mut self, state: bool) -> TkAction {
         self.state = state;
-        TkAction::Redraw
+        TkAction::REDRAW
     }
 }
 

--- a/src/widget/reserve.rs
+++ b/src/widget/reserve.rs
@@ -76,9 +76,9 @@ impl<W: Widget, R: FnMut(&mut dyn SizeHandle, AxisInfo) -> SizeRules + 'static> 
         inner_rules.max(reserve_rules)
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        self.inner.set_rect(size_handle, rect, align);
+        self.inner.set_rect(mgr, rect, align);
     }
 
     #[inline]

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -290,8 +290,9 @@ impl<W: Widget> ScrollWidget for ScrollRegion<W> {
     }
 
     #[inline]
-    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) {
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) -> Coord {
         *mgr += self.scroll.set_offset(offset);
+        self.scroll.offset()
     }
 }
 

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -316,11 +316,11 @@ impl<W: Widget> Layout for ScrollRegion<W> {
         rules
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         let child_size = rect.size.max(self.min_child_size);
         let child_rect = Rect::new(rect.pos, child_size);
-        self.inner.set_rect(size_handle, child_rect, align);
+        self.inner.set_rect(mgr, child_rect, align);
         let _ = self.scroll.set_sizes(rect.size, child_size);
     }
 

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -88,7 +88,7 @@ impl<D: Directional> ScrollBar<D> {
     /// The choice of units is not important (e.g. can be pixels or lines),
     /// so long as both parameters use the same units.
     ///
-    /// Returns [`TkAction::Redraw`] if a redraw is required.
+    /// Returns [`TkAction::REDRAW`] if a redraw is required.
     pub fn set_limits(&mut self, max_value: u32, handle_value: u32) -> TkAction {
         // We should gracefully handle zero, though appearance may be wrong.
         self.handle_value = handle_value.max(1);
@@ -124,7 +124,7 @@ impl<D: Directional> ScrollBar<D> {
     pub fn set_value(&mut self, value: u32) -> TkAction {
         let value = value.min(self.max_value);
         if value == self.value {
-            TkAction::None
+            TkAction::empty()
         } else {
             self.value = value;
             self.handle.set_offset(self.offset()).1
@@ -415,8 +415,8 @@ impl<W: ScrollWidget> ScrollWidget for ScrollBars<W> {
     }
     fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) -> Coord {
         let offset = self.inner.set_scroll_offset(mgr, offset);
-        *mgr +=
-            self.horiz_bar.set_value(offset.0 as u32) + self.vert_bar.set_value(offset.1 as u32);
+        *mgr |=
+            self.horiz_bar.set_value(offset.0 as u32) | self.vert_bar.set_value(offset.1 as u32);
         offset
     }
 }
@@ -534,8 +534,8 @@ impl<W: ScrollWidget> event::SendEvent for ScrollBars<W> {
                     // We assume that the scrollable inner already updated its
                     // offset; we just update the bar positions
                     let offset = self.inner.scroll_offset();
-                    *mgr += self.horiz_bar.set_value(offset.0 as u32)
-                        + self.vert_bar.set_value(offset.1 as u32);
+                    *mgr |= self.horiz_bar.set_value(offset.0 as u32)
+                        | self.vert_bar.set_value(offset.1 as u32);
                     Response::Focus(rect)
                 }
                 r => r,

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -211,9 +211,9 @@ impl<D: Directional> Layout for ScrollBar<D> {
         }
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        self.handle.set_rect(size_handle, rect, align);
+        self.handle.set_rect(mgr, rect, align);
         let _ = self.update_handle();
     }
 
@@ -438,12 +438,12 @@ impl<W: ScrollWidget> Layout for ScrollBars<W> {
         rules
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         let pos = rect.pos;
         let mut child_size = rect.size;
 
-        let bar_width = (size_handle.scrollbar().0).1;
+        let bar_width = mgr.size_handle(|sh| (sh.scrollbar().0).1);
         if self.auto_bars {
             child_size -= Size(bar_width, bar_width);
             self.show_bars = self.inner.scroll_axes(child_size);
@@ -457,14 +457,14 @@ impl<W: ScrollWidget> Layout for ScrollBars<W> {
         }
 
         let child_rect = Rect::new(pos, child_size);
-        self.inner.set_rect(size_handle, child_rect, align);
+        self.inner.set_rect(mgr, child_rect, align);
         let max_scroll_offset = self.inner.max_scroll_offset();
 
         if self.show_bars.0 {
             let pos = Coord(pos.0, pos.1 + child_size.1 as i32);
             let size = Size(child_size.0, bar_width);
             self.horiz_bar
-                .set_rect(size_handle, Rect { pos, size }, AlignHints::NONE);
+                .set_rect(mgr, Rect { pos, size }, AlignHints::NONE);
             let _ = self
                 .horiz_bar
                 .set_limits(max_scroll_offset.0 as u32, rect.size.0);
@@ -473,7 +473,7 @@ impl<W: ScrollWidget> Layout for ScrollBars<W> {
             let pos = Coord(pos.0 + child_size.0 as i32, pos.1);
             let size = Size(bar_width, self.core.rect.size.1);
             self.vert_bar
-                .set_rect(size_handle, Rect { pos, size }, AlignHints::NONE);
+                .set_rect(mgr, Rect { pos, size }, AlignHints::NONE);
             let _ = self
                 .vert_bar
                 .set_limits(max_scroll_offset.1 as u32, rect.size.1);

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -223,10 +223,10 @@ impl<T: SliderType, D: Directional> Layout for Slider<T, D> {
         }
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        self.handle.set_rect(size_handle, rect, align);
-        let min_handle_size = (size_handle.slider().0).0;
+        self.handle.set_rect(mgr, rect, align);
+        let min_handle_size = mgr.size_handle(|sh| (sh.slider().0).0);
         let mut size = rect.size;
         if self.direction.is_horizontal() {
             size.0 = min_handle_size.min(rect.size.0);

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -154,7 +154,7 @@ impl<T: SliderType, D: Directional> Slider<T, D> {
 
     /// Set the value
     ///
-    /// Returns [`TkAction::Redraw`] if a redraw is required.
+    /// Returns [`TkAction::REDRAW`] if a redraw is required.
     pub fn set_value(&mut self, mut value: T) -> TkAction {
         if value < self.range.0 {
             value = self.range.0;
@@ -162,7 +162,7 @@ impl<T: SliderType, D: Directional> Slider<T, D> {
             value = self.range.1;
         }
         if value == self.value {
-            TkAction::None
+            TkAction::empty()
         } else {
             self.value = value;
             self.handle.set_offset(self.offset()).1
@@ -290,7 +290,7 @@ impl<T: SliderType, D: Directional> event::SendEvent for Slider<T, D> {
                         key => return Response::Unhandled(Event::Control(key)),
                     };
                     let action = self.set_value(v);
-                    return if action == TkAction::None {
+                    return if action.is_empty() {
                         Response::None
                     } else {
                         mgr.send_action(action);
@@ -309,7 +309,7 @@ impl<T: SliderType, D: Directional> event::SendEvent for Slider<T, D> {
         } else {
             Response::None
         };
-        *mgr += self.handle.set_offset(self.offset()).1;
+        *mgr |= self.handle.set_offset(self.offset()).1;
         r
     }
 }

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -352,8 +352,8 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
     /// removed.
     pub fn clear(&mut self) -> TkAction {
         let action = match self.widgets.is_empty() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         };
         self.widgets.clear();
         self.handles.clear();
@@ -368,7 +368,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
             self.handles.push(DragHandle::new());
         }
         self.widgets.push(widget);
-        TkAction::Reconfigure
+        TkAction::RECONFIGURE
     }
 
     /// Remove the last child widget
@@ -380,8 +380,8 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
     /// removed.
     pub fn pop(&mut self) -> (Option<W>, TkAction) {
         let action = match self.widgets.is_empty() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         };
         let _ = self.handles.pop();
         (self.widgets.pop(), action)
@@ -397,7 +397,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
             self.handles.push(DragHandle::new());
         }
         self.widgets.insert(index, widget);
-        TkAction::Reconfigure
+        TkAction::RECONFIGURE
     }
 
     /// Removes the child widget at position `index`
@@ -408,7 +408,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
     pub fn remove(&mut self, index: usize) -> (W, TkAction) {
         let _ = self.handles.pop();
         let r = self.widgets.remove(index);
-        (r, TkAction::Reconfigure)
+        (r, TkAction::RECONFIGURE)
     }
 
     /// Replace the child at `index`
@@ -421,7 +421,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
     // we somehow test "has compatible size"?
     pub fn replace(&mut self, index: usize, mut widget: W) -> (W, TkAction) {
         std::mem::swap(&mut widget, &mut self.widgets[index]);
-        (widget, TkAction::Reconfigure)
+        (widget, TkAction::RECONFIGURE)
     }
 
     /// Append child widgets from an iterator
@@ -434,8 +434,8 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         self.handles
             .resize_with(self.widgets.len().saturating_sub(1), || DragHandle::new());
         match len == self.widgets.len() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         }
     }
 
@@ -445,7 +445,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
     pub fn resize_with<F: Fn(usize) -> W>(&mut self, len: usize, f: F) -> TkAction {
         let l0 = self.widgets.len();
         if l0 == len {
-            return TkAction::None;
+            return TkAction::empty();
         } else if l0 > len {
             self.widgets.truncate(len);
         } else {
@@ -456,7 +456,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         }
         self.handles
             .resize_with(self.widgets.len().saturating_sub(1), || DragHandle::new());
-        TkAction::Reconfigure
+        TkAction::RECONFIGURE
     }
 
     /// Retain only widgets satisfying predicate `f`
@@ -471,8 +471,8 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         self.handles
             .resize_with(self.widgets.len().saturating_sub(1), || DragHandle::new());
         match len == self.widgets.len() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         }
     }
 }

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -143,7 +143,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
         solver.finish(&mut self.data)
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         if self.widgets.len() == 0 {
             return;
@@ -162,11 +162,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
         loop {
             assert!(n < self.widgets.len());
             let align = AlignHints::default();
-            self.widgets[n].set_rect(
-                size_handle,
-                setter.child_rect(&mut self.data, n << 1),
-                align,
-            );
+            self.widgets[n].set_rect(mgr, setter.child_rect(&mut self.data, n << 1), align);
 
             if n >= self.handles.len() {
                 break;
@@ -175,7 +171,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
             // TODO(opt): calculate all maximal sizes simultaneously
             let index = (n << 1) + 1;
             let track = setter.maximal_rect_of(&mut self.data, index);
-            self.handles[n].set_rect(size_handle, track, AlignHints::default());
+            self.handles[n].set_rect(mgr, track, AlignHints::default());
             let handle = setter.child_rect(&mut self.data, index);
             let _ = self.handles[n].set_size_and_offset(handle.size, handle.pos - track.pos);
 
@@ -242,7 +238,7 @@ impl<D: Directional, W: Widget> event::SendEvent for Splitter<D, W> {
                         .unwrap_or_else(|_| {
                             // Message is the new offset relative to the track;
                             // the handle has already adjusted its position
-                            mgr.size_handle(|sh| self.adjust_size(sh, n));
+                            self.adjust_size(mgr, n);
                             Response::None
                         });
                 }
@@ -281,7 +277,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         }
     }
 
-    fn adjust_size(&mut self, size_handle: &mut dyn SizeHandle, n: usize) {
+    fn adjust_size(&mut self, mgr: &mut Manager, n: usize) {
         assert!(n < self.handles.len());
         assert_eq!(self.widgets.len(), self.handles.len() + 1);
         let index = 2 * n + 1;
@@ -304,11 +300,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         loop {
             assert!(n < self.widgets.len());
             let align = AlignHints::default();
-            self.widgets[n].set_rect(
-                size_handle,
-                setter.child_rect(&mut self.data, n << 1),
-                align,
-            );
+            self.widgets[n].set_rect(mgr, setter.child_rect(&mut self.data, n << 1), align);
 
             if n >= self.handles.len() {
                 break;
@@ -316,7 +308,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
 
             let index = (n << 1) + 1;
             let track = self.handles[n].track();
-            self.handles[n].set_rect(size_handle, track, AlignHints::default());
+            self.handles[n].set_rect(mgr, track, AlignHints::default());
             let handle = setter.child_rect(&mut self.data, index);
             let _ = self.handles[n].set_size_and_offset(handle.size, handle.pos - track.pos);
 

--- a/src/widget/stack.rs
+++ b/src/widget/stack.rs
@@ -101,7 +101,7 @@ impl<W: Widget> event::SendEvent for Stack<W> {
                 if id <= child.id() {
                     return match child.send(mgr, id, event) {
                         Response::Focus(rect) => {
-                            *mgr += self.set_active(index);
+                            *mgr |= self.set_active(index);
                             Response::Focus(rect)
                         }
                         r => r,
@@ -140,10 +140,10 @@ impl<W: Widget> Stack<W> {
     /// child widgets.
     pub fn set_active(&mut self, active: usize) -> TkAction {
         if self.active == active {
-            TkAction::None
+            TkAction::empty()
         } else {
             self.active = active;
-            TkAction::RegionMoved
+            TkAction::REGION_MOVED
         }
     }
 
@@ -192,8 +192,8 @@ impl<W: Widget> Stack<W> {
     /// removed.
     pub fn clear(&mut self) -> TkAction {
         let action = match self.widgets.is_empty() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         };
         self.widgets.clear();
         action
@@ -204,7 +204,7 @@ impl<W: Widget> Stack<W> {
     /// Triggers a [reconfigure action](Manager::send_action).
     pub fn push(&mut self, widget: W) -> TkAction {
         self.widgets.push(widget);
-        TkAction::Reconfigure
+        TkAction::RECONFIGURE
     }
 
     /// Remove the last child widget
@@ -216,8 +216,8 @@ impl<W: Widget> Stack<W> {
     /// removed.
     pub fn pop(&mut self) -> (Option<W>, TkAction) {
         let action = match self.widgets.is_empty() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         };
         (self.widgets.pop(), action)
     }
@@ -229,7 +229,7 @@ impl<W: Widget> Stack<W> {
     /// Triggers a [reconfigure action](Manager::send_action).
     pub fn insert(&mut self, index: usize, widget: W) -> TkAction {
         self.widgets.insert(index, widget);
-        TkAction::Reconfigure
+        TkAction::RECONFIGURE
     }
 
     /// Removes the child widget at position `index`
@@ -239,7 +239,7 @@ impl<W: Widget> Stack<W> {
     /// Triggers a [reconfigure action](Manager::send_action).
     pub fn remove(&mut self, index: usize) -> (W, TkAction) {
         let r = self.widgets.remove(index);
-        (r, TkAction::Reconfigure)
+        (r, TkAction::RECONFIGURE)
     }
 
     /// Replace the child at `index`
@@ -252,7 +252,7 @@ impl<W: Widget> Stack<W> {
     // we somehow test "has compatible size"?
     pub fn replace(&mut self, index: usize, mut widget: W) -> (W, TkAction) {
         std::mem::swap(&mut widget, &mut self.widgets[index]);
-        (widget, TkAction::Reconfigure)
+        (widget, TkAction::RECONFIGURE)
     }
 
     /// Append child widgets from an iterator
@@ -263,8 +263,8 @@ impl<W: Widget> Stack<W> {
         let len = self.widgets.len();
         self.widgets.extend(iter);
         match len == self.widgets.len() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         }
     }
 
@@ -274,7 +274,7 @@ impl<W: Widget> Stack<W> {
     pub fn resize_with<F: Fn(usize) -> W>(&mut self, len: usize, f: F) -> TkAction {
         let l0 = self.widgets.len();
         if l0 == len {
-            return TkAction::None;
+            return TkAction::empty();
         } else if l0 > len {
             self.widgets.truncate(len);
         } else {
@@ -283,7 +283,7 @@ impl<W: Widget> Stack<W> {
                 self.widgets.push(f(i));
             }
         }
-        TkAction::Reconfigure
+        TkAction::RECONFIGURE
     }
 
     /// Retain only widgets satisfying predicate `f`
@@ -296,8 +296,8 @@ impl<W: Widget> Stack<W> {
         let len = self.widgets.len();
         self.widgets.retain(f);
         match len == self.widgets.len() {
-            true => TkAction::None,
-            false => TkAction::Reconfigure,
+            true => TkAction::empty(),
+            false => TkAction::RECONFIGURE,
         }
     }
 }

--- a/src/widget/stack.rs
+++ b/src/widget/stack.rs
@@ -72,10 +72,10 @@ impl<W: Widget> Layout for Stack<W> {
         rules
     }
 
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         for child in &mut self.widgets {
-            child.set_rect(size_handle, rect, align.clone());
+            child.set_rect(mgr, rect, align.clone());
         }
     }
 

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -204,10 +204,11 @@ where
     }
 
     #[inline]
-    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) {
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) -> Coord {
         let mut action = self.scroll.set_offset(offset);
         action += mgr.size_handle(|h| self.update_widgets(h));
         *mgr += action;
+        self.scroll.offset()
     }
 }
 
@@ -411,7 +412,9 @@ where
         if action != TkAction::None {
             action += mgr.size_handle(|h| self.update_widgets(h));
             *mgr += action;
+            Response::Focus(self.rect())
+        } else {
+            response.void_into()
         }
-        response.void_into()
     }
 }

--- a/src/widget/view/single.rs
+++ b/src/widget/view/single.rs
@@ -91,7 +91,7 @@ impl<A: Accessor<()>, W: ViewWidget<A::Item>> Handler for SingleView<A, W> {
         match event {
             Event::HandleUpdate { .. } => {
                 let value = self.accessor.get(());
-                *mgr += self.child.set(value);
+                *mgr |= self.child.set(value);
                 Response::None
             }
             event => Response::Unhandled(event),

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -168,7 +168,7 @@ impl<W: Widget<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
     fn add_popup(&mut self, mgr: &mut Manager, id: WindowId, popup: kas::Popup) {
         let index = self.popups.len();
         self.popups.push((id, popup));
-        mgr.size_handle(|size_handle| self.resize_popup(size_handle, index));
+        self.resize_popup(mgr, index);
         mgr.send_action(TkAction::REDRAW);
     }
 
@@ -182,9 +182,9 @@ impl<W: Widget<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
         }
     }
 
-    fn resize_popups(&mut self, size_handle: &mut dyn SizeHandle) {
+    fn resize_popups(&mut self, mgr: &mut Manager) {
         for i in 0..self.popups.len() {
-            self.resize_popup(size_handle, i);
+            self.resize_popup(mgr, i);
         }
     }
 
@@ -217,7 +217,7 @@ fn find_rect(widget: &dyn WidgetConfig, id: WidgetId) -> Option<Rect> {
 }
 
 impl<W: Widget> Window<W> {
-    fn resize_popup(&mut self, size_handle: &mut dyn SizeHandle, index: usize) {
+    fn resize_popup(&mut self, mgr: &mut Manager, index: usize) {
         // Notation: p=point/coord, s=size, m=margin
         // r=window/root rect, c=anchor rect
         let r = self.core.rect;
@@ -225,7 +225,7 @@ impl<W: Widget> Window<W> {
 
         let c = find_rect(self.w.as_widget(), popup.parent).unwrap();
         let widget = self.w.find_mut(popup.id).unwrap();
-        let mut cache = layout::SolveCache::find_constraints(widget, size_handle);
+        let mut cache = mgr.size_handle(|sh| layout::SolveCache::find_constraints(widget, sh));
         let ideal = cache.ideal(false);
         let m = cache.margins();
 
@@ -263,6 +263,6 @@ impl<W: Widget> Window<W> {
             Rect::new(Coord(x, y), Size(w, h))
         };
 
-        cache.apply_rect(widget, size_handle, rect, false);
+        cache.apply_rect(widget, mgr, rect, false);
     }
 }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -169,14 +169,14 @@ impl<W: Widget<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
         let index = self.popups.len();
         self.popups.push((id, popup));
         mgr.size_handle(|size_handle| self.resize_popup(size_handle, index));
-        mgr.send_action(TkAction::Redraw);
+        mgr.send_action(TkAction::REDRAW);
     }
 
     fn remove_popup(&mut self, mgr: &mut Manager, id: WindowId) {
         for i in 0..self.popups.len() {
             if id == self.popups[i].0 {
                 self.popups.remove(i);
-                mgr.send_action(TkAction::RegionMoved);
+                mgr.send_action(TkAction::REGION_MOVED);
                 return;
             }
         }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -115,9 +115,9 @@ impl<W: Widget> Layout for Window<W> {
     }
 
     #[inline]
-    fn set_rect(&mut self, size_handle: &mut dyn SizeHandle, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        self.w.set_rect(size_handle, rect, align);
+        self.w.set_rect(mgr, rect, align);
     }
 
     #[inline]


### PR DESCRIPTION
`TkAction` is now a bitflags struct instead of an enum, allowing actions to be triggered independently (instead of progressively).

`Layout::set_rect` now takes `&mut Manager` instead of `&dyn SizeHandle` parameter (we could have simply added a `TkAction` return value, but this seemed the better choice, especially considering the size handle is rarely used here and it adds options like scheduling updates from `set_rect`).

`ViewList::set_rect` can now trigger a reconfigure when required. Currently resizes happen too frequently, but that's for another PR.