### PR TITLE
ViewList selection, set_component, scroll-region margins

### DIFF
--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -270,6 +270,14 @@ impl<'a, D: Draw + DrawRounded + DrawText> draw::DrawHandle for DrawHandle<'a, D
             .rounded_frame(self.pass, outer, inner, 0.5, self.cols.frame);
     }
 
+    fn selection_box(&mut self, rect: Rect) {
+        let inner = Quad::from(rect + self.offset);
+        let outer = inner.grow(self.window.dims.inner_margin.into());
+        // TODO: this should use its own colour and a stippled pattern
+        let col = self.cols.text_sel_bg;
+        self.draw.frame(self.pass, outer, inner, col);
+    }
+
     fn text_offset(
         &mut self,
         pos: Coord,

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -289,6 +289,10 @@ where
             .shaded_round_frame(self.pass, outer, inner, norm, col);
     }
 
+    fn selection_box(&mut self, rect: Rect) {
+        self.as_flat().selection_box(rect);
+    }
+
     fn text_offset(
         &mut self,
         pos: Coord,

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -290,6 +290,13 @@ pub trait DrawHandle {
     /// Draw a separator in the given `rect`
     fn separator(&mut self, rect: Rect);
 
+    /// Draw a selection box
+    ///
+    /// This appears as a dashed box or similar around this `rect`. Note that
+    /// the selection indicator is drawn *outside* of this rect, within a margin
+    /// of size `inner_margin` that is expected to be present around this box.
+    fn selection_box(&mut self, rect: Rect);
+
     /// Draw some text using the standard font
     ///
     /// The `text` is drawn within the rect from `pos` to `text.env().bounds`,
@@ -600,6 +607,9 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn separator(&mut self, rect: Rect) {
         self.deref_mut().separator(rect);
     }
+    fn selection_box(&mut self, rect: Rect) {
+        self.deref_mut().selection_box(rect);
+    }
     fn text_offset(
         &mut self,
         pos: Coord,
@@ -698,6 +708,9 @@ where
     }
     fn separator(&mut self, rect: Rect) {
         self.deref_mut().separator(rect);
+    }
+    fn selection_box(&mut self, rect: Rect) {
+        self.deref_mut().selection_box(rect);
     }
     fn text_offset(
         &mut self,

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -495,6 +495,19 @@ impl<'a> Manager<'a> {
         true
     }
 
+    /// Update the mouse cursor used during a grab
+    ///
+    /// This only succeeds if widget `id` has an active mouse-grab (see
+    /// [`Manager::request_grab`]). The cursor will be reset when the mouse-grab
+    /// ends.
+    pub fn update_grab_cursor(&mut self, id: WidgetId, icon: CursorIcon) {
+        if let Some(ref grab) = self.state.mouse_grab {
+            if grab.start_id == id {
+                self.shell.set_cursor_icon(icon);
+            }
+        }
+    }
+
     /// Set a grab's depress target
     ///
     /// When a grab on mouse or touch input is in effect

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -86,6 +86,17 @@ macro_rules! impl_common {
                     true => self.1,
                 }
             }
+
+            /// Set one component of self, based on a direction
+            ///
+            /// This does not negate components when the direction is reversed.
+            #[inline]
+            pub fn set_component<D: Directional>(&mut self, dir: D, value: i32) {
+                match dir.is_vertical() {
+                    false => self.0 = value,
+                    true => self.1 = value,
+                }
+            }
         }
 
         impl From<(i32, i32)> for $T {

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -67,6 +67,17 @@ impl Quad {
         Quad { a, b }
     }
 
+    /// Grow self in all directions by the given `value`
+    ///
+    /// In debug mode, this asserts `a.le(b)` after shrinking.
+    #[inline]
+    pub fn grow(&self, value: f32) -> Quad {
+        let a = self.a - value;
+        let b = self.b + value;
+        debug_assert!(a.le(b));
+        Quad { a, b }
+    }
+
     /// Shrink self in all directions by the given `value`
     ///
     /// In debug mode, this asserts `a.le(b)` after shrinking.

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -16,6 +16,8 @@ use crate::geom::Size;
 
 // for doc use
 #[allow(unused)]
+use super::FrameRules;
+#[allow(unused)]
 use kas::draw::SizeHandle;
 
 /// Widget sizing information
@@ -61,7 +63,7 @@ use kas::draw::SizeHandle;
 /// margin-merging behaviour, one cannot simply "add" two `SizeRules`. Instead,
 /// when placing one widget next to another, use [`SizeRules::append`] or
 /// [`SizeRules::appended`]; when placing a widget within a frame, use
-/// [`SizeRules::surrounded_by`]. When calculating the size of a sequence of
+/// [`FrameRules::surround`]. When calculating the size of a sequence of
 /// widgets, one may use the [`Sum`] implementation (this assumes that the
 /// sequence is in left-to-right or top-to-bottom order).
 ///

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,7 +26,7 @@ pub use kas::event::{Event, Handler, Manager, ManagerState, Response, SendEvent,
 #[doc(no_inline)]
 pub use kas::geom::{Coord, Offset, Rect, Size};
 #[doc(no_inline)]
-pub use kas::layout::{Align, AlignHints, AxisInfo, Margins, SizeRules, StretchPolicy};
+pub use kas::layout::{Align, AlignHints, AxisInfo, FrameRules, Margins, SizeRules, StretchPolicy};
 #[doc(no_inline)]
 pub use kas::macros::*;
 #[doc(no_inline)]

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -53,11 +53,7 @@ impl<M: 'static> Layout for TextButton<M> {
         let content_rules = size_handle.text_bound(&mut self.label, TextClass::Button, axis);
 
         let (rules, _offset, size) = frame_rules.surround(content_rules);
-        if axis.is_horizontal() {
-            self.frame_size.0 = size;
-        } else {
-            self.frame_size.1 = size;
-        }
+        self.frame_size.set_component(axis, size);
         rules
     }
 

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -37,11 +37,7 @@ impl<M: Clone + Debug + 'static> kas::Layout for ComboBox<M> {
         let content_rules = size_handle.text_bound(&mut self.label, TextClass::Button, axis);
 
         let (rules, _offset, size) = frame_rules.surround(content_rules);
-        if axis.is_horizontal() {
-            self.frame_size.0 = size;
-        } else {
-            self.frame_size.1 = size;
-        }
+        self.frame_size.set_component(axis, size);
         rules
     }
 

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -336,13 +336,8 @@ impl<G: EditGuard> Layout for EditBox<G> {
         let child_rules = self.inner.size_rules(size_handle, axis);
 
         let (rules, offset, size) = frame_rules.surround(child_rules);
-        if axis.is_horizontal() {
-            self.offset.0 = offset;
-            self.frame_size.0 = size;
-        } else {
-            self.offset.1 = offset;
-            self.frame_size.1 = size;
-        }
+        self.offset.set_component(axis, offset);
+        self.frame_size.set_component(axis, size);
         rules
     }
 

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -40,14 +40,8 @@ impl<W: Widget> Layout for Frame<W> {
         let frame_rules = size_handle.frame(axis.is_vertical());
         let child_rules = self.inner.size_rules(size_handle, axis);
         let (rules, offset, size) = frame_rules.surround(child_rules);
-
-        if axis.is_horizontal() {
-            self.offset.0 = offset;
-            self.size.0 = size;
-        } else {
-            self.offset.1 = offset;
-            self.size.1 = size;
-        }
+        self.offset.set_component(axis, offset);
+        self.size.set_component(axis, size);
         rules
     }
 

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -43,13 +43,8 @@ impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
         let frame_rules = size_handle.menu_frame(axis.is_vertical());
         let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelFixed, axis);
         let (rules, offset, size) = frame_rules.surround(text_rules);
-        if axis.is_horizontal() {
-            self.label_off.0 = offset;
-            self.frame_size.0 = size;
-        } else {
-            self.label_off.1 = offset;
-            self.frame_size.1 = size;
-        }
+        self.label_off.set_component(axis, offset);
+        self.frame_size.set_component(axis, size);
         rules
     }
 

--- a/src/widget/menu/menu_frame.rs
+++ b/src/widget/menu/menu_frame.rs
@@ -37,15 +37,8 @@ impl<W: Widget> Layout for MenuFrame<W> {
         let frame_rules = size_handle.frame(axis.is_vertical());
         let child_rules = self.inner.size_rules(size_handle, axis);
         let (rules, offset, size) = frame_rules.surround(child_rules);
-
-        if axis.is_horizontal() {
-            self.offset.0 = offset;
-            self.size.0 = size;
-        } else {
-            self.offset.1 = offset;
-            self.size.1 = size;
-        }
-
+        self.offset.set_component(axis, offset);
+        self.size.set_component(axis, size);
         rules
     }
 

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -108,13 +108,8 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
         let frame_rules = size_handle.menu_frame(axis.is_vertical());
         let text_rules = size_handle.text_bound(&mut self.label, TextClass::LabelFixed, axis);
         let (rules, offset, size) = frame_rules.surround(text_rules);
-        if axis.is_horizontal() {
-            self.label_off.0 = offset;
-            self.frame_size.0 = size;
-        } else {
-            self.label_off.1 = offset;
-            self.frame_size.1 = size;
-        }
+        self.label_off.set_component(axis, offset);
+        self.frame_size.set_component(axis, size);
         rules
     }
 

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -228,6 +228,10 @@ impl ScrollComponent {
 /// A scrollable region
 ///
 /// This region supports scrolling via mouse wheel and click/touch drag.
+///
+/// Scrollbars are not included; use [`ScrollBarRegion`] if you want those.
+///
+/// [`ScrollBarRegion`]: kas::widget::ScrollBarRegion
 #[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
 #[derive(Clone, Debug, Default, Widget)]
@@ -235,6 +239,8 @@ pub struct ScrollRegion<W: Widget> {
     #[widget_core]
     core: CoreData,
     min_child_size: Size,
+    offset: Offset,
+    frame_size: Size,
     scroll: ScrollComponent,
     #[widget]
     inner: W,
@@ -247,6 +253,8 @@ impl<W: Widget> ScrollRegion<W> {
         ScrollRegion {
             core: Default::default(),
             min_child_size: Size::ZERO,
+            offset: Default::default(),
+            frame_size: Default::default(),
             scroll: Default::default(),
             inner,
         }
@@ -303,15 +311,23 @@ impl<W: Widget> Layout for ScrollRegion<W> {
         let line_height = size_handle.line_height(TextClass::Label);
         self.scroll.set_scroll_rate(3.0 * f32::conv(line_height));
         rules.reduce_min_to(line_height);
+
+        // We use a zero-sized frame to push any margins inside the scroll-region.
+        let frame = FrameRules::new(0, 0, 0, (0, 0));
+        let (rules, offset, size) = frame.surround(rules);
+        self.offset.set_component(axis, offset);
+        self.frame_size.set_component(axis, size);
         rules
     }
 
     fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        let child_size = rect.size.max(self.min_child_size);
-        let child_rect = Rect::new(rect.pos, child_size);
+        let child_size = (rect.size - self.frame_size).max(self.min_child_size);
+        let child_rect = Rect::new(rect.pos + self.offset, child_size);
         self.inner.set_rect(mgr, child_rect, align);
-        let _ = self.scroll.set_sizes(rect.size, child_size);
+        let _ = self
+            .scroll
+            .set_sizes(rect.size, child_size + self.frame_size);
     }
 
     #[inline]

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -299,11 +299,7 @@ impl<W: Widget> WidgetConfig for ScrollRegion<W> {
 impl<W: Widget> Layout for ScrollRegion<W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let mut rules = self.inner.size_rules(size_handle, axis);
-        if axis.is_horizontal() {
-            self.min_child_size.0 = rules.min_size();
-        } else {
-            self.min_child_size.1 = rules.min_size();
-        }
+        self.min_child_size.set_component(axis, rules.min_size());
         let line_height = size_handle.line_height(TextClass::Label);
         self.scroll.set_scroll_rate(3.0 * f32::conv(line_height));
         rules.reduce_min_to(line_height);


### PR DESCRIPTION
ViewList now supports item selection via click (toggle on click). This is a little basic and doesn't support things like range-selection or a "select-all" command and has a simple backing type, thus probably needs extending later.

Scroll-region margins saw some revision: contents are now surrounded by a margin correctly, while keeping the margin within the drawable scroll-region.

`Size`, `Coord` and `Offset` now have a `set_component` method, simplifying several `size_rules` impls.