### PR TITLE
Work2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ version = "0.6.0"
 path = "kas-macros"
 
 [dependencies.kas-text]
-version = "0.2.0"
-# git = "https://github.com/kas-gui/kas-text"
-# rev = ""
+version = "0.3.0"
+git = "https://github.com/kas-gui/kas-text"
+rev = "7f3022f03ffacbfe271cea795cf24e434719cffd"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -188,7 +188,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         } as u16;
         let margins = (margin, margin);
         if axis.is_horizontal() {
-            let bound = required.0 as u32;
+            let bound = (required.0).ceil() as u32;
             let min = self.dims.min_line_length;
             let ideal = self.dims.ideal_line_length;
             // NOTE: using different variable-width stretch policies here can
@@ -201,13 +201,13 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
             SizeRules::new(min, ideal, margins, policy)
         } else {
             let min = match class {
-                TextClass::Label => required.1 as u32,
+                TextClass::Label => (required.1).ceil() as u32,
                 TextClass::LabelSingle | TextClass::Button | TextClass::Edit => {
                     self.dims.line_height
                 }
                 TextClass::EditMulti => self.dims.line_height * 3,
             };
-            let ideal = (required.1 as u32).max(min);
+            let ideal = ((required.1).ceil() as u32).max(min);
             let stretch = match class {
                 TextClass::Button | TextClass::Edit | TextClass::LabelSingle => {
                     StretchPolicy::Fixed

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -130,8 +130,9 @@ impl Handler for Clock {
                 self.now = Local::now();
                 let date = self.now.format("%Y-%m-%d").to_string();
                 let time = self.now.format("%H:%M:%S").to_string();
-                *mgr |= set_text_and_prepare(&mut self.date, date)
-                    | set_text_and_prepare(&mut self.time, time);
+                let avail = Size(self.core.rect.size.0, self.core.rect.size.1 / 2);
+                *mgr |= set_text_and_prepare(&mut self.date, date, avail)
+                    | set_text_and_prepare(&mut self.time, time, avail);
                 let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
                 info!("Requesting update in {}ns", ns);
                 mgr.update_on_timer(Duration::new(0, ns), self.id());

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -5,7 +5,7 @@
 
 //! `Window` and `WindowList` types
 
-use log::{debug, info, trace};
+use log::{debug, error, info, trace};
 use std::time::Instant;
 
 use kas::draw::SizeHandle;
@@ -390,7 +390,13 @@ where
         }
 
         let time2 = Instant::now();
-        let frame = self.swap_chain.get_current_frame().unwrap();
+        let frame = match self.swap_chain.get_current_frame() {
+            Ok(frame) => frame,
+            Err(error) => {
+                error!("Frame swap failed: {}", error);
+                return;
+            }
+        };
 
         let time3 = Instant::now();
         // TODO: check frame.optimal ?

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -190,6 +190,14 @@ impl Size {
     pub fn transpose(self) -> Self {
         Size(self.1, self.0)
     }
+
+    /// Saturating sub
+    #[inline]
+    pub fn saturating_sub(self, other: Self) -> Self {
+        let w = self.0.saturating_sub(other.0);
+        let h = self.1.saturating_sub(other.1);
+        Size(w, h)
+    }
 }
 
 impl From<(u32, u32)> for Size {

--- a/src/text.rs
+++ b/src/text.rs
@@ -16,6 +16,7 @@ pub use string::AccelString;
 pub mod util {
     use super::{format, EditableTextApi, Text, TextApi, Vec2};
     use kas::{geom::Size, TkAction};
+    use log::trace;
 
     /// Set the text and prepare
     ///
@@ -34,6 +35,11 @@ pub mod util {
         if let Some(req) = text.prepare() {
             let avail = Vec2::from(avail);
             if !(req.0 <= avail.0 && req.1 <= avail.1) {
+                trace!(
+                    "set_text_and_prepare triggers RESIZE: req={:?}, avail={:?}",
+                    req,
+                    avail
+                );
                 return TkAction::RESIZE;
             }
         }
@@ -57,6 +63,10 @@ pub mod util {
         if let Some(req) = text.prepare() {
             let avail = Vec2::from(avail);
             if !(req.0 <= avail.0 && req.1 <= avail.1) {
+                println!(
+                    "set_string_and_prepare triggers RESIZE: req={:?}, avail={:?}",
+                    req, avail
+                );
                 return TkAction::RESIZE;
             }
         }

--- a/src/text.rs
+++ b/src/text.rs
@@ -14,31 +14,52 @@ mod string;
 pub use string::AccelString;
 
 pub mod util {
-    use super::{format, EditableTextApi, Text, TextApi};
-    use kas::TkAction;
+    use super::{format, EditableTextApi, Text, TextApi, Vec2};
+    use kas::{geom::Size, TkAction};
 
     /// Set the text and prepare
     ///
-    /// This is a convenience function to (1) set the text, (2) call
-    /// [`Text::prepare`] internally and (3) return [`TkAction::RESIZE`] to
-    /// trigger a resize.
-    pub fn set_text_and_prepare<T: format::FormattableText>(text: &mut Text<T>, s: T) -> TkAction {
+    /// Update text and trigger a resize if necessary.
+    ///
+    /// The `avail` parameter is used to determine when a resize is required. If
+    /// this parameter is a little bit wrong then resizes may sometimes happen
+    /// unnecessarily or may not happen when text is slightly too big (e.g.
+    /// spills into the margin area); this behaviour is probably acceptable.
+    pub fn set_text_and_prepare<T: format::FormattableText>(
+        text: &mut Text<T>,
+        s: T,
+        avail: Size,
+    ) -> TkAction {
         text.set_text(s);
-        text.prepare();
-        TkAction::RESIZE
+        if let Some(req) = text.prepare() {
+            let avail = Vec2::from(avail);
+            if !(req.0 <= avail.0 && req.1 <= avail.1) {
+                return TkAction::RESIZE;
+            }
+        }
+        TkAction::empty()
     }
 
     /// Set the text from a string and prepare
     ///
-    /// This is a convenience function to (1) set the text, (2) call
-    /// [`Text::prepare`] internally and (3) return [`TkAction::RESIZE`] to
-    /// trigger a resize.
+    /// Update text and trigger a resize if necessary.
+    ///
+    /// The `avail` parameter is used to determine when a resize is required. If
+    /// this parameter is a little bit wrong then resizes may sometimes happen
+    /// unnecessarily or may not happen when text is slightly too big (e.g.
+    /// spills into the margin area); this behaviour is probably acceptable.
     pub fn set_string_and_prepare<T: format::EditableText>(
         text: &mut Text<T>,
         s: String,
+        avail: Size,
     ) -> TkAction {
         text.set_string(s);
-        text.prepare();
-        TkAction::RESIZE
+        if let Some(req) = text.prepare() {
+            let avail = Vec2::from(avail);
+            if !(req.0 <= avail.0 && req.1 <= avail.1) {
+                return TkAction::RESIZE;
+            }
+        }
+        TkAction::empty()
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -19,6 +19,7 @@ pub struct TextButton<M: Clone + Debug + 'static> {
     #[widget_core]
     core: kas::CoreData,
     keys1: VirtualKeyCodes,
+    frame_size: Size,
     // label_rect: Rect,
     label: Text<AccelString>,
     msg: M,
@@ -38,8 +39,9 @@ impl<M: Clone + Debug + 'static> WidgetConfig for TextButton<M> {
 impl<M: Clone + Debug + 'static> Layout for TextButton<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let sides = size_handle.button_surround();
+        self.frame_size = sides.0 + sides.1;
         let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), sides.0 + sides.1, margins);
+        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), self.frame_size, margins);
 
         let content_rules = size_handle.text_bound(&mut self.label, TextClass::Button, axis);
         content_rules.surrounded_by(frame_rules, true)
@@ -78,6 +80,7 @@ impl<M: Clone + Debug + 'static> TextButton<M> {
         TextButton {
             core: Default::default(),
             keys1: Default::default(),
+            frame_size: Default::default(),
             // label_rect: Default::default(),
             label: text,
             msg,
@@ -107,7 +110,8 @@ impl<M: Clone + Debug + 'static> HasStr for TextButton<M> {
 
 impl<M: Clone + Debug + 'static> SetAccel for TextButton<M> {
     fn set_accel_string(&mut self, string: AccelString) -> TkAction {
-        kas::text::util::set_text_and_prepare(&mut self.label, string)
+        let avail = self.core.rect.size.saturating_sub(self.frame_size);
+        kas::text::util::set_text_and_prepare(&mut self.label, string, avail)
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -110,8 +110,12 @@ impl<M: Clone + Debug + 'static> HasStr for TextButton<M> {
 
 impl<M: Clone + Debug + 'static> SetAccel for TextButton<M> {
     fn set_accel_string(&mut self, string: AccelString) -> TkAction {
+        let mut action = TkAction::empty();
+        if self.label.text().keys() != string.keys() {
+            action |= TkAction::RECONFIGURE;
+        }
         let avail = self.core.rect.size.saturating_sub(self.frame_size);
-        kas::text::util::set_text_and_prepare(&mut self.label, string, avail)
+        action | kas::text::util::set_text_and_prepare(&mut self.label, string, avail)
     }
 }
 

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -26,6 +26,7 @@ use kas::prelude::*;
 /// 4.  Optionally, this widget can handle clicks on the track area via
 ///     [`DragHandle::handle_press_on_track`].
 #[handler(handle=noauto)]
+#[widget(config(cursor_icon = event::CursorIcon::Grab))]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct DragHandle {
     #[widget_core]

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -837,7 +837,8 @@ impl<G: EditGuard> HasStr for EditBox<G> {
 
 impl<G: EditGuard> HasString for EditBox<G> {
     fn set_string(&mut self, string: String) -> TkAction {
-        let action = kas::text::util::set_string_and_prepare(&mut self.text, string);
+        let avail = self.core.rect.size.saturating_sub(self.frame_size);
+        let action = kas::text::util::set_string_and_prepare(&mut self.text, string, avail);
         let _ = G::update(self);
         action
     }

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -111,7 +111,7 @@ impl<T: FormattableText + 'static> Label<T> {
     /// Note: this must not be called before fonts have been initialised
     /// (usually done by the theme when the main loop starts).
     pub fn set_text(&mut self, text: T) -> TkAction {
-        kas::text::util::set_text_and_prepare(&mut self.label, text)
+        kas::text::util::set_text_and_prepare(&mut self.label, text, self.core.rect.size)
     }
 }
 
@@ -123,7 +123,7 @@ impl<T: FormattableText + 'static> HasStr for Label<T> {
 
 impl<T: FormattableText + EditableText + 'static> HasString for Label<T> {
     fn set_string(&mut self, string: String) -> TkAction {
-        kas::text::util::set_string_and_prepare(&mut self.label, string)
+        kas::text::util::set_string_and_prepare(&mut self.label, string, self.core.rect.size)
     }
 }
 
@@ -155,6 +155,6 @@ impl AccelLabel {
 
 impl SetAccel for AccelLabel {
     fn set_accel_string(&mut self, string: AccelString) -> TkAction {
-        kas::text::util::set_text_and_prepare(&mut self.label, string)
+        kas::text::util::set_text_and_prepare(&mut self.label, string, self.core.rect.size)
     }
 }

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -155,6 +155,10 @@ impl AccelLabel {
 
 impl SetAccel for AccelLabel {
     fn set_accel_string(&mut self, string: AccelString) -> TkAction {
-        kas::text::util::set_text_and_prepare(&mut self.label, string, self.core.rect.size)
+        let mut action = TkAction::empty();
+        if self.label.text().keys() != string.keys() {
+            action |= TkAction::RECONFIGURE;
+        }
+        action | kas::text::util::set_text_and_prepare(&mut self.label, string, self.core.rect.size)
     }
 }

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -89,7 +89,10 @@ impl<M: Clone + Debug + 'static> HasStr for MenuEntry<M> {
 
 impl<M: Clone + Debug + 'static> SetAccel for MenuEntry<M> {
     fn set_accel_string(&mut self, string: AccelString) -> TkAction {
-        kas::text::util::set_text_and_prepare(&mut self.label, string)
+        // NOTE: we assume here that top-left and bottom-right frame size is the
+        // same; if not then resizes may not happen exactly when required
+        let size = Size::from(self.label_off);
+        kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
     }
 }
 

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -89,10 +89,14 @@ impl<M: Clone + Debug + 'static> HasStr for MenuEntry<M> {
 
 impl<M: Clone + Debug + 'static> SetAccel for MenuEntry<M> {
     fn set_accel_string(&mut self, string: AccelString) -> TkAction {
+        let mut action = TkAction::empty();
+        if self.label.text().keys() != string.keys() {
+            action |= TkAction::RECONFIGURE;
+        }
         // NOTE: we assume here that top-left and bottom-right frame size is the
         // same; if not then resizes may not happen exactly when required
         let size = Size::from(self.label_off);
-        kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
+        action | kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
     }
 }
 

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -278,9 +278,13 @@ impl<D: Directional, W: Menu> HasStr for SubMenu<D, W> {
 
 impl<D: Directional, W: Menu> SetAccel for SubMenu<D, W> {
     fn set_accel_string(&mut self, string: AccelString) -> TkAction {
+        let mut action = TkAction::empty();
+        if self.label.text().keys() != string.keys() {
+            action |= TkAction::RECONFIGURE;
+        }
         // NOTE: we assume here that top-left and bottom-right frame size is the
         // same; if not then resizes may not happen exactly when required
         let size = Size::from(self.label_off);
-        kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
+        action | kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
     }
 }

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -278,6 +278,9 @@ impl<D: Directional, W: Menu> HasStr for SubMenu<D, W> {
 
 impl<D: Directional, W: Menu> SetAccel for SubMenu<D, W> {
     fn set_accel_string(&mut self, string: AccelString) -> TkAction {
-        kas::text::util::set_text_and_prepare(&mut self.label, string)
+        // NOTE: we assume here that top-left and bottom-right frame size is the
+        // same; if not then resizes may not happen exactly when required
+        let size = Size::from(self.label_off);
+        kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
     }
 }

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -246,6 +246,7 @@ where
         if let Some(handle) = self.data.update_handle() {
             mgr.update_on_handle(handle, self.id());
         }
+        mgr.register_nav_fallback(self.id());
     }
 }
 

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -114,6 +114,7 @@ where
         self.data_range.end = self.data_range.start;
         self.update_widgets(mgr);
         // Force SET_SIZE so that scroll-bar wrappers get updated
+        trace!("update_view triggers SET_SIZE");
         *mgr |= TkAction::SET_SIZE;
     }
 


### PR DESCRIPTION
Reduce the number of resize actions.

Fix rounding with `f32 → u32` conversion on text size requirements.

Fix a bug where *not* reducing the allocated widget number in ViewList caused an issue when frame-swapping? (At any rate, we no longer crash on frame-swap errors and I no longer see any frame-swap errors.)

ViewList is now a nav fallback candidate. Calling `set_accel_string` now triggers a reconfigure if the keys change.

All grab handles now use the "grab" cursor icon (I don't see this icon widely used in other apps, but it certainly helps with positioning when using the splitter and scrollbars).