### PR TITLE
ViewList: multiple selection modes

### DIFF
--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -16,7 +16,7 @@ mod shared;
 mod single;
 
 pub use filter::{Filter, FilterAccessor, SimpleCaseInsensitiveFilter};
-pub use list::ListView;
+pub use list::{ListView, SelectionMode};
 pub use shared::{Accessor, AccessorShared, SharedConst, SharedRc};
 pub use single::SingleView;
 


### PR DESCRIPTION
Allows single/multiple or no selection with `ViewList`, which should be enough for the 7GUIs CRUD example app ...

... except that selection identifiers are dependent on the filter. Solving this requires significant changes to the `Accessor` trait.

Further, the `Accessor` trait needs some tweaks for write support (e.g. for cell editing within a spreadsheet).