### PR TITLE
EditField, README, tweak alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,29 +31,26 @@ For details, see the [Examples README](kas-wgpu/examples/README.md).
 -   Themes (sizing and rendering control) and colour schemes with run-time switching
 -   Accessibility/input: full keyboard control as well as touchscreen and mouse
 -   Bidirectional and rich text support via [KAS-text] with complex glyph shaping via [HarfBuzz]
--   Embedded graphics via custom [WebGPU] graphics pipes
+-   Accelerated graphics via [WebGPU]
+-   Embedded accelerated graphics via custom pipelines
 
 ### Missing features
 
 These aren't here yet!
 
 -   Raster graphics
--   Flow-box layouts
--   CPU and OpenGL rendering (currently only supports drawing via [WebGPU],
-    which should support most modern systems but not all)
--   User-configuration and desktop integration
+-   Flow-box layouts (but rows, columns and grids are enough for most stuff)
+-   CPU-based fallback renderer
+-   Desktop UI integration
 -   And much more, see the [ROADMAP].
 
-## Widgets
+## Learn
 
-Below are some highlights. Find the full list in the [docs](docs.rs/kas/*/kas/widget).
-
--   Single- and multi-line text editing via `EditBox`
--   `ScrollRegion` with `ScrollBar`s
--   Resizable `List` and `Splitter` with drag handles
--   `MenuBar` featuring all expected input methods
--   `RadioBox` with broadcast communication via a group identifier
--   A simple `MessageBox` dialog
+-   API docs: <https://docs.rs/kas>, <https://docs.rs/kas-theme>, <https://docs.rs/kas-wgpu>
+-   [KAS Tutorials](https://kas-gui.github.io/tutorials/)
+-   [Examples](https://github.com/kas-gui/kas/tree/master/kas-wgpu/examples)
+-   [Discuss](https://github.com/kas-gui/kas/discussions)
+-   [KAS Blog](https://kas-gui.github.io/blog/)
 
 
 Installation and dependencies
@@ -85,7 +82,6 @@ following libraries are used: `libharfbuzz.so.0`, `libglib-2.0.so.0`,
 ### Quick-start
 
 Install dependencies:
-
 ```sh
 # For Ubuntu:
 sudo apt-get install build-essential git libxcb-shape0-dev libxcb-xfixes0-dev libharfbuzz-dev
@@ -96,8 +92,7 @@ sudo dnf install libxcb-devel harfbuzz-devel glslc
 ```
 
 Next, clone the repository and run the examples as follows:
-
-```
+```sh
 git clone https://github.com/kas-gui/kas.git
 cd kas
 cargo test
@@ -108,6 +103,11 @@ cargo run --example layout
 cargo run --example mandlebrot
 ```
 
+To build docs locally:
+```
+RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --features markdown --no-deps --all --open
+```
+
 ### Crates
 
 -   `kas`: the *core* of the GUI library, providing most interfaces and logic
@@ -116,7 +116,6 @@ cargo run --example mandlebrot
 -   [KAS-text]: font loading, text layout, text navigation
 -   `kas-theme`: theming support for KAS (API plus two themes; organisation may change)
 -   `kas-wgpu`: provides windowing via [`winit`] and rendering via [WebGPU]
--   `kas-widgets`: (unrealised) - providing extra widgets
 
 A user depends on `kas` to write their complete UI specification, selects a
 theme from `kas-theme`, instances a `kas_wgpu::Toolkit`, adds the window(s),
@@ -128,15 +127,29 @@ The `kas` crate has the following feature flags:
 
 -   `shaping`: enables complex glyph forming for languages such as Arabic.
     This requires that the HarfBuzz library is installed.
--   `internal_doc`: turns on some extra documentation intended for internal
-    usage but not for end users. (This only affects generated documentation.)
--   `winit`: adds compatibility code for winit's event and geometry types.
-    This is currently the only functional windowing/event library.
+-   `markdown`: enables Markdown parsing for rich-text
 -   `serde`: adds (de)serialisation support to various types
 -   `json`: adds config (de)serialisation using JSON (implies `serde`)
 -   `yaml`: adds config (de)serialisation using YAML (implies `serde`)
+-   `winit`: adds compatibility code for winit's event and geometry types.
+    This is currently the only functional windowing/event library.
 -   `stack_dst`: some compatibility impls (see `kas-theme`'s documentation)
+-   `internal_doc`: turns on some extra documentation intended for internal
+    usage but not for end users. (This only affects generated documentation.)
 
+### Configuration
+
+Formats are not yet stabilised, hence reading/writing configuration is disabled
+by default. Ensure that the `yaml` and/or `json` feature flag is enabled, then
+configure with environment variables:
+```sh
+# Set the config path:
+export KAS_CONFIG=kas-config.yaml
+# Use write-mode to write out default config:
+KAS_CONFIG_MODE=writedefault cargo run --example gallery
+# Now just edit the config and run like normal:
+cargo run --example gallery
+```
 
 [KAS-text]: https://github.com/kas-gui/kas-text/
 [`winit`]: https://github.com/rust-windowing/winit/

--- a/kas-theme/src/col.rs
+++ b/kas-theme/src/col.rs
@@ -209,7 +209,7 @@ impl ThemeColours {
     /// Get text colour from class
     pub fn text_class(&self, class: TextClass) -> Colour {
         match class {
-            TextClass::Label | TextClass::LabelSingle => self.label_text,
+            TextClass::Label | TextClass::LabelFixed => self.label_text,
             TextClass::Button => self.button_text,
             TextClass::Edit | TextClass::EditMulti => self.text,
         }

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -45,7 +45,7 @@ struct ListEntryGuard(usize);
 impl EditGuard for ListEntryGuard {
     type Msg = EntryMsg;
 
-    fn edit(entry: &mut EditBox<Self>, _: &mut Manager) -> Option<Self::Msg> {
+    fn edit(entry: &mut EditField<Self>, _: &mut Manager) -> Option<Self::Msg> {
         Some(EntryMsg::Update(entry.guard.0, entry.get_string()))
     }
 }

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -28,11 +28,11 @@ struct Guard;
 impl EditGuard for Guard {
     type Msg = Item;
 
-    fn activate(edit: &mut EditBox<Self>, _: &mut Manager) -> Option<Self::Msg> {
+    fn activate(edit: &mut EditField<Self>, _: &mut Manager) -> Option<Self::Msg> {
         Some(Item::Edit(edit.get_string()))
     }
 
-    fn edit(edit: &mut EditBox<Self>, _: &mut Manager) -> Option<Self::Msg> {
+    fn edit(edit: &mut EditField<Self>, _: &mut Manager) -> Option<Self::Msg> {
         // 7a is the colour of *magic*!
         edit.set_error_state(edit.get_str().len() % (7 + 1) == 0);
         None

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -18,6 +18,9 @@ pub trait Directional: Copy + Sized + std::fmt::Debug + 'static {
     /// This allows compile-time selection of the flipped direction.
     type Flipped: Directional;
 
+    /// Flip over diagonal (i.e. Down ↔ Right)
+    fn flipped(self) -> Self::Flipped;
+
     /// Convert to the [`Direction`] enum
     fn as_direction(self) -> Direction;
 
@@ -50,6 +53,10 @@ macro_rules! fixed {
         impl Directional for $d {
             type Flipped = $df;
             #[inline]
+            fn flipped(self) -> Self::Flipped {
+                $df
+            }
+            #[inline]
             fn as_direction(self) -> Direction {
                 Direction::$d
             }
@@ -77,6 +84,16 @@ pub enum Direction {
 
 impl Directional for Direction {
     type Flipped = Self;
+
+    fn flipped(self) -> Self::Flipped {
+        use Direction::*;
+        match self {
+            Right => Down,
+            Down => Right,
+            Left => Up,
+            Up => Left,
+        }
+    }
 
     #[inline]
     fn as_direction(self) -> Direction {

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -77,8 +77,8 @@ impl std::ops::BitOr for InputState {
 pub enum TextClass {
     /// Label text is drawn over the background colour
     Label,
-    /// Single-line label which does not want to stretch vertically
-    LabelSingle,
+    /// Single-line label with fixed size (does not stretch to fill space)
+    LabelFixed,
     /// Button text is drawn over a button
     Button,
     /// Class of text drawn in a single-line edit box

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -19,6 +19,12 @@ macro_rules! impl_common {
             /// The constant `(0, 0)`
             pub const ZERO: Self = Self(0, 0);
 
+            /// The minimum value
+            pub const MIN: Self = Self(i32::MIN, i32::MIN);
+
+            /// The maximum value
+            pub const MAX: Self = Self(i32::MAX, i32::MAX);
+
             /// True when for all components, `lhs < rhs`
             #[inline]
             pub fn lt(self, rhs: Self) -> bool {

--- a/src/layout/align.rs
+++ b/src/layout/align.rs
@@ -47,12 +47,11 @@ impl AlignHints {
         (self.horiz.unwrap_or(horiz), self.vert.unwrap_or(vert))
     }
 
-    /// Complete via defaults and ideal size information
-    pub fn complete(&self, horiz: Align, vert: Align, ideal: Size) -> CompleteAlignment {
+    /// Complete via default alignments
+    pub fn complete(&self, horiz: Align, vert: Align) -> CompleteAlignment {
         CompleteAlignment {
             halign: self.horiz.unwrap_or(horiz),
             valign: self.vert.unwrap_or(vert),
-            ideal,
         }
     }
 }
@@ -64,16 +63,17 @@ impl AlignHints {
 pub struct CompleteAlignment {
     halign: Align,
     valign: Align,
-    ideal: Size,
 }
 
 impl CompleteAlignment {
-    /// Adjust the given `rect` according to alignment, returning the result
-    pub fn apply(&self, rect: Rect) -> Rect {
-        let ideal = self.ideal;
+    /// Construct a rect of size `ideal` within `rect` using the given alignment
+    ///
+    /// Note: this does not stretch, even with [`Align::Stretch`], since widget
+    /// stretching should be determined by the [`StretchPolicy`] instead.
+    pub fn aligned_rect(&self, ideal: Size, rect: Rect) -> Rect {
         let mut pos = rect.pos;
         let mut size = rect.size;
-        if self.halign != Align::Stretch && ideal.0 < size.0 {
+        if ideal.0 < size.0 {
             pos.0 += match self.halign {
                 Align::Centre => (size.0 - ideal.0) / 2,
                 Align::BR => size.0 - ideal.0,
@@ -81,7 +81,7 @@ impl CompleteAlignment {
             };
             size.0 = ideal.0;
         }
-        if self.valign != Align::Stretch && ideal.1 < size.1 {
+        if ideal.1 < size.1 {
             pos.1 += match self.valign {
                 Align::Centre => (size.1 - ideal.1) / 2,
                 Align::BR => size.1 - ideal.1,
@@ -90,10 +90,5 @@ impl CompleteAlignment {
             size.1 = ideal.1;
         }
         Rect { pos, size }
-    }
-
-    /// Get `Align` members
-    pub fn align(&self) -> (Align, Align) {
-        (self.halign, self.valign)
     }
 }

--- a/src/layout/align.rs
+++ b/src/layout/align.rs
@@ -5,6 +5,8 @@
 
 //! Alignment types
 
+#[allow(unused)]
+use super::StretchPolicy; // for doc-links
 use crate::geom::{Rect, Size};
 
 pub use crate::text::Align;
@@ -23,8 +25,8 @@ pub use crate::text::Align;
 /// # let rect = Rect::new(Coord::ZERO, Size::ZERO);
 /// let pref_size = Size(30, 20); // usually size comes from SizeHandle
 /// let rect = align
-///     .complete(Align::Stretch, Align::Centre, pref_size)
-///     .apply(rect);
+///     .complete(Align::Stretch, Align::Centre)
+///     .aligned_rect(pref_size, rect);
 /// // self.core.rect = rect;
 /// ```
 #[derive(Copy, Clone, Debug, Default)]

--- a/src/layout/grid_solver.rs
+++ b/src/layout/grid_solver.rs
@@ -255,13 +255,15 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> GridSetter<RT, CT, S> {
         storage.set_dims(cols, rows);
 
         if cols > 0 {
-            let align = align.horiz.unwrap_or(Align::Stretch);
+            let align = align.horiz.unwrap_or(Align::Default);
             let (rules, widths) = storage.rules_and_widths();
-            let ideal = rules[cols].ideal_size();
+            let max_size = rules[cols].max_size();
+            let mut total = rect.size.0;
 
             w_offsets.as_mut()[0] = 0;
-            if align != Align::Stretch && rect.size.0 > ideal {
-                let extra = rect.size.0 - ideal;
+            if total > max_size {
+                let extra = total - max_size;
+                total = max_size;
                 w_offsets.as_mut()[0] = match align {
                     Align::Default | Align::TL | Align::Stretch => 0,
                     Align::Centre => extra / 2,
@@ -269,7 +271,7 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> GridSetter<RT, CT, S> {
                 };
             }
 
-            SizeRules::solve_seq_total(widths, rules, rect.size.0);
+            SizeRules::solve_seq_total(widths, rules, total);
             for i in 1..w_offsets.as_mut().len() {
                 let i1 = i - 1;
                 let m1 = storage.width_rules()[i1].margins_i32().1;
@@ -279,13 +281,15 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> GridSetter<RT, CT, S> {
         }
 
         if rows > 0 {
-            let align = align.vert.unwrap_or(Align::Stretch);
+            let align = align.vert.unwrap_or(Align::Default);
             let (rules, heights) = storage.rules_and_heights();
-            let ideal = rules[rows].ideal_size();
+            let max_size = rules[rows].max_size();
+            let mut total = rect.size.1;
 
             h_offsets.as_mut()[0] = 0;
-            if align != Align::Stretch && rect.size.1 > ideal {
-                let extra = rect.size.1 - ideal;
+            if total > max_size {
+                let extra = total - max_size;
+                total = max_size;
                 h_offsets.as_mut()[0] = match align {
                     Align::Default | Align::TL | Align::Stretch => 0,
                     Align::Centre => extra / 2,
@@ -293,7 +297,7 @@ impl<RT: RowTemp, CT: RowTemp, S: GridStorage> GridSetter<RT, CT, S> {
                 };
             }
 
-            SizeRules::solve_seq_total(heights, rules, rect.size.1);
+            SizeRules::solve_seq_total(heights, rules, total);
             for i in 1..h_offsets.as_mut().len() {
                 let i1 = i - 1;
                 let m1 = storage.height_rules()[i1].margins_i32().1;

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -113,6 +113,12 @@ impl AxisInfo {
 impl Directional for AxisInfo {
     type Flipped = Self;
 
+    fn flipped(mut self) -> Self::Flipped {
+        self.vertical = !self.vertical;
+        self.has_fixed = false;
+        self
+    }
+
     #[inline]
     fn as_direction(self) -> Direction {
         match self.vertical {

--- a/src/layout/row_solver.rs
+++ b/src/layout/row_solver.rs
@@ -138,12 +138,12 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
             let is_horiz = direction.is_horizontal();
             let mut width = if is_horiz { rect.size.0 } else { rect.size.1 };
             let (rules, widths) = storage.rules_and_widths();
-            let ideal = rules[len].ideal_size();
+            let max_size = rules[len].max_size();
             let align = if is_horiz { align.horiz } else { align.vert };
-            let align = align.unwrap_or(Align::Stretch);
-            if align != Align::Stretch && width > ideal {
-                let extra = width - ideal;
-                width = ideal;
+            let align = align.unwrap_or(Align::Default);
+            if rect.size.0 > max_size {
+                let extra = width - max_size;
+                width = max_size;
                 let offset = match align {
                     Align::Default | Align::TL | Align::Stretch => 0,
                     Align::Centre => extra / 2,

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -249,6 +249,18 @@ impl SizeRules {
         self.b
     }
 
+    /// Get the max size
+    ///
+    /// With most stretch policies, this returns `i32::MAX`, but with
+    /// [`StretchPolicy::Fixed`], this is [`SizeRules::ideal_size`].
+    #[inline]
+    pub fn max_size(self) -> i32 {
+        match self.stretch {
+            StretchPolicy::Fixed => self.b,
+            _ => i32::MAX,
+        }
+    }
+
     /// Get the `(pre, post)` margin sizes
     #[inline]
     pub fn margins(self) -> (u16, u16) {

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -54,11 +54,21 @@ impl Margins {
         }
     }
 
+    /// Sum of horizontal margins
+    #[inline]
+    pub fn sum_horiz(&self) -> i32 {
+        i32::from(self.horiz.0) + i32::from(self.horiz.1)
+    }
+
+    /// Sum of vertical margins
+    #[inline]
+    pub fn sum_vert(&self) -> i32 {
+        i32::from(self.vert.0) + i32::from(self.vert.1)
+    }
+
     /// Pad a size with margins
     pub fn pad(self, size: Size) -> Size {
-        let w = size.0 + i32::from(self.horiz.0) + i32::from(self.horiz.1);
-        let h = size.1 + i32::from(self.vert.0) + i32::from(self.vert.1);
-        Size::new(w, h)
+        Size::new(size.0 + self.sum_horiz(), size.1 + self.sum_vert())
     }
 }
 

--- a/src/layout/sizer.rs
+++ b/src/layout/sizer.rs
@@ -189,7 +189,7 @@ impl SolveCache {
     ) {
         let mut width = rect.size.0;
         if inner_margin {
-            width -= i32::from(self.margins.horiz.0) + i32::from(self.margins.horiz.1);
+            width -= self.margins.sum_horiz();
         }
 
         // We call size_rules not because we want the result, but because our
@@ -214,7 +214,7 @@ impl SolveCache {
         if inner_margin {
             rect.pos += Size::from((self.margins.horiz.0, self.margins.vert.0));
             rect.size.0 = width;
-            rect.size.1 -= i32::from(self.margins.vert.0) + i32::from(self.margins.vert.1);
+            rect.size.1 -= self.margins.sum_vert();
         }
         widget.set_rect(mgr, rect, AlignHints::NONE);
 

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -42,8 +42,8 @@ impl<M: 'static> Layout for CheckBoxBare<M> {
 
     fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         let rect = align
-            .complete(Align::Centre, Align::Centre, self.rect().size)
-            .apply(rect);
+            .complete(Align::Centre, Align::Centre)
+            .aligned_rect(self.rect().size, rect);
         self.core.rect = rect;
     }
 

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -42,7 +42,7 @@ impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
         let size = size_handle.menu_frame();
         self.label_off = size;
         let frame_rules = SizeRules::extract_fixed(axis, size + size, Margins::ZERO);
-        let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelSingle, axis);
+        let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelFixed, axis);
         text_rules.surrounded_by(frame_rules, true)
     }
 

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -106,7 +106,7 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
         let size = size_handle.menu_frame();
         self.label_off = size;
         let frame_rules = SizeRules::extract_fixed(axis, size + size, Margins::ZERO);
-        let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelSingle, axis);
+        let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelFixed, axis);
         text_rules.surrounded_by(frame_rules, true)
     }
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -81,7 +81,7 @@ pub use checkbox::{CheckBox, CheckBoxBare};
 pub use combobox::ComboBox;
 pub use dialog::MessageBox;
 pub use drag::DragHandle;
-pub use editbox::{EditBox, EditGuard};
+pub use editbox::{EditBox, EditField, EditGuard};
 pub use filler::Filler;
 pub use frame::Frame;
 pub use label::{AccelLabel, Label, StrLabel, StringLabel};

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -95,8 +95,8 @@ impl<M: 'static> Layout for RadioBoxBare<M> {
 
     fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         let rect = align
-            .complete(Align::Centre, Align::Centre, self.rect().size)
-            .apply(rect);
+            .complete(Align::Centre, Align::Centre)
+            .aligned_rect(self.rect().size, rect);
         self.core.rect = rect;
     }
 

--- a/src/widget/stack.rs
+++ b/src/widget/stack.rs
@@ -75,7 +75,7 @@ impl<W: Widget> Layout for Stack<W> {
     fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
         for child in &mut self.widgets {
-            child.set_rect(mgr, rect, align.clone());
+            child.set_rect(mgr, rect, align);
         }
     }
 


### PR DESCRIPTION
`EditBox` is now a wrapper around `EditField`, which inherited most of the old `EditBox`'s logic. `EditField` can be used directly (without borders or background).

Some changes to alignment and stretch policies (see commits).

Readme update.