### PR TITLE
Conv and ConvFloat conversion traits, i32 in Size, new Offset type, fn extract

### DIFF
--- a/kas-macros/src/layout.rs
+++ b/kas-macros/src/layout.rs
@@ -57,14 +57,14 @@ pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<To
     }
 
     let col_temp = if cols > 16 {
-        quote! { Vec<u32> }
+        quote! { Vec<i32> }
     } else {
-        quote! { [u32; #cols] }
+        quote! { [i32; #cols] }
     };
     let row_temp = if rows > 16 {
-        quote! { Vec<u32> }
+        quote! { Vec<i32> }
     } else {
-        quote! { [u32; #rows] }
+        quote! { [i32; #rows] }
     };
 
     Ok(match layout.layout {
@@ -76,7 +76,7 @@ pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<To
         l @ LayoutType::Right | l @ LayoutType::Left => quote! {
             type Data = kas::layout::FixedRowStorage::<
                 [kas::layout::SizeRules; #cols + 1],
-                [u32; #cols],
+                [i32; #cols],
             >;
             type Solver = kas::layout::RowSolver::<
                 Self::Data,
@@ -90,7 +90,7 @@ pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<To
         l @ LayoutType::Down | l @ LayoutType::Up => quote! {
             type Data = kas::layout::FixedRowStorage::<
                 [kas::layout::SizeRules; #rows + 1],
-                [u32; #rows],
+                [i32; #rows],
             >;
             type Solver = kas::layout::RowSolver::<
                 Self::Data,

--- a/kas-macros/src/layout.rs
+++ b/kas-macros/src/layout.rs
@@ -211,9 +211,9 @@ pub(crate) fn derive(
         });
 
         draw.append_all(quote! {
-            let c0 = self.#ident.rect().pos;
-            let c1 = c0 + Coord::from(self.#ident.rect().size);
-            if c0.0 <= pos1.0 && c1.0 >= pos0.0 && c0.1 <= pos1.1 && c1.1 >= pos0.1 {
+            let c1 = self.#ident.rect().pos;
+            let c2 = self.#ident.rect().pos2();
+            if c1.0 <= pos2.0 && c2.0 >= pos1.0 && c1.1 <= pos2.1 && c2.1 >= pos1.1 {
                 self.#ident.draw(draw_handle, mgr, disabled);
             }
         });
@@ -295,8 +295,8 @@ pub(crate) fn derive(
             use kas::{geom::Coord, WidgetCore};
 
             let rect = draw_handle.target_rect();
-            let pos0 = rect.pos;
-            let pos1 = rect.pos + Coord::from(rect.size);
+            let pos1 = rect.pos;
+            let pos2 = rect.pos2();
             let disabled = disabled || self.is_disabled();
             #draw
         }

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -143,7 +143,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
     }
     fn menu_frame(&self) -> Size {
         let f = self.dims.frame;
-        Size(f, f / 2)
+        Size::new(f, f / 2)
     }
 
     fn inner_margin(&self) -> Size {

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -139,7 +139,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
 
     fn frame(&self) -> Size {
         let f = self.dims.frame;
-        Size::uniform(f)
+        Size::splat(f)
     }
     fn menu_frame(&self) -> Size {
         let f = self.dims.frame;
@@ -147,11 +147,11 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
     }
 
     fn inner_margin(&self) -> Size {
-        Size::uniform(self.dims.inner_margin.into())
+        Size::splat(self.dims.inner_margin.into())
     }
 
     fn outer_margins(&self) -> Margins {
-        Margins::uniform(self.dims.outer_margin)
+        Margins::splat(self.dims.outer_margin)
     }
 
     fn line_height(&self, _: TextClass) -> i32 {
@@ -224,17 +224,17 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
     }
 
     fn button_surround(&self) -> (Size, Size) {
-        let s = Size::uniform(self.dims.button_frame);
+        let s = Size::splat(self.dims.button_frame);
         (s, s)
     }
 
     fn edit_surround(&self) -> (Size, Size) {
-        let s = Size::uniform(self.dims.frame + i32::from(self.dims.inner_margin));
+        let s = Size::splat(self.dims.frame + i32::from(self.dims.inner_margin));
         (s, s)
     }
 
     fn checkbox(&self) -> Size {
-        Size::uniform(self.dims.checkbox)
+        Size::splat(self.dims.checkbox)
     }
 
     #[inline]

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -47,8 +47,8 @@ pub struct Dimensions {
     pub line_height: u32,
     pub min_line_length: u32,
     pub ideal_line_length: u32,
-    pub outer_margin: u32,
-    pub inner_margin: u32,
+    pub outer_margin: u16,
+    pub inner_margin: u16,
     pub frame: u32,
     pub button_frame: u32,
     pub checkbox: u32,
@@ -64,8 +64,8 @@ impl Dimensions {
         let dpem = dpp * pt_size;
         let line_height = kas::text::fonts::fonts().get(font_id).height(dpem).ceil() as u32;
 
-        let outer_margin = (params.outer_margin * scale_factor).round() as u32;
-        let inner_margin = (params.inner_margin * scale_factor).round() as u32;
+        let outer_margin = (params.outer_margin * scale_factor).round() as u16;
+        let inner_margin = (params.inner_margin * scale_factor).round() as u16;
         let frame = (params.frame_size * scale_factor).round() as u32;
         Dimensions {
             scale_factor,
@@ -79,7 +79,7 @@ impl Dimensions {
             inner_margin,
             frame,
             button_frame: (params.button_frame * scale_factor).round() as u32,
-            checkbox: (9.0 * dpp).round() as u32 + 2 * (inner_margin + frame),
+            checkbox: (9.0 * dpp).round() as u32 + 2 * (u32::from(inner_margin) + frame),
             scrollbar: Size::from(params.scrollbar_size * scale_factor),
             slider: Size::from(params.slider_size * scale_factor),
             progress_bar: Size::from(params.progress_bar * scale_factor),
@@ -138,20 +138,20 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
     }
 
     fn frame(&self) -> Size {
-        let f = self.dims.frame as u32;
+        let f = self.dims.frame;
         Size::uniform(f)
     }
     fn menu_frame(&self) -> Size {
-        let f = self.dims.frame as u32;
+        let f = self.dims.frame;
         Size(f, f / 2)
     }
 
     fn inner_margin(&self) -> Size {
-        Size::uniform(self.dims.inner_margin as u32)
+        Size::uniform(self.dims.inner_margin.into())
     }
 
     fn outer_margins(&self) -> Margins {
-        Margins::uniform(self.dims.outer_margin as u16)
+        Margins::uniform(self.dims.outer_margin)
     }
 
     fn line_height(&self, _: TextClass) -> u32 {
@@ -185,7 +185,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         let margin = match class {
             TextClass::Label | TextClass::LabelSingle => self.dims.outer_margin,
             TextClass::Button | TextClass::Edit | TextClass::EditMulti => self.dims.inner_margin,
-        } as u16;
+        };
         let margins = (margin, margin);
         if axis.is_horizontal() {
             let bound = (required.0).ceil() as u32;
@@ -229,7 +229,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
     }
 
     fn edit_surround(&self) -> (Size, Size) {
-        let s = Size::uniform(self.dims.frame as u32 + self.dims.inner_margin as u32);
+        let s = Size::uniform(self.dims.frame + u32::from(self.dims.inner_margin));
         (s, s)
     }
 

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -44,14 +44,14 @@ pub struct Dimensions {
     pub dpp: f32,
     pub pt_size: f32,
     pub font_marker_width: f32,
-    pub line_height: u32,
-    pub min_line_length: u32,
-    pub ideal_line_length: u32,
+    pub line_height: i32,
+    pub min_line_length: i32,
+    pub ideal_line_length: i32,
     pub outer_margin: u16,
     pub inner_margin: u16,
-    pub frame: u32,
-    pub button_frame: u32,
-    pub checkbox: u32,
+    pub frame: i32,
+    pub button_frame: i32,
+    pub checkbox: i32,
     pub scrollbar: Size,
     pub slider: Size,
     pub progress_bar: Size,
@@ -62,24 +62,24 @@ impl Dimensions {
         let font_id = Default::default();
         let dpp = scale_factor * (96.0 / 72.0);
         let dpem = dpp * pt_size;
-        let line_height = kas::text::fonts::fonts().get(font_id).height(dpem).ceil() as u32;
+        let line_height = kas::text::fonts::fonts().get(font_id).height(dpem).ceil() as i32;
 
         let outer_margin = (params.outer_margin * scale_factor).round() as u16;
         let inner_margin = (params.inner_margin * scale_factor).round() as u16;
-        let frame = (params.frame_size * scale_factor).round() as u32;
+        let frame = (params.frame_size * scale_factor).round() as i32;
         Dimensions {
             scale_factor,
             dpp,
             pt_size,
             font_marker_width: (1.6 * scale_factor).round().max(1.0),
             line_height,
-            min_line_length: (8.0 * dpem).round() as u32,
-            ideal_line_length: (24.0 * dpem).round() as u32,
+            min_line_length: (8.0 * dpem).round() as i32,
+            ideal_line_length: (24.0 * dpem).round() as i32,
             outer_margin,
             inner_margin,
             frame,
-            button_frame: (params.button_frame * scale_factor).round() as u32,
-            checkbox: (9.0 * dpp).round() as u32 + 2 * (u32::from(inner_margin) + frame),
+            button_frame: (params.button_frame * scale_factor).round() as i32,
+            checkbox: (9.0 * dpp).round() as i32 + 2 * (i32::from(inner_margin) + frame),
             scrollbar: Size::from(params.scrollbar_size * scale_factor),
             slider: Size::from(params.slider_size * scale_factor),
             progress_bar: Size::from(params.progress_bar * scale_factor),
@@ -154,7 +154,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         Margins::uniform(self.dims.outer_margin)
     }
 
-    fn line_height(&self, _: TextClass) -> u32 {
+    fn line_height(&self, _: TextClass) -> i32 {
         self.dims.line_height
     }
 
@@ -188,7 +188,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         };
         let margins = (margin, margin);
         if axis.is_horizontal() {
-            let bound = (required.0).ceil() as u32;
+            let bound = (required.0).ceil() as i32;
             let min = self.dims.min_line_length;
             let ideal = self.dims.ideal_line_length;
             // NOTE: using different variable-width stretch policies here can
@@ -201,13 +201,13 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
             SizeRules::new(min, ideal, margins, policy)
         } else {
             let min = match class {
-                TextClass::Label => (required.1).ceil() as u32,
+                TextClass::Label => (required.1).ceil() as i32,
                 TextClass::LabelSingle | TextClass::Button | TextClass::Edit => {
                     self.dims.line_height
                 }
                 TextClass::EditMulti => self.dims.line_height * 3,
             };
-            let ideal = ((required.1).ceil() as u32).max(min);
+            let ideal = ((required.1).ceil() as i32).max(min);
             let stretch = match class {
                 TextClass::Button | TextClass::Edit | TextClass::LabelSingle => {
                     StretchPolicy::Fixed
@@ -229,7 +229,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
     }
 
     fn edit_surround(&self) -> (Size, Size) {
-        let s = Size::uniform(self.dims.frame + u32::from(self.dims.inner_margin));
+        let s = Size::uniform(self.dims.frame + i32::from(self.dims.inner_margin));
         (s, s)
     }
 
@@ -242,12 +242,12 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         self.checkbox()
     }
 
-    fn scrollbar(&self) -> (Size, u32) {
+    fn scrollbar(&self) -> (Size, i32) {
         let size = self.dims.scrollbar;
         (size, 2 * size.0)
     }
 
-    fn slider(&self) -> (Size, u32) {
+    fn slider(&self) -> (Size, i32) {
         let size = self.dims.slider;
         (size, 2 * size.0)
     }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -435,7 +435,6 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         if let Some(col) = self.cols.check_mark_state(state, checked) {
             let radius = inner.size().sum() * (1.0 / 16.0);
             let inner = inner.shrink(self.window.dims.inner_margin as f32 + radius);
-            let radius = radius as f32;
             self.draw
                 .rounded_line(self.pass, inner.a, inner.b, radius, col);
             self.draw

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -71,7 +71,7 @@ pub struct DrawHandle<'a, D: Draw> {
     pub(crate) window: &'a mut DimensionsWindow,
     pub(crate) cols: &'a ThemeColours,
     pub(crate) rect: Rect,
-    pub(crate) offset: Size,
+    pub(crate) offset: Offset,
     pub(crate) pass: Pass,
 }
 
@@ -116,7 +116,7 @@ where
             window: transmute::<&'a mut Self::Window, &'static mut Self::Window>(window),
             cols: transmute::<&'a ThemeColours, &'static ThemeColours>(&self.cols),
             rect,
-            offset: Size::ZERO,
+            offset: Offset::ZERO,
             pass: super::START_PASS,
         }
     }
@@ -134,7 +134,7 @@ where
             window,
             cols: &self.cols,
             rect,
-            offset: Size::ZERO,
+            offset: Offset::ZERO,
             pass: super::START_PASS,
         }
     }
@@ -210,14 +210,14 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         }
     }
 
-    fn draw_device(&mut self) -> (kas::draw::Pass, Size, &mut dyn kas::draw::Draw) {
+    fn draw_device(&mut self) -> (kas::draw::Pass, Offset, &mut dyn kas::draw::Draw) {
         (self.pass, self.offset, self.draw)
     }
 
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Size,
+        offset: Offset,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn draw::DrawHandle),
     ) {
@@ -272,7 +272,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
     ) {
@@ -282,7 +282,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             .text(self.pass, pos.into(), bounds, offset.into(), text, col);
     }
 
-    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass) {
+    fn text_effects(&mut self, pos: Coord, offset: Offset, text: &dyn TextApi, class: TextClass) {
         self.draw.text_col_effects(
             self.pass,
             (pos + self.offset).into(),
@@ -313,7 +313,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -361,7 +361,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         &mut self,
         pos: Coord,
         mut bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -11,6 +11,7 @@ use std::f32;
 use std::ops::Range;
 
 use crate::{Dimensions, DimensionsParams, DimensionsWindow, Theme, ThemeColours, Window};
+use kas::conv::Conv;
 use kas::draw::{
     self, ClipRegion, Colour, Draw, DrawRounded, DrawShared, DrawText, InputState, Pass,
     SizeHandle, TextClass,
@@ -342,12 +343,12 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
                 aux: col,
             },
             Effect {
-                start: range.start as u32,
+                start: u32::conv(range.start),
                 flags: Default::default(),
                 aux: self.cols.text_sel,
             },
             Effect {
-                start: range.end as u32,
+                start: u32::conv(range.end),
                 flags: Default::default(),
                 aux: col,
             },

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -71,7 +71,7 @@ pub struct DrawHandle<'a, D: Draw> {
     pub(crate) window: &'a mut DimensionsWindow,
     pub(crate) cols: &'a ThemeColours,
     pub(crate) rect: Rect,
-    pub(crate) offset: Coord,
+    pub(crate) offset: Size,
     pub(crate) pass: Pass,
 }
 
@@ -116,7 +116,7 @@ where
             window: transmute::<&'a mut Self::Window, &'static mut Self::Window>(window),
             cols: transmute::<&'a ThemeColours, &'static ThemeColours>(&self.cols),
             rect,
-            offset: Coord::ZERO,
+            offset: Size::ZERO,
             pass: super::START_PASS,
         }
     }
@@ -134,7 +134,7 @@ where
             window,
             cols: &self.cols,
             rect,
-            offset: Coord::ZERO,
+            offset: Size::ZERO,
             pass: super::START_PASS,
         }
     }
@@ -210,14 +210,14 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         }
     }
 
-    fn draw_device(&mut self) -> (kas::draw::Pass, Coord, &mut dyn kas::draw::Draw) {
+    fn draw_device(&mut self) -> (kas::draw::Pass, Size, &mut dyn kas::draw::Draw) {
         (self.pass, self.offset, self.draw)
     }
 
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Coord,
+        offset: Size,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn draw::DrawHandle),
     ) {
@@ -272,7 +272,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
     ) {
@@ -282,7 +282,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             .text(self.pass, pos.into(), bounds, offset.into(), text, col);
     }
 
-    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass) {
+    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass) {
         self.draw.text_col_effects(
             self.pass,
             (pos + self.offset).into(),
@@ -313,7 +313,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -361,7 +361,7 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
         &mut self,
         pos: Coord,
         mut bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -67,7 +67,7 @@ pub struct DrawHandle<'a, D: Draw> {
     window: &'a mut DimensionsWindow,
     cols: &'a ThemeColours,
     rect: Rect,
-    offset: Size,
+    offset: Offset,
     pass: Pass,
 }
 
@@ -112,7 +112,7 @@ where
             window: transmute::<&'a mut Self::Window, &'static mut Self::Window>(window),
             cols: transmute::<&'a ThemeColours, &'static ThemeColours>(&self.cols),
             rect,
-            offset: Size::ZERO,
+            offset: Offset::ZERO,
             pass: super::START_PASS,
         }
     }
@@ -130,7 +130,7 @@ where
             window,
             cols: &self.cols,
             rect,
-            offset: Size::ZERO,
+            offset: Offset::ZERO,
             pass: super::START_PASS,
         }
     }
@@ -224,14 +224,14 @@ where
         }
     }
 
-    fn draw_device(&mut self) -> (kas::draw::Pass, Size, &mut dyn kas::draw::Draw) {
+    fn draw_device(&mut self) -> (kas::draw::Pass, Offset, &mut dyn kas::draw::Draw) {
         (self.pass, self.offset, self.draw)
     }
 
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Size,
+        offset: Offset,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn draw::DrawHandle),
     ) {
@@ -291,14 +291,14 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
     ) {
         self.as_flat().text_offset(pos, bounds, offset, text, class);
     }
 
-    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass) {
+    fn text_effects(&mut self, pos: Coord, offset: Offset, text: &dyn TextApi, class: TextClass) {
         self.as_flat().text_effects(pos, offset, text, class);
     }
 
@@ -310,7 +310,7 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -323,7 +323,7 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -67,7 +67,7 @@ pub struct DrawHandle<'a, D: Draw> {
     window: &'a mut DimensionsWindow,
     cols: &'a ThemeColours,
     rect: Rect,
-    offset: Coord,
+    offset: Size,
     pass: Pass,
 }
 
@@ -112,7 +112,7 @@ where
             window: transmute::<&'a mut Self::Window, &'static mut Self::Window>(window),
             cols: transmute::<&'a ThemeColours, &'static ThemeColours>(&self.cols),
             rect,
-            offset: Coord::ZERO,
+            offset: Size::ZERO,
             pass: super::START_PASS,
         }
     }
@@ -130,7 +130,7 @@ where
             window,
             cols: &self.cols,
             rect,
-            offset: Coord::ZERO,
+            offset: Size::ZERO,
             pass: super::START_PASS,
         }
     }
@@ -224,14 +224,14 @@ where
         }
     }
 
-    fn draw_device(&mut self) -> (kas::draw::Pass, Coord, &mut dyn kas::draw::Draw) {
+    fn draw_device(&mut self) -> (kas::draw::Pass, Size, &mut dyn kas::draw::Draw) {
         (self.pass, self.offset, self.draw)
     }
 
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Coord,
+        offset: Size,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn draw::DrawHandle),
     ) {
@@ -291,14 +291,14 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
     ) {
         self.as_flat().text_offset(pos, bounds, offset, text, class);
     }
 
-    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass) {
+    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass) {
         self.as_flat().text_effects(pos, offset, text, class);
     }
 
@@ -310,7 +310,7 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -323,7 +323,7 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -44,7 +44,7 @@ pub trait Theme<D: DrawShared>: ThemeApi {
     /// `9/8 = 1.125` works well with many 1440p screens. It is recommended to
     /// round dimensions to the nearest integer, and cache the result:
     /// ```notest
-    /// self.margin = (MARGIN * factor).round() as u32;
+    /// self.margin = i32::conv_nearest(MARGIN * factor);
     /// ```
     ///
     /// A reference to the draw backend is provided allowing configuration.

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -97,9 +97,9 @@ impl Layout for Clock {
         }
 
         let secs = self.now.time().num_seconds_from_midnight();
-        let a_sec = (secs % 60) as f32 * (PI / 30.0);
-        let a_min = (secs % 3600) as f32 * (PI / 1800.0);
-        let a_hour = (secs % (12 * 3600)) as f32 * (PI / (12.0 * 1800.0));
+        let a_sec = f32::conv(secs % 60) * (PI / 30.0);
+        let a_min = f32::conv(secs % 3600) * (PI / 1800.0);
+        let a_hour = f32::conv(secs % 43200) * (PI / (21600.0));
 
         line_seg(a_hour, 0.0, half * 0.55, half * 0.03, col_hands);
         line_seg(a_min, 0.0, half * 0.8, half * 0.015, col_hands);

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -131,7 +131,8 @@ impl Handler for Clock {
                 let date = self.now.format("%Y-%m-%d").to_string();
                 let time = self.now.format("%H:%M:%S").to_string();
                 let avail = Size(self.core.rect.size.0, self.core.rect.size.1 / 2);
-                *mgr |= set_text_and_prepare(&mut self.date, date, avail)
+                *mgr |= TkAction::REDRAW
+                    | set_text_and_prepare(&mut self.date, date, avail)
                     | set_text_and_prepare(&mut self.time, time, avail);
                 let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
                 info!("Requesting update in {}ns", ns);

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -42,7 +42,7 @@ impl Layout for Clock {
     fn set_rect(&mut self, _: &mut Manager, rect: Rect, _align: AlignHints) {
         // Force to square
         let size = rect.size.0.min(rect.size.1);
-        let size = Size::uniform(size);
+        let size = Size::splat(size);
         let excess = rect.size - size;
         let pos = rect.pos + (excess * 0.5);
         self.core.rect = Rect { pos, size };

--- a/kas-wgpu/examples/filter-list.rs
+++ b/kas-wgpu/examples/filter-list.rs
@@ -62,11 +62,11 @@ mod data {
             let dur = self.end - self.start;
             let secs = dur.num_seconds();
             let step_secs = self.step.num_seconds();
-            1 + ((secs - 1) / step_secs) as usize
+            1 + usize::conv((secs - 1) / step_secs)
         }
 
         fn get(&self, index: usize) -> Self::Item {
-            let date = self.start + self.step * index as i32;
+            let date = self.start + self.step * i32::conv(index);
             date.format("%A %e %B %Y, %T").to_string()
         }
     }

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -21,7 +21,7 @@ enum Item {
     Radio(WidgetId),
     Edit(String),
     Slider(i32),
-    Scroll(u32),
+    Scroll(i32),
 }
 
 struct Guard;
@@ -198,7 +198,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             fn handle_slider(&mut self, _: &mut Manager, msg: i32) -> Response<Item> {
                 Response::Msg(Item::Slider(msg))
             }
-            fn handle_scroll(&mut self, mgr: &mut Manager, msg: u32) -> Response<Item> {
+            fn handle_scroll(&mut self, mgr: &mut Manager, msg: i32) -> Response<Item> {
                 let ratio = msg as f32 / self.sc.max_value() as f32;
                 *mgr |= self.pg.set_value(ratio);
                 Response::Msg(Item::Scroll(msg))

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -410,7 +410,7 @@ impl WidgetConfig for Mandlebrot {
 impl Layout for Mandlebrot {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, a: AxisInfo) -> SizeRules {
         let virt_size = if a.is_horizontal() { 300.0 } else { 200.0 };
-        let min_size = (virt_size * size_handle.scale_factor()).round() as u32;
+        let min_size = (virt_size * size_handle.scale_factor()).round() as i32;
         let ideal_size = min_size * 10; // prefer big but not larger than screen size
         SizeRules::new(min_size, ideal_size, (0, 0), StretchPolicy::Maximize)
     }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -429,7 +429,7 @@ impl Layout for Mandlebrot {
         let (pass, offset, draw) = draw_handle.draw_device();
         // TODO: our view transform assumes that offset = 0.
         // Here it is but in general we should be able to handle an offset here!
-        assert_eq!(offset, Coord::ZERO, "view transform assumption violated");
+        assert_eq!(offset, Size::ZERO, "view transform assumption violated");
 
         let draw = draw
             .as_any_mut()

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -241,7 +241,7 @@ impl CustomPipe for Pipe {
             usage: wgpu::BufferUsage::COPY_SRC,
         });
 
-        let byte_len = size_of::<Scale>() as u64;
+        let byte_len = u64::conv(size_of::<Scale>());
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &window.scale_buf, 0, byte_len);
     }
 
@@ -258,7 +258,7 @@ impl CustomPipe for Pipe {
             usage: wgpu::BufferUsage::COPY_SRC,
         });
 
-        let byte_len = size_of::<UnifRect>() as u64;
+        let byte_len = u64::conv(size_of::<UnifRect>());
         encoder.copy_buffer_to_buffer(&rect_buf, 0, &window.rect_buf, 0, byte_len);
 
         let iter = [window.iterations];
@@ -268,7 +268,7 @@ impl CustomPipe for Pipe {
             usage: wgpu::BufferUsage::COPY_SRC,
         });
 
-        let byte_len = size_of::<i32>() as u64;
+        let byte_len = u64::conv(size_of::<i32>());
         encoder.copy_buffer_to_buffer(&iter_buf, 0, &window.iter_buf, 0, byte_len);
 
         // NOTE: we prepare vertex buffers here. Due to lifetime restrictions on
@@ -282,7 +282,7 @@ impl CustomPipe for Pipe {
                     usage: wgpu::BufferUsage::VERTEX,
                 });
                 pass.1 = Some(buffer);
-                pass.2 = pass.0.len() as u32;
+                pass.2 = u32::conv(pass.0.len());
                 pass.0.clear();
             } else {
                 pass.1 = None;

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -410,7 +410,7 @@ impl WidgetConfig for Mandlebrot {
 impl Layout for Mandlebrot {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, a: AxisInfo) -> SizeRules {
         let virt_size = if a.is_horizontal() { 300.0 } else { 200.0 };
-        let min_size = (virt_size * size_handle.scale_factor()).round() as i32;
+        let min_size = i32::conv_floor(virt_size * size_handle.scale_factor());
         let ideal_size = min_size * 10; // prefer big but not larger than screen size
         SizeRules::new(min_size, ideal_size, (0, 0), StretchPolicy::Maximize)
     }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -429,7 +429,7 @@ impl Layout for Mandlebrot {
         let (pass, offset, draw) = draw_handle.draw_device();
         // TODO: our view transform assumes that offset = 0.
         // Here it is but in general we should be able to handle an offset here!
-        assert_eq!(offset, Size::ZERO, "view transform assumption violated");
+        assert_eq!(offset, Offset::ZERO, "view transform assumption violated");
 
         let draw = draw
             .as_any_mut()

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -29,8 +29,8 @@ fn make_depth_texture(device: &wgpu::Device, size: Size) -> Option<TextureView> 
     let tex = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("window depth"),
         size: wgpu::Extent3d {
-            width: size.0,
-            height: size.1,
+            width: u32::conv(size.0),
+            height: u32::conv(size.1),
             depth: 1,
         },
         mip_level_count: 1,
@@ -187,10 +187,10 @@ impl<C: CustomPipe> DrawPipe<C> {
                     depth_stencil_attachment: Some(depth_stencil_attachment.clone()),
                 });
                 rpass.set_scissor_rect(
-                    rect.pos.0 as u32,
-                    rect.pos.1 as u32,
-                    rect.size.0,
-                    rect.size.1,
+                    u32::conv(rect.pos.0),
+                    u32::conv(rect.pos.1),
+                    u32::conv(rect.size.0),
+                    u32::conv(rect.size.1),
                 );
 
                 ss.as_ref().map(|buf| buf.render(&mut rpass));
@@ -231,8 +231,8 @@ impl<C: CustomPipe> DrawPipe<C> {
                 &mut encoder,
                 frame_view,
                 depth_stencil_attachment,
-                size.0,
-                size.1,
+                u32::conv(size.0),
+                u32::conv(size.1),
             )
             .expect("glyph_brush.draw_queued");
 

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -81,10 +81,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         let f = a.0 / a.1;
         let norm = [dir.1.sin() * f, -dir.1.cos() * f, 1.0];
 
-        let rect = Rect {
-            pos: Coord::ZERO,
-            size,
-        };
+        let rect = Rect::new(Coord::ZERO, size);
 
         let shaded_square = self.shaded_square.new_window(device, size, norm);
         let shaded_round = self.shaded_round.new_window(device, size, norm);

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -14,6 +14,7 @@ use super::{
     flat_round, shaded_round, shaded_square, CustomPipe, CustomPipeBuilder, CustomWindow, DrawPipe,
     DrawWindow, ShaderManager, TEX_FORMAT,
 };
+use kas::conv::Conv;
 use kas::draw::{Colour, Draw, DrawRounded, DrawShaded, DrawShared, Pass};
 use kas::geom::{Coord, Quad, Rect, Size, Vec2};
 
@@ -262,9 +263,9 @@ impl<CW: CustomWindow + 'static> Draw for DrawWindow<CW> {
     }
 
     fn add_clip_region(&mut self, rect: Rect, depth: f32) -> Pass {
-        let pass = self.clip_regions.len();
+        let pass = u32::conv(self.clip_regions.len());
         self.clip_regions.push(rect);
-        Pass::new_pass_with_depth(pass as u32, depth)
+        Pass::new_pass_with_depth(pass, depth)
     }
 
     #[inline]

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -9,6 +9,7 @@ use std::mem::size_of;
 use wgpu::util::DeviceExt;
 
 use crate::draw::{Rgb, ShaderManager};
+use kas::conv::Conv;
 use kas::draw::{Colour, Pass};
 use kas::geom::{Quad, Size, Vec2, Vec3};
 
@@ -55,7 +56,7 @@ pub struct RenderBuffer<'a> {
 impl<'a> RenderBuffer<'a> {
     /// Do the render
     pub fn render(&'a self, rpass: &mut wgpu::RenderPass<'a>) {
-        let count = self.vertices.len() as u32;
+        let count = u32::conv(self.vertices.len());
         rpass.set_pipeline(self.pipe);
         rpass.set_bind_group(0, self.bind_group, &[]);
         rpass.set_vertex_buffer(0, self.buffer.slice(..));
@@ -218,7 +219,7 @@ impl Window {
             contents: bytemuck::cast_slice(&scale_factor),
             usage: wgpu::BufferUsage::COPY_SRC,
         });
-        let byte_len = size_of::<Scale>() as u64;
+        let byte_len = u64::conv(size_of::<Scale>());
 
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &self.scale_buf, 0, byte_len);
     }

--- a/kas-wgpu/src/draw/shaded_round.rs
+++ b/kas-wgpu/src/draw/shaded_round.rs
@@ -10,6 +10,7 @@ use std::mem::size_of;
 use wgpu::util::DeviceExt;
 
 use crate::draw::{Rgb, ShaderManager};
+use kas::conv::Conv;
 use kas::draw::{Colour, Pass};
 use kas::geom::{Quad, Size, Vec2, Vec3};
 
@@ -56,7 +57,7 @@ pub struct RenderBuffer<'a> {
 impl<'a> RenderBuffer<'a> {
     /// Do the render
     pub fn render(&'a self, rpass: &mut wgpu::RenderPass<'a>) {
-        let count = self.vertices.len() as u32;
+        let count = u32::conv(self.vertices.len());
         rpass.set_pipeline(self.pipe);
         rpass.set_bind_group(0, self.bind_group, &[]);
         rpass.set_vertex_buffer(0, self.buffer.slice(..));
@@ -241,7 +242,7 @@ impl Window {
             contents: bytemuck::cast_slice(&scale_factor),
             usage: wgpu::BufferUsage::COPY_SRC,
         });
-        let byte_len = size_of::<Scale>() as u64;
+        let byte_len = u64::conv(size_of::<Scale>());
 
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &self.scale_buf, 0, byte_len);
     }

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -10,6 +10,7 @@ use std::mem::size_of;
 use wgpu::util::DeviceExt;
 
 use crate::draw::{Rgb, ShaderManager};
+use kas::conv::Conv;
 use kas::draw::{Colour, Pass};
 use kas::geom::{Quad, Size, Vec2, Vec3};
 
@@ -45,7 +46,7 @@ pub struct RenderBuffer<'a> {
 impl<'a> RenderBuffer<'a> {
     /// Do the render
     pub fn render(&'a self, rpass: &mut wgpu::RenderPass<'a>) {
-        let count = self.vertices.len() as u32;
+        let count = u32::conv(self.vertices.len());
         rpass.set_pipeline(self.pipe);
         rpass.set_bind_group(0, self.bind_group, &[]);
         rpass.set_vertex_buffer(0, self.buffer.slice(..));
@@ -217,7 +218,7 @@ impl Window {
             contents: bytemuck::cast_slice(&scale_factor),
             usage: wgpu::BufferUsage::COPY_SRC,
         });
-        let byte_len = size_of::<Scale>() as u64;
+        let byte_len = u64::conv(size_of::<Scale>());
 
         encoder.copy_buffer_to_buffer(&scale_buf, 0, &self.scale_buf, 0, byte_len);
     }

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -293,7 +293,7 @@ where
 {
     /// Swap-chain size
     fn sc_size(&self) -> Size {
-        Size(
+        Size::new(
             i32::conv(self.sc_desc.width),
             i32::conv(self.sc_desc.height),
         )

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -141,10 +141,10 @@ macro_rules! impl_via_as_max_check {
     };
 }
 
-impl_via_as_max_check!(u16: i8, u8);
-impl_via_as_max_check!(u32: i8, i16, u8, u16);
-impl_via_as_max_check!(u64: i8, i16, i32, u8, u16, u32, usize);
-impl_via_as_max_check!(u128: i8, i16, i32, i64, u8, u16, u32, u64, usize);
+impl_via_as_max_check!(u16: i8, i16, u8);
+impl_via_as_max_check!(u32: i8, i16, i32, u8, u16);
+impl_via_as_max_check!(u64: i8, i16, i32, i64, u8, u16, u32, usize);
+impl_via_as_max_check!(u128: i8, i16, i32, i64, i128, u8, u16, u32, u64, usize);
 impl_via_as_max_check!(usize: i8, i16, i32, isize, u8, u16, u32);
 
 // Assumption: $y::MAX and $y::MIN are representable as $x

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1,0 +1,171 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Safer type conversion utilities
+//!
+//! We define our own type conversion utilities since `From`, `TryFrom`,
+//! `num_traits::NumCast` and `cast` (crate) don't always do what we need (or
+//! can be cumbersome to use for fallible casts) and we prefer to avoid the `as`
+//! keyword (which doesn't always preserve value).
+
+use std::mem::size_of;
+
+// Borrowed from static_assertions:
+macro_rules! const_assert {
+    ($x:expr $(,)?) => {
+        #[allow(unknown_lints, eq_op)]
+        const _: [(); 0 - !{
+            const ASSERT: bool = $x;
+            ASSERT
+        } as usize] = [];
+    };
+}
+
+const_assert!(size_of::<isize>() >= size_of::<i32>());
+const_assert!(size_of::<isize>() <= size_of::<i64>());
+const_assert!(size_of::<usize>() == size_of::<isize>());
+
+/// Value conversion trait
+///
+/// Very roughly, this trait is [`From`] but with more assumptions (or
+/// `T::try_from(x).unwrap()`), and restricted to numeric conversions.
+///
+/// -   Conversions should preserve values precisely
+/// -   Conversions are expected to succeed but may fail
+/// -   We assume that `isize` and `usize` are 32 or 64 bits
+///
+/// Fallible conversions are allowed. In Debug builds failure must always panic
+/// but in Release builds this is not required (similar to overflow checks on
+/// integer arithmetic).
+///
+/// [`From`]: std::convert::From
+pub trait Conv<T> {
+    fn conv(v: T) -> Self;
+}
+
+macro_rules! impl_via_from {
+    ($x:ty: $y:ty) => {
+        impl Conv<$x> for $y {
+            #[inline]
+            fn conv(x: $x) -> $y {
+                <$y>::from(x)
+            }
+        }
+    };
+    ($x:ty: $y:ty, $($yy:ty),+) => {
+        impl_via_from!($x: $y);
+        impl_via_from!($x: $($yy),+);
+    };
+}
+
+impl_via_from!(bool: i16, i32, i64, i128, isize);
+impl_via_from!(bool: u8, u16, u32, u64, u128, usize);
+impl_via_from!(f32: f64);
+impl_via_from!(i8: f32, f64, i16, i32, i64, i128, isize);
+impl_via_from!(i16: f32, f64, i32, i64, i128, isize);
+impl_via_from!(i32: f64, i64, i128);
+impl_via_from!(i64: i128);
+impl_via_from!(u8: f32, f64, i16, i32, i64, i128, isize);
+impl_via_from!(u8: u16, u32, u64, u128, usize);
+impl_via_from!(u16: f32, f64, i32, i64, i128, u32, u64, u128, usize);
+impl_via_from!(u32: f64, i64, i128, u32, u64, u128);
+impl_via_from!(u64: i128, u128);
+
+// These rely on the const assertions above
+macro_rules! impl_via_as {
+    ($x:ty: $y:ty) => {
+        impl Conv<$x> for $y {
+            #[inline]
+            fn conv(x: $x) -> $y {
+                x as $y
+            }
+        }
+    };
+    ($x:ty: $y:ty, $($yy:ty),+) => {
+        impl_via_as!($x: $y);
+        impl_via_as!($x: $($yy),+);
+    };
+}
+
+impl_via_as!(i32: isize);
+impl_via_as!(isize: i64, i128);
+impl_via_as!(u32: usize);
+impl_via_as!(usize: u64, u128);
+
+impl Conv<u16> for isize {
+    #[inline]
+    fn conv(v: u16) -> isize {
+        isize::conv(i32::from(v))
+    }
+}
+
+macro_rules! impl_via_as_neg_check {
+    ($x:ty: $y:ty) => {
+        impl Conv<$x> for $y {
+            #[inline]
+            fn conv(x: $x) -> $y {
+                debug_assert!(x >= 0);
+                x as $y
+            }
+        }
+    };
+    ($x:ty: $y:ty, $($yy:ty),+) => {
+        impl_via_as_neg_check!($x: $y);
+        impl_via_as_neg_check!($x: $($yy),+);
+    };
+}
+
+impl_via_as_neg_check!(i8: u8, u16, u32, u64, u128, usize);
+impl_via_as_neg_check!(i16: u16, u32, u64, u128, usize);
+impl_via_as_neg_check!(i32: u32, u64, u128, usize);
+impl_via_as_neg_check!(i64: u64, u128);
+impl_via_as_neg_check!(i128: u128);
+impl_via_as_neg_check!(isize: u32, u64, u128, usize);
+
+// Assumption: $y::MAX is representable as $x
+macro_rules! impl_via_as_max_check {
+    ($x:ty: $y:ty) => {
+        impl Conv<$x> for $y {
+            #[inline]
+            fn conv(x: $x) -> $y {
+                debug_assert!(x <= <$y>::MAX as $x);
+                x as $y
+            }
+        }
+    };
+    ($x:ty: $y:ty, $($yy:ty),+) => {
+        impl_via_as_max_check!($x: $y);
+        impl_via_as_max_check!($x: $($yy),+);
+    };
+}
+
+impl_via_as_max_check!(u16: i8, u8);
+impl_via_as_max_check!(u32: i8, i16, u8, u16);
+impl_via_as_max_check!(u64: i8, i16, i32, u8, u16, u32, usize);
+impl_via_as_max_check!(u128: i8, i16, i32, i64, u8, u16, u32, u64, usize);
+impl_via_as_max_check!(usize: i8, i16, i32, isize, u8, u16, u32);
+
+// Assumption: $y::MAX and $y::MIN are representable as $x
+macro_rules! impl_via_as_range_check {
+    ($x:ty: $y:ty) => {
+        impl Conv<$x> for $y {
+            #[inline]
+            fn conv(x: $x) -> $y {
+                debug_assert!(<$y>::MIN as $x <= x && x <= <$y>::MAX as $x);
+                x as $y
+            }
+        }
+    };
+    ($x:ty: $y:ty, $($yy:ty),+) => {
+        impl_via_as_range_check!($x: $y);
+        impl_via_as_range_check!($x: $($yy),+);
+    };
+}
+
+impl_via_as_range_check!(i16: i8, u8);
+impl_via_as_range_check!(i32: i8, i16, u8, u16);
+impl_via_as_range_check!(i64: i8, i16, i32, isize, u8, u16, u32);
+impl_via_as_range_check!(i128: i8, i16, i32, i64, isize, u8, u16, u32, u64);
+impl_via_as_range_check!(isize: i8, i16, i32);

--- a/src/data.rs
+++ b/src/data.rs
@@ -210,7 +210,7 @@ impl CompleteAlignment {
                 Align::Centre => (size.0 - ideal.0) / 2,
                 Align::BR => size.0 - ideal.0,
                 Align::Default | Align::TL | Align::Stretch => 0,
-            } as i32;
+            };
             size.0 = ideal.0;
         }
         if self.valign != Align::Stretch && ideal.1 < size.1 {
@@ -218,7 +218,7 @@ impl CompleteAlignment {
                 Align::Centre => (size.1 - ideal.1) / 2,
                 Align::BR => size.1 - ideal.1,
                 Align::Default | Align::TL | Align::Stretch => 0,
-            } as i32;
+            };
             size.1 = ideal.1;
         }
         Rect { pos, size }
@@ -276,7 +276,7 @@ pub trait Directional: Copy + Sized + std::fmt::Debug + 'static {
 
     /// Extract a size
     #[inline]
-    fn extract_size(self, size: Size) -> u32 {
+    fn extract_size(self, size: Size) -> i32 {
         if self.is_horizontal() {
             size.0
         } else {

--- a/src/data.rs
+++ b/src/data.rs
@@ -91,8 +91,8 @@ impl TryFrom<u32> for WidgetId {
 impl TryFrom<u64> for WidgetId {
     type Error = ();
     fn try_from(x: u64) -> Result<WidgetId, ()> {
-        if x <= u32::MAX as u64 {
-            if let Some(nz) = NonZeroU32::new(x as u32) {
+        if let Ok(x) = u32::try_from(x) {
+            if let Some(nz) = NonZeroU32::new(x) {
                 return Ok(WidgetId(nz));
             }
         }
@@ -110,7 +110,7 @@ impl From<WidgetId> for u32 {
 impl From<WidgetId> for u64 {
     #[inline]
     fn from(id: WidgetId) -> u64 {
-        id.0.get() as u64
+        id.0.get().into()
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 use std::u32;
 
 use super::Align;
-use crate::geom::{Coord, Rect, Size};
+use crate::geom::{Rect, Size};
 
 // for doc use
 #[allow(unused)]
@@ -262,26 +262,6 @@ pub trait Directional: Copy + Sized + std::fmt::Debug + 'static {
     #[inline]
     fn is_reversed(self) -> bool {
         ((self.as_direction() as u32) & 2) == 2
-    }
-
-    /// Extract a coordinate
-    #[inline]
-    fn extract_coord(self, coord: Coord) -> i32 {
-        if self.is_horizontal() {
-            coord.0
-        } else {
-            coord.1
-        }
-    }
-
-    /// Extract a size
-    #[inline]
-    fn extract_size(self, size: Size) -> i32 {
-        if self.is_horizontal() {
-            size.0
-        } else {
-            size.1
-        }
     }
 }
 

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -9,7 +9,7 @@ use std::convert::AsRef;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 
 use kas::draw::{Draw, Pass};
-use kas::geom::{Coord, Rect, Size, Vec2};
+use kas::geom::{Coord, Offset, Rect, Size, Vec2};
 use kas::layout::{AxisInfo, Margins, SizeRules};
 use kas::text::{format::FormattableText, AccelString, Text, TextApi, TextDisplay};
 use kas::Direction;
@@ -251,11 +251,11 @@ pub trait DrawHandle {
     /// [`kas::widget::ScrollRegion`] to adjust its contents.
     /// ```
     /// # use kas::geom::*;
-    /// # let offset = Size::ZERO;
-    /// # let rect = Rect::new(Coord::ZERO, offset);
+    /// # let offset = Offset::ZERO;
+    /// # let rect = Rect::new(Coord::ZERO, Size::ZERO);
     /// let rect = rect + offset;
     /// ```
-    fn draw_device(&mut self) -> (Pass, Size, &mut dyn Draw);
+    fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Draw);
 
     /// Construct a new draw-handle on a given region and pass to a callback.
     ///
@@ -267,7 +267,7 @@ pub trait DrawHandle {
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Size,
+        offset: Offset,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     );
@@ -302,7 +302,7 @@ pub trait DrawHandle {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
     );
@@ -312,7 +312,7 @@ pub trait DrawHandle {
     /// [`DrawHandle::text_offset`] already supports *font* effects: bold,
     /// emphasis, text size. In addition, this method supports underline and
     /// strikethrough effects.
-    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass);
+    fn text_effects(&mut self, pos: Coord, offset: Offset, text: &dyn TextApi, class: TextClass);
 
     /// Draw an `AccelString` text
     ///
@@ -327,7 +327,7 @@ pub trait DrawHandle {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -338,7 +338,7 @@ pub trait DrawHandle {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,
@@ -416,7 +416,7 @@ pub trait DrawHandleExt: DrawHandle {
     /// The dimensions required for this text may be queried with [`SizeHandle::text_bound`].
     fn text<T: FormattableText>(&mut self, pos: Coord, text: &Text<T>, class: TextClass) {
         let bounds = text.env().bounds.into();
-        self.text_offset(pos, bounds, Size::ZERO, text.as_ref(), class);
+        self.text_offset(pos, bounds, Offset::ZERO, text.as_ref(), class);
     }
 
     /// Draw some text using the standard font, with a subset selected
@@ -428,7 +428,7 @@ pub trait DrawHandleExt: DrawHandle {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: T,
         range: R,
         class: TextClass,
@@ -572,13 +572,13 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
         self.deref_mut().size_handle_dyn(f)
     }
-    fn draw_device(&mut self) -> (Pass, Size, &mut dyn Draw) {
+    fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Draw) {
         self.deref_mut().draw_device()
     }
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Size,
+        offset: Offset,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     ) {
@@ -600,14 +600,14 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
     ) {
         self.deref_mut()
             .text_offset(pos, bounds, offset, text, class)
     }
-    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass) {
+    fn text_effects(&mut self, pos: Coord, offset: Offset, text: &dyn TextApi, class: TextClass) {
         self.deref_mut().text_effects(pos, offset, text, class);
     }
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
@@ -617,7 +617,7 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -629,7 +629,7 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,
@@ -671,13 +671,13 @@ where
     fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
         self.deref_mut().size_handle_dyn(f)
     }
-    fn draw_device(&mut self) -> (Pass, Size, &mut dyn Draw) {
+    fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Draw) {
         self.deref_mut().draw_device()
     }
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Size,
+        offset: Offset,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     ) {
@@ -699,14 +699,14 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
     ) {
         self.deref_mut()
             .text_offset(pos, bounds, offset, text, class)
     }
-    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass) {
+    fn text_effects(&mut self, pos: Coord, offset: Offset, text: &dyn TextApi, class: TextClass) {
         self.deref_mut().text_effects(pos, offset, text, class);
     }
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
@@ -716,7 +716,7 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -728,7 +728,7 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Size,
+        offset: Offset,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,
@@ -774,6 +774,7 @@ mod test {
 
         let bounds = Vec2(100.0, 30.0);
         let text = kas::text::Text::new_single("sample");
-        draw_handle.text_selected(Coord::ZERO, bounds, Size::ZERO, &text, .., TextClass::Label)
+        let class = TextClass::Label;
+        draw_handle.text_selected(Coord::ZERO, bounds, Offset::ZERO, &text, .., class)
     }
 }

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -115,7 +115,7 @@ pub trait SizeHandle {
     /// recommended to calculate sizes as follows:
     /// ```
     /// # let scale_factor = 1.5f32;
-    /// let size = (100.0 * scale_factor).round() as u32;
+    /// let size = (100.0 * scale_factor).round() as i32;
     /// ```
     ///
     /// This value may change during a program's execution (e.g. when a window
@@ -149,7 +149,7 @@ pub trait SizeHandle {
     fn outer_margins(&self) -> Margins;
 
     /// The height of a line of text
-    fn line_height(&self, class: TextClass) -> u32;
+    fn line_height(&self, class: TextClass) -> i32;
 
     /// Update a [`Text`] and get a size bound
     ///
@@ -200,7 +200,7 @@ pub trait SizeHandle {
     /// -   `min_len`: minimum length for the whole bar
     ///
     /// Required bound: `min_len >= size.0`.
-    fn scrollbar(&self) -> (Size, u32);
+    fn scrollbar(&self) -> (Size, i32);
 
     /// Dimensions for a slider
     ///
@@ -211,7 +211,7 @@ pub trait SizeHandle {
     /// -   `min_len`: minimum length for the whole bar
     ///
     /// Required bound: `min_len >= size.0`.
-    fn slider(&self) -> (Size, u32);
+    fn slider(&self) -> (Size, i32);
 
     /// Dimensions for a progress bar
     ///
@@ -468,7 +468,7 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
         self.deref().outer_margins()
     }
 
-    fn line_height(&self, class: TextClass) -> u32 {
+    fn line_height(&self, class: TextClass) -> i32 {
         self.deref().line_height(class)
     }
     fn text_bound(
@@ -496,10 +496,10 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
     fn radiobox(&self) -> Size {
         self.deref().radiobox()
     }
-    fn scrollbar(&self) -> (Size, u32) {
+    fn scrollbar(&self) -> (Size, i32) {
         self.deref().scrollbar()
     }
-    fn slider(&self) -> (Size, u32) {
+    fn slider(&self) -> (Size, i32) {
         self.deref().slider()
     }
     fn progress_bar(&self) -> Size {
@@ -529,7 +529,7 @@ where
         self.deref().outer_margins()
     }
 
-    fn line_height(&self, class: TextClass) -> u32 {
+    fn line_height(&self, class: TextClass) -> i32 {
         self.deref().line_height(class)
     }
     fn text_bound(
@@ -557,10 +557,10 @@ where
     fn radiobox(&self) -> Size {
         self.deref().radiobox()
     }
-    fn scrollbar(&self) -> (Size, u32) {
+    fn scrollbar(&self) -> (Size, i32) {
         self.deref().scrollbar()
     }
-    fn slider(&self) -> (Size, u32) {
+    fn slider(&self) -> (Size, i32) {
         self.deref().slider()
     }
     fn progress_bar(&self) -> Size {

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -251,11 +251,11 @@ pub trait DrawHandle {
     /// [`kas::widget::ScrollRegion`] to adjust its contents.
     /// ```
     /// # use kas::geom::*;
-    /// # let offset = Coord::ZERO;
-    /// # let rect = Rect::new(offset, Size::ZERO);
+    /// # let offset = Size::ZERO;
+    /// # let rect = Rect::new(Coord::ZERO, offset);
     /// let rect = rect + offset;
     /// ```
-    fn draw_device(&mut self) -> (Pass, Coord, &mut dyn Draw);
+    fn draw_device(&mut self) -> (Pass, Size, &mut dyn Draw);
 
     /// Construct a new draw-handle on a given region and pass to a callback.
     ///
@@ -267,7 +267,7 @@ pub trait DrawHandle {
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Coord,
+        offset: Size,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     );
@@ -302,7 +302,7 @@ pub trait DrawHandle {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
     );
@@ -312,7 +312,7 @@ pub trait DrawHandle {
     /// [`DrawHandle::text_offset`] already supports *font* effects: bold,
     /// emphasis, text size. In addition, this method supports underline and
     /// strikethrough effects.
-    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass);
+    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass);
 
     /// Draw an `AccelString` text
     ///
@@ -327,7 +327,7 @@ pub trait DrawHandle {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -338,7 +338,7 @@ pub trait DrawHandle {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,
@@ -416,7 +416,7 @@ pub trait DrawHandleExt: DrawHandle {
     /// The dimensions required for this text may be queried with [`SizeHandle::text_bound`].
     fn text<T: FormattableText>(&mut self, pos: Coord, text: &Text<T>, class: TextClass) {
         let bounds = text.env().bounds.into();
-        self.text_offset(pos, bounds, Coord::ZERO, text.as_ref(), class);
+        self.text_offset(pos, bounds, Size::ZERO, text.as_ref(), class);
     }
 
     /// Draw some text using the standard font, with a subset selected
@@ -428,7 +428,7 @@ pub trait DrawHandleExt: DrawHandle {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: T,
         range: R,
         class: TextClass,
@@ -572,13 +572,13 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
         self.deref_mut().size_handle_dyn(f)
     }
-    fn draw_device(&mut self) -> (Pass, Coord, &mut dyn Draw) {
+    fn draw_device(&mut self) -> (Pass, Size, &mut dyn Draw) {
         self.deref_mut().draw_device()
     }
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Coord,
+        offset: Size,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     ) {
@@ -600,14 +600,14 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
     ) {
         self.deref_mut()
             .text_offset(pos, bounds, offset, text, class)
     }
-    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass) {
+    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass) {
         self.deref_mut().text_effects(pos, offset, text, class);
     }
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
@@ -617,7 +617,7 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -629,7 +629,7 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,
@@ -671,13 +671,13 @@ where
     fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
         self.deref_mut().size_handle_dyn(f)
     }
-    fn draw_device(&mut self) -> (Pass, Coord, &mut dyn Draw) {
+    fn draw_device(&mut self) -> (Pass, Size, &mut dyn Draw) {
         self.deref_mut().draw_device()
     }
     fn clip_region(
         &mut self,
         rect: Rect,
-        offset: Coord,
+        offset: Size,
         class: ClipRegion,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     ) {
@@ -699,14 +699,14 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
     ) {
         self.deref_mut()
             .text_offset(pos, bounds, offset, text, class)
     }
-    fn text_effects(&mut self, pos: Coord, offset: Coord, text: &dyn TextApi, class: TextClass) {
+    fn text_effects(&mut self, pos: Coord, offset: Size, text: &dyn TextApi, class: TextClass) {
         self.deref_mut().text_effects(pos, offset, text, class);
     }
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
@@ -716,7 +716,7 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
@@ -728,7 +728,7 @@ where
         &mut self,
         pos: Coord,
         bounds: Vec2,
-        offset: Coord,
+        offset: Size,
         text: &TextDisplay,
         class: TextClass,
         byte: usize,
@@ -772,9 +772,8 @@ mod test {
 
         let _size = draw_handle.size_handle(|h| h.frame());
 
-        let zero = Coord::ZERO;
         let bounds = Vec2(100.0, 30.0);
         let text = kas::text::Text::new_single("sample");
-        draw_handle.text_selected(zero, bounds, zero, &text, .., TextClass::Label)
+        draw_handle.text_selected(Coord::ZERO, bounds, Size::ZERO, &text, .., TextClass::Label)
     }
 }

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -115,7 +115,7 @@ pub trait SizeHandle {
     /// recommended to calculate sizes as follows:
     /// ```
     /// # let scale_factor = 1.5f32;
-    /// let size = (100.0 * scale_factor).round() as i32;
+    /// let size = i32::conv_ceil(100.0 * scale_factor);
     /// ```
     ///
     /// This value may change during a program's execution (e.g. when a window

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -114,6 +114,7 @@ pub trait SizeHandle {
     /// may have a factor of 2 or higher; this may be fractional. It is
     /// recommended to calculate sizes as follows:
     /// ```
+    /// use kas::conv::*;
     /// # let scale_factor = 1.5f32;
     /// let size = i32::conv_ceil(100.0 * scale_factor);
     /// ```

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -42,6 +42,7 @@ mod handle;
 
 use std::any::Any;
 
+use crate::conv::Conv;
 use crate::geom::{Quad, Rect, Vec2};
 use crate::text::{Effect, TextDisplay};
 
@@ -69,7 +70,7 @@ impl Pass {
     /// This value is returned as `usize` but is always safe to store `as u32`.
     #[inline]
     pub fn pass(self) -> usize {
-        self.0 as usize
+        usize::conv(self.0)
     }
 
     /// The depth value

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -9,7 +9,7 @@
 use super::{GrabMode, Manager, Response}; // for doc-links
 use super::{MouseButton, UpdateHandle, VirtualKeyCode};
 
-use crate::geom::{Coord, DVec2, Size};
+use crate::geom::{Coord, DVec2, Offset};
 use crate::{WidgetId, WindowId};
 
 /// Events addressed to a widget
@@ -118,7 +118,7 @@ pub enum Event {
         source: PressSource,
         cur_id: Option<WidgetId>,
         coord: Coord,
-        delta: Size,
+        delta: Offset,
     },
     /// End of a click/touch press
     ///
@@ -341,5 +341,5 @@ pub enum ScrollDelta {
     /// Scroll a given number of lines
     LineDelta(f32, f32),
     /// Scroll a given number of pixels
-    PixelDelta(Size),
+    PixelDelta(Offset),
 }

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -9,7 +9,7 @@
 use super::{GrabMode, Manager, Response}; // for doc-links
 use super::{MouseButton, UpdateHandle, VirtualKeyCode};
 
-use crate::geom::{Coord, DVec2};
+use crate::geom::{Coord, DVec2, Size};
 use crate::{WidgetId, WindowId};
 
 /// Events addressed to a widget
@@ -118,7 +118,7 @@ pub enum Event {
         source: PressSource,
         cur_id: Option<WidgetId>,
         coord: Coord,
-        delta: Coord,
+        delta: Size,
     },
     /// End of a click/touch press
     ///
@@ -341,5 +341,5 @@ pub enum ScrollDelta {
     /// Scroll a given number of lines
     LineDelta(f32, f32),
     /// Scroll a given number of pixels
-    PixelDelta(Coord),
+    PixelDelta(Size),
 }

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -145,8 +145,8 @@ impl ManagerState {
                 }
 
                 let index = grab.n;
-                if (index as usize) < MAX_PAN_GRABS {
-                    grab.coords[index as usize] = (coord, coord);
+                if usize::from(index) < MAX_PAN_GRABS {
+                    grab.coords[usize::from(index)] = (coord, coord);
                 }
                 grab.n = index + 1;
                 return (gi as u16, index);
@@ -173,26 +173,26 @@ impl ManagerState {
         self.pan_grab.remove(index);
         if let Some(grab) = &mut self.mouse_grab {
             let p0 = grab.pan_grab.0;
-            if p0 >= index as u16 && p0 != u16::MAX {
+            if usize::from(p0) >= index && p0 != u16::MAX {
                 grab.pan_grab.0 = p0 - 1;
             }
         }
         for grab in self.touch_grab.iter_mut() {
             let p0 = grab.1.pan_grab.0;
-            if p0 >= index as u16 && p0 != u16::MAX {
+            if usize::from(p0) >= index && p0 != u16::MAX {
                 grab.1.pan_grab.0 = p0 - 1;
             }
         }
     }
 
     fn remove_pan_grab(&mut self, g: (u16, u16)) {
-        if let Some(grab) = self.pan_grab.get_mut(g.0 as usize) {
+        if let Some(grab) = self.pan_grab.get_mut(usize::from(g.0)) {
             grab.n -= 1;
             if grab.n == 0 {
-                return self.remove_pan(g.0 as usize);
+                return self.remove_pan(g.0.into());
             }
             assert!(grab.source_is_touch);
-            for i in (g.1 as usize)..(grab.n as usize - 1) {
+            for i in (usize::from(g.1))..(usize::from(grab.n) - 1) {
                 grab.coords[i] = grab.coords[i + 1];
             }
         } else {
@@ -204,9 +204,9 @@ impl ManagerState {
             let grab = grab.1;
             if grab.pan_grab.0 == g.0 && grab.pan_grab.1 > g.1 {
                 grab.pan_grab.1 -= 1;
-                if (grab.pan_grab.1 as usize) == MAX_PAN_GRABS - 1 {
+                if usize::from(grab.pan_grab.1) == MAX_PAN_GRABS - 1 {
                     let v = grab.coord.into();
-                    self.pan_grab[g.0 as usize].coords[grab.pan_grab.1 as usize] = (v, v);
+                    self.pan_grab[usize::from(g.0)].coords[usize::from(grab.pan_grab.1)] = (v, v);
                 }
             }
         }

--- a/src/event/manager.rs
+++ b/src/event/manager.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 use std::u16;
 
 use super::*;
+use crate::conv::Conv;
 use crate::geom::Coord;
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
@@ -149,11 +150,11 @@ impl ManagerState {
                     grab.coords[usize::from(index)] = (coord, coord);
                 }
                 grab.n = index + 1;
-                return (gi as u16, index);
+                return (u16::conv(gi), index);
             }
         }
 
-        let gj = self.pan_grab.len() as u16;
+        let gj = u16::conv(self.pan_grab.len());
         let n = 1;
         let mut coords: [(Coord, Coord); MAX_PAN_GRABS] = Default::default();
         coords[0] = (coord, coord);

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use std::u16;
 
 use super::*;
+use crate::conv::Conv;
 use crate::draw::SizeHandle;
 use crate::geom::Coord;
 #[allow(unused)]
@@ -576,7 +577,7 @@ impl<'a> Manager<'a> {
                     for index in 0..widget.len() {
                         let w = widget.get(index).unwrap();
                         if w.is_ancestor_of(id) {
-                            self.state.nav_stack.push(index as u32);
+                            self.state.nav_stack.push(u32::conv(index));
                             widget_stack.push(widget);
                             widget = w;
                             continue 'l;
@@ -599,7 +600,7 @@ impl<'a> Manager<'a> {
         } else {
             // Reconstruct widget_stack:
             for index in self.state.nav_stack.iter().cloned() {
-                let new = widget.get(index as usize).unwrap();
+                let new = widget.get(usize::conv(index)).unwrap();
                 widget_stack.push(widget);
                 widget = new;
             }
@@ -623,7 +624,7 @@ impl<'a> Manager<'a> {
                         None => break $lt,
                         Some(w) => w,
                     };
-                    $nav_stack.push(index as u32);
+                    $nav_stack.push(u32::conv(index));
                     $widget_stack.push($widget);
                     $widget = new;
                     true
@@ -639,7 +640,7 @@ impl<'a> Manager<'a> {
                 let mut index;
                 match ($nav_stack.pop(), $widget_stack.pop()) {
                     (Some(i), Some(w)) => {
-                        index = i as usize;
+                        index = usize::conv(i);
                         $widget = w;
                     }
                     _ => break $lt,
@@ -672,7 +673,7 @@ impl<'a> Manager<'a> {
                         None => break $lt,
                         Some(w) => w,
                     };
-                    $nav_stack.push(index as u32);
+                    $nav_stack.push(u32::conv(index));
                     $widget_stack.push($widget);
                     $widget = new;
                 }

--- a/src/event/manager/mgr_shell.rs
+++ b/src/event/manager/mgr_shell.rs
@@ -12,7 +12,7 @@ use std::mem::swap;
 use std::time::{Duration, Instant};
 
 use super::*;
-use crate::geom::{Coord, DVec2, Size};
+use crate::geom::{Coord, DVec2, Offset};
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
 use crate::{ShellWindow, TkAction, Widget, WidgetId};
@@ -524,9 +524,9 @@ impl<'a> Manager<'a> {
                     MouseScrollDelta::LineDelta(x, y) => ScrollDelta::LineDelta(x, y),
                     MouseScrollDelta::PixelDelta(pos) => {
                         // The delta is given as a PhysicalPosition, so we need
-                        // to convert to our vector type (Size) here.
+                        // to convert to our vector type (Offset) here.
                         let coord = Coord::from(pos);
-                        ScrollDelta::PixelDelta(Size(coord.0, coord.1))
+                        ScrollDelta::PixelDelta(Offset(coord.0, coord.1))
                     }
                 });
                 if let Some(id) = self.state.hover {

--- a/src/event/manager/mgr_shell.rs
+++ b/src/event/manager/mgr_shell.rs
@@ -12,7 +12,7 @@ use std::mem::swap;
 use std::time::{Duration, Instant};
 
 use super::*;
-use crate::geom::{Coord, DVec2};
+use crate::geom::{Coord, DVec2, Size};
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
 use crate::{ShellWindow, TkAction, Widget, WidgetId};
@@ -522,7 +522,12 @@ impl<'a> Manager<'a> {
 
                 let event = Event::Scroll(match delta {
                     MouseScrollDelta::LineDelta(x, y) => ScrollDelta::LineDelta(x, y),
-                    MouseScrollDelta::PixelDelta(pos) => ScrollDelta::PixelDelta(pos.into()),
+                    MouseScrollDelta::PixelDelta(pos) => {
+                        // The delta is given as a PhysicalPosition, so we need
+                        // to convert to our vector type (Size) here.
+                        let coord = Coord::from(pos);
+                        ScrollDelta::PixelDelta(Size(coord.0, coord.1))
+                    }
                 });
                 if let Some(id) = self.state.hover {
                     self.send_event(widget, id, event);

--- a/src/event/manager/mgr_shell.rs
+++ b/src/event/manager/mgr_shell.rs
@@ -486,9 +486,10 @@ impl<'a> Manager<'a> {
                             delta,
                         };
                         self.send_event(widget, grab.start_id, event);
-                    } else if let Some(pan) = self.state.pan_grab.get_mut(grab.pan_grab.0 as usize)
+                    } else if let Some(pan) =
+                        self.state.pan_grab.get_mut(usize::conv(grab.pan_grab.0))
                     {
-                        pan.coords[grab.pan_grab.1 as usize].1 = coord;
+                        pan.coords[usize::conv(grab.pan_grab.1)].1 = coord;
                     }
                 } else if let Some(id) = self.state.popups.last().map(|(_, p)| p.parent) {
                     let source = PressSource::Mouse(FAKE_MOUSE_BUTTON, 0);
@@ -624,10 +625,11 @@ impl<'a> Manager<'a> {
                             }
                             self.send_event(widget, id, event);
                         } else if let Some(pan_grab) = pan_grab {
-                            if (pan_grab.1 as usize) < MAX_PAN_GRABS {
-                                if let Some(pan) = self.state.pan_grab.get_mut(pan_grab.0 as usize)
+                            if usize::conv(pan_grab.1) < MAX_PAN_GRABS {
+                                if let Some(pan) =
+                                    self.state.pan_grab.get_mut(usize::conv(pan_grab.0))
                                 {
-                                    pan.coords[pan_grab.1 as usize].1 = coord;
+                                    pan.coords[usize::conv(pan_grab.1)].1 = coord;
                                 }
                             }
                         }

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -19,9 +19,9 @@ impl Coord {
     /// A coord of `(0, 0)`
     pub const ZERO: Coord = Coord(0, 0);
 
-    /// A `Coord` with uniform value `n` on both axes
+    /// A `Coord` with value `n` on both axes
     #[inline]
-    pub fn uniform(n: i32) -> Self {
+    pub fn splat(n: i32) -> Self {
         Coord(n, n)
     }
 
@@ -167,9 +167,9 @@ impl Size {
     /// A size of `(0, 0)`
     pub const ZERO: Size = Size(0, 0);
 
-    /// Uniform size in each dimension
+    /// Uniform size on each axis (square)
     #[inline]
-    pub fn uniform(v: i32) -> Self {
+    pub fn splat(v: i32) -> Self {
         Size(v, v)
     }
 
@@ -337,7 +337,7 @@ impl Rect {
     /// Shrink self in all directions by the given `n`
     #[inline]
     pub fn shrink(&self, n: i32) -> Rect {
-        let pos = self.pos + Coord::uniform(n);
+        let pos = self.pos + Coord::splat(n);
         let w = self.size.0.saturating_sub(n + n);
         let h = self.size.1.saturating_sub(n + n);
         let size = Size(w, h);

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -225,9 +225,9 @@ impl Size {
         Self(n, n)
     }
 
-    /// Saturating subtraction
+    /// Subtraction, clamping the result to 0 or greater
     #[inline]
-    pub fn saturating_sub(self, rhs: Self) -> Self {
+    pub fn clamped_sub(self, rhs: Self) -> Self {
         // This impl should aid vectorisation. We avoid Sub impl because of its check.
         Size(self.0 - rhs.0, self.1 - rhs.1).max(Size::ZERO)
     }
@@ -501,7 +501,7 @@ impl Rect {
     #[inline]
     pub fn shrink(&self, n: i32) -> Rect {
         let pos = self.pos + Offset::splat(n);
-        let size = self.size.saturating_sub(Size::splat(n + n));
+        let size = self.size.clamped_sub(Size::splat(n + n));
         Rect { pos, size }
     }
 }

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -171,7 +171,7 @@ impl std::ops::SubAssign<Size> for Coord {
 
 impl From<Coord> for kas_text::Vec2 {
     fn from(pos: Coord) -> kas_text::Vec2 {
-        kas_text::Vec2(pos.0 as f32, pos.1 as f32)
+        Vec2::from(pos).into()
     }
 }
 
@@ -298,7 +298,8 @@ impl std::ops::Mul<f32> for Size {
     #[inline]
     fn mul(self, x: f32) -> Self {
         debug_assert!(x >= 0.0);
-        Size((self.0 as f32 * x) as i32, (self.1 as f32 * x) as i32)
+        let v = Vec2::from(self) * x;
+        v.into()
     }
 }
 impl std::ops::Div<f32> for Size {
@@ -307,7 +308,8 @@ impl std::ops::Div<f32> for Size {
     #[inline]
     fn div(self, x: f32) -> Self {
         debug_assert!(x >= 0.0);
-        Size((self.0 as f32 / x) as i32, (self.1 as f32 / x) as i32)
+        let v = Vec2::from(self) / x;
+        v.into()
     }
 }
 
@@ -328,7 +330,7 @@ impl From<(u16, u16)> for Size {
 impl From<Size> for kas_text::Vec2 {
     fn from(size: Size) -> kas_text::Vec2 {
         debug_assert!(size.0 >= 0 && size.1 >= 0);
-        kas_text::Vec2(size.0 as f32, size.1 as f32)
+        Vec2::from(size).into()
     }
 }
 
@@ -441,7 +443,8 @@ impl std::ops::Mul<f32> for Offset {
 
     #[inline]
     fn mul(self, x: f32) -> Self {
-        Offset((self.0 as f32 * x) as i32, (self.1 as f32 * x) as i32)
+        let v = Vec2::from(self) * x;
+        v.into()
     }
 }
 impl std::ops::Div<f32> for Offset {
@@ -449,7 +452,8 @@ impl std::ops::Div<f32> for Offset {
 
     #[inline]
     fn div(self, x: f32) -> Self {
-        Offset((self.0 as f32 / x) as i32, (self.1 as f32 / x) as i32)
+        let v = Vec2::from(self) / x;
+        v.into()
     }
 }
 
@@ -461,7 +465,7 @@ impl From<Size> for Offset {
 
 impl From<Offset> for kas_text::Vec2 {
     fn from(size: Offset) -> kas_text::Vec2 {
-        kas_text::Vec2(size.0 as f32, size.1 as f32)
+        Vec2::from(size).into()
     }
 }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -305,7 +305,10 @@ impl std::ops::SubAssign for Size {
     }
 }
 
-/// A rectangular region.
+/// An axis-aligned rectangular region
+///
+/// The region is defined by a point `pos` and an extent `size`, allowing easy
+/// translations. It is empty unless `size` is positive on both axes.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub struct Rect {
     pub pos: Coord,
@@ -319,9 +322,9 @@ impl Rect {
         Rect { pos, size }
     }
 
-    /// Get pos + size
+    /// Get second point (pos + size)
     #[inline]
-    pub fn pos_end(&self) -> Coord {
+    pub fn pos2(&self) -> Coord {
         self.pos + self.size
     }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -70,7 +70,7 @@ impl From<(i32, i32)> for Coord {
 impl From<Size> for Coord {
     #[inline]
     fn from(size: Size) -> Coord {
-        Coord(size.0 as i32, size.1 as i32)
+        Coord(size.0, size.1)
     }
 }
 
@@ -97,7 +97,7 @@ impl std::ops::Add<Size> for Coord {
 
     #[inline]
     fn add(self, other: Size) -> Self {
-        Coord(self.0 + other.0 as i32, self.1 + other.1 as i32)
+        Coord(self.0 + other.0, self.1 + other.1)
     }
 }
 
@@ -106,7 +106,7 @@ impl std::ops::Sub<Size> for Coord {
 
     #[inline]
     fn sub(self, other: Size) -> Self {
-        Coord(self.0 - other.0 as i32, self.1 - other.1 as i32)
+        Coord(self.0 - other.0, self.1 - other.1)
     }
 }
 
@@ -154,14 +154,14 @@ impl std::ops::AddAssign<Coord> for Coord {
 impl std::ops::AddAssign<Size> for Coord {
     #[inline]
     fn add_assign(&mut self, rhs: Size) {
-        self.0 += rhs.0 as i32;
-        self.1 += rhs.1 as i32;
+        self.0 += rhs.0;
+        self.1 += rhs.1;
     }
 }
 
 /// A `(w, h)` size.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
-pub struct Size(pub u32, pub u32);
+pub struct Size(pub i32, pub i32);
 
 impl Size {
     /// A size of `(0, 0)`
@@ -169,7 +169,7 @@ impl Size {
 
     /// Uniform size in each dimension
     #[inline]
-    pub const fn uniform(v: u32) -> Self {
+    pub fn uniform(v: i32) -> Self {
         Size(v, v)
     }
 
@@ -200,15 +200,15 @@ impl Size {
     }
 }
 
-impl From<(u32, u32)> for Size {
-    fn from(size: (u32, u32)) -> Size {
+impl From<(i32, i32)> for Size {
+    fn from(size: (i32, i32)) -> Size {
         Size(size.0, size.1)
     }
 }
 
 impl From<Coord> for Size {
     fn from(coord: Coord) -> Size {
-        Size(coord.0 as u32, coord.1 as u32)
+        Size(coord.0, coord.1)
     }
 }
 
@@ -216,7 +216,7 @@ impl From<Coord> for Size {
 impl<X: Pixel> From<PhysicalSize<X>> for Size {
     #[inline]
     fn from(size: PhysicalSize<X>) -> Size {
-        let size: (u32, u32) = size.cast::<u32>().into();
+        let size: (i32, i32) = size.cast::<i32>().into();
         Size(size.0, size.1)
     }
 }
@@ -225,7 +225,7 @@ impl<X: Pixel> From<PhysicalSize<X>> for Size {
 impl<X: Pixel> From<Size> for PhysicalSize<X> {
     #[inline]
     fn from(size: Size) -> PhysicalSize<X> {
-        let pos: PhysicalSize<u32> = (size.0, size.1).into();
+        let pos: PhysicalSize<i32> = (size.0, size.1).into();
         pos.cast()
     }
 }
@@ -262,11 +262,11 @@ impl std::ops::Sub for Size {
     }
 }
 
-impl std::ops::Mul<u32> for Size {
+impl std::ops::Mul<i32> for Size {
     type Output = Self;
 
     #[inline]
-    fn mul(self, x: u32) -> Self {
+    fn mul(self, x: i32) -> Self {
         Size(self.0 * x, self.1 * x)
     }
 }
@@ -276,15 +276,15 @@ impl std::ops::Mul<f32> for Size {
 
     #[inline]
     fn mul(self, x: f32) -> Self {
-        Size((self.0 as f32 * x) as u32, (self.1 as f32 * x) as u32)
+        Size((self.0 as f32 * x) as i32, (self.1 as f32 * x) as i32)
     }
 }
 
-impl std::ops::Div<u32> for Size {
+impl std::ops::Div<i32> for Size {
     type Output = Self;
 
     #[inline]
-    fn div(self, x: u32) -> Self {
+    fn div(self, x: i32) -> Self {
         Size(self.0 / x, self.1 / x)
     }
 }
@@ -329,15 +329,15 @@ impl Rect {
     #[inline]
     pub fn contains(&self, c: Coord) -> bool {
         c.0 >= self.pos.0
-            && c.0 < self.pos.0 + (self.size.0 as i32)
+            && c.0 < self.pos.0 + (self.size.0)
             && c.1 >= self.pos.1
-            && c.1 < self.pos.1 + (self.size.1 as i32)
+            && c.1 < self.pos.1 + (self.size.1)
     }
 
     /// Shrink self in all directions by the given `n`
     #[inline]
-    pub fn shrink(&self, n: u32) -> Rect {
-        let pos = self.pos + Coord::uniform(n as i32);
+    pub fn shrink(&self, n: i32) -> Rect {
+        let pos = self.pos + Coord::uniform(n);
         let w = self.size.0.saturating_sub(n + n);
         let h = self.size.1.saturating_sub(n + n);
         let size = Size(w, h);

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -6,6 +6,7 @@
 //! Geometry data types
 
 use kas::conv::Conv;
+use kas::{Direction, Directional};
 #[cfg(feature = "winit")]
 use winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize, Pixel};
 
@@ -40,6 +41,21 @@ macro_rules! impl_common {
             #[inline]
             pub fn transpose(self) -> Self {
                 Self(self.1, self.0)
+            }
+
+            /// Extract one component, based on a direction
+            ///
+            /// Panics if direction is reversed. We should decide whether to
+            /// negate in this case (maybe for coord and offset but not for size).
+            #[inline]
+            pub fn extract<D: Directional>(self, dir: D) -> i32 {
+                match dir.as_direction() {
+                    Direction::Right => self.0,
+                    Direction::Down => self.1,
+                    Direction::Left | Direction::Up => {
+                        panic!("extract not defined for left/up directions!")
+                    }
+                }
             }
         }
 

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -346,7 +346,7 @@ macro_rules! impl_vec2 {
         impl From<$T> for Size {
             #[inline]
             fn from(arg: $T) -> Self {
-                Size(arg.0.round() as u32, arg.1.round() as u32)
+                Size(arg.0.round() as i32, arg.1.round() as i32)
             }
         }
 

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -7,6 +7,7 @@
 //!
 //! For drawing operations, all dimensions use the `f32` type.
 
+use kas::conv::{Conv, ConvFloat};
 use kas::geom::{Coord, Offset, Rect, Size};
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
@@ -325,28 +326,28 @@ macro_rules! impl_vec2 {
         impl From<Coord> for $T {
             #[inline]
             fn from(arg: Coord) -> Self {
-                $T(arg.0 as $f, arg.1 as $f)
+                $T(<$f>::conv(arg.0), <$f>::conv(arg.1))
             }
         }
 
         impl From<Size> for $T {
             #[inline]
             fn from(arg: Size) -> Self {
-                $T(arg.0 as $f, arg.1 as $f)
+                $T(<$f>::conv(arg.0), <$f>::conv(arg.1))
             }
         }
 
         impl From<Offset> for $T {
             #[inline]
             fn from(arg: Offset) -> Self {
-                $T(arg.0 as $f, arg.1 as $f)
+                $T(<$f>::conv(arg.0), <$f>::conv(arg.1))
             }
         }
 
         impl From<$T> for Coord {
             #[inline]
             fn from(arg: $T) -> Self {
-                Coord(arg.0.round() as i32, arg.1.round() as i32)
+                Coord(i32::conv_nearest(arg.0), i32::conv_nearest(arg.1))
             }
         }
 
@@ -360,7 +361,7 @@ macro_rules! impl_vec2 {
         impl From<$T> for Offset {
             #[inline]
             fn from(arg: $T) -> Self {
-                Offset(arg.0.round() as i32, arg.1.round() as i32)
+                Offset(i32::conv_nearest(arg.0), i32::conv_nearest(arg.1))
             }
         }
 

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -353,16 +353,16 @@ macro_rules! impl_vec2 {
         impl From<kas_text::Vec2> for $T {
             #[inline]
             fn from(size: kas_text::Vec2) -> Self {
-                $T(size.0 as $f, size.1 as $f)
-            }
-        }
-
-        impl From<$T> for kas_text::Vec2 {
-            fn from(size: $T) -> kas_text::Vec2 {
-                kas_text::Vec2(size.0 as f32, size.1 as f32)
+                $T(size.0.into(), size.1.into())
             }
         }
     };
+}
+
+impl From<Vec2> for kas_text::Vec2 {
+    fn from(size: Vec2) -> kas_text::Vec2 {
+        kas_text::Vec2(size.0, size.1)
+    }
 }
 
 impl_vec2!(Vec2, f32);

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -7,7 +7,7 @@
 //!
 //! For drawing operations, all dimensions use the `f32` type.
 
-use kas::geom::{Coord, Rect, Size};
+use kas::geom::{Coord, Offset, Rect, Size};
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
 /// Axis-aligned 2D cuboid, specified via two corners `a` and `b`
@@ -336,6 +336,13 @@ macro_rules! impl_vec2 {
             }
         }
 
+        impl From<Offset> for $T {
+            #[inline]
+            fn from(arg: Offset) -> Self {
+                $T(arg.0 as $f, arg.1 as $f)
+            }
+        }
+
         impl From<$T> for Coord {
             #[inline]
             fn from(arg: $T) -> Self {
@@ -346,7 +353,14 @@ macro_rules! impl_vec2 {
         impl From<$T> for Size {
             #[inline]
             fn from(arg: $T) -> Self {
-                Size(arg.0.round() as i32, arg.1.round() as i32)
+                Offset::from(arg).into()
+            }
+        }
+
+        impl From<$T> for Offset {
+            #[inline]
+            fn from(arg: $T) -> Self {
+                Offset(arg.0.round() as i32, arg.1.round() as i32)
             }
         }
 

--- a/src/layout/grid_solver.rs
+++ b/src/layout/grid_solver.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 
 use super::{AxisInfo, GridStorage, RowTemp, RulesSetter, RulesSolver, SizeRules};
 use crate::conv::Conv;
-use crate::geom::{Coord, Rect, Size};
+use crate::geom::{Coord, Offset, Rect, Size};
 use kas::{Align, AlignHints};
 
 /// Per-child information
@@ -318,7 +318,7 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> RulesSetter for GridSetter<RT, CT
     fn child_rect(&mut self, storage: &mut Self::Storage, info: Self::ChildInfo) -> Rect {
         let x = self.w_offsets.as_mut()[usize::conv(info.col)];
         let y = self.h_offsets.as_mut()[usize::conv(info.row)];
-        let pos = self.pos + Size(x, y);
+        let pos = self.pos + Offset(x, y);
 
         let i1 = usize::conv(info.col_end) - 1;
         let w = storage.widths()[i1] + self.w_offsets.as_mut()[i1]

--- a/src/layout/grid_solver.rs
+++ b/src/layout/grid_solver.rs
@@ -318,7 +318,7 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> RulesSetter for GridSetter<RT, CT
     fn child_rect(&mut self, storage: &mut Self::Storage, info: Self::ChildInfo) -> Rect {
         let x = self.w_offsets.as_mut()[usize::conv(info.col)];
         let y = self.h_offsets.as_mut()[usize::conv(info.row)];
-        let pos = self.pos + Coord(x, y);
+        let pos = self.pos + Size(x, y);
 
         let i1 = usize::conv(info.col_end) - 1;
         let w = storage.widths()[i1] + self.w_offsets.as_mut()[i1]

--- a/src/layout/grid_solver.rs
+++ b/src/layout/grid_solver.rs
@@ -271,10 +271,9 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> GridSetter<RT, CT, S> {
             SizeRules::solve_seq_total(widths, rules, rect.size.0);
             for i in 1..w_offsets.as_mut().len() {
                 let i1 = i - 1;
-                let m1 = storage.width_rules()[i1].margins().1;
-                let m0 = storage.width_rules()[i].margins().0;
-                w_offsets.as_mut()[i] =
-                    w_offsets.as_mut()[i1] + storage.widths()[i1] + m1.max(m0) as u32;
+                let m1 = storage.width_rules()[i1].margins_u32().1;
+                let m0 = storage.width_rules()[i].margins_u32().0;
+                w_offsets.as_mut()[i] = w_offsets.as_mut()[i1] + storage.widths()[i1] + m1.max(m0);
             }
         }
 
@@ -296,10 +295,9 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> GridSetter<RT, CT, S> {
             SizeRules::solve_seq_total(heights, rules, rect.size.1);
             for i in 1..h_offsets.as_mut().len() {
                 let i1 = i - 1;
-                let m1 = storage.height_rules()[i1].margins().1;
-                let m0 = storage.height_rules()[i].margins().0;
-                h_offsets.as_mut()[i] =
-                    h_offsets.as_mut()[i1] + storage.heights()[i1] + m1.max(m0) as u32;
+                let m1 = storage.height_rules()[i1].margins_u32().1;
+                let m0 = storage.height_rules()[i].margins_u32().0;
+                h_offsets.as_mut()[i] = h_offsets.as_mut()[i1] + storage.heights()[i1] + m1.max(m0);
             }
         }
 

--- a/src/layout/grid_solver.rs
+++ b/src/layout/grid_solver.rs
@@ -272,8 +272,8 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> GridSetter<RT, CT, S> {
             SizeRules::solve_seq_total(widths, rules, rect.size.0);
             for i in 1..w_offsets.as_mut().len() {
                 let i1 = i - 1;
-                let m1 = storage.width_rules()[i1].margins_u32().1;
-                let m0 = storage.width_rules()[i].margins_u32().0;
+                let m1 = storage.width_rules()[i1].margins_i32().1;
+                let m0 = storage.width_rules()[i].margins_i32().0;
                 w_offsets.as_mut()[i] = w_offsets.as_mut()[i1] + storage.widths()[i1] + m1.max(m0);
             }
         }
@@ -296,8 +296,8 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> GridSetter<RT, CT, S> {
             SizeRules::solve_seq_total(heights, rules, rect.size.1);
             for i in 1..h_offsets.as_mut().len() {
                 let i1 = i - 1;
-                let m1 = storage.height_rules()[i1].margins_u32().1;
-                let m0 = storage.height_rules()[i].margins_u32().0;
+                let m1 = storage.height_rules()[i1].margins_i32().1;
+                let m0 = storage.height_rules()[i].margins_i32().0;
                 h_offsets.as_mut()[i] = h_offsets.as_mut()[i1] + storage.heights()[i1] + m1.max(m0);
             }
         }
@@ -316,8 +316,8 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> RulesSetter for GridSetter<RT, CT
     type ChildInfo = GridChildInfo;
 
     fn child_rect(&mut self, storage: &mut Self::Storage, info: Self::ChildInfo) -> Rect {
-        let x = self.w_offsets.as_mut()[usize::conv(info.col)] as i32;
-        let y = self.h_offsets.as_mut()[usize::conv(info.row)] as i32;
+        let x = self.w_offsets.as_mut()[usize::conv(info.col)];
+        let y = self.h_offsets.as_mut()[usize::conv(info.row)];
         let pos = self.pos + Coord(x, y);
 
         let i1 = usize::conv(info.col_end) - 1;

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -40,7 +40,7 @@ mod size_rules;
 mod sizer;
 mod storage;
 
-use crate::geom::Size;
+use kas::{Direction, Directional};
 
 pub use grid_solver::{GridChildInfo, GridSetter, GridSolver};
 pub use row_solver::{RowPositionSolver, RowSetter, RowSolver};
@@ -106,14 +106,16 @@ impl AxisInfo {
             None
         }
     }
+}
 
-    /// Extract horizontal or vertical component of a [`Size`]
+impl Directional for AxisInfo {
+    type Flipped = Self;
+
     #[inline]
-    pub fn extract_size(&self, size: Size) -> i32 {
-        if !self.vertical {
-            size.0
-        } else {
-            size.1
+    fn as_direction(self) -> Direction {
+        match self.vertical {
+            false => Direction::Right,
+            true => Direction::Down,
         }
     }
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -59,7 +59,7 @@ pub use storage::{
 pub struct AxisInfo {
     vertical: bool,
     has_fixed: bool,
-    other_axis: u32,
+    other_axis: i32,
 }
 
 impl AxisInfo {
@@ -67,7 +67,7 @@ impl AxisInfo {
     ///
     /// This method is *usually* not required by user code.
     #[inline]
-    pub fn new(vertical: bool, fixed: Option<u32>) -> Self {
+    pub fn new(vertical: bool, fixed: Option<i32>) -> Self {
         AxisInfo {
             vertical,
             has_fixed: fixed.is_some(),
@@ -89,7 +89,7 @@ impl AxisInfo {
 
     /// Size of other axis, if fixed
     #[inline]
-    pub fn other(&self) -> Option<u32> {
+    pub fn other(&self) -> Option<i32> {
         if self.has_fixed {
             Some(self.other_axis)
         } else {
@@ -99,7 +99,7 @@ impl AxisInfo {
 
     /// Size of other axis, if fixed and `vertical` matches this axis.
     #[inline]
-    pub fn size_other_if_fixed(&self, vertical: bool) -> Option<u32> {
+    pub fn size_other_if_fixed(&self, vertical: bool) -> Option<i32> {
         if vertical == self.vertical && self.has_fixed {
             Some(self.other_axis)
         } else {
@@ -109,7 +109,7 @@ impl AxisInfo {
 
     /// Extract horizontal or vertical component of a [`Size`]
     #[inline]
-    pub fn extract_size(&self, size: Size) -> u32 {
+    pub fn extract_size(&self, size: Size) -> i32 {
         if !self.vertical {
             size.0
         } else {

--- a/src/layout/row_solver.rs
+++ b/src/layout/row_solver.rs
@@ -206,17 +206,17 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
             offsets[len - 1] = pos as u32;
             for i in (0..(len - 1)).rev() {
                 let i1 = i + 1;
-                let m1 = storage.rules()[i1].margins().1;
-                let m0 = storage.rules()[i].margins().0;
-                offsets[i] = offsets[i1] + storage.widths()[i1] + m1.max(m0) as u32;
+                let m1 = storage.rules()[i1].margins_u32().1;
+                let m0 = storage.rules()[i].margins_u32().0;
+                offsets[i] = offsets[i1] + storage.widths()[i1] + m1.max(m0);
             }
         } else {
             offsets[0] = pos as u32;
             for i in 1..len {
                 let i1 = i - 1;
-                let m1 = storage.rules()[i1].margins().1;
-                let m0 = storage.rules()[i].margins().0;
-                offsets[i] = offsets[i1] + storage.widths()[i1] + m1.max(m0) as u32;
+                let m1 = storage.rules()[i1].margins_u32().1;
+                let m0 = storage.rules()[i].margins_u32().0;
+                offsets[i] = offsets[i1] + storage.widths()[i1] + m1.max(m0);
             }
         }
     }
@@ -251,8 +251,9 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RulesSetter for RowSetter<D, T, 
         let len = storage.widths().len();
         let post_rules = SizeRules::min_sum(&storage.rules()[(index + 1)..len]);
 
-        let size1 = pre_rules.min_size() as i32 + pre_rules.margins().1.max(m.0) as i32;
-        let size2 = size1 as u32 + post_rules.min_size() + post_rules.margins().0.max(m.1) as u32;
+        let size1 = pre_rules.min_size() as i32 + i32::from(pre_rules.margins().1.max(m.0));
+        let size2 =
+            size1 as u32 + post_rules.min_size() + u32::from(post_rules.margins().0.max(m.1));
 
         let mut rect = self.rect;
         if self.direction.is_horizontal() {

--- a/src/layout/row_solver.rs
+++ b/src/layout/row_solver.rs
@@ -146,7 +146,7 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
                     Align::Default | Align::TL | Align::Stretch => 0,
                     Align::Centre => extra / 2,
                     Align::BR => extra,
-                } as i32;
+                };
                 if is_horiz {
                     rect.pos.0 += offset;
                 } else {
@@ -203,25 +203,25 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
         };
 
         if self.direction.is_reversed() {
-            offsets[len - 1] = pos as u32;
+            offsets[len - 1] = pos;
             for i in (0..(len - 1)).rev() {
                 let i1 = i + 1;
-                let m1 = storage.rules()[i1].margins_u32().1;
-                let m0 = storage.rules()[i].margins_u32().0;
+                let m1 = storage.rules()[i1].margins_i32().1;
+                let m0 = storage.rules()[i].margins_i32().0;
                 offsets[i] = offsets[i1] + storage.widths()[i1] + m1.max(m0);
             }
         } else {
-            offsets[0] = pos as u32;
+            offsets[0] = pos;
             for i in 1..len {
                 let i1 = i - 1;
-                let m1 = storage.rules()[i1].margins_u32().1;
-                let m0 = storage.rules()[i].margins_u32().0;
+                let m1 = storage.rules()[i1].margins_i32().1;
+                let m0 = storage.rules()[i].margins_i32().0;
                 offsets[i] = offsets[i1] + storage.widths()[i1] + m1.max(m0);
             }
         }
     }
 
-    pub fn solve_range(&mut self, storage: &mut S, range: Range<usize>, width: u32) {
+    pub fn solve_range(&mut self, storage: &mut S, range: Range<usize>, width: i32) {
         assert!(range.end <= self.offsets.as_mut().len());
 
         let (rules, widths) = storage.rules_and_widths();
@@ -236,10 +236,10 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RulesSetter for RowSetter<D, T, 
     fn child_rect(&mut self, storage: &mut Self::Storage, index: Self::ChildInfo) -> Rect {
         let mut rect = self.rect;
         if self.direction.is_horizontal() {
-            rect.pos.0 = self.offsets.as_mut()[index] as i32;
+            rect.pos.0 = self.offsets.as_mut()[index];
             rect.size.0 = storage.widths()[index];
         } else {
-            rect.pos.1 = self.offsets.as_mut()[index] as i32;
+            rect.pos.1 = self.offsets.as_mut()[index];
             rect.size.1 = storage.widths()[index];
         }
         rect
@@ -251,9 +251,8 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RulesSetter for RowSetter<D, T, 
         let len = storage.widths().len();
         let post_rules = SizeRules::min_sum(&storage.rules()[(index + 1)..len]);
 
-        let size1 = pre_rules.min_size() as i32 + i32::from(pre_rules.margins().1.max(m.0));
-        let size2 =
-            size1 as u32 + post_rules.min_size() + u32::from(post_rules.margins().0.max(m.1));
+        let size1 = pre_rules.min_size() + i32::from(pre_rules.margins().1.max(m.0));
+        let size2 = size1 + post_rules.min_size() + i32::from(post_rules.margins().0.max(m.1));
 
         let mut rect = self.rect;
         if self.direction.is_horizontal() {

--- a/src/layout/row_solver.rs
+++ b/src/layout/row_solver.rs
@@ -319,8 +319,8 @@ impl<D: Directional> RowPositionSolver<D> {
     /// Call `f` on each child intersecting the given `rect`
     pub fn for_children<W: Widget, F: FnMut(&W)>(self, widgets: &[W], rect: Rect, mut f: F) {
         let (pos, end) = match self.direction.is_reversed() {
-            false => (rect.pos, rect.pos + rect.size),
-            true => (rect.pos + rect.size, rect.pos),
+            false => (rect.pos, rect.pos2()),
+            true => (rect.pos2(), rect.pos),
         };
         let start = match self.binary_search(widgets, pos) {
             Ok(i) => i,

--- a/src/layout/row_solver.rs
+++ b/src/layout/row_solver.rs
@@ -257,10 +257,10 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RulesSetter for RowSetter<D, T, 
         let mut rect = self.rect;
         if self.direction.is_horizontal() {
             rect.pos.0 = self.rect.pos.0 + size1;
-            rect.size.0 = self.rect.size.0.saturating_sub(size2);
+            rect.size.0 = (self.rect.size.0 - size2).max(0);
         } else {
             rect.pos.1 = self.rect.pos.1 + size1;
-            rect.size.1 = self.rect.size.1.saturating_sub(size2);
+            rect.size.1 = (self.rect.size.1 - size2).max(0);
         }
         rect
     }

--- a/src/layout/row_solver.rs
+++ b/src/layout/row_solver.rs
@@ -340,8 +340,8 @@ impl<D: Directional> RowPositionSolver<D> {
             let do_break = match self.direction.as_direction() {
                 Direction::Right => child.rect().pos.0 >= end.0,
                 Direction::Down => child.rect().pos.1 >= end.1,
-                Direction::Left => child.rect().pos_end().0 < end.0,
-                Direction::Up => child.rect().pos_end().1 < end.1,
+                Direction::Left => child.rect().pos2().0 < end.0,
+                Direction::Up => child.rect().pos2().1 < end.1,
             };
             if do_break {
                 break;

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -30,12 +30,12 @@ pub struct Margins {
 
 impl Margins {
     /// Zero-sized margins
-    pub const ZERO: Margins = Margins::uniform(0);
+    pub const ZERO: Margins = Margins::splat(0);
 
     /// Margins with equal size on each edge.
     #[inline]
-    pub const fn uniform(size: u16) -> Self {
-        Margins::hv_uniform(size, size)
+    pub const fn splat(size: u16) -> Self {
+        Margins::hv_splat(size, size)
     }
 
     /// Margins via horizontal and vertical sizes
@@ -46,7 +46,7 @@ impl Margins {
 
     /// Margins via horizontal and vertical sizes
     #[inline]
-    pub const fn hv_uniform(h: u16, v: u16) -> Self {
+    pub const fn hv_splat(h: u16, v: u16) -> Self {
         Margins {
             horiz: (h, h),
             vert: (v, v),

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -9,6 +9,7 @@ use smallvec::SmallVec;
 use std::fmt;
 use std::iter::Sum;
 
+use crate::conv::Conv;
 use crate::geom::Size;
 
 // for doc use
@@ -484,11 +485,11 @@ impl SizeRules {
                     let mut any_removed = true;
                     while any_removed {
                         any_removed = false;
-                        let count = targets.len() as u32;
+                        let count = u32::conv(targets.len());
                         let ceil = (avail + count - 1) / count; // round up
                         let mut t = 0;
                         while t < targets.len() {
-                            let i = targets[t] as usize;
+                            let i = usize::conv(targets[t]);
                             if out[i] >= base(i) + ceil {
                                 avail -= out[i] - base(i);
                                 targets.remove(t);
@@ -505,16 +506,16 @@ impl SizeRules {
                     // Since no more are removed by a ceiling, all remaining
                     // targets will be (approx) equal. Arbitrarily distribute
                     // rounding errors to the first ones.
-                    let count = targets.len() as u32;
+                    let count = u32::conv(targets.len());
                     let per_elt = avail / count;
-                    let extra = (avail - per_elt * count) as usize;
+                    let extra = usize::conv(avail - per_elt * count);
                     assert!(extra < targets.len());
                     for t in 0..extra {
-                        let i = targets[t] as usize;
+                        let i = usize::conv(targets[t]);
                         out[i] = base(i) + per_elt + 1;
                     }
                     for t in extra..targets.len() {
-                        let i = targets[t] as usize;
+                        let i = usize::conv(targets[t]);
                         out[i] = base(i) + per_elt;
                     }
                 }
@@ -532,7 +533,7 @@ impl SizeRules {
                         sum += out[i];
                         if rules[i].stretch == highest_stretch {
                             over += out[i] - rules[i].b;
-                            targets.push(i as u32);
+                            targets.push(u32::conv(i));
                         }
                     }
 
@@ -547,7 +548,7 @@ impl SizeRules {
                     for i in 0..N {
                         if out[i] < rules[i].b {
                             over += out[i] - rules[i].a;
-                            targets.push(i as u32);
+                            targets.push(u32::conv(i));
                         }
                     }
 
@@ -567,10 +568,10 @@ impl SizeRules {
                     let mut any_removed = true;
                     while any_removed {
                         any_removed = false;
-                        let floor = avail / targets.len() as u32;
+                        let floor = avail / u32::conv(targets.len());
                         let mut t = 0;
                         while t < targets.len() {
-                            let i = targets[t] as usize;
+                            let i = usize::conv(targets[t]);
                             if out[i] <= base(i) + floor {
                                 avail -= out[i] - base(i);
                                 targets.remove(t);
@@ -582,15 +583,15 @@ impl SizeRules {
                     }
 
                     // All targets remaining must be reduced to floor, bar rounding errors
-                    let floor = avail / targets.len() as u32;
-                    let extra = avail as usize - floor as usize * targets.len();
+                    let floor = avail / u32::conv(targets.len());
+                    let extra = usize::conv(avail) - usize::conv(floor) * targets.len();
                     assert!(extra < targets.len());
                     for t in 0..extra {
-                        let i = targets[t] as usize;
+                        let i = usize::conv(targets[t]);
                         out[i] = base(i) + floor + 1;
                     }
                     for t in extra..targets.len() {
-                        let i = targets[t] as usize;
+                        let i = usize::conv(targets[t]);
                         out[i] = base(i) + floor;
                     }
                 }
@@ -624,7 +625,7 @@ impl SizeRules {
                                 out[i] = rules[i].b;
                             } else if stretch == highest_affected {
                                 avail += out[i] - rules[i].b;
-                                targets.push(i as u32);
+                                targets.push(u32::conv(i));
                             }
                         }
                     }
@@ -642,7 +643,7 @@ impl SizeRules {
                         out[i] = out[i].min(rules[i].b);
                         sum += out[i];
                         if out[i] > rules[i].a {
-                            targets.push(i as u32);
+                            targets.push(u32::conv(i));
                         }
                     }
                     if sum > target {
@@ -747,9 +748,11 @@ impl SizeRules {
         }
 
         let highest_stretch = sum.stretch;
-        let count = (0..len)
-            .filter(|i| rules[*i].stretch == highest_stretch)
-            .count() as u32;
+        let count = u32::conv(
+            (0..len)
+                .filter(|i| rules[*i].stretch == highest_stretch)
+                .count(),
+        );
         let a_per_elt = excess_a / count;
         let b_per_elt = excess_b / count;
         let mut extra_a = excess_a - count * a_per_elt;

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -58,7 +58,7 @@ impl Margins {
     pub fn pad(self, size: Size) -> Size {
         let w = size.0 + i32::from(self.horiz.0) + i32::from(self.horiz.1);
         let h = size.1 + i32::from(self.vert.0) + i32::from(self.vert.1);
-        Size(w, h)
+        Size::new(w, h)
     }
 }
 

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -54,8 +54,8 @@ impl Margins {
 
     /// Pad a size with margins
     pub fn pad(self, size: Size) -> Size {
-        let w = size.0 + (self.horiz.0 + self.horiz.1) as u32;
-        let h = size.1 + (self.vert.0 + self.vert.1) as u32;
+        let w = size.0 + u32::from(self.horiz.0) + u32::from(self.horiz.1);
+        let h = size.1 + u32::from(self.vert.0) + u32::from(self.vert.1);
         Size(w, h)
     }
 }
@@ -249,6 +249,12 @@ impl SizeRules {
         self.m
     }
 
+    /// Get the `(pre, post)` margin sizes, cast to `u32`
+    #[inline]
+    pub fn margins_u32(self) -> (u32, u32) {
+        (self.m.0.into(), self.m.1.into())
+    }
+
     /// Get the stretch policy
     #[inline]
     pub fn stretch(self) -> StretchPolicy {
@@ -292,7 +298,7 @@ impl SizeRules {
     ///
     /// Panics if either factor is 0.
     pub fn multiply_with_margin(&mut self, min_factor: u32, ideal_factor: u32) {
-        let margin = self.m.0 as u32 + self.m.1 as u32;
+        let margin = u32::from(self.m.0) + u32::from(self.m.1);
         assert!(min_factor > 0);
         assert!(ideal_factor > 0);
         self.a = min_factor * self.a + (min_factor - 1) * margin;
@@ -307,7 +313,7 @@ impl SizeRules {
     /// Note also that appending [`SizeRules::EMPTY`] does include interior
     /// margins (those between `EMPTY` and the other rules) within the result.
     pub fn append(&mut self, rhs: SizeRules) {
-        let c = self.m.1.max(rhs.m.0) as u32;
+        let c: u32 = self.m.1.max(rhs.m.0).into();
         self.a += rhs.a + c;
         self.b += rhs.b + c;
         self.m.1 = rhs.m.1;
@@ -324,7 +330,7 @@ impl SizeRules {
     /// margins (those between `EMPTY` and the other rules) within the result.
     #[inline]
     pub fn appended(self, rhs: SizeRules) -> Self {
-        let c = self.m.1.max(rhs.m.0) as u32;
+        let c: u32 = self.m.1.max(rhs.m.0).into();
         SizeRules {
             a: self.a + rhs.a + c,
             b: self.b + rhs.b + c,
@@ -340,7 +346,7 @@ impl SizeRules {
     /// the frame's margins.
     pub fn surrounded_by(self, frame: SizeRules, internal_margins: bool) -> Self {
         let (c, m) = if internal_margins {
-            ((self.m.0 + self.m.1) as u32, frame.m)
+            ((self.m.0 + self.m.1).into(), frame.m)
         } else {
             (0, (self.m.0.max(frame.m.0), self.m.1.max(frame.m.1)))
         };
@@ -367,7 +373,7 @@ impl SizeRules {
 
         let mut rules = range[0];
         for r in &range[1..] {
-            rules.a += rules.m.1.max(r.m.0) as u32 + r.a;
+            rules.a += u32::from(rules.m.1.max(r.m.0)) + r.a;
         }
         rules.b = rules.a;
         rules.m.1 = range[range.len() - 1].m.1;
@@ -458,7 +464,7 @@ impl SizeRules {
             let mut dist_over_b = out[0].saturating_sub(rules[0].b);
             for i in 1..N {
                 out[i] = out[i].max(rules[i].a);
-                margin_sum += (rules[i - 1].m.1).max(rules[i].m.0) as u32;
+                margin_sum += u32::from((rules[i - 1].m.1).max(rules[i].m.0));
                 sum += out[i];
                 dist_under_b += rules[i].b.saturating_sub(out[i]);
                 dist_over_b += out[i].saturating_sub(rules[i].b);

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -11,6 +11,7 @@ use std::iter::Sum;
 
 use crate::conv::Conv;
 use crate::geom::Size;
+use crate::Directional;
 
 // for doc use
 #[allow(unused)]
@@ -199,22 +200,14 @@ impl SizeRules {
 
     /// Construct fixed-size rules from given data
     #[inline]
-    pub fn extract_fixed(vertical: bool, size: Size, margin: Margins) -> Self {
-        if !vertical {
-            SizeRules {
-                a: size.0,
-                b: size.0,
-                m: margin.horiz,
-                stretch: StretchPolicy::Fixed,
-            }
+    pub fn extract_fixed<D: Directional>(dir: D, size: Size, margin: Margins) -> Self {
+        let size = size.extract(dir);
+        let m = if dir.is_horizontal() {
+            margin.horiz
         } else {
-            SizeRules {
-                a: size.1,
-                b: size.1,
-                m: margin.vert,
-                stretch: StretchPolicy::Fixed,
-            }
-        }
+            margin.vert
+        };
+        SizeRules::fixed(size, m)
     }
 
     /// Construct with custom rules

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -189,7 +189,7 @@ impl SolveCache {
     ) {
         let mut width = rect.size.0;
         if inner_margin {
-            width -= (self.margins.horiz.0 + self.margins.horiz.1) as u32;
+            width -= u32::from(self.margins.horiz.0) + u32::from(self.margins.horiz.1);
         }
 
         // We call size_rules not because we want the result, but because our
@@ -212,9 +212,12 @@ impl SolveCache {
         }
 
         if inner_margin {
-            rect.pos += Coord(self.margins.horiz.0 as i32, self.margins.vert.0 as i32);
+            rect.pos += Coord(
+                i32::from(self.margins.horiz.0),
+                i32::from(self.margins.vert.0),
+            );
             rect.size.0 = width;
-            rect.size.1 -= (self.margins.vert.0 + self.margins.vert.1) as u32;
+            rect.size.1 -= u32::from(self.margins.vert.0) + u32::from(self.margins.vert.1);
         }
         widget.set_rect(mgr, rect, AlignHints::NONE);
 

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -78,8 +78,8 @@ pub trait RulesSetter {
 pub fn solve_size_rules<W: Widget>(
     widget: &mut W,
     size_handle: &mut dyn SizeHandle,
-    x_size: Option<u32>,
-    y_size: Option<u32>,
+    x_size: Option<i32>,
+    y_size: Option<i32>,
 ) {
     widget.size_rules(size_handle, AxisInfo::new(false, y_size));
     widget.size_rules(size_handle, AxisInfo::new(true, x_size));
@@ -102,7 +102,7 @@ pub struct SolveCache {
     ideal: Size,
     margins: Margins,
     refresh_rules: bool,
-    last_width: u32,
+    last_width: i32,
 }
 
 impl SolveCache {
@@ -189,7 +189,7 @@ impl SolveCache {
     ) {
         let mut width = rect.size.0;
         if inner_margin {
-            width -= u32::from(self.margins.horiz.0) + u32::from(self.margins.horiz.1);
+            width -= i32::from(self.margins.horiz.0) + i32::from(self.margins.horiz.1);
         }
 
         // We call size_rules not because we want the result, but because our
@@ -217,7 +217,7 @@ impl SolveCache {
                 i32::from(self.margins.vert.0),
             );
             rect.size.0 = width;
-            rect.size.1 -= u32::from(self.margins.vert.0) + u32::from(self.margins.vert.1);
+            rect.size.1 -= i32::from(self.margins.vert.0) + i32::from(self.margins.vert.1);
         }
         widget.set_rect(mgr, rect, AlignHints::NONE);
 

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use super::{AxisInfo, Margins, SizeRules};
 use crate::draw::SizeHandle;
 use crate::event::Manager;
-use crate::geom::{Coord, Rect, Size};
+use crate::geom::{Rect, Size};
 use crate::{AlignHints, Widget, WidgetConfig};
 
 /// A [`SizeRules`] solver for layouts
@@ -212,10 +212,7 @@ impl SolveCache {
         }
 
         if inner_margin {
-            rect.pos += Coord(
-                i32::from(self.margins.horiz.0),
-                i32::from(self.margins.vert.0),
-            );
+            rect.pos += Size::from((self.margins.horiz.0, self.margins.vert.0));
             rect.size.0 = width;
             rect.size.1 -= i32::from(self.margins.vert.0) + i32::from(self.margins.vert.1);
         }

--- a/src/layout/storage.rs
+++ b/src/layout/storage.rs
@@ -26,12 +26,12 @@ pub trait RowStorage: sealed::Sealed + Clone {
     }
 
     #[doc(hidden)]
-    fn widths(&mut self) -> &mut [u32] {
+    fn widths(&mut self) -> &mut [i32] {
         self.rules_and_widths().1
     }
 
     #[doc(hidden)]
-    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [u32]);
+    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [i32]);
 }
 
 /// Fixed-length row storage
@@ -39,7 +39,7 @@ pub trait RowStorage: sealed::Sealed + Clone {
 /// Argument types:
 ///
 /// - `R` is expected to be `[SizeRules; cols + 1]`
-/// - `W` is expected to be `[u32; cols]`
+/// - `W` is expected to be `[i32; cols]`
 #[derive(Clone, Debug, Default)]
 pub struct FixedRowStorage<R: Clone, W: Clone> {
     rules: R,
@@ -51,14 +51,14 @@ impl<R: Clone, W: Clone> Storage for FixedRowStorage<R, W> {}
 impl<R, W> RowStorage for FixedRowStorage<R, W>
 where
     R: Clone + AsRef<[SizeRules]> + AsMut<[SizeRules]>,
-    W: Clone + AsRef<[u32]> + AsMut<[u32]>,
+    W: Clone + AsRef<[i32]> + AsMut<[i32]>,
 {
     fn set_dim(&mut self, cols: usize) {
         assert_eq!(self.rules.as_ref().len(), cols + 1);
         assert_eq!(self.widths.as_ref().len(), cols);
     }
 
-    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [u32]) {
+    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [i32]) {
         (self.rules.as_mut(), self.widths.as_mut())
     }
 }
@@ -67,7 +67,7 @@ where
 #[derive(Clone, Debug, Default)]
 pub struct DynRowStorage {
     rules: Vec<SizeRules>,
-    widths: Vec<u32>,
+    widths: Vec<i32>,
 }
 
 impl Storage for DynRowStorage {}
@@ -78,7 +78,7 @@ impl RowStorage for DynRowStorage {
         self.widths.resize(cols, 0);
     }
 
-    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [u32]) {
+    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [i32]) {
         (&mut self.rules, &mut self.widths)
     }
 }
@@ -86,16 +86,16 @@ impl RowStorage for DynRowStorage {
 /// Temporary storage type.
 ///
 /// For dynamic-length rows and fixed-length rows with more than 16 items use
-/// `Vec<u32>`. For fixed-length rows up to 16 items, use `[u32; rows]`.
+/// `Vec<i32>`. For fixed-length rows up to 16 items, use `[i32; rows]`.
 pub trait RowTemp: Default + sealed::Sealed {
     #[doc(hidden)]
-    fn as_mut(&mut self) -> &mut [u32];
+    fn as_mut(&mut self) -> &mut [i32];
     #[doc(hidden)]
     fn set_len(&mut self, len: usize);
 }
 
-impl RowTemp for Vec<u32> {
-    fn as_mut(&mut self) -> &mut [u32] {
+impl RowTemp for Vec<i32> {
+    fn as_mut(&mut self) -> &mut [i32] {
         self
     }
     fn set_len(&mut self, len: usize) {
@@ -106,15 +106,15 @@ impl RowTemp for Vec<u32> {
 // TODO: use const generics
 macro_rules! impl_row_temporary {
     ($n:literal) => {
-        impl RowTemp for [u32; $n] {
-            fn as_mut(&mut self) -> &mut [u32] {
+        impl RowTemp for [i32; $n] {
+            fn as_mut(&mut self) -> &mut [i32] {
                 self
             }
             fn set_len(&mut self, len: usize) {
                 assert_eq!(self.len(), len);
             }
         }
-        impl sealed::Sealed for [u32; $n] {}
+        impl sealed::Sealed for [i32; $n] {}
     };
     ($n:literal $($more:literal)*) => {
         impl_row_temporary!($n);
@@ -143,18 +143,18 @@ pub trait GridStorage: sealed::Sealed + Clone {
     }
 
     #[doc(hidden)]
-    fn widths(&mut self) -> &mut [u32] {
+    fn widths(&mut self) -> &mut [i32] {
         self.rules_and_widths().1
     }
     #[doc(hidden)]
-    fn heights(&mut self) -> &mut [u32] {
+    fn heights(&mut self) -> &mut [i32] {
         self.rules_and_heights().1
     }
 
     #[doc(hidden)]
-    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [u32]);
+    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [i32]);
     #[doc(hidden)]
-    fn rules_and_heights(&mut self) -> (&mut [SizeRules], &mut [u32]);
+    fn rules_and_heights(&mut self) -> (&mut [SizeRules], &mut [i32]);
 }
 
 /// Fixed-length grid storage
@@ -163,8 +163,8 @@ pub trait GridStorage: sealed::Sealed + Clone {
 ///
 /// - `WR` is expected to be `[SizeRules; cols + 1]`
 /// - `HR` is expected to be `[SizeRules; rows + 1]`
-/// - `W` is expected to be `[u32; cols]` or `Vec<u32>`
-/// - `H` is expected to be `[u32; rows]` or `Vec<u32>`
+/// - `W` is expected to be `[i32; cols]` or `Vec<i32>`
+/// - `H` is expected to be `[i32; rows]` or `Vec<i32>`
 #[derive(Clone, Debug, Default)]
 pub struct FixedGridStorage<WR: Clone, HR: Clone, W: Clone, H: Clone> {
     width_rules: WR,
@@ -179,18 +179,18 @@ impl<WR, HR, W, H> GridStorage for FixedGridStorage<WR, HR, W, H>
 where
     WR: Clone + AsRef<[SizeRules]> + AsMut<[SizeRules]>,
     HR: Clone + AsRef<[SizeRules]> + AsMut<[SizeRules]>,
-    W: Clone + AsRef<[u32]> + AsMut<[u32]>,
-    H: Clone + AsRef<[u32]> + AsMut<[u32]>,
+    W: Clone + AsRef<[i32]> + AsMut<[i32]>,
+    H: Clone + AsRef<[i32]> + AsMut<[i32]>,
 {
     fn set_dims(&mut self, cols: usize, rows: usize) {
         assert_eq!(self.width_rules.as_ref().len(), cols + 1);
         assert_eq!(self.height_rules.as_ref().len(), rows + 1);
     }
 
-    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [u32]) {
+    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [i32]) {
         (self.width_rules.as_mut(), self.widths.as_mut())
     }
-    fn rules_and_heights(&mut self) -> (&mut [SizeRules], &mut [u32]) {
+    fn rules_and_heights(&mut self) -> (&mut [SizeRules], &mut [i32]) {
         (self.height_rules.as_mut(), self.heights.as_mut())
     }
 }
@@ -200,8 +200,8 @@ where
 pub struct DynGridStorage {
     width_rules: Vec<SizeRules>,
     height_rules: Vec<SizeRules>,
-    widths: Vec<u32>,
-    heights: Vec<u32>,
+    widths: Vec<i32>,
+    heights: Vec<i32>,
 }
 
 impl Storage for DynGridStorage {}
@@ -212,10 +212,10 @@ impl GridStorage for DynGridStorage {
         self.height_rules.resize(rows + 1, SizeRules::EMPTY);
     }
 
-    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [u32]) {
+    fn rules_and_widths(&mut self) -> (&mut [SizeRules], &mut [i32]) {
         (&mut self.width_rules, &mut self.widths)
     }
-    fn rules_and_heights(&mut self) -> (&mut [SizeRules], &mut [u32]) {
+    fn rules_and_heights(&mut self) -> (&mut [SizeRules], &mut [i32]) {
         (&mut self.height_rules, &mut self.heights)
     }
 }
@@ -224,7 +224,7 @@ mod sealed {
     pub trait Sealed {}
     impl<R: Clone, W: Clone> Sealed for super::FixedRowStorage<R, W> {}
     impl Sealed for super::DynRowStorage {}
-    impl Sealed for Vec<u32> {}
+    impl Sealed for Vec<i32> {}
     impl<WR: Clone, HR: Clone, W: Clone, H: Clone> Sealed for super::FixedGridStorage<WR, HR, W, H> {}
     impl Sealed for super::DynGridStorage {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod traits;
 
 // public implementations:
 pub mod class;
+pub mod conv;
 pub mod draw;
 pub mod event;
 pub mod geom;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -22,7 +22,7 @@ pub use kas::draw::{DrawHandle, DrawHandleExt, SizeHandle};
 #[doc(no_inline)]
 pub use kas::event::{Event, Handler, Manager, ManagerState, Response, SendEvent, VoidMsg};
 #[doc(no_inline)]
-pub use kas::geom::{Coord, Rect, Size};
+pub use kas::geom::{Coord, Offset, Rect, Size};
 #[doc(no_inline)]
 pub use kas::layout::{AxisInfo, Margins, SizeRules, StretchPolicy};
 #[doc(no_inline)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,7 +16,7 @@
 #[doc(no_inline)]
 pub use kas::class::*;
 #[doc(no_inline)]
-pub use kas::conv::Conv;
+pub use kas::conv::{Conv, ConvFloat};
 #[doc(no_inline)]
 pub use kas::draw::{DrawHandle, DrawHandleExt, SizeHandle};
 #[doc(no_inline)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,6 +16,8 @@
 #[doc(no_inline)]
 pub use kas::class::*;
 #[doc(no_inline)]
+pub use kas::conv::Conv;
+#[doc(no_inline)]
 pub use kas::draw::{DrawHandle, DrawHandleExt, SizeHandle};
 #[doc(no_inline)]
 pub use kas::event::{Event, Handler, Manager, ManagerState, Response, SendEvent, VoidMsg};

--- a/src/text.rs
+++ b/src/text.rs
@@ -43,7 +43,7 @@ pub mod util {
                 return TkAction::RESIZE;
             }
         }
-        TkAction::empty()
+        TkAction::REDRAW
     }
 
     /// Set the text from a string and prepare
@@ -70,6 +70,6 @@ pub mod util {
                 return TkAction::RESIZE;
             }
         }
-        TkAction::empty()
+        TkAction::REDRAW
     }
 }

--- a/src/text/string.rs
+++ b/src/text/string.rs
@@ -11,6 +11,7 @@
 
 use smallvec::{smallvec, SmallVec};
 
+use kas::conv::Conv;
 use kas::event::{VirtualKeyCode as VK, VirtualKeyCodes};
 use kas::text::format::{FontToken, FormattableText};
 #[cfg(not(feature = "gat"))]
@@ -55,7 +56,7 @@ impl AccelString {
                     break;
                 }
                 Some((j, c)) => {
-                    let pos = buf.len() as u32;
+                    let pos = u32::conv(buf.len());
                     buf.push(c);
                     if effects.last().map(|e| e.start == pos).unwrap_or(false) {
                         effects.last_mut().unwrap().flags = EffectFlags::UNDERLINE;
@@ -75,7 +76,7 @@ impl AccelString {
 
                     if let Some((k, _)) = chars.next() {
                         effects.push(Effect {
-                            start: pos + (k - j) as u32,
+                            start: pos + u32::conv(k - j),
                             flags: EffectFlags::empty(),
                             aux: (),
                         });

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -10,7 +10,7 @@ use std::fmt;
 
 use crate::draw::{DrawHandle, InputState, SizeHandle};
 use crate::event::{self, ConfigureManager, Manager, ManagerState};
-use crate::geom::{Coord, Rect, Size};
+use crate::geom::{Coord, Offset, Rect};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::{AlignHints, CoreData, TkAction, WidgetId};
 
@@ -420,10 +420,10 @@ pub trait Layout: WidgetChildren {
     /// subtracted to translate out.
     ///
     /// In most cases, the translation will be zero. Widgets should return
-    /// [`Size::ZERO`] for non-existant children.
+    /// [`Offset::ZERO`] for non-existant children.
     #[inline]
-    fn translation(&self, _child_index: usize) -> Size {
-        Size::ZERO
+    fn translation(&self, _child_index: usize) -> Offset {
+        Offset::ZERO
     }
 
     /// Iterate through children in spatial order

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -10,7 +10,7 @@ use std::fmt;
 
 use crate::draw::{DrawHandle, InputState, SizeHandle};
 use crate::event::{self, ConfigureManager, Manager, ManagerState};
-use crate::geom::{Coord, Rect};
+use crate::geom::{Coord, Rect, Size};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::{AlignHints, CoreData, TkAction, WidgetId};
 
@@ -420,10 +420,10 @@ pub trait Layout: WidgetChildren {
     /// subtracted to translate out.
     ///
     /// In most cases, the translation will be zero. Widgets should return
-    /// [`Coord::ZERO`] for non-existant children.
+    /// [`Size::ZERO`] for non-existant children.
     #[inline]
-    fn translation(&self, _child_index: usize) -> Coord {
-        Coord::ZERO
+    fn translation(&self, _child_index: usize) -> Size {
+        Size::ZERO
     }
 
     /// Iterate through children in spatial order

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -41,7 +41,7 @@ impl<M: Clone + Debug + 'static> Layout for TextButton<M> {
         let sides = size_handle.button_surround();
         self.frame_size = sides.0 + sides.1;
         let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), self.frame_size, margins);
+        let frame_rules = SizeRules::extract_fixed(axis, self.frame_size, margins);
 
         let content_rules = size_handle.text_bound(&mut self.label, TextClass::Button, axis);
         content_rules.surrounded_by(frame_rules, true)

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -114,7 +114,7 @@ impl<M: Clone + Debug + 'static> SetAccel for TextButton<M> {
         if self.label.text().keys() != string.keys() {
             action |= TkAction::RECONFIGURE;
         }
-        let avail = self.core.rect.size.saturating_sub(self.frame_size);
+        let avail = self.core.rect.size.clamped_sub(self.frame_size);
         action | kas::text::util::set_text_and_prepare(&mut self.label, string, avail)
     }
 }

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -37,7 +37,7 @@ impl<M: 'static> Layout for CheckBoxBare<M> {
         let size = size_handle.checkbox();
         self.core.rect.size = size;
         let margins = size_handle.outer_margins();
-        SizeRules::extract_fixed(axis.is_vertical(), size, margins)
+        SizeRules::extract_fixed(axis, size, margins)
     }
 
     fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -122,7 +122,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
         if self.active != index {
             self.active = index;
             let string = self.popup.inner[self.active].get_string();
-            let avail = self.core.rect.size.saturating_sub(self.frame_size);
+            let avail = self.core.rect.size.clamped_sub(self.frame_size);
             kas::text::util::set_text_and_prepare(&mut self.label, string, avail)
         } else {
             TkAction::empty()

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -149,7 +149,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     pub fn push<T: Into<AccelString>>(&mut self, label: T, msg: M) -> TkAction {
         self.messages.push(msg);
         let column = &mut self.popup.inner.inner;
-        let len = column.len() as u64;
+        let len = u64::conv(column.len());
         column.push(MenuEntry::new(label, len))
         // TODO: localised reconfigure
     }
@@ -164,7 +164,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     pub fn insert<T: Into<AccelString>>(&mut self, index: usize, label: T, msg: M) -> TkAction {
         self.messages.insert(index, msg);
         let column = &mut self.popup.inner.inner;
-        let len = column.len() as u64;
+        let len = u64::conv(column.len());
         column.insert(index, MenuEntry::new(label, len))
         // TODO: localised reconfigure
     }
@@ -223,7 +223,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
             },
             Response::Focus(x) => Response::Focus(x),
             Response::Msg(msg) => {
-                let index = msg as usize;
+                let index = usize::conv(msg);
                 *mgr |= self.set_active(index);
                 if let Some(id) = self.popup_id {
                     mgr.close_window(id);
@@ -244,7 +244,7 @@ impl<T: Into<AccelString>, M: Clone + Debug> FromIterator<(T, M)> for ComboBox<M
         let mut choices = Vec::with_capacity(len);
         let mut messages = Vec::with_capacity(len);
         for (i, (label, msg)) in iter.enumerate() {
-            choices.push(MenuEntry::new(label, i as u64));
+            choices.push(MenuEntry::new(label, u64::conv(i)));
             messages.push(msg);
         }
         ComboBox::new_(choices, messages)
@@ -258,7 +258,7 @@ impl<'a, M: Clone + Debug + 'static> FromIterator<&'a (&'static str, M)> for Com
         let mut choices = Vec::with_capacity(len);
         let mut messages = Vec::with_capacity(len);
         for (i, (label, msg)) in iter.enumerate() {
-            choices.push(MenuEntry::new(*label, i as u64));
+            choices.push(MenuEntry::new(*label, u64::conv(i)));
             messages.push(msg.clone());
         }
         ComboBox::new_(choices, messages)

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -36,7 +36,7 @@ impl<M: Clone + Debug + 'static> kas::Layout for ComboBox<M> {
         let sides = size_handle.button_surround();
         self.frame_size = sides.0 + sides.1;
         let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), self.frame_size, margins);
+        let frame_rules = SizeRules::extract_fixed(axis, self.frame_size, margins);
 
         let content_rules = size_handle.text_bound(&mut self.label, TextClass::Button, axis);
         content_rules.surrounded_by(frame_rules, true)

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -109,7 +109,7 @@ impl DragHandle {
             return self.offset();
         }
 
-        self.press_coord = Size::from(self.core.rect.size / 2) + self.track.pos;
+        self.press_coord = self.core.rect.size / 2 + self.track.pos;
 
         // Since the press is not on the handle, we move the bar immediately.
         let (offset, action) = self.set_offset(coord - self.press_coord);

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -51,7 +51,7 @@ impl DragHandle {
     /// Set a new handle size and offset
     ///
     /// Returns [`TkAction::REDRAW`] if a redraw is required.
-    pub fn set_size_and_offset(&mut self, size: Size, offset: Size) -> TkAction {
+    pub fn set_size_and_offset(&mut self, size: Size, offset: Offset) -> TkAction {
         self.core.rect.size = size;
         self.set_offset(offset).1
     }
@@ -64,7 +64,7 @@ impl DragHandle {
 
     /// Get the current handle offset
     #[inline]
-    pub fn offset(&self) -> Size {
+    pub fn offset(&self) -> Offset {
         self.core.rect.pos - self.track.pos
     }
 
@@ -72,8 +72,8 @@ impl DragHandle {
     ///
     /// This depends on size of the handle and the track.
     #[inline]
-    pub fn max_offset(&self) -> Size {
-        self.track.size - self.core.rect.size
+    pub fn max_offset(&self) -> Offset {
+        Offset::from(self.track.size) - Offset::from(self.core.rect.size)
     }
 
     /// Set a new handle offset
@@ -81,8 +81,8 @@ impl DragHandle {
     /// Returns the new offset (after clamping input) and an action: empty if
     /// the handle hasn't moved; `REDRAW` if it has (though this widget is
     /// not directly responsible for drawing, so this may not be accurate).
-    pub fn set_offset(&mut self, offset: Size) -> (Size, TkAction) {
-        let offset = offset.clamp(Size::ZERO, self.max_offset());
+    pub fn set_offset(&mut self, offset: Offset) -> (Offset, TkAction) {
+        let offset = offset.clamp(Offset::ZERO, self.max_offset());
         let handle_pos = self.track.pos + offset;
         if handle_pos != self.core.rect.pos {
             self.core.rect.pos = handle_pos;
@@ -104,12 +104,12 @@ impl DragHandle {
         mgr: &mut Manager,
         source: PressSource,
         coord: Coord,
-    ) -> Size {
+    ) -> Offset {
         if !self.grab_press(mgr, source, coord) {
             return self.offset();
         }
 
-        self.press_coord = self.core.rect.size / 2 + self.track.pos;
+        self.press_coord = self.track.pos + self.core.rect.size / 2;
 
         // Since the press is not on the handle, we move the bar immediately.
         let (offset, action) = self.set_offset(coord - self.press_coord);
@@ -151,7 +151,7 @@ impl Layout for DragHandle {
 }
 
 impl event::Handler for DragHandle {
-    type Msg = Size;
+    type Msg = Offset;
 
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         match event {

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -168,10 +168,10 @@ impl Default for TouchPhase {
 pub struct EditBox<G: 'static = ()> {
     #[widget_core]
     core: CoreData,
-    frame_offset: Size,
+    frame_offset: Offset,
     frame_size: Size,
     text_pos: Coord,
-    view_offset: Size,
+    view_offset: Offset,
     editable: bool,
     multi_line: bool,
     text: Text<String>,
@@ -792,11 +792,11 @@ impl<G> EditBox<G> {
         mgr.redraw(self.id());
     }
 
-    fn pan_delta(&mut self, mgr: &mut Manager, delta: Size) -> bool {
+    fn pan_delta(&mut self, mgr: &mut Manager, delta: Offset) -> bool {
         let bounds = Vec2::from(self.text.env().bounds);
         let max_offset = (self.required - bounds).ceil();
-        let max_offset = Size::from(max_offset).max(Size::ZERO);
-        let new_offset = (self.view_offset - delta).min(max_offset).max(Size::ZERO);
+        let max_offset = Offset::from(max_offset).max(Offset::ZERO);
+        let new_offset = (self.view_offset - delta).min(max_offset).max(Offset::ZERO);
         if new_offset != self.view_offset {
             self.view_offset = new_offset;
             mgr.redraw(self.id());
@@ -817,11 +817,11 @@ impl<G> EditBox<G> {
             let min_y = (marker.pos.1 - marker.descent - bounds.1).ceil();
             let max_x = (marker.pos.0).floor();
             let max_y = (marker.pos.1 - marker.ascent).floor();
-            let min = Size(min_x as i32, min_y as i32);
-            let max = Size(max_x as i32, max_y as i32);
+            let min = Offset(min_x as i32, min_y as i32);
+            let max = Offset(max_x as i32, max_y as i32);
 
             let max_offset = (self.required - bounds).ceil();
-            let max_offset = Size::from(max_offset).max(Size::ZERO);
+            let max_offset = Offset::from(max_offset).max(Offset::ZERO);
             let max = max.min(max_offset);
 
             self.view_offset = self.view_offset.max(min).min(max);
@@ -958,7 +958,7 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                         let dist = 3.0 * self.text.env().height(Default::default());
                         let x = (x * dist).round() as i32;
                         let y = (y * dist).round() as i32;
-                        Size(x, y)
+                        Offset(x, y)
                     }
                     ScrollDelta::PixelDelta(coord) => coord,
                 };

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -837,7 +837,7 @@ impl<G: EditGuard> HasStr for EditBox<G> {
 
 impl<G: EditGuard> HasString for EditBox<G> {
     fn set_string(&mut self, string: String) -> TkAction {
-        let avail = self.core.rect.size.saturating_sub(self.frame_size);
+        let avail = self.core.rect.size.clamped_sub(self.frame_size);
         let action = kas::text::util::set_string_and_prepare(&mut self.text, string, avail);
         let _ = G::update(self);
         action

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -205,7 +205,7 @@ impl<G: 'static> Layout for EditBox<G> {
         let frame_size = frame_offset + frame_sides.1;
 
         let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), frame_size, margins);
+        let frame_rules = SizeRules::extract_fixed(axis, frame_size, margins);
 
         let class = if self.multi_line {
             TextClass::EditMulti

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -218,12 +218,12 @@ impl<G: 'static> Layout for EditBox<G> {
         let rules = content_rules.surrounded_by(frame_rules, true);
         if axis.is_horizontal() {
             self.core.rect.size.0 = rules.ideal_size();
-            self.frame_offset.0 = frame_offset.0 as i32 + m.0 as i32;
-            self.frame_size.0 = frame_size.0 + (m.0 + m.1) as u32;
+            self.frame_offset.0 = frame_offset.0 as i32 + i32::from(m.0);
+            self.frame_size.0 = frame_size.0 + u32::from(m.0) + u32::from(m.1);
         } else {
             self.core.rect.size.1 = rules.ideal_size();
-            self.frame_offset.1 = frame_offset.1 as i32 + m.0 as i32;
-            self.frame_size.1 = frame_size.1 + (m.0 + m.1) as u32;
+            self.frame_offset.1 = frame_offset.1 as i32 + i32::from(m.0);
+            self.frame_size.1 = frame_size.1 + u32::from(m.0) + u32::from(m.1);
         }
         rules
     }

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -813,12 +813,12 @@ impl<G> EditBox<G> {
         let edit_pos = self.selection.edit_pos();
         if let Some(marker) = self.text.text_glyph_pos(edit_pos).next_back() {
             let bounds = Vec2::from(self.text.env().bounds);
-            let min_x = (marker.pos.0 - bounds.0).ceil();
-            let min_y = (marker.pos.1 - marker.descent - bounds.1).ceil();
-            let max_x = (marker.pos.0).floor();
-            let max_y = (marker.pos.1 - marker.ascent).floor();
-            let min = Offset(min_x as i32, min_y as i32);
-            let max = Offset(max_x as i32, max_y as i32);
+            let min_x = marker.pos.0 - bounds.0;
+            let min_y = marker.pos.1 - marker.descent - bounds.1;
+            let max_x = marker.pos.0;
+            let max_y = marker.pos.1 - marker.ascent;
+            let min = Offset(i32::conv_ceil(min_x), i32::conv_ceil(min_y));
+            let max = Offset(i32::conv_floor(max_x), i32::conv_floor(max_y));
 
             let max_offset = (self.required - bounds).ceil();
             let max_offset = Offset::from(max_offset).max(Offset::ZERO);
@@ -956,8 +956,8 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                     ScrollDelta::LineDelta(x, y) => {
                         // We arbitrarily scroll 3 lines:
                         let dist = 3.0 * self.text.env().height(Default::default());
-                        let x = (x * dist).round() as i32;
-                        let y = (y * dist).round() as i32;
+                        let x = i32::conv_nearest(x * dist);
+                        let y = i32::conv_nearest(y * dist);
                         Offset(x, y)
                     }
                     ScrollDelta::PixelDelta(coord) => coord,

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -168,10 +168,10 @@ impl Default for TouchPhase {
 pub struct EditBox<G: 'static = ()> {
     #[widget_core]
     core: CoreData,
-    frame_offset: Coord,
+    frame_offset: Size,
     frame_size: Size,
     text_pos: Coord,
-    view_offset: Coord,
+    view_offset: Size,
     editable: bool,
     multi_line: bool,
     text: Text<String>,
@@ -792,11 +792,11 @@ impl<G> EditBox<G> {
         mgr.redraw(self.id());
     }
 
-    fn pan_delta(&mut self, mgr: &mut Manager, delta: Coord) -> bool {
+    fn pan_delta(&mut self, mgr: &mut Manager, delta: Size) -> bool {
         let bounds = Vec2::from(self.text.env().bounds);
         let max_offset = (self.required - bounds).ceil();
-        let max_offset = Coord::from(max_offset).max(Coord::ZERO);
-        let new_offset = (self.view_offset - delta).min(max_offset).max(Coord::ZERO);
+        let max_offset = Size::from(max_offset).max(Size::ZERO);
+        let new_offset = (self.view_offset - delta).min(max_offset).max(Size::ZERO);
         if new_offset != self.view_offset {
             self.view_offset = new_offset;
             mgr.redraw(self.id());
@@ -817,11 +817,11 @@ impl<G> EditBox<G> {
             let min_y = (marker.pos.1 - marker.descent - bounds.1).ceil();
             let max_x = (marker.pos.0).floor();
             let max_y = (marker.pos.1 - marker.ascent).floor();
-            let min = Coord(min_x as i32, min_y as i32);
-            let max = Coord(max_x as i32, max_y as i32);
+            let min = Size(min_x as i32, min_y as i32);
+            let max = Size(max_x as i32, max_y as i32);
 
             let max_offset = (self.required - bounds).ceil();
-            let max_offset = Coord::from(max_offset).max(Coord::ZERO);
+            let max_offset = Size::from(max_offset).max(Size::ZERO);
             let max = max.min(max_offset);
 
             self.view_offset = self.view_offset.max(min).min(max);
@@ -958,7 +958,7 @@ impl<G: EditGuard + 'static> event::Handler for EditBox<G> {
                         let dist = 3.0 * self.text.env().height(Default::default());
                         let x = (x * dist).round() as i32;
                         let y = (y * dist).round() as i32;
-                        Coord(x, y)
+                        Size(x, y)
                     }
                     ScrollDelta::PixelDelta(coord) => coord,
                 };

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -213,17 +213,17 @@ impl<G: 'static> Layout for EditBox<G> {
             TextClass::Edit
         };
         let content_rules = size_handle.text_bound(&mut self.text, class, axis);
-        let m = content_rules.margins();
+        let m = content_rules.margins_i32();
 
         let rules = content_rules.surrounded_by(frame_rules, true);
         if axis.is_horizontal() {
             self.core.rect.size.0 = rules.ideal_size();
-            self.frame_offset.0 = frame_offset.0 as i32 + i32::from(m.0);
-            self.frame_size.0 = frame_size.0 + u32::from(m.0) + u32::from(m.1);
+            self.frame_offset.0 = frame_offset.0 + m.0;
+            self.frame_size.0 = frame_size.0 + m.0 + m.1;
         } else {
             self.core.rect.size.1 = rules.ideal_size();
-            self.frame_offset.1 = frame_offset.1 as i32 + i32::from(m.0);
-            self.frame_size.1 = frame_size.1 + u32::from(m.0) + u32::from(m.1);
+            self.frame_offset.1 = frame_offset.1 + m.0;
+            self.frame_size.1 = frame_size.1 + m.0 + m.1;
         }
         rules
     }

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -42,7 +42,7 @@ impl<W: Widget> Layout for Frame<W> {
         let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, margins);
 
         let child_rules = self.inner.size_rules(size_handle, axis);
-        let m = child_rules.margins_u32();
+        let m = child_rules.margins_i32();
 
         if axis.is_horizontal() {
             self.m0.0 = size.0 + m.0;

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -42,14 +42,14 @@ impl<W: Widget> Layout for Frame<W> {
         let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, margins);
 
         let child_rules = self.inner.size_rules(size_handle, axis);
-        let m = child_rules.margins();
+        let m = child_rules.margins_u32();
 
         if axis.is_horizontal() {
-            self.m0.0 = size.0 + m.0 as u32;
-            self.m1.0 = size.0 + m.1 as u32;
+            self.m0.0 = size.0 + m.0;
+            self.m1.0 = size.0 + m.1;
         } else {
-            self.m0.1 = size.1 + m.0 as u32;
-            self.m1.1 = size.1 + m.1 as u32;
+            self.m0.1 = size.1 + m.0;
+            self.m1.1 = size.1 + m.1;
         }
 
         child_rules.surrounded_by(frame_rules, true)

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -39,7 +39,7 @@ impl<W: Widget> Layout for Frame<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.frame();
         let margins = Margins::ZERO;
-        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, margins);
+        let frame_rules = SizeRules::extract_fixed(axis, size + size, margins);
 
         let child_rules = self.inner.size_rules(size_handle, axis);
         let m = child_rules.margins_i32();

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -38,7 +38,7 @@ impl<T: FormattableText + 'static> Layout for Label<T> {
     default fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
         draw_handle.text_effects(
             self.core.rect.pos,
-            Coord::ZERO,
+            Size::ZERO,
             &self.label,
             TextClass::Label,
         );
@@ -47,7 +47,7 @@ impl<T: FormattableText + 'static> Layout for Label<T> {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
         draw_handle.text_effects(
             self.core.rect.pos,
-            Coord::ZERO,
+            Size::ZERO,
             &self.label,
             TextClass::Label,
         );

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -38,7 +38,7 @@ impl<T: FormattableText + 'static> Layout for Label<T> {
     default fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
         draw_handle.text_effects(
             self.core.rect.pos,
-            Size::ZERO,
+            Offset::ZERO,
             &self.label,
             TextClass::Label,
         );
@@ -47,7 +47,7 @@ impl<T: FormattableText + 'static> Layout for Label<T> {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
         draw_handle.text_effects(
             self.core.rect.pos,
-            Size::ZERO,
+            Offset::ZERO,
             &self.label,
             TextClass::Label,
         );

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -134,7 +134,7 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
     fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         let dim = (self.direction, self.widgets.len());
-        let mut setter = layout::RowSetter::<D, Vec<u32>, _>::new(rect, dim, align, &mut self.data);
+        let mut setter = layout::RowSetter::<D, Vec<i32>, _>::new(rect, dim, align, &mut self.data);
 
         for (n, child) in self.widgets.iter_mut().enumerate() {
             let align = AlignHints::default();

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -95,8 +95,8 @@ impl<M: Clone + Debug + 'static> SetAccel for MenuEntry<M> {
         }
         // NOTE: we assume here that top-left and bottom-right frame size is the
         // same; if not then resizes may not happen exactly when required
-        let size = self.label_off;
-        action | kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
+        let size = self.label_off + self.label_off;
+        action | kas::text::util::set_text_and_prepare(&mut self.label, string, size)
     }
 }
 

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -120,7 +120,7 @@ impl<M: Clone + Debug> Menu for MenuEntry<M> {}
 pub struct MenuToggle<M: 'static> {
     #[widget_core]
     core: CoreData,
-    layout_data: layout::FixedRowStorage<[SizeRules; 3], [u32; 2]>,
+    layout_data: layout::FixedRowStorage<[SizeRules; 3], [i32; 2]>,
     #[widget]
     checkbox: CheckBoxBare<M>,
     #[widget]
@@ -222,7 +222,7 @@ impl<M: 'static> Layout for MenuToggle<M> {
 
     fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        let mut setter = layout::RowSetter::<_, [u32; 2], _>::new(
+        let mut setter = layout::RowSetter::<_, [i32; 2], _>::new(
             rect,
             (kas::Right, 2usize),
             align,

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -40,7 +40,7 @@ impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.menu_frame();
         self.label_off = size;
-        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, Margins::ZERO);
+        let frame_rules = SizeRules::extract_fixed(axis, size + size, Margins::ZERO);
         let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelSingle, axis);
         text_rules.surrounded_by(frame_rules, true)
     }

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -22,7 +22,7 @@ pub struct MenuEntry<M: Clone + Debug + 'static> {
     #[widget_core]
     core: kas::CoreData,
     label: Text<AccelString>,
-    label_off: Coord,
+    label_off: Size,
     msg: M,
 }
 
@@ -39,7 +39,7 @@ impl<M: Clone + Debug + 'static> WidgetConfig for MenuEntry<M> {
 impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.menu_frame();
-        self.label_off = size.into();
+        self.label_off = size;
         let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, Margins::ZERO);
         let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelSingle, axis);
         text_rules.surrounded_by(frame_rules, true)
@@ -70,7 +70,7 @@ impl<M: Clone + Debug + 'static> MenuEntry<M> {
         MenuEntry {
             core: Default::default(),
             label: Text::new_single(label.into()),
-            label_off: Coord::ZERO,
+            label_off: Size::ZERO,
             msg,
         }
     }
@@ -95,7 +95,7 @@ impl<M: Clone + Debug + 'static> SetAccel for MenuEntry<M> {
         }
         // NOTE: we assume here that top-left and bottom-right frame size is the
         // same; if not then resizes may not happen exactly when required
-        let size = Size::from(self.label_off);
+        let size = self.label_off;
         action | kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
     }
 }

--- a/src/widget/menu/menu_frame.rs
+++ b/src/widget/menu/menu_frame.rs
@@ -39,7 +39,7 @@ impl<W: Widget> Layout for MenuFrame<W> {
         let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, margins);
 
         let child_rules = self.inner.size_rules(size_handle, axis);
-        let m = child_rules.margins_u32();
+        let m = child_rules.margins_i32();
 
         if axis.is_horizontal() {
             self.m0.0 = size.0 + m.0;

--- a/src/widget/menu/menu_frame.rs
+++ b/src/widget/menu/menu_frame.rs
@@ -36,7 +36,7 @@ impl<W: Widget> Layout for MenuFrame<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.frame();
         let margins = Margins::ZERO;
-        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, margins);
+        let frame_rules = SizeRules::extract_fixed(axis, size + size, margins);
 
         let child_rules = self.inner.size_rules(size_handle, axis);
         let m = child_rules.margins_i32();

--- a/src/widget/menu/menu_frame.rs
+++ b/src/widget/menu/menu_frame.rs
@@ -39,14 +39,14 @@ impl<W: Widget> Layout for MenuFrame<W> {
         let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, margins);
 
         let child_rules = self.inner.size_rules(size_handle, axis);
-        let m = child_rules.margins();
+        let m = child_rules.margins_u32();
 
         if axis.is_horizontal() {
-            self.m0.0 = size.0 + m.0 as u32;
-            self.m1.0 = size.0 + m.1 as u32;
+            self.m0.0 = size.0 + m.0;
+            self.m1.0 = size.0 + m.1;
         } else {
-            self.m0.1 = size.1 + m.0 as u32;
-            self.m1.1 = size.1 + m.1 as u32;
+            self.m0.1 = size.1 + m.0;
+            self.m1.1 = size.1 + m.1;
         }
 
         child_rules.surrounded_by(frame_rules, true)

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -21,7 +21,7 @@ pub struct SubMenu<D: Directional, W: Menu> {
     core: CoreData,
     direction: D,
     label: Text<AccelString>,
-    label_off: Coord,
+    label_off: Size,
     #[widget]
     pub list: MenuFrame<Column<W>>,
     popup_id: Option<WindowId>,
@@ -62,7 +62,7 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
             core: Default::default(),
             direction,
             label: Text::new_single(label.into()),
-            label_off: Coord::ZERO,
+            label_off: Size::ZERO,
             list: MenuFrame::new(Column::new(list)),
             popup_id: None,
         }
@@ -104,7 +104,7 @@ impl<D: Directional, W: Menu> WidgetConfig for SubMenu<D, W> {
 impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.menu_frame();
-        self.label_off = size.into();
+        self.label_off = size;
         let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, Margins::ZERO);
         let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelSingle, axis);
         text_rules.surrounded_by(frame_rules, true)
@@ -284,7 +284,7 @@ impl<D: Directional, W: Menu> SetAccel for SubMenu<D, W> {
         }
         // NOTE: we assume here that top-left and bottom-right frame size is the
         // same; if not then resizes may not happen exactly when required
-        let size = Size::from(self.label_off);
+        let size = self.label_off;
         action | kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
     }
 }

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -105,7 +105,7 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let size = size_handle.menu_frame();
         self.label_off = size;
-        let frame_rules = SizeRules::extract_fixed(axis.is_vertical(), size + size, Margins::ZERO);
+        let frame_rules = SizeRules::extract_fixed(axis, size + size, Margins::ZERO);
         let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelSingle, axis);
         text_rules.surrounded_by(frame_rules, true)
     }

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -284,7 +284,7 @@ impl<D: Directional, W: Menu> SetAccel for SubMenu<D, W> {
         }
         // NOTE: we assume here that top-left and bottom-right frame size is the
         // same; if not then resizes may not happen exactly when required
-        let size = self.label_off;
-        action | kas::text::util::set_text_and_prepare(&mut self.label, string, size + size)
+        let size = self.label_off + self.label_off;
+        action | kas::text::util::set_text_and_prepare(&mut self.label, string, size)
     }
 }

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -90,7 +90,7 @@ impl<M: 'static> Layout for RadioBoxBare<M> {
         let size = size_handle.radiobox();
         self.core.rect.size = size;
         let margins = size_handle.outer_margins();
-        SizeRules::extract_fixed(axis.is_vertical(), size, margins)
+        SizeRules::extract_fixed(axis, size, margins)
     }
 
     fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {

--- a/src/widget/reserve.rs
+++ b/src/widget/reserve.rs
@@ -51,7 +51,7 @@ impl<W: Widget, R: FnMut(&mut dyn SizeHandle, AxisInfo) -> SizeRules + 'static> 
     /// use kas::prelude::*;
     ///
     /// let label = Reserve::new(Filler::new(), |size_handle, axis| {
-    ///     let size = (size_handle.scale_factor() * 100.0).round() as u32;
+    ///     let size = (size_handle.scale_factor() * 100.0).round() as i32;
     ///     SizeRules::fixed(size, (0, 0))
     /// });
     ///```

--- a/src/widget/reserve.rs
+++ b/src/widget/reserve.rs
@@ -51,7 +51,7 @@ impl<W: Widget, R: FnMut(&mut dyn SizeHandle, AxisInfo) -> SizeRules + 'static> 
     /// use kas::prelude::*;
     ///
     /// let label = Reserve::new(Filler::new(), |size_handle, axis| {
-    ///     let size = (size_handle.scale_factor() * 100.0).round() as i32;
+    ///     let size = i32::conv_ceil(size_handle.scale_factor() * 100.0);
     ///     SizeRules::fixed(size, (0, 0))
     /// });
     ///```

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -181,15 +181,15 @@ impl ScrollComponent {
                     ControlKey::Right => LineDelta(1.0, 0.0),
                     ControlKey::Up => LineDelta(0.0, 1.0),
                     ControlKey::Down => LineDelta(0.0, -1.0),
-                    ControlKey::PageUp => PixelDelta(Offset(0, window_size.1 as i32 / 2)),
-                    ControlKey::PageDown => PixelDelta(Offset(0, -(window_size.1 as i32 / 2))),
+                    ControlKey::PageUp => PixelDelta(Offset(0, window_size.1 / 2)),
+                    ControlKey::PageDown => PixelDelta(Offset(0, -(window_size.1 / 2))),
                     key => return (action, Response::Unhandled(Event::Control(key))),
                 };
 
                 let d = match delta {
                     LineDelta(x, y) => Offset(
-                        (-self.scroll_rate * x) as i32,
-                        (self.scroll_rate * y) as i32,
+                        i32::conv_nearest(-self.scroll_rate * x),
+                        i32::conv_nearest(self.scroll_rate * y),
                     ),
                     PixelDelta(d) => d,
                 };
@@ -198,8 +198,8 @@ impl ScrollComponent {
             Event::Scroll(delta) => {
                 let d = match delta {
                     LineDelta(x, y) => Offset(
-                        (-self.scroll_rate * x) as i32,
-                        (self.scroll_rate * y) as i32,
+                        i32::conv_nearest(-self.scroll_rate * x),
+                        i32::conv_nearest(self.scroll_rate * y),
                     ),
                     PixelDelta(d) => d,
                 };
@@ -305,7 +305,7 @@ impl<W: Widget> Layout for ScrollRegion<W> {
             self.min_child_size.1 = rules.min_size();
         }
         let line_height = size_handle.line_height(TextClass::Label);
-        self.scroll.set_scroll_rate(3.0 * line_height as f32);
+        self.scroll.set_scroll_rate(3.0 * f32::conv(line_height));
         rules.reduce_min_to(line_height);
         rules
     }

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -141,8 +141,8 @@ impl<D: Directional> ScrollBar<D> {
 
     fn update_handle(&mut self) -> TkAction {
         let len = self.len();
-        let total = self.max_value as u64 + self.handle_value as u64;
-        let handle_len = self.handle_value as u64 * len as u64 / total;
+        let total = u64::from(self.max_value) + u64::from(self.handle_value);
+        let handle_len = u64::from(self.handle_value) * len as u64 / total;
         self.handle_len = (handle_len as u32).max(self.min_handle_len).min(len);
         let mut size = self.core.rect.size;
         if self.direction.is_horizontal() {
@@ -156,8 +156,8 @@ impl<D: Directional> ScrollBar<D> {
     // translate value to offset in local coordinates
     fn offset(&self) -> Coord {
         let len = self.len() - self.handle_len;
-        let lhs = self.value as u64 * len as u64;
-        let rhs = self.max_value as u64;
+        let lhs = u64::from(self.value) * len as u64;
+        let rhs = u64::from(self.max_value);
         let mut pos = if rhs == 0 {
             0
         } else {
@@ -183,7 +183,7 @@ impl<D: Directional> ScrollBar<D> {
             offset = len - offset;
         }
 
-        let lhs = offset as u64 * self.max_value as u64;
+        let lhs = u64::from(offset) * u64::from(self.max_value);
         let rhs = len as u64;
         if rhs == 0 {
             debug_assert_eq!(self.value, 0);

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -154,7 +154,7 @@ impl<D: Directional> ScrollBar<D> {
     }
 
     // translate value to offset in local coordinates
-    fn offset(&self) -> Size {
+    fn offset(&self) -> Offset {
         let len = self.bar_len() - self.handle_len;
         let lhs = i64::from(self.value) * i64::conv(len);
         let rhs = i64::from(self.max_value);
@@ -167,13 +167,13 @@ impl<D: Directional> ScrollBar<D> {
             pos = len - pos;
         }
         match self.direction.is_vertical() {
-            false => Size(pos, 0),
-            true => Size(0, pos),
+            false => Offset(pos, 0),
+            true => Offset(0, pos),
         }
     }
 
     // true if not equal to old value
-    fn set_offset(&mut self, offset: Size) -> bool {
+    fn set_offset(&mut self, offset: Offset) -> bool {
         let len = self.bar_len() - self.handle_len;
         let mut offset = match self.direction.is_vertical() {
             false => offset.0,
@@ -275,16 +275,16 @@ pub trait ScrollWidget: Widget {
     /// Get the maximum scroll offset
     ///
     /// Note: the minimum scroll offset is always zero.
-    fn max_scroll_offset(&self) -> Size;
+    fn max_scroll_offset(&self) -> Offset;
 
     /// Get the current scroll offset
     ///
     /// Contents of the scroll region are translated by this offset (to convert
     /// coordinates from the outer region to the scroll region, add this offset).
     ///
-    /// The offset is restricted between [`Size::ZERO`] and
+    /// The offset is restricted between [`Offset::ZERO`] and
     /// [`ScrollRegion::max_scroll_offset`].
-    fn scroll_offset(&self) -> Size;
+    fn scroll_offset(&self) -> Offset;
 
     /// Set the scroll offset
     ///
@@ -294,7 +294,7 @@ pub trait ScrollWidget: Widget {
     ///
     /// The offset is clamped to the available scroll range and applied. The
     /// resulting offset is returned.
-    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Size) -> Size;
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Offset) -> Offset;
 }
 
 /// A scrollable region with bars
@@ -407,13 +407,13 @@ impl<W: ScrollWidget> ScrollWidget for ScrollBars<W> {
     fn scroll_axes(&self, size: Size) -> (bool, bool) {
         self.inner.scroll_axes(size)
     }
-    fn max_scroll_offset(&self) -> Size {
+    fn max_scroll_offset(&self) -> Offset {
         self.inner.max_scroll_offset()
     }
-    fn scroll_offset(&self) -> Size {
+    fn scroll_offset(&self) -> Offset {
         self.inner.scroll_offset()
     }
-    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Size) -> Size {
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Offset) -> Offset {
         let offset = self.inner.set_scroll_offset(mgr, offset);
         *mgr |= self.horiz_bar.set_value(offset.0) | self.vert_bar.set_value(offset.1);
         offset
@@ -444,7 +444,7 @@ impl<W: ScrollWidget> Layout for ScrollBars<W> {
 
         let bar_width = mgr.size_handle(|sh| (sh.scrollbar().0).1);
         if self.auto_bars {
-            child_size -= Size(bar_width, bar_width);
+            child_size -= Size::splat(bar_width);
             self.show_bars = self.inner.scroll_axes(child_size);
         } else {
             if self.show_bars.0 {
@@ -461,14 +461,14 @@ impl<W: ScrollWidget> Layout for ScrollBars<W> {
 
         if self.show_bars.0 {
             let pos = Coord(pos.0, pos.1 + child_size.1);
-            let size = Size(child_size.0, bar_width);
+            let size = Size::new(child_size.0, bar_width);
             self.horiz_bar
                 .set_rect(mgr, Rect { pos, size }, AlignHints::NONE);
             let _ = self.horiz_bar.set_limits(max_scroll_offset.0, rect.size.0);
         }
         if self.show_bars.1 {
             let pos = Coord(pos.0 + child_size.0, pos.1);
-            let size = Size(bar_width, self.core.rect.size.1);
+            let size = Size::new(bar_width, self.core.rect.size.1);
             self.vert_bar
                 .set_rect(mgr, Rect { pos, size }, AlignHints::NONE);
             let _ = self.vert_bar.set_limits(max_scroll_offset.1, rect.size.1);
@@ -510,7 +510,7 @@ impl<W: ScrollWidget> event::SendEvent for ScrollBars<W> {
                 .send(mgr, id, event)
                 .try_into()
                 .unwrap_or_else(|msg| {
-                    let offset = Size(msg, self.inner.scroll_offset().1);
+                    let offset = Offset(msg, self.inner.scroll_offset().1);
                     self.inner.set_scroll_offset(mgr, offset);
                     Response::None
                 })
@@ -519,7 +519,7 @@ impl<W: ScrollWidget> event::SendEvent for ScrollBars<W> {
                 .send(mgr, id, event)
                 .try_into()
                 .unwrap_or_else(|msg| {
-                    let offset = Size(self.inner.scroll_offset().0, msg);
+                    let offset = Offset(self.inner.scroll_offset().0, msg);
                     self.inner.set_scroll_offset(mgr, offset);
                     Response::None
                 })

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -154,7 +154,7 @@ impl<D: Directional> ScrollBar<D> {
     }
 
     // translate value to offset in local coordinates
-    fn offset(&self) -> Coord {
+    fn offset(&self) -> Size {
         let len = self.bar_len() - self.handle_len;
         let lhs = i64::from(self.value) * i64::conv(len);
         let rhs = i64::from(self.max_value);
@@ -167,13 +167,13 @@ impl<D: Directional> ScrollBar<D> {
             pos = len - pos;
         }
         match self.direction.is_vertical() {
-            false => Coord(pos, 0),
-            true => Coord(0, pos),
+            false => Size(pos, 0),
+            true => Size(0, pos),
         }
     }
 
     // true if not equal to old value
-    fn set_offset(&mut self, offset: Coord) -> bool {
+    fn set_offset(&mut self, offset: Size) -> bool {
         let len = self.bar_len() - self.handle_len;
         let mut offset = match self.direction.is_vertical() {
             false => offset.0,
@@ -275,16 +275,16 @@ pub trait ScrollWidget: Widget {
     /// Get the maximum scroll offset
     ///
     /// Note: the minimum scroll offset is always zero.
-    fn max_scroll_offset(&self) -> Coord;
+    fn max_scroll_offset(&self) -> Size;
 
     /// Get the current scroll offset
     ///
     /// Contents of the scroll region are translated by this offset (to convert
     /// coordinates from the outer region to the scroll region, add this offset).
     ///
-    /// The offset is restricted between [`Coord::ZERO`] and
+    /// The offset is restricted between [`Size::ZERO`] and
     /// [`ScrollRegion::max_scroll_offset`].
-    fn scroll_offset(&self) -> Coord;
+    fn scroll_offset(&self) -> Size;
 
     /// Set the scroll offset
     ///
@@ -294,7 +294,7 @@ pub trait ScrollWidget: Widget {
     ///
     /// The offset is clamped to the available scroll range and applied. The
     /// resulting offset is returned.
-    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) -> Coord;
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Size) -> Size;
 }
 
 /// A scrollable region with bars
@@ -407,13 +407,13 @@ impl<W: ScrollWidget> ScrollWidget for ScrollBars<W> {
     fn scroll_axes(&self, size: Size) -> (bool, bool) {
         self.inner.scroll_axes(size)
     }
-    fn max_scroll_offset(&self) -> Coord {
+    fn max_scroll_offset(&self) -> Size {
         self.inner.max_scroll_offset()
     }
-    fn scroll_offset(&self) -> Coord {
+    fn scroll_offset(&self) -> Size {
         self.inner.scroll_offset()
     }
-    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) -> Coord {
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Size) -> Size {
         let offset = self.inner.set_scroll_offset(mgr, offset);
         *mgr |= self.horiz_bar.set_value(offset.0) | self.vert_bar.set_value(offset.1);
         offset
@@ -510,7 +510,7 @@ impl<W: ScrollWidget> event::SendEvent for ScrollBars<W> {
                 .send(mgr, id, event)
                 .try_into()
                 .unwrap_or_else(|msg| {
-                    let offset = Coord(msg, self.inner.scroll_offset().1);
+                    let offset = Size(msg, self.inner.scroll_offset().1);
                     self.inner.set_scroll_offset(mgr, offset);
                     Response::None
                 })
@@ -519,7 +519,7 @@ impl<W: ScrollWidget> event::SendEvent for ScrollBars<W> {
                 .send(mgr, id, event)
                 .try_into()
                 .unwrap_or_else(|msg| {
-                    let offset = Coord(self.inner.scroll_offset().0, msg);
+                    let offset = Size(self.inner.scroll_offset().0, msg);
                     self.inner.set_scroll_offset(mgr, offset);
                     Response::None
                 })

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -142,8 +142,8 @@ impl<D: Directional> ScrollBar<D> {
     fn update_handle(&mut self) -> TkAction {
         let len = self.len();
         let total = u64::from(self.max_value) + u64::from(self.handle_value);
-        let handle_len = u64::from(self.handle_value) * len as u64 / total;
-        self.handle_len = (handle_len as u32).max(self.min_handle_len).min(len);
+        let handle_len = u64::from(self.handle_value) * u64::conv(len) / total;
+        self.handle_len = u32::conv(handle_len).max(self.min_handle_len).min(len);
         let mut size = self.core.rect.size;
         if self.direction.is_horizontal() {
             size.0 = self.handle_len;
@@ -156,12 +156,12 @@ impl<D: Directional> ScrollBar<D> {
     // translate value to offset in local coordinates
     fn offset(&self) -> Coord {
         let len = self.len() - self.handle_len;
-        let lhs = u64::from(self.value) * len as u64;
+        let lhs = u64::from(self.value) * u64::conv(len);
         let rhs = u64::from(self.max_value);
         let mut pos = if rhs == 0 {
             0
         } else {
-            (((lhs + (rhs / 2)) / rhs) as u32).min(len)
+            u32::conv((lhs + (rhs / 2)) / rhs).min(len)
         };
         if self.direction.is_reversed() {
             pos = len - pos;
@@ -184,12 +184,12 @@ impl<D: Directional> ScrollBar<D> {
         }
 
         let lhs = u64::from(offset) * u64::from(self.max_value);
-        let rhs = len as u64;
+        let rhs = u64::conv(len);
         if rhs == 0 {
             debug_assert_eq!(self.value, 0);
             return false;
         }
-        let value = ((lhs + (rhs / 2)) / rhs) as u32;
+        let value = u32::conv((lhs + (rhs / 2)) / rhs);
         let value = value.min(self.max_value);
         if value != self.value {
             self.value = value;

--- a/src/widget/separator.rs
+++ b/src/widget/separator.rs
@@ -50,7 +50,7 @@ impl<M: Debug> Separator<M> {
 
 impl<M: Debug> Layout for Separator<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        SizeRules::extract_fixed(axis.is_vertical(), size_handle.frame(), Default::default())
+        SizeRules::extract_fixed(axis, size_handle.frame(), Default::default())
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -170,7 +170,7 @@ impl<T: SliderType, D: Directional> Slider<T, D> {
     }
 
     // translate value to offset in local coordinates
-    fn offset(&self) -> Coord {
+    fn offset(&self) -> Size {
         let a = self.value - self.range.0;
         let b = self.range.1 - self.range.0;
         let max_offset = self.handle.max_offset();
@@ -180,13 +180,13 @@ impl<T: SliderType, D: Directional> Slider<T, D> {
             frac = 1.0 - frac;
         }
         match self.direction.is_vertical() {
-            false => Coord((max_offset.0 as f64 * frac) as i32, 0),
-            true => Coord(0, (max_offset.1 as f64 * frac) as i32),
+            false => Size((max_offset.0 as f64 * frac) as i32, 0),
+            true => Size(0, (max_offset.1 as f64 * frac) as i32),
         }
     }
 
     // true if not equal to old value
-    fn set_offset(&mut self, offset: Coord) -> bool {
+    fn set_offset(&mut self, offset: Size) -> bool {
         let b = self.range.1 - self.range.0;
         let max_offset = self.handle.max_offset();
         let mut a = match self.direction.is_vertical() {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -26,7 +26,10 @@ pub trait SliderType:
     /// Return the result of multiplying self by an `f64` scalar
     ///
     /// Note: the `scalar` is expected to be between 0 and 1, hence this
-    /// operation should not produce a value outside the range of `Self`.
+    /// operation should not produce a value larger than self.
+    ///
+    /// Also note that this method is not required to preserve precision
+    /// (e.g. `u128::mul_64` may drop some low-order bits with large numbers).
     fn mul_f64(self, scalar: f64) -> Self;
 }
 
@@ -180,8 +183,8 @@ impl<T: SliderType, D: Directional> Slider<T, D> {
             frac = 1.0 - frac;
         }
         match self.direction.is_vertical() {
-            false => Offset((max_offset.0 as f64 * frac) as i32, 0),
-            true => Offset(0, (max_offset.1 as f64 * frac) as i32),
+            false => Offset(i32::conv_floor(max_offset.0 as f64 * frac), 0),
+            true => Offset(0, i32::conv_floor(max_offset.1 as f64 * frac)),
         }
     }
 

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -170,7 +170,7 @@ impl<T: SliderType, D: Directional> Slider<T, D> {
     }
 
     // translate value to offset in local coordinates
-    fn offset(&self) -> Size {
+    fn offset(&self) -> Offset {
         let a = self.value - self.range.0;
         let b = self.range.1 - self.range.0;
         let max_offset = self.handle.max_offset();
@@ -180,13 +180,13 @@ impl<T: SliderType, D: Directional> Slider<T, D> {
             frac = 1.0 - frac;
         }
         match self.direction.is_vertical() {
-            false => Size((max_offset.0 as f64 * frac) as i32, 0),
-            true => Size(0, (max_offset.1 as f64 * frac) as i32),
+            false => Offset((max_offset.0 as f64 * frac) as i32, 0),
+            true => Offset(0, (max_offset.1 as f64 * frac) as i32),
         }
     }
 
     // true if not equal to old value
-    fn set_offset(&mut self, offset: Size) -> bool {
+    fn set_offset(&mut self, offset: Offset) -> bool {
         let b = self.range.1 - self.range.0;
         let max_offset = self.handle.max_offset();
         let mut a = match self.direction.is_vertical() {

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -284,7 +284,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
 
         let is_horiz = self.direction.is_horizontal();
         let extract_p = |p: Coord| if is_horiz { p.0 } else { p.1 } as u32;
-        let extract_s = |s: Size| if is_horiz { s.0 } else { s.1 } as u32;
+        let extract_s = |s: Size| if is_horiz { s.0 } else { s.1 };
         let hrect = self.handles[n].rect();
         let width1 = extract_p(hrect.pos - self.core.rect.pos) as u32;
         let width2 = extract_s(self.core.rect.size - hrect.size) - width1;

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -283,11 +283,10 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         let index = 2 * n + 1;
 
         let is_horiz = self.direction.is_horizontal();
-        let extract_p = |p: Coord| if is_horiz { p.0 } else { p.1 };
-        let extract_s = |s: Size| if is_horiz { s.0 } else { s.1 };
+        let extract = |s: Size| if is_horiz { s.0 } else { s.1 };
         let hrect = self.handles[n].rect();
-        let width1 = extract_p(hrect.pos - self.core.rect.pos);
-        let width2 = extract_s(self.core.rect.size - hrect.size) - width1;
+        let width1 = extract(hrect.pos - self.core.rect.pos);
+        let width2 = extract(self.core.rect.size - hrect.size) - width1;
 
         let dim = (self.direction, WidgetChildren::len(self));
         let mut setter =

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -119,7 +119,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
         }
         assert!(self.handles.len() + 1 == self.widgets.len());
 
-        let handle_size = axis.extract_size(size_handle.frame());
+        let handle_size = size_handle.frame().extract(axis);
 
         let dim = (self.direction, WidgetChildren::len(self));
         let mut solver = layout::RowSolver::new(axis, dim, &mut self.data);
@@ -282,11 +282,9 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         assert_eq!(self.widgets.len(), self.handles.len() + 1);
         let index = 2 * n + 1;
 
-        let is_horiz = self.direction.is_horizontal();
-        let extract = |s: Size| if is_horiz { s.0 } else { s.1 };
         let hrect = self.handles[n].rect();
-        let width1 = extract(hrect.pos - self.core.rect.pos);
-        let width2 = extract(self.core.rect.size - hrect.size) - width1;
+        let width1 = (hrect.pos - self.core.rect.pos).extract(self.direction);
+        let width2 = (self.core.rect.size - hrect.size).extract(self.direction) - width1;
 
         let dim = (self.direction, WidgetChildren::len(self));
         let mut setter =

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -156,7 +156,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
         if aa.unwrap_or(Align::Stretch) != Align::Stretch {
             warn!("Splitter: found alignment != Stretch");
         }
-        let mut setter = layout::RowSetter::<D, Vec<u32>, _>::new(rect, dim, align, &mut self.data);
+        let mut setter = layout::RowSetter::<D, Vec<i32>, _>::new(rect, dim, align, &mut self.data);
 
         let mut n = 0;
         loop {
@@ -283,15 +283,15 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         let index = 2 * n + 1;
 
         let is_horiz = self.direction.is_horizontal();
-        let extract_p = |p: Coord| if is_horiz { p.0 } else { p.1 } as u32;
+        let extract_p = |p: Coord| if is_horiz { p.0 } else { p.1 };
         let extract_s = |s: Size| if is_horiz { s.0 } else { s.1 };
         let hrect = self.handles[n].rect();
-        let width1 = extract_p(hrect.pos - self.core.rect.pos) as u32;
+        let width1 = extract_p(hrect.pos - self.core.rect.pos);
         let width2 = extract_s(self.core.rect.size - hrect.size) - width1;
 
         let dim = (self.direction, WidgetChildren::len(self));
         let mut setter =
-            layout::RowSetter::<D, Vec<u32>, _>::new_unsolved(self.core.rect, dim, &mut self.data);
+            layout::RowSetter::<D, Vec<i32>, _>::new_unsolved(self.core.rect, dim, &mut self.data);
         setter.solve_range(&mut self.data, 0..index, width1);
         setter.solve_range(&mut self.data, (index + 1)..dim.1, width2);
         setter.update_offsets(&mut self.data);

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -138,7 +138,7 @@ where
         // TODO: we may wish to notify self.data of the range it should cache
         let w_len = self.widgets.len();
         let (old_start, old_end) = (self.data_range.start(), self.data_range.end());
-        let offset = u64::conv(self.direction.extract_size(self.scroll_offset()));
+        let offset = u64::conv(self.scroll_offset().extract(self.direction));
         let mut first_data = usize::conv(offset / u64::conv(self.child_skip));
         first_data = (first_data + w_len)
             .min(self.data.len())

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -138,8 +138,8 @@ where
         // TODO: we may wish to notify self.data of the range it should cache
         let w_len = self.widgets.len();
         let (old_start, old_end) = (self.data_range.start(), self.data_range.end());
-        let offset = self.direction.extract_coord(self.scroll_offset()) as usize;
-        let mut first_data = offset / self.child_skip as usize;
+        let offset = u64::conv(self.direction.extract_coord(self.scroll_offset()));
+        let mut first_data = usize::conv(offset / u64::from(self.child_skip));
         first_data = (first_data + w_len)
             .min(self.data.len())
             .saturating_sub(w_len);
@@ -156,7 +156,7 @@ where
         };
         let mut pos_start = self.core.rect.pos;
         if self.direction.is_reversed() {
-            pos_start += skip * (w_len - 1) as i32;
+            pos_start += skip * i32::conv(w_len - 1);
             skip = skip * -1;
         }
         let mut rect = Rect::new(pos_start, child_size);
@@ -168,7 +168,7 @@ where
             if i == 0 || (data_num < old_start || data_num >= old_end) {
                 let w = &mut self.widgets[i];
                 action |= w.set(self.data.get(data_num));
-                rect.pos = pos_start + skip * data_num as i32;
+                rect.pos = pos_start + skip * i32::conv(data_num);
                 w.set_rect(mgr, rect, self.align_hints);
             }
         }
@@ -186,8 +186,9 @@ where
     fn scroll_axes(&self, size: Size) -> (bool, bool) {
         // TODO: maybe we should support a scrollbar on the other axis?
         // We would need to report a fake min-child-size to enable scrolling.
-        let min_size = ((self.child_size_min + self.child_inter_margin) * self.data.len() as u32)
-            .saturating_sub(self.child_inter_margin);
+        let min_size = ((self.child_size_min + self.child_inter_margin)
+            * u32::conv(self.data.len()))
+        .saturating_sub(self.child_inter_margin);
         (
             self.direction.is_horizontal() && min_size > size.0,
             self.direction.is_vertical() && min_size > size.1,
@@ -315,7 +316,7 @@ where
         self.align_hints = align;
 
         let old_num = self.widgets.len();
-        let num = (num as usize).min(data_len);
+        let num = (usize::conv(num)).min(data_len);
         if num > old_num {
             debug!("allocating widgets (old len = {}, new = {})", old_num, num);
             *mgr |= TkAction::RECONFIGURE;

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -266,7 +266,7 @@ where
         if axis.is_vertical() == self.direction.is_vertical() {
             self.child_size_min = rules.min_size();
             self.child_size_ideal = rules.ideal_size();
-            self.child_inter_margin = rules.margins().0 as u32 + rules.margins().1 as u32;
+            self.child_inter_margin = rules.margins_u32().0 + rules.margins_u32().1;
             rules.multiply_with_margin(2, self.ideal_visible);
             rules.set_stretch(rules.stretch().max(StretchPolicy::HighUtility));
         }

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -36,12 +36,12 @@ pub struct ListView<
     direction: D,
     data_range: Range,
     align_hints: AlignHints,
-    ideal_visible: u32,
-    child_size_min: u32,
-    child_size_ideal: u32,
-    child_inter_margin: u32,
-    child_skip: u32,
-    child_size: u32,
+    ideal_visible: i32,
+    child_size_min: i32,
+    child_size_ideal: i32,
+    child_inter_margin: i32,
+    child_skip: i32,
+    child_size: i32,
     scroll: ScrollComponent,
 }
 
@@ -127,7 +127,7 @@ where
     ///
     /// This affects the (ideal) size request and whether children are sized
     /// according to their ideal or minimum size but not the minimum size.
-    pub fn with_num_visible(mut self, number: u32) -> Self {
+    pub fn with_num_visible(mut self, number: i32) -> Self {
         self.ideal_visible = number;
         self
     }
@@ -139,7 +139,7 @@ where
         let w_len = self.widgets.len();
         let (old_start, old_end) = (self.data_range.start(), self.data_range.end());
         let offset = u64::conv(self.direction.extract_coord(self.scroll_offset()));
-        let mut first_data = usize::conv(offset / u64::from(self.child_skip));
+        let mut first_data = usize::conv(offset / u64::conv(self.child_skip));
         first_data = (first_data + w_len)
             .min(self.data.len())
             .saturating_sub(w_len);
@@ -147,11 +147,11 @@ where
         let (child_size, mut skip) = match self.direction.is_vertical() {
             false => (
                 Size(self.child_size, self.rect().size.1),
-                Coord(self.child_skip as i32, 0),
+                Coord(self.child_skip, 0),
             ),
             true => (
                 Size(self.rect().size.0, self.child_size),
-                Coord(0, self.child_skip as i32),
+                Coord(0, self.child_skip),
             ),
         };
         let mut pos_start = self.core.rect.pos;
@@ -187,7 +187,7 @@ where
         // TODO: maybe we should support a scrollbar on the other axis?
         // We would need to report a fake min-child-size to enable scrolling.
         let min_size = ((self.child_size_min + self.child_inter_margin)
-            * u32::conv(self.data.len()))
+            * i32::conv(self.data.len()))
         .saturating_sub(self.child_inter_margin);
         (
             self.direction.is_horizontal() && min_size > size.0,
@@ -267,7 +267,7 @@ where
         if axis.is_vertical() == self.direction.is_vertical() {
             self.child_size_min = rules.min_size();
             self.child_size_ideal = rules.ideal_size();
-            self.child_inter_margin = rules.margins_u32().0 + rules.margins_u32().1;
+            self.child_inter_margin = rules.margins_i32().0 + rules.margins_i32().1;
             rules.multiply_with_margin(2, self.ideal_visible);
             rules.set_stretch(rules.stretch().max(StretchPolicy::HighUtility));
         }
@@ -278,7 +278,7 @@ where
         self.core.rect = rect;
 
         let data_len = self.data.len();
-        let data_len32 = u32::try_from(data_len).unwrap();
+        let data_len32 = i32::try_from(data_len).unwrap();
         let mut child_size = rect.size;
         let content_size;
         let skip;

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -186,9 +186,9 @@ where
     fn scroll_axes(&self, size: Size) -> (bool, bool) {
         // TODO: maybe we should support a scrollbar on the other axis?
         // We would need to report a fake min-child-size to enable scrolling.
-        let min_size = ((self.child_size_min + self.child_inter_margin)
-            * i32::conv(self.data.len()))
-        .saturating_sub(self.child_inter_margin);
+        let item_min = self.child_size_min + self.child_inter_margin;
+        let num = i32::conv(self.data.len());
+        let min_size = (item_min * num - self.child_inter_margin).max(0);
         (
             self.direction.is_horizontal() && min_size > size.0,
             self.direction.is_vertical() && min_size > size.1,
@@ -295,7 +295,7 @@ where
             align.horiz = None;
             num = (rect.size.0 + skip.0 - 1) / skip.0 + 1;
 
-            let full_width = (skip.0 * data_len32).saturating_sub(self.child_inter_margin);
+            let full_width = (skip.0 * data_len32 - self.child_inter_margin).max(0);
             content_size = Size::new(full_width, child_size.1);
         } else {
             if child_size.1 >= self.ideal_visible * self.child_size_ideal {
@@ -309,7 +309,7 @@ where
             align.vert = None;
             num = (rect.size.1 + skip.1 - 1) / skip.1 + 1;
 
-            let full_height = (skip.1 * data_len32).saturating_sub(self.child_inter_margin);
+            let full_height = (skip.1 * data_len32 - self.child_inter_margin).max(0);
             content_size = Size::new(child_size.0, full_height);
         }
 

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -138,7 +138,7 @@ where
         // TODO: we may wish to notify self.data of the range it should cache
         let w_len = self.widgets.len();
         let (old_start, old_end) = (self.data_range.start(), self.data_range.end());
-        let offset = u64::conv(self.direction.extract_coord(self.scroll_offset()));
+        let offset = u64::conv(self.direction.extract_size(self.scroll_offset()));
         let mut first_data = usize::conv(offset / u64::conv(self.child_skip));
         first_data = (first_data + w_len)
             .min(self.data.len())
@@ -147,11 +147,11 @@ where
         let (child_size, mut skip) = match self.direction.is_vertical() {
             false => (
                 Size(self.child_size, self.rect().size.1),
-                Coord(self.child_skip, 0),
+                Size(self.child_skip, 0),
             ),
             true => (
                 Size(self.rect().size.0, self.child_size),
-                Coord(0, self.child_skip),
+                Size(0, self.child_skip),
             ),
         };
         let mut pos_start = self.core.rect.pos;
@@ -196,17 +196,17 @@ where
     }
 
     #[inline]
-    fn max_scroll_offset(&self) -> Coord {
+    fn max_scroll_offset(&self) -> Size {
         self.scroll.max_offset()
     }
 
     #[inline]
-    fn scroll_offset(&self) -> Coord {
+    fn scroll_offset(&self) -> Size {
         self.scroll.offset()
     }
 
     #[inline]
-    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Coord) -> Coord {
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Size) -> Size {
         *mgr |= self.scroll.set_offset(offset);
         self.update_widgets(mgr);
         self.scroll.offset()

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -146,12 +146,12 @@ where
         let data_range = first_data..(first_data + w_len).min(self.data.len());
         let (child_size, mut skip) = match self.direction.is_vertical() {
             false => (
-                Size(self.child_size, self.rect().size.1),
-                Size(self.child_skip, 0),
+                Size::new(self.child_size, self.rect().size.1),
+                Offset(self.child_skip, 0),
             ),
             true => (
-                Size(self.rect().size.0, self.child_size),
-                Size(0, self.child_skip),
+                Size::new(self.rect().size.0, self.child_size),
+                Offset(0, self.child_skip),
             ),
         };
         let mut pos_start = self.core.rect.pos;
@@ -196,17 +196,17 @@ where
     }
 
     #[inline]
-    fn max_scroll_offset(&self) -> Size {
+    fn max_scroll_offset(&self) -> Offset {
         self.scroll.max_offset()
     }
 
     #[inline]
-    fn scroll_offset(&self) -> Size {
+    fn scroll_offset(&self) -> Offset {
         self.scroll.offset()
     }
 
     #[inline]
-    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Size) -> Size {
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Offset) -> Offset {
         *mgr |= self.scroll.set_offset(offset);
         self.update_widgets(mgr);
         self.scroll.offset()
@@ -290,13 +290,13 @@ where
                 child_size.0 = self.child_size_min;
             }
             self.child_size = child_size.0;
-            skip = Size(child_size.0 + self.child_inter_margin, 0);
+            skip = Offset(child_size.0 + self.child_inter_margin, 0);
             self.child_skip = skip.0;
             align.horiz = None;
             num = (rect.size.0 + skip.0 - 1) / skip.0 + 1;
 
             let full_width = (skip.0 * data_len32).saturating_sub(self.child_inter_margin);
-            content_size = Size(full_width, child_size.1);
+            content_size = Size::new(full_width, child_size.1);
         } else {
             if child_size.1 >= self.ideal_visible * self.child_size_ideal {
                 child_size.1 = self.child_size_ideal;
@@ -304,13 +304,13 @@ where
                 child_size.1 = self.child_size_min;
             }
             self.child_size = child_size.1;
-            skip = Size(0, child_size.1 + self.child_inter_margin);
+            skip = Offset(0, child_size.1 + self.child_inter_margin);
             self.child_skip = skip.1;
             align.vert = None;
             num = (rect.size.1 + skip.1 - 1) / skip.1 + 1;
 
             let full_height = (skip.1 * data_len32).saturating_sub(self.child_inter_margin);
-            content_size = Size(child_size.0, full_height);
+            content_size = Size::new(child_size.0, full_height);
         }
 
         self.align_hints = align;

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -230,11 +230,11 @@ impl<W: Widget> Window<W> {
         let m = cache.margins();
 
         let is_reversed = popup.direction.is_reversed();
-        let place_in = |rp, rs: i32, cp: i32, cs, ideal, m: (u16, u16)| -> (i32, i32) {
+        let place_in = |rp, rs: i32, cp: i32, cs: i32, ideal, m: (u16, u16)| -> (i32, i32) {
             let m: (i32, i32) = (m.0.into(), m.1.into());
             let before: i32 = cp - (rp + m.1);
             let before = before.max(0);
-            let after = rs.saturating_sub(cs + before + m.0);
+            let after = (rs - (cs + before + m.0)).max(0);
             if after >= ideal {
                 if is_reversed && before >= ideal {
                     (cp - ideal - m.1, ideal)

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -139,7 +139,7 @@ impl<W: Widget> Layout for Window<W> {
         self.w.draw(draw_handle, mgr, disabled);
         for popup in &self.popups {
             let class = ClipRegion::Popup;
-            draw_handle.clip_region(self.core.rect, Size::ZERO, class, &mut |draw_handle| {
+            draw_handle.clip_region(self.core.rect, Offset::ZERO, class, &mut |draw_handle| {
                 self.find(popup.1.id)
                     .map(|w| w.draw(draw_handle, mgr, disabled));
             });
@@ -257,11 +257,11 @@ impl<W: Widget> Window<W> {
         let rect = if popup.direction.is_horizontal() {
             let (x, w) = place_in(r.pos.0, r.size.0, c.pos.0, c.size.0, ideal.0, m.horiz);
             let (y, h) = place_out(r.pos.1, r.size.1, c.pos.1, c.size.1, ideal.1);
-            Rect::new(Coord(x, y), Size(w, h))
+            Rect::new(Coord(x, y), Size::new(w, h))
         } else {
             let (x, w) = place_out(r.pos.0, r.size.0, c.pos.0, c.size.0, ideal.0);
             let (y, h) = place_in(r.pos.1, r.size.1, c.pos.1, c.size.1, ideal.1, m.vert);
-            Rect::new(Coord(x, y), Size(w, h))
+            Rect::new(Coord(x, y), Size::new(w, h))
         };
 
         cache.apply_rect(widget, mgr, rect, false);

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -139,7 +139,7 @@ impl<W: Widget> Layout for Window<W> {
         self.w.draw(draw_handle, mgr, disabled);
         for popup in &self.popups {
             let class = ClipRegion::Popup;
-            draw_handle.clip_region(self.core.rect, Coord::ZERO, class, &mut |draw_handle| {
+            draw_handle.clip_region(self.core.rect, Size::ZERO, class, &mut |draw_handle| {
                 self.find(popup.1.id)
                     .map(|w| w.draw(draw_handle, mgr, disabled));
             });

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -231,21 +231,22 @@ impl<W: Widget> Window<W> {
 
         let is_reversed = popup.direction.is_reversed();
         let place_in = |rp, rs: u32, cp: i32, cs, ideal, m: (u16, u16)| -> (i32, u32) {
-            let before: i32 = cp - (rp + m.1 as i32);
+            let before: i32 = cp - (rp + i32::from(m.1));
             let before = before.max(0) as u32;
-            let after = rs.saturating_sub(cs + before + m.0 as u32);
+            let after = rs.saturating_sub(cs + before + u32::from(m.0));
+            let m: (i32, i32) = (m.0.into(), m.1.into());
             if after >= ideal {
                 if is_reversed && before >= ideal {
-                    (cp - ideal as i32 - m.1 as i32, ideal)
+                    (cp - ideal as i32 - m.1, ideal)
                 } else {
-                    (cp + cs as i32 + m.0 as i32, ideal)
+                    (cp + cs as i32 + m.0, ideal)
                 }
             } else if before >= ideal {
-                (cp - ideal as i32 - m.1 as i32, ideal)
+                (cp - ideal as i32 - m.1, ideal)
             } else if before > after {
                 (rp, before)
             } else {
-                (cp + cs as i32 + m.0 as i32, after)
+                (cp + cs as i32 + m.0, after)
             }
         };
         let place_out = |rp, rs, cp: i32, cs, ideal: u32| -> (i32, u32) {

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -230,27 +230,27 @@ impl<W: Widget> Window<W> {
         let m = cache.margins();
 
         let is_reversed = popup.direction.is_reversed();
-        let place_in = |rp, rs: u32, cp: i32, cs, ideal, m: (u16, u16)| -> (i32, u32) {
-            let before: i32 = cp - (rp + i32::from(m.1));
-            let before = before.max(0) as u32;
-            let after = rs.saturating_sub(cs + before + u32::from(m.0));
+        let place_in = |rp, rs: i32, cp: i32, cs, ideal, m: (u16, u16)| -> (i32, i32) {
             let m: (i32, i32) = (m.0.into(), m.1.into());
+            let before: i32 = cp - (rp + m.1);
+            let before = before.max(0);
+            let after = rs.saturating_sub(cs + before + m.0);
             if after >= ideal {
                 if is_reversed && before >= ideal {
-                    (cp - ideal as i32 - m.1, ideal)
+                    (cp - ideal - m.1, ideal)
                 } else {
-                    (cp + cs as i32 + m.0, ideal)
+                    (cp + cs + m.0, ideal)
                 }
             } else if before >= ideal {
-                (cp - ideal as i32 - m.1, ideal)
+                (cp - ideal - m.1, ideal)
             } else if before > after {
                 (rp, before)
             } else {
-                (cp + cs as i32 + m.0, after)
+                (cp + cs + m.0, after)
             }
         };
-        let place_out = |rp, rs, cp: i32, cs, ideal: u32| -> (i32, u32) {
-            let pos = cp.min(rp + rs as i32 - ideal as i32).max(rp);
+        let place_out = |rp, rs, cp: i32, cs, ideal: i32| -> (i32, i32) {
+            let pos = cp.min(rp + rs - ideal).max(rp);
             let size = ideal.max(cs).min(rs);
             (pos, size)
         };


### PR DESCRIPTION
Replaces most uses of `as` for type-casting with new conversion traits, with accuracy checks at least during debug mode. (Possibly these traits should be spun off into a new crate.)

The `Size` type now uses `i32` instead of `u32` to avoid converting everywhere.

`Size` was made a vector type, then vector uses were replaced with a new `Offset` type so that `Size` can check values are non-negative *at least sometimes*.

Also fixes some missing redraws.