### PR TITLE
Margins, FrameRules

### DIFF
--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -233,7 +233,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
     }
 
     fn edit_surround(&self) -> (Size, Size) {
-        let s = Size::splat(self.dims.frame + i32::from(self.dims.inner_margin));
+        let s = Size::splat(self.dims.frame);
         (s, s)
     }
 

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -146,6 +146,9 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         let f = self.dims.frame;
         Size::new(f, f / 2)
     }
+    fn separator(&self) -> Size {
+        Size::splat(self.dims.frame)
+    }
 
     fn inner_margin(&self) -> Size {
         Size::splat(self.dims.inner_margin.into())

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -26,6 +26,8 @@ pub struct DimensionsParams {
     pub outer_margin: f32,
     /// Margin inside a frame before contents
     pub inner_margin: f32,
+    /// Margin between text elements
+    pub text_margin: f32,
     /// Frame size
     pub frame_size: f32,
     /// Button frame size (non-flat outer region)
@@ -50,6 +52,7 @@ pub struct Dimensions {
     pub ideal_line_length: i32,
     pub outer_margin: u16,
     pub inner_margin: u16,
+    pub text_margin: u16,
     pub frame: i32,
     pub button_frame: i32,
     pub checkbox: i32,
@@ -67,6 +70,7 @@ impl Dimensions {
 
         let outer_margin = (params.outer_margin * scale_factor).cast_nearest();
         let inner_margin = (params.inner_margin * scale_factor).cast_nearest();
+        let text_margin = (params.text_margin * scale_factor).cast_nearest();
         let frame = (params.frame_size * scale_factor).cast_nearest();
         Dimensions {
             scale_factor,
@@ -78,6 +82,7 @@ impl Dimensions {
             ideal_line_length: (24.0 * dpem).cast_nearest(),
             outer_margin,
             inner_margin,
+            text_margin,
             frame,
             button_frame: (params.button_frame * scale_factor).cast_nearest(),
             checkbox: i32::conv_nearest(9.0 * dpp) + 2 * (i32::from(inner_margin) + frame),
@@ -188,10 +193,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
             });
         });
 
-        let margin = match class {
-            TextClass::Label | TextClass::LabelFixed => self.dims.outer_margin,
-            TextClass::Button | TextClass::Edit | TextClass::EditMulti => self.dims.inner_margin,
-        };
+        let margin = self.dims.text_margin;
         let margins = (margin, margin);
         if axis.is_horizontal() {
             let bound = i32::conv_ceil(required.0);
@@ -240,7 +242,7 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
 
     fn edit_surround(&self, _vert: bool) -> FrameRules {
         let inner = self.dims.inner_margin.into();
-        let outer = self.dims.outer_margin;
+        let outer = 0;
         FrameRules::new_sym(self.dims.frame, inner, (outer, outer))
     }
 

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -13,7 +13,7 @@ use std::f32;
 use kas::conv::{Cast, CastFloat, ConvFloat};
 use kas::draw::{self, TextClass};
 use kas::geom::{Size, Vec2};
-use kas::layout::{AxisInfo, Margins, SizeRules, StretchPolicy};
+use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, StretchPolicy};
 use kas::text::{TextApi, TextApiExt};
 
 /// Parameterisation of [`Dimensions`]
@@ -138,13 +138,15 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         self.dims.scale_factor
     }
 
-    fn frame(&self) -> Size {
-        let f = self.dims.frame;
-        Size::splat(f)
+    fn frame(&self, _vert: bool) -> FrameRules {
+        FrameRules::new_sym(self.dims.frame, 0, (0, 0))
     }
-    fn menu_frame(&self) -> Size {
-        let f = self.dims.frame;
-        Size::new(f, f / 2)
+    fn menu_frame(&self, vert: bool) -> FrameRules {
+        let mut size = self.dims.frame;
+        if vert {
+            size /= 2;
+        }
+        FrameRules::new_sym(size, 0, (0, 0))
     }
     fn separator(&self) -> Size {
         Size::splat(self.dims.frame)
@@ -230,14 +232,16 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
         self.dims.font_marker_width
     }
 
-    fn button_surround(&self) -> (Size, Size) {
-        let s = Size::splat(self.dims.button_frame);
-        (s, s)
+    fn button_surround(&self, _vert: bool) -> FrameRules {
+        let inner = self.dims.inner_margin.into();
+        let outer = self.dims.outer_margin;
+        FrameRules::new_sym(self.dims.frame, inner, (outer, outer))
     }
 
-    fn edit_surround(&self) -> (Size, Size) {
-        let s = Size::splat(self.dims.frame);
-        (s, s)
+    fn edit_surround(&self, _vert: bool) -> FrameRules {
+        let inner = self.dims.inner_margin.into();
+        let outer = self.dims.outer_margin;
+        FrameRules::new_sym(self.dims.frame, inner, (outer, outer))
     }
 
     fn checkbox(&self) -> Size {

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -60,6 +60,7 @@ impl FlatTheme {
 const DIMS: DimensionsParams = DimensionsParams {
     outer_margin: 8.0,
     inner_margin: 1.0,
+    text_margin: 2.0,
     frame_size: 4.0,
     button_frame: 6.0,
     scrollbar_size: Vec2::splat(8.0),

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -347,7 +347,7 @@ where
         self.draw.rect(self.pass, inner, col);
 
         if let Some(col) = self.cols.nav_region(state) {
-            let outer = outer.shrink(self.window.dims.button_frame as f32 / 3.0);
+            let outer = outer.shrink(self.window.dims.inner_margin as f32);
             self.draw.rounded_frame(self.pass, outer, inner, 0.5, col);
         }
     }

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -56,6 +56,7 @@ impl ShadedTheme {
 const DIMS: DimensionsParams = DimensionsParams {
     outer_margin: 6.0,
     inner_margin: 1.0,
+    text_margin: 2.0,
     frame_size: 5.0,
     button_frame: 5.0,
     scrollbar_size: Vec2::splat(8.0),

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -138,6 +138,9 @@ pub trait SizeHandle {
     /// Like [`SizeHandle::frame`] this method returns the frame on each side.
     fn menu_frame(&self) -> Size;
 
+    /// Size of a separator frame between items
+    fn separator(&self) -> Size;
+
     /// The margin around content within a widget
     ///
     /// Though inner margins are *usually* empty, they are sometimes drawn to,
@@ -466,6 +469,9 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
     fn menu_frame(&self) -> Size {
         self.deref().menu_frame()
     }
+    fn separator(&self) -> Size {
+        self.deref().separator()
+    }
     fn inner_margin(&self) -> Size {
         self.deref().inner_margin()
     }
@@ -526,6 +532,9 @@ where
     }
     fn menu_frame(&self) -> Size {
         self.deref().menu_frame()
+    }
+    fn separator(&self) -> Size {
+        self.deref().separator()
     }
     fn inner_margin(&self) -> Size {
         self.deref().inner_margin()

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -11,7 +11,7 @@ use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use kas::dir::Direction;
 use kas::draw::{Draw, Pass};
 use kas::geom::{Coord, Offset, Rect, Size, Vec2};
-use kas::layout::{AxisInfo, Margins, SizeRules};
+use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use kas::text::{format::FormattableText, AccelString, Text, TextApi, TextDisplay};
 
 // for doc use
@@ -125,18 +125,14 @@ pub trait SizeHandle {
     fn scale_factor(&self) -> f32;
 
     /// Size of a frame around child widget(s)
-    ///
-    /// Returns dimensions of the frame on each side.
-    fn frame(&self) -> Size;
+    fn frame(&self, vert: bool) -> FrameRules;
 
     /// Menu frame
     ///
     /// Menu items have a larger-than-usual margin / invisible frame around
     /// them. This should be drawn with [`DrawHandle::menu_frame`],
     /// though likely the theme will only draw when highlighted.
-    ///
-    /// Like [`SizeHandle::frame`] this method returns the frame on each side.
-    fn menu_frame(&self) -> Size;
+    fn menu_frame(&self, vert: bool) -> FrameRules;
 
     /// Size of a separator frame between items
     fn separator(&self) -> Size;
@@ -175,19 +171,13 @@ pub trait SizeHandle {
     fn edit_marker_width(&self) -> f32;
 
     /// Size of the sides of a button.
-    ///
-    /// Returns `(top_left, bottom_right)` dimensions as two `Size`s.
-    /// Excludes size of content area.
-    fn button_surround(&self) -> (Size, Size);
+    fn button_surround(&self, vert: bool) -> FrameRules;
 
     /// Size of the frame around an edit box, including margin
     ///
-    /// Returns two [`Size`] values, `(tl, br)`. `tl` is the size of left and
-    /// top sides, and `br` is the size of right and bottom sides.
-    ///
     /// Note: though text should not be drawn in the margin, the edit cursor
     /// may be. The margin included here should be large enough!
-    fn edit_surround(&self) -> (Size, Size);
+    fn edit_surround(&self, vert: bool) -> FrameRules;
 
     /// Size of the element drawn by [`DrawHandle::checkbox`].
     fn checkbox(&self) -> Size;
@@ -463,11 +453,11 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
         self.deref().scale_factor()
     }
 
-    fn frame(&self) -> Size {
-        self.deref().frame()
+    fn frame(&self, vert: bool) -> FrameRules {
+        self.deref().frame(vert)
     }
-    fn menu_frame(&self) -> Size {
-        self.deref().menu_frame()
+    fn menu_frame(&self, vert: bool) -> FrameRules {
+        self.deref().menu_frame(vert)
     }
     fn separator(&self) -> Size {
         self.deref().separator()
@@ -494,11 +484,11 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
         self.deref().edit_marker_width()
     }
 
-    fn button_surround(&self) -> (Size, Size) {
-        self.deref().button_surround()
+    fn button_surround(&self, vert: bool) -> FrameRules {
+        self.deref().button_surround(vert)
     }
-    fn edit_surround(&self) -> (Size, Size) {
-        self.deref().edit_surround()
+    fn edit_surround(&self, vert: bool) -> FrameRules {
+        self.deref().edit_surround(vert)
     }
 
     fn checkbox(&self) -> Size {
@@ -527,11 +517,11 @@ where
         self.deref().scale_factor()
     }
 
-    fn frame(&self) -> Size {
-        self.deref().frame()
+    fn frame(&self, vert: bool) -> FrameRules {
+        self.deref().frame(vert)
     }
-    fn menu_frame(&self) -> Size {
-        self.deref().menu_frame()
+    fn menu_frame(&self, vert: bool) -> FrameRules {
+        self.deref().menu_frame(vert)
     }
     fn separator(&self) -> Size {
         self.deref().separator()
@@ -558,11 +548,11 @@ where
         self.deref().edit_marker_width()
     }
 
-    fn button_surround(&self) -> (Size, Size) {
-        self.deref().button_surround()
+    fn button_surround(&self, vert: bool) -> FrameRules {
+        self.deref().button_surround(vert)
     }
-    fn edit_surround(&self) -> (Size, Size) {
-        self.deref().edit_surround()
+    fn edit_surround(&self, vert: bool) -> FrameRules {
+        self.deref().edit_surround(vert)
     }
 
     fn checkbox(&self) -> Size {

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -774,7 +774,7 @@ mod test {
         // We can't call this method without constructing an actual DrawHandle.
         // But we don't need to: we just want to test that methods are callable.
 
-        let _size = draw_handle.size_handle(|h| h.frame());
+        let _scale = draw_handle.size_handle(|h| h.scale_factor());
 
         let bounds = Vec2(100.0, 30.0);
         let text = kas::text::Text::new_single("sample");

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -49,7 +49,7 @@ pub use grid_solver::{GridChildInfo, GridSetter, GridSolver};
 pub use row_solver::{RowPositionSolver, RowSetter, RowSolver};
 pub use single_solver::{SingleSetter, SingleSolver};
 pub use size_rules::SizeRules;
-pub use size_types::{Margins, StretchPolicy};
+pub use size_types::{FrameRules, Margins, StretchPolicy};
 pub use sizer::{solve_size_rules, RulesSetter, RulesSolver, SolveCache};
 pub use storage::{
     DynGridStorage, DynRowStorage, FixedGridStorage, FixedRowStorage, GridStorage, RowStorage,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -38,6 +38,7 @@ mod grid_solver;
 mod row_solver;
 mod single_solver;
 mod size_rules;
+mod size_types;
 mod sizer;
 mod storage;
 
@@ -47,7 +48,8 @@ pub use align::{Align, AlignHints, CompleteAlignment};
 pub use grid_solver::{GridChildInfo, GridSetter, GridSolver};
 pub use row_solver::{RowPositionSolver, RowSetter, RowSolver};
 pub use single_solver::{SingleSetter, SingleSolver};
-pub use size_rules::{Margins, SizeRules, StretchPolicy};
+pub use size_rules::SizeRules;
+pub use size_types::{Margins, StretchPolicy};
 pub use sizer::{solve_size_rules, RulesSetter, RulesSolver, SolveCache};
 pub use storage::{
     DynGridStorage, DynRowStorage, FixedGridStorage, FixedRowStorage, GridStorage, RowStorage,

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -9,6 +9,7 @@ use smallvec::SmallVec;
 use std::fmt;
 use std::iter::Sum;
 
+use super::{Margins, StretchPolicy};
 use crate::conv::{Cast, Conv};
 use crate::dir::Directional;
 use crate::geom::Size;
@@ -16,82 +17,6 @@ use crate::geom::Size;
 // for doc use
 #[allow(unused)]
 use kas::draw::SizeHandle;
-
-/// Margin sizes
-///
-/// Used by the layout system for margins around child widgets. Margins may be
-/// drawn in and handle events like any other widget area.
-#[derive(Copy, Clone, Debug, Default)]
-pub struct Margins {
-    /// Size of horizontal margins
-    pub horiz: (u16, u16),
-    /// Size of vertical margins
-    pub vert: (u16, u16),
-}
-
-impl Margins {
-    /// Zero-sized margins
-    pub const ZERO: Margins = Margins::splat(0);
-
-    /// Margins with equal size on each edge.
-    #[inline]
-    pub const fn splat(size: u16) -> Self {
-        Margins::hv_splat(size, size)
-    }
-
-    /// Margins via horizontal and vertical sizes
-    #[inline]
-    pub const fn hv(horiz: (u16, u16), vert: (u16, u16)) -> Self {
-        Margins { horiz, vert }
-    }
-
-    /// Margins via horizontal and vertical sizes
-    #[inline]
-    pub const fn hv_splat(h: u16, v: u16) -> Self {
-        Margins {
-            horiz: (h, h),
-            vert: (v, v),
-        }
-    }
-
-    /// Sum of horizontal margins
-    #[inline]
-    pub fn sum_horiz(&self) -> i32 {
-        i32::from(self.horiz.0) + i32::from(self.horiz.1)
-    }
-
-    /// Sum of vertical margins
-    #[inline]
-    pub fn sum_vert(&self) -> i32 {
-        i32::from(self.vert.0) + i32::from(self.vert.1)
-    }
-
-    /// Pad a size with margins
-    pub fn pad(self, size: Size) -> Size {
-        Size::new(size.0 + self.sum_horiz(), size.1 + self.sum_vert())
-    }
-}
-
-/// Policy for stretching widgets beyond ideal size
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub enum StretchPolicy {
-    /// Do not exceed ideal size
-    Fixed,
-    /// Can be stretched to fill space but without utility
-    Filler,
-    /// Extra space has low utility
-    LowUtility,
-    /// Extra space has high utility
-    HighUtility,
-    /// Greedily consume as much space as possible
-    Maximize,
-}
-
-impl Default for StretchPolicy {
-    fn default() -> Self {
-        StretchPolicy::Fixed
-    }
-}
 
 /// Widget sizing information
 ///

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -282,25 +282,6 @@ impl SizeRules {
         }
     }
 
-    /// Return the rules for self surrounded by `frame`
-    ///
-    /// If `internal_margins` are true, then space is allocated for `self`'s
-    /// margins inside the frame; if not, then `self`'s margins are merged with
-    /// the frame's margins.
-    pub fn surrounded_by(self, frame: SizeRules, internal_margins: bool) -> Self {
-        let (c, m) = if internal_margins {
-            ((self.m.0 + self.m.1).into(), frame.m)
-        } else {
-            (0, (self.m.0.max(frame.m.0), self.m.1.max(frame.m.1)))
-        };
-        SizeRules {
-            a: self.a + frame.a + c,
-            b: self.b + frame.b + c,
-            m,
-            stretch: self.stretch.max(frame.stretch),
-        }
-    }
-
     /// Return the result of appending all given ranges
     pub fn sum(range: &[SizeRules]) -> SizeRules {
         range.iter().sum()

--- a/src/layout/size_types.rs
+++ b/src/layout/size_types.rs
@@ -1,0 +1,88 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Types used by size rules
+
+use crate::geom::Size;
+
+// for doc use
+#[allow(unused)]
+use kas::draw::SizeHandle;
+
+/// Margin sizes
+///
+/// Used by the layout system for margins around child widgets. Margins may be
+/// drawn in and handle events like any other widget area.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Margins {
+    /// Size of horizontal margins
+    pub horiz: (u16, u16),
+    /// Size of vertical margins
+    pub vert: (u16, u16),
+}
+
+impl Margins {
+    /// Zero-sized margins
+    pub const ZERO: Margins = Margins::splat(0);
+
+    /// Margins with equal size on each edge.
+    #[inline]
+    pub const fn splat(size: u16) -> Self {
+        Margins::hv_splat(size, size)
+    }
+
+    /// Margins via horizontal and vertical sizes
+    #[inline]
+    pub const fn hv(horiz: (u16, u16), vert: (u16, u16)) -> Self {
+        Margins { horiz, vert }
+    }
+
+    /// Margins via horizontal and vertical sizes
+    #[inline]
+    pub const fn hv_splat(h: u16, v: u16) -> Self {
+        Margins {
+            horiz: (h, h),
+            vert: (v, v),
+        }
+    }
+
+    /// Sum of horizontal margins
+    #[inline]
+    pub fn sum_horiz(&self) -> i32 {
+        i32::from(self.horiz.0) + i32::from(self.horiz.1)
+    }
+
+    /// Sum of vertical margins
+    #[inline]
+    pub fn sum_vert(&self) -> i32 {
+        i32::from(self.vert.0) + i32::from(self.vert.1)
+    }
+
+    /// Pad a size with margins
+    pub fn pad(self, size: Size) -> Size {
+        Size::new(size.0 + self.sum_horiz(), size.1 + self.sum_vert())
+    }
+}
+
+/// Policy for stretching widgets beyond ideal size
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum StretchPolicy {
+    /// Do not exceed ideal size
+    Fixed,
+    /// Can be stretched to fill space but without utility
+    Filler,
+    /// Extra space has low utility
+    LowUtility,
+    /// Extra space has high utility
+    HighUtility,
+    /// Greedily consume as much space as possible
+    Maximize,
+}
+
+impl Default for StretchPolicy {
+    fn default() -> Self {
+        StretchPolicy::Fixed
+    }
+}

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -49,13 +49,16 @@ impl<M: 'static> WidgetConfig for TextButton<M> {
 
 impl<M: 'static> Layout for TextButton<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let sides = size_handle.button_surround();
-        self.frame_size = sides.0 + sides.1;
-        let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis, self.frame_size, margins);
-
+        let frame_rules = size_handle.button_surround(axis.is_vertical());
         let content_rules = size_handle.text_bound(&mut self.label, TextClass::Button, axis);
-        content_rules.surrounded_by(frame_rules, true)
+
+        let (rules, _offset, size) = frame_rules.surround(content_rules);
+        if axis.is_horizontal() {
+            self.frame_size.0 = size;
+        } else {
+            self.frame_size.1 = size;
+        }
+        rules
     }
 
     fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -33,13 +33,16 @@ pub struct ComboBox<M: Clone + Debug + 'static> {
 
 impl<M: Clone + Debug + 'static> kas::Layout for ComboBox<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let sides = size_handle.button_surround();
-        self.frame_size = sides.0 + sides.1;
-        let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis, self.frame_size, margins);
-
+        let frame_rules = size_handle.button_surround(axis.is_vertical());
         let content_rules = size_handle.text_bound(&mut self.label, TextClass::Button, axis);
-        content_rules.surrounded_by(frame_rules, true)
+
+        let (rules, _offset, size) = frame_rules.surround(content_rules);
+        if axis.is_horizontal() {
+            self.frame_size.0 = size;
+        } else {
+            self.frame_size.1 = size;
+        }
+        rules
     }
 
     fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -332,25 +332,18 @@ impl<G: EditGuard> EditBox<G> {
 
 impl<G: EditGuard> Layout for EditBox<G> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let frame_sides = size_handle.edit_surround();
-        let frame_offset = frame_sides.0;
-        let frame_size = frame_offset + frame_sides.1;
-
-        let margins = size_handle.outer_margins();
-        let frame_rules = SizeRules::extract_fixed(axis, frame_size, margins);
-
+        let frame_rules = size_handle.edit_surround(axis.is_vertical());
         let child_rules = self.inner.size_rules(size_handle, axis);
-        let m = child_rules.margins_i32();
 
+        let (rules, offset, size) = frame_rules.surround(child_rules);
         if axis.is_horizontal() {
-            self.offset.0 = frame_offset.0 + m.0;
-            self.frame_size.0 = frame_size.0 + m.0 + m.1;
+            self.offset.0 = offset;
+            self.frame_size.0 = size;
         } else {
-            self.offset.1 = frame_offset.1 + m.0;
-            self.frame_size.1 = frame_size.1 + m.0 + m.1;
+            self.offset.1 = offset;
+            self.frame_size.1 = size;
         }
-
-        child_rules.surrounded_by(frame_rules, true)
+        rules
     }
 
     fn set_rect(&mut self, mgr: &mut Manager, mut rect: Rect, align: AlignHints) {

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -369,7 +369,8 @@ impl<G: EditGuard> Layout for EditBox<G> {
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
-        let mut input_state = self.input_state(mgr, disabled);
+        // We draw highlights for input state of inner:
+        let mut input_state = self.inner.input_state(mgr, disabled);
         input_state.error = self.inner.has_error();
         draw_handle.edit_box(self.core.rect, input_state);
         let disabled = disabled || self.is_disabled();

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -18,8 +18,8 @@ pub struct Frame<W: Widget> {
     core: CoreData,
     #[widget]
     pub inner: W,
-    m0: Size,
-    m1: Size,
+    offset: Offset,
+    size: Size,
 }
 
 impl<W: Widget> Frame<W> {
@@ -29,36 +29,32 @@ impl<W: Widget> Frame<W> {
         Frame {
             core: Default::default(),
             inner,
-            m0: Size::ZERO,
-            m1: Size::ZERO,
+            offset: Offset::ZERO,
+            size: Size::ZERO,
         }
     }
 }
 
 impl<W: Widget> Layout for Frame<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let size = size_handle.frame();
-        let margins = Margins::ZERO;
-        let frame_rules = SizeRules::extract_fixed(axis, size + size, margins);
-
+        let frame_rules = size_handle.frame(axis.is_vertical());
         let child_rules = self.inner.size_rules(size_handle, axis);
-        let m = child_rules.margins_i32();
+        let (rules, offset, size) = frame_rules.surround(child_rules);
 
         if axis.is_horizontal() {
-            self.m0.0 = size.0 + m.0;
-            self.m1.0 = size.0 + m.1;
+            self.offset.0 = offset;
+            self.size.0 = size;
         } else {
-            self.m0.1 = size.1 + m.0;
-            self.m1.1 = size.1 + m.1;
+            self.offset.1 = offset;
+            self.size.1 = size;
         }
-
-        child_rules.surrounded_by(frame_rules, true)
+        rules
     }
 
     fn set_rect(&mut self, mgr: &mut Manager, mut rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        rect.pos += self.m0;
-        rect.size -= self.m0 + self.m1;
+        rect.pos += self.offset;
+        rect.size -= self.size;
         self.inner.set_rect(mgr, rect, align);
     }
 

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -23,7 +23,8 @@ pub struct MenuEntry<M: Clone + Debug + 'static> {
     #[widget_core]
     core: kas::CoreData,
     label: Text<AccelString>,
-    label_off: Size,
+    label_off: Offset,
+    frame_size: Size,
     msg: M,
 }
 
@@ -39,17 +40,24 @@ impl<M: Clone + Debug + 'static> WidgetConfig for MenuEntry<M> {
 
 impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        let size = size_handle.menu_frame();
-        self.label_off = size;
-        let frame_rules = SizeRules::extract_fixed(axis, size + size, Margins::ZERO);
+        let frame_rules = size_handle.menu_frame(axis.is_vertical());
         let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelFixed, axis);
-        text_rules.surrounded_by(frame_rules, true)
+        let (rules, offset, size) = frame_rules.surround(text_rules);
+        if axis.is_horizontal() {
+            self.label_off.0 = offset;
+            self.frame_size.0 = size;
+        } else {
+            self.label_off.1 = offset;
+            self.frame_size.1 = size;
+        }
+        rules
     }
 
     fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
+        let size = rect.size - self.frame_size;
         self.label.update_env(|env| {
-            env.set_bounds(rect.size.into());
+            env.set_bounds(size.into());
             env.set_align(align.unwrap_or(Align::Default, Align::Centre));
         });
     }
@@ -71,7 +79,8 @@ impl<M: Clone + Debug + 'static> MenuEntry<M> {
         MenuEntry {
             core: Default::default(),
             label: Text::new_single(label.into()),
-            label_off: Size::ZERO,
+            label_off: Offset::ZERO,
+            frame_size: Size::ZERO,
             msg,
         }
     }
@@ -94,10 +103,8 @@ impl<M: Clone + Debug + 'static> SetAccel for MenuEntry<M> {
         if self.label.text().keys() != string.keys() {
             action |= TkAction::RECONFIGURE;
         }
-        // NOTE: we assume here that top-left and bottom-right frame size is the
-        // same; if not then resizes may not happen exactly when required
-        let size = self.label_off + self.label_off;
-        action | kas::text::util::set_text_and_prepare(&mut self.label, string, size)
+        let avail = self.core.rect.size.clamped_sub(self.frame_size);
+        action | kas::text::util::set_text_and_prepare(&mut self.label, string, avail)
     }
 }
 

--- a/src/widget/separator.rs
+++ b/src/widget/separator.rs
@@ -13,8 +13,7 @@ use kas::{event, prelude::*};
 
 /// A separator
 ///
-/// This widget draws a bar when in a list. It may expand larger than expected
-/// if no other widget will fill spare space.
+/// This widget draws a bar when in a list.
 #[handler(msg=M)]
 #[derive(Clone, Debug, Default, Widget)]
 pub struct Separator<M: Debug + 'static> {
@@ -50,7 +49,7 @@ impl<M: Debug> Separator<M> {
 
 impl<M: Debug> Layout for Separator<M> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        SizeRules::extract_fixed(axis, size_handle.frame(), Default::default())
+        SizeRules::extract_fixed(axis, size_handle.separator(), Default::default())
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -120,7 +120,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
         }
         assert!(self.handles.len() + 1 == self.widgets.len());
 
-        let handle_size = size_handle.frame().extract(axis);
+        let handle_size = size_handle.separator().extract(axis);
 
         let dim = (self.direction, self.num_children());
         let mut solver = layout::RowSolver::new(axis, dim, &mut self.data);


### PR DESCRIPTION
Adds a `FrameRules` type as a special variant of `SizeRules`.

Some fixes and tweaks around margins, and new `text_margin` (between `inner_margin` and `outer_margin`).