### PR TITLE
View widgets: trait revision, reliable keys

### DIFF
--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -574,9 +574,9 @@ pub fn make_widget(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // TODO: we should probably not rely on recursive macro expansion here!
     // (I.e. use direct code generation for Widget derivation, instead of derive.)
     let toks = (quote! { {
+        #[derive(Debug, kas::macros::Widget)]
         #handler
         #extra_attrs
-        #[derive(Debug, kas::macros::Widget)]
         struct AnonWidget #impl_generics #where_clause {
             #field_toks
         }

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -19,9 +19,9 @@ use kas::widget::Window;
 use kas::{event, prelude::*};
 use kas_wgpu::draw::DrawWindow;
 
+#[derive(Clone, Debug, kas :: macros :: Widget)]
 #[handler(handle=noauto)]
 #[widget(config = noauto)]
-#[derive(Clone, Debug, kas :: macros :: Widget)]
 struct Clock {
     #[widget_core]
     core: kas::CoreData,

--- a/kas-wgpu/examples/dynamic.rs
+++ b/kas-wgpu/examples/dynamic.rs
@@ -60,9 +60,9 @@ impl EditGuard for ListEntryGuard {
 // activating any RadioBox sends a message to all others using the same
 // UpdateHandle, which is quite slow with thousands of entries!
 // (This issue does not occur when RadioBoxes are independent.)
+#[derive(Clone, Debug, Widget)]
 #[layout(column)]
 #[handler(msg=EntryMsg)]
-#[derive(Clone, Debug, Widget)]
 struct ListEntry {
     #[widget_core]
     core: CoreData,

--- a/kas-wgpu/examples/filter-list.rs
+++ b/kas-wgpu/examples/filter-list.rs
@@ -8,7 +8,7 @@
 use kas::dir::Down;
 use kas::event::UpdateHandle;
 use kas::prelude::*;
-use kas::widget::view::{ListData, ListView, SelectionMode, SimpleCaseInsensitiveFilter};
+use kas::widget::view::{ListData, ListMsg, ListView, SelectionMode, SimpleCaseInsensitiveFilter};
 use kas::widget::{EditBox, Label, RadioBox, ScrollBars, Window};
 
 #[cfg(not(feature = "generator"))]
@@ -131,7 +131,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     mgr.trigger_update(update, 0);
                     None
                 }),
-                #[widget] list: ScrollBars<ListView<Down, data::Shared>> =
+                #[widget(handler = select)] list: ScrollBars<ListView<Down, data::Shared>> =
                     ScrollBars::new(ListView::new(data)),
             }
             impl {
@@ -141,6 +141,14 @@ fn main() -> Result<(), kas_wgpu::Error> {
                     mode: SelectionMode
                 ) -> Response<VoidMsg> {
                     *mgr |= self.list.set_selection_mode(mode);
+                    Response::None
+                }
+                fn select(
+                    &mut self,
+                    _: &mut Manager,
+                    msg: ListMsg<usize, VoidMsg>,
+                ) -> Response<VoidMsg> {
+                    println!("Selection message: {:?}", msg);
                     Response::None
                 }
             }

--- a/kas-wgpu/examples/filter-list.rs
+++ b/kas-wgpu/examples/filter-list.rs
@@ -8,16 +8,16 @@
 use kas::dir::Down;
 use kas::event::UpdateHandle;
 use kas::prelude::*;
-use kas::widget::view::{Accessor, ListView, SelectionMode, SimpleCaseInsensitiveFilter};
+use kas::widget::view::{ListData, ListView, SelectionMode, SimpleCaseInsensitiveFilter};
 use kas::widget::{EditBox, Label, RadioBox, ScrollBars, Window};
 
 #[cfg(not(feature = "generator"))]
 mod data {
-    use kas::widget::view::{FilterAccessor, SharedConst, SimpleCaseInsensitiveFilter};
+    use kas::widget::view::{FilteredList, SharedConst, SimpleCaseInsensitiveFilter};
     use std::{cell::RefCell, rc::Rc};
 
     type SC = &'static SharedConst<[&'static str]>;
-    pub type Shared = Rc<RefCell<FilterAccessor<usize, SC, SimpleCaseInsensitiveFilter>>>;
+    pub type Shared = Rc<RefCell<FilteredList<SC, SimpleCaseInsensitiveFilter>>>;
 
     const MONTHS: &[&str] = &[
         "January",
@@ -36,7 +36,7 @@ mod data {
 
     pub fn get() -> Shared {
         let filter = SimpleCaseInsensitiveFilter::new("");
-        Rc::new(RefCell::new(FilterAccessor::new(MONTHS.into(), filter)))
+        Rc::new(RefCell::new(FilteredList::new(MONTHS.into(), filter)))
     }
 }
 
@@ -47,12 +47,12 @@ mod data {
 mod data {
     use chrono::{DateTime, Duration, Local};
     use kas::conv::Conv;
-    use kas::widget::view::{Accessor, FilterAccessor, SimpleCaseInsensitiveFilter};
+    use kas::widget::view::{FilteredList, ListData, SimpleCaseInsensitiveFilter};
     use std::{cell::RefCell, rc::Rc};
 
-    // pub type Shared = Rc<RefCell<DateGenerator>>;
-    pub type Shared =
-        Rc<RefCell<FilterAccessor<usize, DateGenerator, SimpleCaseInsensitiveFilter>>>;
+    // Alternative: unfiltered version (must (de)comment a few bits of code)
+    // pub type Shared = DateGenerator;
+    pub type Shared = Rc<RefCell<FilteredList<DateGenerator, SimpleCaseInsensitiveFilter>>>;
 
     #[derive(Debug)]
     pub struct DateGenerator {
@@ -61,7 +61,14 @@ mod data {
         step: Duration,
     }
 
-    impl Accessor<usize> for DateGenerator {
+    impl DateGenerator {
+        fn gen(&self, index: usize) -> String {
+            let date = self.start + self.step * i32::conv(index);
+            date.format("%A %e %B %Y, %T").to_string()
+        }
+    }
+    impl ListData for DateGenerator {
+        type Key = usize;
         type Item = String;
         fn len(&self) -> usize {
             let dur = self.end - self.start;
@@ -70,9 +77,13 @@ mod data {
             1 + usize::conv((secs - 1) / step_secs)
         }
 
-        fn get(&self, index: usize) -> Self::Item {
-            let date = self.start + self.step * i32::conv(index);
-            date.format("%A %e %B %Y, %T").to_string()
+        fn get_cloned(&self, index: &usize) -> Option<Self::Item> {
+            Some(self.gen(*index))
+        }
+
+        fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+            let end = self.len().min(start + limit);
+            (start..end).map(|i| (i, self.gen(i))).collect()
         }
     }
 
@@ -82,8 +93,9 @@ mod data {
             end: Local::now() + Duration::days(365),
             step: Duration::seconds(999),
         };
+        // gen
         let filter = SimpleCaseInsensitiveFilter::new("");
-        Rc::new(RefCell::new(FilterAccessor::new(gen, filter)))
+        Rc::new(RefCell::new(FilteredList::new(gen, filter)))
     }
 }
 
@@ -103,7 +115,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
     };
 
     let data = data::get();
-    println!("filter-list: {} entries", data.borrow().len());
+    println!("filter-list: {} entries", data.len());
     let data2 = data.clone();
     let window = Window::new(
         "Filter-list",

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -40,9 +40,9 @@ impl EditGuard for Guard {
     }
 }
 
+#[derive(Debug, Widget)]
 #[layout(grid)]
 #[handler(msg = VoidMsg)]
-#[derive(Debug, Widget)]
 struct TextEditPopup {
     #[widget_core]
     core: CoreData,

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -371,9 +371,9 @@ impl PipeWindow {
     }
 }
 
+#[derive(Clone, Debug, kas :: macros :: Widget)]
 #[widget(config=noauto)]
 #[handler(handle=noauto)]
-#[derive(Clone, Debug, kas :: macros :: Widget)]
 struct Mandlebrot {
     #[widget_core]
     core: kas::CoreData,
@@ -521,9 +521,9 @@ impl event::Handler for Mandlebrot {
     }
 }
 
+#[derive(Debug, Widget)]
 #[layout(grid)]
 #[handler(msg = event::VoidMsg)]
-#[derive(Debug, Widget)]
 struct MandlebrotWindow {
     #[widget_core]
     core: CoreData,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -56,9 +56,9 @@
 //! ```
 //! use kas::{event, prelude::*};
 //!
+//! #[derive(Clone, Debug, Widget)]
 //! #[layout(single)]
 //! #[handler(generics = <> where W: Widget<Msg = event::VoidMsg>)]
-//! #[derive(Clone, Debug, Widget)]
 //! struct WrapperWidget<W: Widget> {
 //!     #[widget_core] core: CoreData,
 //!     #[widget] child: W,
@@ -201,9 +201,9 @@
 //! ```
 //! # use kas::macros::Widget;
 //! # use kas::{CoreData, Layout, Widget, event::Handler};
+//! #[derive(Clone, Debug, Default, Widget)]
 //! #[layout(single)]
 //! #[handler(msg = <W as Handler>::Msg, generics = <> where W: Layout)]
-//! #[derive(Clone, Debug, Default, Widget)]
 //! pub struct Frame<W: Widget> {
 //!     #[widget_core]
 //!     core: CoreData,
@@ -253,9 +253,9 @@
 //! #[derive(Debug)]
 //! enum ChildMessage { A }
 //!
+//! #[derive(Debug, Widget)]
 //! #[layout(column)]
 //! #[handler(generics = <> where W: Widget<Msg = ChildMessage>)]
-//! #[derive(Debug, Widget)]
 //! struct MyWidget<W: Widget> {
 //!     #[widget_core] core: CoreData,
 //!     #[layout_data] layout_data: <Self as LayoutData>::Data,

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -13,9 +13,9 @@ use kas::event::{self, VirtualKeyCode, VirtualKeyCodes};
 use kas::prelude::*;
 
 /// A push-button with a text label
+#[derive(Clone, Widget)]
 #[handler(handle=noauto)]
 #[widget(config=noauto)]
-#[derive(Clone, Widget)]
 pub struct TextButton<M: 'static> {
     #[widget_core]
     core: kas::CoreData,

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -12,9 +12,9 @@ use super::AccelLabel;
 use kas::{event, prelude::*};
 
 /// A bare checkbox (no label)
+#[derive(Clone, Default, Widget)]
 #[widget(config(key_nav = true))]
 #[handler(handle=noauto)]
-#[derive(Clone, Default, Widget)]
 pub struct CheckBoxBare<M: 'static> {
     #[widget_core]
     core: CoreData,
@@ -141,10 +141,10 @@ impl<M: 'static> event::Handler for CheckBoxBare<M> {
 
 /// A checkable box with optional label
 // TODO: use a generic wrapper for CheckBox and RadioBox?
+#[derive(Clone, Default, Widget)]
 #[layout(row, area=checkbox)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[widget(config=noauto)]
-#[derive(Clone, Default, Widget)]
 pub struct CheckBox<M: 'static> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -86,7 +86,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     }
 
     #[inline]
-    fn new_(column: Vec<MenuEntry<u64>>, messages: Vec<M>) -> Self {
+    fn new_(column: Vec<MenuEntry<()>>, messages: Vec<M>) -> Self {
         assert!(column.len() > 0, "ComboBox: expected at least one choice");
         let label = Text::new_single(column[0].get_string().into());
         ComboBox {
@@ -148,8 +148,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     pub fn push<T: Into<AccelString>>(&mut self, label: T, msg: M) -> TkAction {
         self.messages.push(msg);
         let column = &mut self.popup.inner.inner;
-        let len = u64::conv(column.len());
-        column.push(MenuEntry::new(label, len))
+        column.push(MenuEntry::new(label, ()))
         // TODO: localised reconfigure
     }
 
@@ -163,8 +162,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
     pub fn insert<T: Into<AccelString>>(&mut self, index: usize, label: T, msg: M) -> TkAction {
         self.messages.insert(index, msg);
         let column = &mut self.popup.inner.inner;
-        let len = u64::conv(column.len());
-        column.insert(index, MenuEntry::new(label, len))
+        column.insert(index, MenuEntry::new(label, ()))
         // TODO: localised reconfigure
     }
 
@@ -198,7 +196,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
 }
 
 impl<M: Clone + Debug + 'static> ComboBox<M> {
-    fn map_response(&mut self, mgr: &mut Manager, r: Response<u64>) -> Response<M> {
+    fn map_response(&mut self, mgr: &mut Manager, r: Response<(usize, ())>) -> Response<M> {
         match r {
             Response::None => Response::None,
             Response::Unhandled(event) => match event {
@@ -221,8 +219,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
                 event => Response::Unhandled(event),
             },
             Response::Focus(x) => Response::Focus(x),
-            Response::Msg(msg) => {
-                let index = usize::conv(msg);
+            Response::Msg((index, ())) => {
                 *mgr |= self.set_active(index);
                 if let Some(id) = self.popup_id {
                     mgr.close_window(id);
@@ -242,8 +239,8 @@ impl<T: Into<AccelString>, M: Clone + Debug> FromIterator<(T, M)> for ComboBox<M
         let len = iter.size_hint().1.unwrap_or(0);
         let mut choices = Vec::with_capacity(len);
         let mut messages = Vec::with_capacity(len);
-        for (i, (label, msg)) in iter.enumerate() {
-            choices.push(MenuEntry::new(label, i.cast()));
+        for (label, msg) in iter {
+            choices.push(MenuEntry::new(label, ()));
             messages.push(msg);
         }
         ComboBox::new_(choices, messages)
@@ -256,8 +253,8 @@ impl<'a, M: Clone + Debug + 'static> FromIterator<&'a (&'static str, M)> for Com
         let len = iter.size_hint().1.unwrap_or(0);
         let mut choices = Vec::with_capacity(len);
         let mut messages = Vec::with_capacity(len);
-        for (i, (label, msg)) in iter.enumerate() {
-            choices.push(MenuEntry::new(*label, i.cast()));
+        for (label, msg) in iter {
+            choices.push(MenuEntry::new(*label, ()));
             messages.push(msg.clone());
         }
         ComboBox::new_(choices, messages)
@@ -374,10 +371,10 @@ impl<M: Clone + Debug + 'static> event::SendEvent for ComboBox<M> {
 
 #[derive(Clone, Debug, Widget)]
 #[layout(single)]
-#[handler(msg=u64)]
+#[handler(msg=(usize, ()))]
 struct ComboPopup {
     #[widget_core]
     core: CoreData,
     #[widget]
-    inner: MenuFrame<Column<MenuEntry<u64>>>,
+    inner: MenuFrame<Column<MenuEntry<()>>>,
 }

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -15,9 +15,9 @@ use kas::prelude::*;
 use kas::WindowId;
 
 /// A pop-up multiple choice menu
+#[derive(Clone, Debug, Widget)]
 #[widget(config(key_nav = true))]
 #[handler(noauto)]
-#[derive(Clone, Debug, Widget)]
 pub struct ComboBox<M: Clone + Debug + 'static> {
     #[widget_core]
     core: CoreData,
@@ -372,9 +372,9 @@ impl<M: Clone + Debug + 'static> event::SendEvent for ComboBox<M> {
     }
 }
 
+#[derive(Clone, Debug, Widget)]
 #[layout(single)]
 #[handler(msg=u64)]
-#[derive(Clone, Debug, Widget)]
 struct ComboPopup {
     #[widget_core]
     core: CoreData,

--- a/src/widget/dialog.rs
+++ b/src/widget/dialog.rs
@@ -20,9 +20,9 @@ enum DialogButton {
 }
 
 /// A simple message box.
+#[derive(Clone, Debug, Widget)]
 #[layout(column)]
 #[widget(config=noauto)]
-#[derive(Clone, Debug, Widget)]
 pub struct MessageBox<T: FormattableText + 'static> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -25,9 +25,9 @@ use kas::prelude::*;
 /// 3.  [`Layout::draw`] does nothing. The parent should handle all drawing.
 /// 4.  Optionally, this widget can handle clicks on the track area via
 ///     [`DragHandle::handle_press_on_track`].
+#[derive(Clone, Debug, Default, Widget)]
 #[handler(handle=noauto)]
 #[widget(config(cursor_icon = event::CursorIcon::Grab))]
-#[derive(Clone, Debug, Default, Widget)]
 pub struct DragHandle {
     #[widget_core]
     core: CoreData,

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -393,9 +393,9 @@ impl<G: EditGuard> HasString for EditBox<G> {
 /// Optionally, [`EditField::multi_line`] mode can be activated (enabling
 /// line-wrapping and a larger vertical height). This mode is only recommended
 /// for short texts for performance reasons.
+#[derive(Clone, Default, Debug, Widget)]
 #[widget(config(key_nav = true, cursor_icon = event::CursorIcon::Text))]
 #[handler(handle=noauto, generics = <> where G: EditGuard)]
-#[derive(Clone, Default, Debug, Widget)]
 pub struct EditField<G: EditGuard = ()> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/editbox.rs
+++ b/src/widget/editbox.rs
@@ -380,6 +380,19 @@ impl<G: EditGuard> HasString for EditBox<G> {
     }
 }
 
+impl<G: EditGuard> std::ops::Deref for EditBox<G> {
+    type Target = EditField<G>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<G: EditGuard> std::ops::DerefMut for EditBox<G> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
 /// A text-edit field (single- or multi-line)
 ///
 /// Usually one uses a derived type like [`EditBox`] instead. This field does

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -11,8 +11,8 @@ use kas::{event, prelude::*};
 ///
 /// This widget provides a simple abstraction: drawing a frame around its
 /// contents.
-#[handler(msg = <W as Handler>::Msg)]
 #[derive(Clone, Debug, Default, Widget)]
+#[handler(msg = <W as Handler>::Msg)]
 pub struct Frame<W: Widget> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -86,9 +86,9 @@ pub type RefList<'a, D, M> = List<D, &'a mut dyn Widget<Msg = M>>;
 /// children.
 ///
 /// [`make_widget`]: ../macros/index.html#the-make_widget-macro
+#[derive(Clone, Default, Debug, Widget)]
 #[handler(send=noauto, msg=<W as event::Handler>::Msg)]
 #[widget(children=noauto)]
-#[derive(Clone, Default, Debug, Widget)]
 pub struct List<D: Directional, W: Widget> {
     first_id: WidgetId,
     #[widget_core]

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -87,7 +87,7 @@ pub type RefList<'a, D, M> = List<D, &'a mut dyn Widget<Msg = M>>;
 ///
 /// [`make_widget`]: ../macros/index.html#the-make_widget-macro
 #[derive(Clone, Default, Debug, Widget)]
-#[handler(send=noauto, msg=<W as event::Handler>::Msg)]
+#[handler(send=noauto, msg=(usize, <W as event::Handler>::Msg))]
 #[widget(children=noauto)]
 pub struct List<D: Directional, W: Widget> {
     first_id: WidgetId,
@@ -176,9 +176,13 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
 impl<D: Directional, W: Widget> event::SendEvent for List<D, W> {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         if !self.is_disabled() {
-            for child in &mut self.widgets {
+            for (i, child) in self.widgets.iter_mut().enumerate() {
                 if id <= child.id() {
-                    return child.send(mgr, id, event);
+                    let r = child.send(mgr, id, event);
+                    return match Response::try_from(r) {
+                        Ok(r) => r,
+                        Err(msg) => Response::Msg((i, msg)),
+                    };
                 }
             }
         }

--- a/src/widget/menu/menu_entry.rs
+++ b/src/widget/menu/menu_entry.rs
@@ -16,9 +16,9 @@ use kas::prelude::*;
 use kas::widget::{AccelLabel, CheckBoxBare};
 
 /// A standard menu entry
+#[derive(Clone, Debug, Default, Widget)]
 #[widget(config=noauto)]
 #[handler(handle=noauto)]
-#[derive(Clone, Debug, Default, Widget)]
 pub struct MenuEntry<M: Clone + Debug + 'static> {
     #[widget_core]
     core: kas::CoreData,
@@ -117,9 +117,9 @@ impl<M: Clone + Debug + 'static> event::Handler for MenuEntry<M> {
 impl<M: Clone + Debug> Menu for MenuEntry<M> {}
 
 /// A menu entry which can be toggled
+#[derive(Clone, Default, Widget)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[widget(config=noauto)]
-#[derive(Clone, Default, Widget)]
 pub struct MenuToggle<M: 'static> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/menu/menu_frame.rs
+++ b/src/widget/menu/menu_frame.rs
@@ -8,8 +8,8 @@
 use kas::{event, prelude::*};
 
 /// A frame around content, plus background
-#[handler(msg = <W as Handler>::Msg)]
 #[derive(Clone, Debug, Default, Widget)]
+#[handler(msg = <W as Handler>::Msg)]
 pub struct MenuFrame<W: Widget> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/menu/menubar.rs
+++ b/src/widget/menu/menubar.rs
@@ -203,8 +203,10 @@ impl<D: Directional, W: Menu> event::SendEvent for MenuBar<D, W> {
 
         if id <= self.bar.id() {
             return match self.bar.send(mgr, id, event) {
+                Response::None => Response::None,
+                Response::Focus(rect) => Response::Focus(rect),
                 Response::Unhandled(event) => self.handle(mgr, event),
-                r => r,
+                Response::Msg((_, msg)) => Response::Msg(msg),
             };
         }
 

--- a/src/widget/menu/menubar.rs
+++ b/src/widget/menu/menubar.rs
@@ -18,8 +18,8 @@ const DELAY: Duration = Duration::from_millis(200);
 ///
 /// This widget houses a sequence of menu buttons, allowing input actions across
 /// menus.
-#[handler(noauto)]
 #[derive(Clone, Debug, Widget)]
+#[handler(noauto)]
 pub struct MenuBar<D: Directional, W: Menu> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -189,6 +189,8 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
             }
 
             match r {
+                Response::None => Response::None,
+                Response::Focus(rect) => Response::Focus(rect),
                 Response::Unhandled(event) => match event {
                     Event::Command(key, _) if self.popup_id.is_some() => {
                         if self.popup_id.is_some() {
@@ -220,11 +222,10 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
                     }
                     event => Response::Unhandled(event),
                 },
-                Response::Msg(msg) => {
+                Response::Msg((_, msg)) => {
                     self.close_menu(mgr);
                     Response::Msg(msg)
                 }
-                r => r,
             }
         } else {
             Manager::handle_generic(self, mgr, event)

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -13,9 +13,9 @@ use kas::widget::Column;
 use kas::WindowId;
 
 /// A sub-menu
+#[derive(Clone, Debug, Widget)]
 #[widget(config=noauto)]
 #[handler(noauto)]
-#[derive(Clone, Debug, Widget)]
 pub struct SubMenu<D: Directional, W: Menu> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -15,9 +15,9 @@ use kas::event::{self, UpdateHandle};
 use kas::prelude::*;
 
 /// A bare radiobox (no label)
+#[derive(Clone, Widget)]
 #[handler(handle=noauto)]
 #[widget(config=noauto)]
-#[derive(Clone, Widget)]
 pub struct RadioBoxBare<M: 'static> {
     #[widget_core]
     core: CoreData,
@@ -176,10 +176,10 @@ impl<M: 'static> HasBool for RadioBoxBare<M> {
 }
 
 /// A radiobox with optional label
+#[derive(Clone, Widget)]
 #[layout(row, area=radiobox)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[widget(config=noauto)]
-#[derive(Clone, Widget)]
 pub struct RadioBox<M: 'static> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/reserve.rs
+++ b/src/widget/reserve.rs
@@ -21,8 +21,8 @@ pub type ReserveP<W> = Reserve<W, fn(&mut dyn SizeHandle, AxisInfo) -> SizeRules
 /// In a few cases it is desirable to reserve more space for a widget than
 /// required for the current content, e.g. if a label's text may change. This
 /// widget can be used for this by wrapping the base widget.
-#[handler(msg = <W as Handler>::Msg)]
 #[derive(Clone, Default, Widget)]
+#[handler(msg = <W as Handler>::Msg)]
 pub struct Reserve<W: Widget, R: FnMut(&mut dyn SizeHandle, AxisInfo) -> SizeRules + 'static> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -232,9 +232,9 @@ impl ScrollComponent {
 /// Scrollbars are not included; use [`ScrollBarRegion`] if you want those.
 ///
 /// [`ScrollBarRegion`]: kas::widget::ScrollBarRegion
+#[derive(Clone, Debug, Default, Widget)]
 #[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
-#[derive(Clone, Debug, Default, Widget)]
 pub struct ScrollRegion<W: Widget> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -14,8 +14,8 @@ use kas::{event, prelude::*};
 ///
 /// Scroll bars allow user-input of a value between 0 and a defined maximum,
 /// and allow the size of the handle to be specified.
-#[handler(send=noauto, msg = i32)]
 #[derive(Clone, Debug, Default, Widget)]
+#[handler(send=noauto, msg = i32)]
 pub struct ScrollBar<D: Directional> {
     #[widget_core]
     core: CoreData,
@@ -313,9 +313,9 @@ pub type ScrollBarRegion<W> = ScrollBars<ScrollRegion<W>>;
 /// the result looks poor when content is scrolled. Instead the content should
 /// force internal margins by wrapping contents with a (zero-sized) frame.
 /// [`ScrollRegion`] already does this.
+#[derive(Clone, Debug, Default, Widget)]
 #[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
-#[derive(Clone, Debug, Default, Widget)]
 pub struct ScrollBars<W: ScrollWidget> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/separator.rs
+++ b/src/widget/separator.rs
@@ -14,8 +14,8 @@ use kas::{event, prelude::*};
 /// A separator
 ///
 /// This widget draws a bar when in a list.
-#[handler(msg=M)]
 #[derive(Clone, Debug, Default, Widget)]
+#[handler(msg=M)]
 pub struct Separator<M: Debug + 'static> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -84,9 +84,9 @@ impl SliderType for Duration {
 /// A slider
 ///
 /// Sliders allow user input of a value from a fixed range.
+#[derive(Clone, Debug, Default, Widget)]
 #[handler(send=noauto, msg = T)]
 #[widget(config(key_nav = true))]
-#[derive(Clone, Debug, Default, Widget)]
 pub struct Slider<T: SliderType, D: Directional> {
     #[widget_core]
     core: CoreData,

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -70,9 +70,9 @@ pub type RefSplitter<'a, D, M> = Splitter<D, &'a mut dyn Widget<Msg = M>>;
 ///
 /// Similar to [`kas::widget::List`] but with draggable handles between items.
 // TODO: better doc
+#[derive(Clone, Default, Debug, Widget)]
 #[handler(send=noauto, msg=<W as event::Handler>::Msg)]
 #[widget(children=noauto)]
-#[derive(Clone, Default, Debug, Widget)]
 pub struct Splitter<D: Directional, W: Widget> {
     first_id: WidgetId,
     #[widget_core]

--- a/src/widget/stack.rs
+++ b/src/widget/stack.rs
@@ -30,9 +30,9 @@ pub type RefStack<'a, M> = Stack<&'a mut dyn Widget<Msg = M>>;
 ///
 /// Configuring and resizing elements is O(n) in the number of children.
 /// Drawing and event handling is O(1).
+#[derive(Clone, Default, Debug, Widget)]
 #[handler(send=noauto, msg=<W as event::Handler>::Msg)]
 #[widget(children=noauto)]
-#[derive(Clone, Default, Debug, Widget)]
 pub struct Stack<W: Widget> {
     first_id: WidgetId,
     #[widget_core]

--- a/src/widget/view/data_traits.rs
+++ b/src/widget/view/data_traits.rs
@@ -1,0 +1,214 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Data traits for view widgets
+//!
+//! This module holds these traits and basic impls for derived types.
+
+#[allow(unused)]
+use kas::event::Manager;
+use kas::event::UpdateHandle;
+use std::cell::RefCell;
+use std::fmt::Debug;
+use std::ops::Deref;
+
+/// Trait for viewable single data items
+// Note: we require Debug + 'static to allow widgets using this to implement
+// WidgetCore, which requires Debug + Any.
+pub trait SingleData: Debug {
+    type Item: Clone;
+
+    // TODO(gat): add get<'a>(&self) -> Self::ItemRef<'a> and get_mut
+
+    /// Get data (clone)
+    fn get_cloned(&self) -> Self::Item;
+
+    /// Get an update handle, if any is used
+    ///
+    /// Widgets may use this `handle` to call `mgr.update_on_handle(handle, self.id())`.
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        None
+    }
+}
+
+/// Trait for writable single data items
+pub trait SingleDataMut: SingleData {
+    /// Set data
+    fn set(&self, value: Self::Item) -> UpdateHandle;
+}
+
+/// Trait for viewable data lists
+pub trait ListData: Debug {
+    /// Key type
+    type Key: Clone + Debug + PartialEq + Eq;
+
+    /// Item type
+    type Item: Clone;
+
+    /// Number of data items available
+    ///
+    /// Note: users may assume this is `O(1)`.
+    fn len(&self) -> usize;
+
+    // TODO(gat): add get<'a>(&self) -> Self::ItemRef<'a> and get_mut
+
+    /// Get data by key (clone)
+    fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item>;
+
+    // TODO(gat): replace with an iterator
+    /// Iterate over (key, value) pairs as a vec
+    ///
+    /// The result will be in deterministic implementation-defined order, with
+    /// a length of `max(limit, data_len)` where `data_len` is the number of
+    /// items available.
+    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+        self.iter_vec_from(0, limit)
+    }
+
+    /// Iterate over (key, value) pairs as a vec
+    ///
+    /// The result is the same as `self.iter_vec(start + limit).skip(start)`.
+    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)>;
+
+    /// Get an update handle, if any is used
+    ///
+    /// Widgets may use this `handle` to call `mgr.update_on_handle(handle, self.id())`.
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        None
+    }
+}
+
+/// Trait for writable data lists
+pub trait ListDataMut: ListData {
+    /// Set data by key
+    fn set(&self, key: Self::Key, item: Self::Item) -> UpdateHandle;
+}
+
+impl<T: Clone + Debug> ListData for [T] {
+    type Key = usize;
+    type Item = T;
+
+    fn len(&self) -> usize {
+        (*self).len()
+    }
+
+    fn get_cloned(&self, key: &usize) -> Option<Self::Item> {
+        self.get(*key).cloned()
+    }
+
+    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+        self.iter().cloned().enumerate().take(limit).collect()
+    }
+
+    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+        self.iter()
+            .cloned()
+            .enumerate()
+            .skip(start)
+            .take(limit)
+            .collect()
+    }
+}
+
+// TODO(spec): implement using Deref; for now can't since it "might" conflict
+// with a RefCell impl on a derived type downstream, according to the solver.
+// impl<T: Deref + Debug> SingleData for T
+// where
+//     <T as Deref>::Target: SingleData,
+macro_rules! impl_via_deref {
+    ($t: ident: $derived:ty) => {
+        impl<$t: SingleData + ?Sized> SingleData for $derived {
+            type Item = $t::Item;
+            fn get_cloned(&self) -> Self::Item {
+                self.deref().get_cloned()
+            }
+            fn update_handle(&self) -> Option<UpdateHandle> {
+                self.deref().update_handle()
+            }
+        }
+        impl<$t: SingleDataMut + ?Sized> SingleDataMut for $derived {
+            fn set(&self, value: Self::Item) -> UpdateHandle {
+                self.deref().set(value)
+            }
+        }
+
+        impl<$t: ListData + ?Sized> ListData for $derived {
+            type Key = $t::Key;
+            type Item = $t::Item;
+
+            fn len(&self) -> usize {
+                self.deref().len()
+            }
+            fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
+                self.deref().get_cloned(key)
+            }
+
+            fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+                self.deref().iter_vec(limit)
+            }
+            fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+                self.deref().iter_vec_from(start, limit)
+            }
+
+            fn update_handle(&self) -> Option<UpdateHandle> {
+                self.deref().update_handle()
+            }
+        }
+        impl<$t: ListDataMut + ?Sized> ListDataMut for $derived {
+            fn set(&self, key: Self::Key, item: Self::Item) -> UpdateHandle {
+                self.deref().set(key, item)
+            }
+        }
+    };
+    ($t: ident: $derived:ty, $($dd:ty),+) => {
+        impl_via_deref!($t: $derived);
+        impl_via_deref!($t: $($dd),+);
+    };
+}
+impl_via_deref!(T: &T, &mut T);
+impl_via_deref!(T: std::rc::Rc<T>, std::sync::Arc<T>, Box<T>);
+
+impl<T: SingleData> SingleData for RefCell<T> {
+    type Item = T::Item;
+    fn get_cloned(&self) -> Self::Item {
+        self.borrow().get_cloned()
+    }
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        self.borrow().update_handle()
+    }
+}
+impl<T: SingleDataMut> SingleDataMut for RefCell<T> {
+    fn set(&self, value: Self::Item) -> UpdateHandle {
+        self.borrow_mut().set(value)
+    }
+}
+
+impl<T: ListData> ListData for RefCell<T> {
+    type Key = T::Key;
+    type Item = T::Item;
+
+    fn len(&self) -> usize {
+        self.borrow().len()
+    }
+    fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
+        self.borrow().get_cloned(key)
+    }
+
+    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+        self.borrow().iter_vec(limit)
+    }
+    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+        self.borrow().iter_vec_from(start, limit)
+    }
+
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        self.borrow().update_handle()
+    }
+}
+impl<T: ListDataMut> ListDataMut for RefCell<T> {
+    fn set(&self, key: Self::Key, item: Self::Item) -> UpdateHandle {
+        self.borrow().set(key, item)
+    }
+}

--- a/src/widget/view/list.rs
+++ b/src/widget/view/list.rs
@@ -32,9 +32,9 @@ impl Default for SelectionMode {
 // TODO: do we need to keep the A::Item: Default bound used by allocate?
 
 /// List view widget
+#[derive(Clone, Debug, Widget)]
 #[handler(send=noauto, msg=<W as Handler>::Msg)]
 #[widget(children=noauto, config=noauto)]
-#[derive(Clone, Debug, Widget)]
 pub struct ListView<
     D: Directional,
     A: Accessor<usize>,

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -10,20 +10,21 @@
 use super::Label;
 use kas::prelude::*;
 
+mod data_traits;
 mod filter;
 mod list;
 mod shared;
 mod single;
 
-pub use filter::{Filter, FilterAccessor, SimpleCaseInsensitiveFilter};
+pub use data_traits::{ListData, SingleData, SingleDataMut};
+pub use filter::{Filter, FilteredList, SimpleCaseInsensitiveFilter};
 pub use list::{ListView, SelectionMode};
-pub use shared::{Accessor, AccessorShared, SharedConst, SharedRc};
-pub use single::{SingleData, SingleDataMut, SingleView};
+pub use shared::{SharedConst, SharedRc};
+pub use single::SingleView;
 
 /// View widgets
 ///
 /// Implementors are able to view data of type `T`.
-/// Note: we pass `&T` to better match up with [`Accessor::get`].
 pub trait ViewWidget<T>: Widget {
     /// Construct a default instance (with no data)
     fn default() -> Self

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -18,7 +18,7 @@ mod single;
 
 pub use data_traits::{ListData, SingleData, SingleDataMut};
 pub use filter::{Filter, FilteredList, SimpleCaseInsensitiveFilter};
-pub use list::{ListView, SelectionMode};
+pub use list::{ListMsg, ListView, SelectionMode};
 pub use shared::{SharedConst, SharedRc};
 pub use single::SingleView;
 

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -18,7 +18,7 @@ mod single;
 pub use filter::{Filter, FilterAccessor, SimpleCaseInsensitiveFilter};
 pub use list::{ListView, SelectionMode};
 pub use shared::{Accessor, AccessorShared, SharedConst, SharedRc};
-pub use single::SingleView;
+pub use single::{SingleData, SingleDataMut, SingleView};
 
 /// View widgets
 ///

--- a/src/widget/view/shared.rs
+++ b/src/widget/view/shared.rs
@@ -5,6 +5,7 @@
 
 //! Shared data for view widgets
 
+use super::{SingleData, SingleDataMut};
 #[allow(unused)]
 use kas::event::Manager;
 use kas::event::UpdateHandle;
@@ -191,9 +192,26 @@ impl<T: Clone + Debug + 'static> Accessor<()> for SharedRc<T> {
         Some(self.handle)
     }
 }
-
 impl<T: Clone + Debug + 'static> AccessorShared<()> for SharedRc<T> {
     fn set(&self, _: (), value: T) -> UpdateHandle {
+        *self.data.borrow_mut() = value;
+        self.handle
+    }
+}
+
+impl<T: Clone + Debug + 'static> SingleData for SharedRc<T> {
+    type Item = T;
+
+    fn get_cloned(&self) -> Self::Item {
+        self.data.borrow().to_owned()
+    }
+
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        Some(self.handle)
+    }
+}
+impl<T: Clone + Debug + 'static> SingleDataMut for SharedRc<T> {
+    fn set(&self, value: Self::Item) -> UpdateHandle {
         *self.data.borrow_mut() = value;
         self.handle
     }

--- a/src/widget/view/shared.rs
+++ b/src/widget/view/shared.rs
@@ -5,108 +5,13 @@
 
 //! Shared data for view widgets
 
-use super::{SingleData, SingleDataMut};
+use super::{ListData, SingleData, SingleDataMut};
 #[allow(unused)]
 use kas::event::Manager;
 use kas::event::UpdateHandle;
 use std::cell::RefCell;
 use std::fmt::Debug;
 use std::rc::Rc;
-
-/// Base trait required by view widgets
-// Note: we require Debug + 'static to allow widgets using this to implement
-// WidgetCore, which requires Debug + Any.
-pub trait Accessor<I>: Debug + 'static {
-    type Item;
-
-    /// Size descriptor
-    ///
-    /// Note: for `I == ()` we consider `()` a valid index; in other cases we
-    /// usually expect `index < accessor.len()` (for each component).
-    fn len(&self) -> I;
-
-    /// Access data by index
-    // TODO: note that we do not return a reference for compatibility with Rc, RefCell, Mutex etc.
-    // Investigate using a guard/lock for data access?
-    fn get(&self, index: I) -> Self::Item;
-
-    /// Get an update handle, if any is used
-    ///
-    /// Widgets may use this `handle` to call `mgr.update_on_handle(handle, self.id())`.
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        None
-    }
-}
-
-/// Extension trait for shared data for view widgets
-pub trait AccessorShared<I>: Accessor<I> {
-    /// Set data at the given index
-    ///
-    /// The caller should call [`Manager::trigger_update`] using the returned
-    /// update handle, using an appropriate transformation of the index for the
-    /// payload (the transformation defined by implementing view widgets).
-    /// Calling `trigger_update` is unnecessary before the UI has been started.
-    fn set(&self, index: I, value: Self::Item) -> UpdateHandle;
-}
-
-// TODO(spec): implement Accessor<I> and AccessorShared<I> for T: Deref + 'static
-// where <T as Deref>::Target: Accessor<I>
-// Instead we implement for a few more specific types
-
-impl<I, T: Accessor<I> + ?Sized> Accessor<I> for &'static T {
-    type Item = T::Item;
-    fn len(&self) -> I {
-        (**self).len()
-    }
-    fn get(&self, index: I) -> Self::Item {
-        (**self).get(index)
-    }
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        (**self).update_handle()
-    }
-}
-impl<I, T: AccessorShared<I> + ?Sized> AccessorShared<I> for &'static T {
-    fn set(&self, index: I, value: Self::Item) -> UpdateHandle {
-        (**self).set(index, value)
-    }
-}
-
-impl<I, T: Accessor<I> + ?Sized> Accessor<I> for Rc<T> {
-    type Item = T::Item;
-    fn len(&self) -> I {
-        (**self).len()
-    }
-    fn get(&self, index: I) -> Self::Item {
-        (**self).get(index)
-    }
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        (**self).update_handle()
-    }
-}
-impl<I, T: AccessorShared<I> + ?Sized> AccessorShared<I> for Rc<T> {
-    fn set(&self, index: I, value: Self::Item) -> UpdateHandle {
-        (**self).set(index, value)
-    }
-}
-
-impl<I, T: Accessor<I> + ?Sized> Accessor<I> for RefCell<T> {
-    type Item = T::Item;
-    fn len(&self) -> I {
-        self.borrow().len()
-    }
-    fn get(&self, index: I) -> Self::Item {
-        self.borrow().get(index)
-    }
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        self.borrow().update_handle()
-    }
-}
-
-impl<I, T: AccessorShared<I> + ?Sized> AccessorShared<I> for RefCell<T> {
-    fn set(&self, index: I, value: Self::Item) -> UpdateHandle {
-        self.borrow_mut().set(index, value)
-    }
-}
 
 /// Wrapper for shared constant data
 ///
@@ -134,34 +39,43 @@ impl<T: Debug + 'static + ?Sized> From<&T> for &SharedConst<T> {
     }
 }
 
-impl<T: Clone + Debug + 'static> Accessor<()> for SharedConst<T> {
+impl<T: Clone + Debug + 'static + ?Sized> SingleData for SharedConst<T> {
     type Item = T;
-    fn len(&self) -> () {
-        ()
-    }
-    fn get(&self, _: ()) -> T {
+
+    fn get_cloned(&self) -> Self::Item {
         self.0.clone()
     }
 }
 
-impl<T: Clone + Debug + 'static> Accessor<usize> for SharedConst<[T]> {
-    type Item = T;
+impl<T: ListData + 'static + ?Sized> ListData for SharedConst<T> {
+    type Key = T::Key;
+    type Item = T::Item;
+
     fn len(&self) -> usize {
         self.0.len()
     }
-    fn get(&self, index: usize) -> T {
-        self.0[index].to_owned()
+
+    fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
+        self.0.get_cloned(key)
+    }
+
+    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+        self.0.iter_vec(limit)
+    }
+
+    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+        self.0.iter_vec_from(start, limit)
     }
 }
 
 /// Wrapper for single-thread shared data
 #[derive(Clone, Debug)]
-pub struct SharedRc<T: Clone + Debug + 'static> {
+pub struct SharedRc<T: Debug> {
     handle: UpdateHandle,
     data: Rc<RefCell<T>>,
 }
 
-impl<T: Default + Clone + Debug + 'static> Default for SharedRc<T> {
+impl<T: Default + Debug> Default for SharedRc<T> {
     fn default() -> Self {
         SharedRc {
             handle: UpdateHandle::new(),
@@ -170,7 +84,7 @@ impl<T: Default + Clone + Debug + 'static> Default for SharedRc<T> {
     }
 }
 
-impl<T: Clone + Debug + 'static> SharedRc<T> {
+impl<T: Debug> SharedRc<T> {
     /// Construct with given data
     pub fn new(data: T) -> Self {
         SharedRc {
@@ -180,26 +94,7 @@ impl<T: Clone + Debug + 'static> SharedRc<T> {
     }
 }
 
-impl<T: Clone + Debug + 'static> Accessor<()> for SharedRc<T> {
-    type Item = T;
-    fn len(&self) -> () {
-        ()
-    }
-    fn get(&self, _: ()) -> T {
-        self.data.borrow().to_owned()
-    }
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        Some(self.handle)
-    }
-}
-impl<T: Clone + Debug + 'static> AccessorShared<()> for SharedRc<T> {
-    fn set(&self, _: (), value: T) -> UpdateHandle {
-        *self.data.borrow_mut() = value;
-        self.handle
-    }
-}
-
-impl<T: Clone + Debug + 'static> SingleData for SharedRc<T> {
+impl<T: Clone + Debug> SingleData for SharedRc<T> {
     type Item = T;
 
     fn get_cloned(&self) -> Self::Item {
@@ -210,9 +105,34 @@ impl<T: Clone + Debug + 'static> SingleData for SharedRc<T> {
         Some(self.handle)
     }
 }
-impl<T: Clone + Debug + 'static> SingleDataMut for SharedRc<T> {
+impl<T: Clone + Debug> SingleDataMut for SharedRc<T> {
     fn set(&self, value: Self::Item) -> UpdateHandle {
         *self.data.borrow_mut() = value;
         self.handle
+    }
+}
+
+impl<T: ListData> ListData for SharedRc<T> {
+    type Key = T::Key;
+    type Item = T::Item;
+
+    fn len(&self) -> usize {
+        self.data.borrow().len()
+    }
+
+    fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
+        self.data.borrow().get_cloned(key)
+    }
+
+    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+        self.data.borrow().iter_vec(limit)
+    }
+
+    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+        self.data.borrow().iter_vec_from(start, limit)
+    }
+
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        Some(self.handle)
     }
 }

--- a/src/widget/view/single.rs
+++ b/src/widget/view/single.rs
@@ -5,66 +5,97 @@
 
 //! Single view widget
 
-use super::{Accessor, AccessorShared, DefaultView, ViewWidget};
+use super::{DefaultView, ViewWidget};
+use kas::event::UpdateHandle;
 use kas::prelude::*;
-use std::fmt;
+use std::fmt::{self, Debug};
+
+/// Trait for viewable single data items
+// Note: we require Debug + 'static to allow widgets using this to implement
+// WidgetCore, which requires Debug + Any.
+pub trait SingleData: Debug + 'static {
+    type Item: Clone;
+
+    // TODO(gat): add get<'a>(&self) -> Self::ItemRef<'a> and get_mut
+
+    /// Get data (clone)
+    fn get_cloned(&self) -> Self::Item;
+
+    /// Get an update handle, if any is used
+    ///
+    /// Widgets may use this `handle` to call `mgr.update_on_handle(handle, self.id())`.
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        None
+    }
+}
+
+/// Trait for writable single data items
+pub trait SingleDataMut: SingleData {
+    /// Set data
+    fn set(&self, value: Self::Item) -> UpdateHandle;
+}
 
 /// Single view widget
 #[derive(Clone, Widget)]
 #[widget(config=noauto)]
 #[layout(single)]
 #[handler(handle=noauto)]
-pub struct SingleView<A: Accessor<()>, W = <<A as Accessor<()>>::Item as DefaultView>::Widget>
+pub struct SingleView<D: SingleData, W = <<D as SingleData>::Item as DefaultView>::Widget>
 where
-    W: ViewWidget<<A as Accessor<()>>::Item>,
+    W: ViewWidget<D::Item>,
 {
     #[widget_core]
     core: CoreData,
-    accessor: A,
+    data: D,
     #[widget]
     child: W,
 }
 
-impl<A: Accessor<()> + Default, W: ViewWidget<A::Item>> Default for SingleView<A, W> {
+impl<D: SingleData + Default, W: ViewWidget<D::Item>> Default for SingleView<D, W> {
     fn default() -> Self {
-        let accessor = A::default();
-        let child = W::new(accessor.get(()));
+        let data = D::default();
+        let child = W::new(data.get_cloned());
         SingleView {
             core: Default::default(),
-            accessor,
+            data,
             child,
         }
     }
 }
 
-impl<A: Accessor<()>, W: ViewWidget<A::Item>> SingleView<A, W> {
+impl<D: SingleData, W: ViewWidget<D::Item>> SingleView<D, W> {
     /// Construct a new instance
-    pub fn new(accessor: A) -> Self {
-        let child = W::new(accessor.get(()));
+    pub fn new(data: D) -> Self {
+        let child = W::new(data.get_cloned());
         SingleView {
             core: Default::default(),
-            accessor,
+            data,
             child,
         }
     }
 
-    /// Get the data accessor
-    pub fn accessor(&self) -> &A {
-        &self.accessor
+    /// Access the data object
+    pub fn data(&self) -> &D {
+        &self.data
+    }
+
+    /// Access the data object (mut)
+    pub fn data_mut(&mut self) -> &mut D {
+        &mut self.data
     }
 
     /// Get a copy of the shared value
-    pub fn get_value(&self) -> A::Item {
-        self.accessor.get(())
+    pub fn get_value(&self) -> D::Item {
+        self.data.get_cloned()
     }
 }
 
-impl<A: AccessorShared<()>, W: ViewWidget<A::Item>> SingleView<A, W> {
+impl<D: SingleDataMut, W: ViewWidget<D::Item>> SingleView<D, W> {
     /// Set shared data
     ///
     /// Other widgets sharing this data are notified of the update.
-    pub fn set_value(&self, mgr: &mut Manager, data: A::Item) {
-        let handle = self.accessor.set((), data);
+    pub fn set_value(&self, mgr: &mut Manager, data: D::Item) {
+        let handle = self.data.set(data);
         mgr.trigger_update(handle, 0);
     }
 
@@ -72,25 +103,25 @@ impl<A: AccessorShared<()>, W: ViewWidget<A::Item>> SingleView<A, W> {
     ///
     /// This is purely a convenience method over [`SingleView::get_value`] and
     /// [`SingleView::set_value`]. It always notifies other widgets sharing the data.
-    pub fn update_value<F: Fn(A::Item) -> A::Item>(&self, mgr: &mut Manager, f: F) {
+    pub fn update_value<F: Fn(D::Item) -> D::Item>(&self, mgr: &mut Manager, f: F) {
         self.set_value(mgr, f(self.get_value()));
     }
 }
 
-impl<A: Accessor<()>, W: ViewWidget<A::Item>> WidgetConfig for SingleView<A, W> {
+impl<D: SingleData, W: ViewWidget<D::Item>> WidgetConfig for SingleView<D, W> {
     fn configure(&mut self, mgr: &mut Manager) {
-        if let Some(handle) = self.accessor.update_handle() {
+        if let Some(handle) = self.data.update_handle() {
             mgr.update_on_handle(handle, self.id());
         }
     }
 }
 
-impl<A: Accessor<()>, W: ViewWidget<A::Item>> Handler for SingleView<A, W> {
+impl<D: SingleData, W: ViewWidget<D::Item>> Handler for SingleView<D, W> {
     type Msg = <W as Handler>::Msg;
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         match event {
             Event::HandleUpdate { .. } => {
-                let value = self.accessor.get(());
+                let value = self.data.get_cloned();
                 *mgr |= self.child.set(value);
                 Response::None
             }
@@ -99,12 +130,12 @@ impl<A: Accessor<()>, W: ViewWidget<A::Item>> Handler for SingleView<A, W> {
     }
 }
 
-impl<A: Accessor<()>, W: ViewWidget<A::Item>> fmt::Debug for SingleView<A, W> {
+impl<D: SingleData, W: ViewWidget<D::Item>> fmt::Debug for SingleView<D, W> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "SingleView {{ core: {:?}, accessor: {:?}, child: {:?} }}",
-            self.core, self.accessor, self.child,
+            "SingleView {{ core: {:?}, data: {:?}, child: {:?} }}",
+            self.core, self.data, self.child,
         )
     }
 }

--- a/src/widget/view/single.rs
+++ b/src/widget/view/single.rs
@@ -11,9 +11,7 @@ use kas::prelude::*;
 use std::fmt::{self, Debug};
 
 /// Trait for viewable single data items
-// Note: we require Debug + 'static to allow widgets using this to implement
-// WidgetCore, which requires Debug + Any.
-pub trait SingleData: Debug + 'static {
+pub trait SingleData: Debug {
     type Item: Clone;
 
     // TODO(gat): add get<'a>(&self) -> Self::ItemRef<'a> and get_mut
@@ -40,7 +38,7 @@ pub trait SingleDataMut: SingleData {
 #[widget(config=noauto)]
 #[layout(single)]
 #[handler(handle=noauto)]
-pub struct SingleView<D: SingleData, W = <<D as SingleData>::Item as DefaultView>::Widget>
+pub struct SingleView<D: SingleData + 'static, W = <<D as SingleData>::Item as DefaultView>::Widget>
 where
     W: ViewWidget<D::Item>,
 {
@@ -51,7 +49,7 @@ where
     child: W,
 }
 
-impl<D: SingleData + Default, W: ViewWidget<D::Item>> Default for SingleView<D, W> {
+impl<D: SingleData + 'static + Default, W: ViewWidget<D::Item>> Default for SingleView<D, W> {
     fn default() -> Self {
         let data = D::default();
         let child = W::new(data.get_cloned());
@@ -63,7 +61,7 @@ impl<D: SingleData + Default, W: ViewWidget<D::Item>> Default for SingleView<D, 
     }
 }
 
-impl<D: SingleData, W: ViewWidget<D::Item>> SingleView<D, W> {
+impl<D: SingleData + 'static, W: ViewWidget<D::Item>> SingleView<D, W> {
     /// Construct a new instance
     pub fn new(data: D) -> Self {
         let child = W::new(data.get_cloned());
@@ -90,7 +88,7 @@ impl<D: SingleData, W: ViewWidget<D::Item>> SingleView<D, W> {
     }
 }
 
-impl<D: SingleDataMut, W: ViewWidget<D::Item>> SingleView<D, W> {
+impl<D: SingleDataMut + 'static, W: ViewWidget<D::Item>> SingleView<D, W> {
     /// Set shared data
     ///
     /// Other widgets sharing this data are notified of the update.
@@ -108,7 +106,7 @@ impl<D: SingleDataMut, W: ViewWidget<D::Item>> SingleView<D, W> {
     }
 }
 
-impl<D: SingleData, W: ViewWidget<D::Item>> WidgetConfig for SingleView<D, W> {
+impl<D: SingleData + 'static, W: ViewWidget<D::Item>> WidgetConfig for SingleView<D, W> {
     fn configure(&mut self, mgr: &mut Manager) {
         if let Some(handle) = self.data.update_handle() {
             mgr.update_on_handle(handle, self.id());
@@ -116,7 +114,7 @@ impl<D: SingleData, W: ViewWidget<D::Item>> WidgetConfig for SingleView<D, W> {
     }
 }
 
-impl<D: SingleData, W: ViewWidget<D::Item>> Handler for SingleView<D, W> {
+impl<D: SingleData + 'static, W: ViewWidget<D::Item>> Handler for SingleView<D, W> {
     type Msg = <W as Handler>::Msg;
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         match event {
@@ -130,7 +128,7 @@ impl<D: SingleData, W: ViewWidget<D::Item>> Handler for SingleView<D, W> {
     }
 }
 
-impl<D: SingleData, W: ViewWidget<D::Item>> fmt::Debug for SingleView<D, W> {
+impl<D: SingleData + 'static, W: ViewWidget<D::Item>> fmt::Debug for SingleView<D, W> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/src/widget/view/single.rs
+++ b/src/widget/view/single.rs
@@ -5,33 +5,9 @@
 
 //! Single view widget
 
-use super::{DefaultView, ViewWidget};
-use kas::event::UpdateHandle;
+use super::{DefaultView, SingleData, SingleDataMut, ViewWidget};
 use kas::prelude::*;
-use std::fmt::{self, Debug};
-
-/// Trait for viewable single data items
-pub trait SingleData: Debug {
-    type Item: Clone;
-
-    // TODO(gat): add get<'a>(&self) -> Self::ItemRef<'a> and get_mut
-
-    /// Get data (clone)
-    fn get_cloned(&self) -> Self::Item;
-
-    /// Get an update handle, if any is used
-    ///
-    /// Widgets may use this `handle` to call `mgr.update_on_handle(handle, self.id())`.
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        None
-    }
-}
-
-/// Trait for writable single data items
-pub trait SingleDataMut: SingleData {
-    /// Set data
-    fn set(&self, value: Self::Item) -> UpdateHandle;
-}
+use std::fmt::{self};
 
 /// Single view widget
 #[derive(Clone, Widget)]

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -15,8 +15,8 @@ use kas::prelude::*;
 use kas::{Future, WindowId};
 
 /// The main instantiation of the [`Window`] trait.
-#[handler(send=noauto, generics = <> where W: Widget<Msg = VoidMsg>)]
 #[derive(Widget)]
+#[handler(send=noauto, generics = <> where W: Widget<Msg = VoidMsg>)]
 pub struct Window<W: Widget + 'static> {
     #[widget_core]
     core: CoreData,


### PR DESCRIPTION
This replaces the `Accessor` trait with `SingleData`, `SingleDataMut`, `ListData`, `ListDataMut`. In a way these are simpler; they also have a type of iterator (a ridiculous vec generator until GATs allow real iterators).

Keys are now the same for a list and its filtered version, so list selection now works properly on filtered lists.

Also moves `derive(Widget)` before its attributes (avoids a warning with recent Rustc).

---

This code needs significant optimisation (some enabled by GATs, some to do with filtering, probably some other opts too), but appears to work fine other than perf.

One notable possibility: `update_widgets` gets called whenever scrolling occurs, which may be multiple times per frame — especially since rendering appears to only happen after event handling is finished. With fast scrolling this can essentially block drawing until the mouse stops moving. We could try solving this by only calling `update_widgets` after receiving all events (via `ManagerState::update`), but in this case state would be incorrect if other event handlers referring to the list's children somehow get called before `update`.