### PR TITLE
Examples: async-event, cursor gallery

### DIFF
--- a/kas-macros/src/args.rs
+++ b/kas-macros/src/args.rs
@@ -24,6 +24,7 @@ pub struct Child {
     pub args: WidgetAttrArgs,
 }
 
+#[derive(Debug)]
 pub struct Args {
     pub core_data: Member,
     pub layout_data: Option<Member>,
@@ -415,6 +416,7 @@ impl ToTokens for GridPos {
     }
 }
 
+#[derive(Debug)]
 pub struct WidgetArgs {
     pub config: Option<WidgetConfig>,
     pub children: bool,
@@ -429,6 +431,7 @@ impl Default for WidgetArgs {
     }
 }
 
+#[derive(Debug)]
 pub struct WidgetConfig {
     pub key_nav: bool,
     pub hover_highlight: bool,
@@ -558,6 +561,7 @@ impl ToTokens for LayoutType {
     }
 }
 
+#[derive(Debug)]
 pub struct LayoutArgs {
     pub span: Span,
     pub layout: LayoutType,
@@ -798,6 +802,7 @@ impl ToTokens for HandlerArgs {
     }
 }
 
+#[derive(Debug)]
 pub enum ChildType {
     Fixed(Type), // fixed type
     // A given type using generics internally
@@ -807,6 +812,7 @@ pub enum ChildType {
     Generic(Option<Type>, Option<TypeTraitObject>),
 }
 
+#[derive(Debug)]
 pub struct WidgetField {
     pub widget_attr: Option<WidgetAttr>,
     pub ident: Option<Ident>,
@@ -814,6 +820,7 @@ pub struct WidgetField {
     pub value: Expr,
 }
 
+#[derive(Debug)]
 pub struct MakeWidget {
     // handler attribute
     pub handler: Option<HandlerArgs>,

--- a/kas-macros/src/layout.rs
+++ b/kas-macros/src/layout.rs
@@ -11,11 +11,11 @@ use syn::Member;
 
 pub(crate) fn data_type(children: &Vec<Child>, layout: &LayoutArgs) -> Result<TokenStream> {
     if layout.layout == LayoutType::Single {
-        if !children.len() == 1 {
+        if children.len() != 1 {
             return Err(Error::new(
                 layout.span,
                 format_args!(
-                    "expected 1 child when using layout 'single'; found {}",
+                    "expected 1 child marked #[widget] when using layout 'single'; found {}",
                     children.len()
                 ),
             ));

--- a/kas-wgpu/examples/README.md
+++ b/kas-wgpu/examples/README.md
@@ -88,6 +88,10 @@ An example demonstrating a custom draw pipe.
 
 ![Mandlebrot](../../screenshots/mandlebrot.png)
 
+### Async event
+
+Demonstrates how to send data from another thread.
+
 Copyright and Licence
 -------
 

--- a/kas-wgpu/examples/README.md
+++ b/kas-wgpu/examples/README.md
@@ -92,6 +92,11 @@ An example demonstrating a custom draw pipe.
 
 Demonstrates how to send data from another thread.
 
+### Cursors
+
+Gallery of available mouse cursors.
+
+
 Copyright and Licence
 -------
 

--- a/kas-wgpu/examples/async-event.rs
+++ b/kas-wgpu/examples/async-event.rs
@@ -63,7 +63,7 @@ impl WidgetConfig for ColourSquare {
 impl Layout for ColourSquare {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
         let factor = size_handle.scale_factor();
-        SizeRules::fixed_scaled(100.0, (10.0, 10.0), factor)
+        SizeRules::fixed_scaled(100.0, 10.0, factor)
     }
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
         let (pass, offset, draw) = draw_handle.draw_device();

--- a/kas-wgpu/examples/async-event.rs
+++ b/kas-wgpu/examples/async-event.rs
@@ -63,9 +63,7 @@ impl WidgetConfig for ColourSquare {
 impl Layout for ColourSquare {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
         let factor = size_handle.scale_factor();
-        let size = (100.0 * factor).cast_nearest();
-        let margin = (10.0 * factor).cast_nearest();
-        SizeRules::fixed(size, (margin, margin))
+        SizeRules::fixed_scaled(100.0, (10.0, 10.0), factor)
     }
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
         let (pass, offset, draw) = draw_handle.draw_device();

--- a/kas-wgpu/examples/async-event.rs
+++ b/kas-wgpu/examples/async-event.rs
@@ -1,0 +1,120 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Asynchronous event demo
+//!
+//! This is a copy-cat of Druid's async event example.
+
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use kas::draw::Colour;
+use kas::event::{Event, Manager, Response, UpdateHandle, VoidMsg};
+use kas::prelude::*;
+use kas::widget::Window;
+
+fn main() -> Result<(), kas_wgpu::Error> {
+    env_logger::init();
+    let theme = kas_theme::FlatTheme::new();
+    let toolkit = kas_wgpu::Toolkit::new(theme)?;
+
+    // We construct a proxy from the toolkit to enable cross-thread communication.
+    let proxy = toolkit.create_proxy();
+
+    // An "update handle" is used to notify our widget.
+    let handle = UpdateHandle::new();
+
+    // The sender and receiver need to communicate. We use Arc<Mutex<T>>, but
+    // could instead use global statics or std::sync::mpsc or even encode our
+    // data within the update payload (a u64, so some compression required).
+    let colour = Arc::new(Mutex::new(Colour::grey(1.0)));
+    let colour2 = colour.clone();
+
+    thread::spawn(move || generate_colors(proxy, handle, colour2));
+
+    let widget = ColourSquare {
+        core: Default::default(),
+        colour,
+        handle,
+    };
+
+    let window = Window::new("Async event demo", widget);
+    toolkit.with(window)?.run()
+}
+
+#[derive(Debug, Widget)]
+#[handler(handle = noauto)]
+#[widget(config = noauto)]
+struct ColourSquare {
+    #[widget_core]
+    core: CoreData,
+    colour: Arc<Mutex<Colour>>,
+    handle: UpdateHandle,
+}
+impl WidgetConfig for ColourSquare {
+    fn configure(&mut self, mgr: &mut Manager) {
+        // register to receive updates on this handle
+        mgr.update_on_handle(self.handle, self.id());
+    }
+}
+impl Layout for ColourSquare {
+    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
+        let factor = size_handle.scale_factor();
+        let size = (100.0 * factor).cast_nearest();
+        let margin = (10.0 * factor).cast_nearest();
+        SizeRules::fixed(size, (margin, margin))
+    }
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
+        let (pass, offset, draw) = draw_handle.draw_device();
+        let col = *self.colour.lock().unwrap();
+        draw.rect(pass, (self.rect() + offset).into(), col);
+    }
+}
+impl Handler for ColourSquare {
+    type Msg = VoidMsg;
+    fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<VoidMsg> {
+        match event {
+            Event::HandleUpdate { .. } => {
+                // Note: event has `handle` and `payload` params.
+                // We only need to request a redraw.
+                mgr.redraw(self.id());
+                Response::None
+            }
+            event => Response::Unhandled(event),
+        }
+    }
+}
+
+fn generate_colors(
+    proxy: kas_wgpu::ToolkitProxy,
+    handle: UpdateHandle,
+    colour: Arc<Mutex<Colour>>,
+) {
+    // This function is called in a separate thread, and runs until the program ends.
+    let start_time = Instant::now();
+
+    loop {
+        let hue = (Instant::now() - start_time).as_secs_f32() / 5.0;
+
+        // convert from HSV, using S=V=1 (see Wikipedia):
+        let f = |n| {
+            let k: f32 = (n + hue * 6.0) % 6.0;
+            1.0 - k.min(4.0 - k).clamp(0.0, 1.0)
+        };
+        let c = Colour::new(f(5.0), f(3.0), f(1.0));
+
+        // Communicate the colour ...
+        *colour.lock().unwrap() = c;
+        // .. and notify of an update.
+        // (Note: the 0 here is the u64 payload, which could pass useful data!)
+        if proxy.trigger_update(handle, 0).is_err() {
+            // Sending failed; we should quit
+            break;
+        }
+
+        thread::sleep(Duration::from_millis(20));
+    }
+}

--- a/kas-wgpu/examples/calculator.rs
+++ b/kas-wgpu/examples/calculator.rs
@@ -132,8 +132,6 @@ impl Calculator {
         }
     }
 
-    // alternative, single line display
-    #[allow(unused)]
     fn display(&self) -> String {
         // Single-line display:
         /*if self.line_buf.is_empty() {

--- a/kas-wgpu/examples/cursors.rs
+++ b/kas-wgpu/examples/cursors.rs
@@ -11,6 +11,7 @@ use kas::widget::{Column, Label, StrLabel, Window};
 
 #[derive(Clone, Debug, Widget)]
 #[widget(config = noauto)]
+#[layout(single)]
 struct CursorWidget {
     #[widget_core]
     core: CoreData,
@@ -21,22 +22,6 @@ struct CursorWidget {
 impl WidgetConfig for CursorWidget {
     fn cursor_icon(&self) -> CursorIcon {
         self.cursor
-    }
-}
-// We implement Layout manually, mainly because we want Layout::find_id to point
-// at *self*, not self.label.
-impl Layout for CursorWidget {
-    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        self.label.size_rules(size_handle, axis)
-    }
-
-    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
-        self.core_data_mut().rect = rect;
-        self.label.set_rect(mgr, rect, align);
-    }
-
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
-        self.label.draw(draw_handle, mgr, disabled);
     }
 }
 

--- a/kas-wgpu/examples/cursors.rs
+++ b/kas-wgpu/examples/cursors.rs
@@ -1,0 +1,115 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Cursor gallery
+
+use kas::event::{CursorIcon, VoidMsg};
+use kas::prelude::*;
+use kas::widget::{Column, Label, StrLabel, Window};
+
+#[derive(Clone, Debug, Widget)]
+#[widget(config = noauto)]
+struct CursorWidget {
+    #[widget_core]
+    core: CoreData,
+    #[widget]
+    label: StrLabel,
+    cursor: CursorIcon,
+}
+impl WidgetConfig for CursorWidget {
+    fn cursor_icon(&self) -> CursorIcon {
+        self.cursor
+    }
+}
+// We implement Layout manually, mainly because we want Layout::find_id to point
+// at *self*, not self.label.
+impl Layout for CursorWidget {
+    fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        self.label.size_rules(size_handle, axis)
+    }
+
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
+        self.core_data_mut().rect = rect;
+        self.label.set_rect(mgr, rect, align);
+    }
+
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
+        self.label.draw(draw_handle, mgr, disabled);
+    }
+}
+
+// Using a macro lets us stringify! the type name
+macro_rules! cursor {
+    ($name: tt) => {
+        CursorWidget {
+            core: Default::default(),
+            label: Label::new(stringify!($name)),
+            cursor: CursorIcon::$name,
+        }
+    };
+}
+
+fn main() -> Result<(), kas_wgpu::Error> {
+    env_logger::init();
+
+    // These are winit::window::CursorIcon enum variants
+    let column = Column::new(vec![
+        cursor!(Default),
+        cursor!(Crosshair),
+        cursor!(Hand),
+        cursor!(Arrow),
+        cursor!(Move),
+        cursor!(Text),
+        cursor!(Wait),
+        cursor!(Help),
+        cursor!(Progress),
+        cursor!(NotAllowed),
+        cursor!(ContextMenu),
+        cursor!(Cell),
+        cursor!(VerticalText),
+        cursor!(Alias),
+        cursor!(Copy),
+        cursor!(NoDrop),
+        cursor!(Grab),
+        cursor!(Grabbing),
+        cursor!(AllScroll),
+        cursor!(ZoomIn),
+        cursor!(ZoomOut),
+        cursor!(EResize),
+        cursor!(NResize),
+        cursor!(NeResize),
+        cursor!(NwResize),
+        cursor!(SResize),
+        cursor!(SeResize),
+        cursor!(SwResize),
+        cursor!(WResize),
+        cursor!(EwResize),
+        cursor!(NsResize),
+        cursor!(NeswResize),
+        cursor!(NwseResize),
+        cursor!(ColResize),
+        cursor!(RowResize),
+    ]);
+
+    // Since Column has message type (usize, Child::Msg) we must convert
+    // (maybe after Rust's specialisation is ready this can be automatic).
+    let gallery = make_widget! {
+        #[layout(single)]
+        #[handler(msg = VoidMsg)]
+        struct {
+            #[widget(handler = handle)] _ = column,
+        }
+        impl {
+            fn handle(&mut self, _: &mut Manager, msg: (usize, VoidMsg)) -> Response<VoidMsg> {
+                // This variant is of course impossible...
+                Response::Msg(msg.1)
+            }
+        }
+    };
+
+    let window = Window::new("Cursor gallery", gallery);
+    let theme = kas_theme::FlatTheme::new();
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
+}

--- a/kas-wgpu/examples/layout.rs
+++ b/kas-wgpu/examples/layout.rs
@@ -3,7 +3,7 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! Gallery of all widgets
+//! Demonstration of widget and text layouts
 
 use kas::event::VoidMsg;
 use kas::macros::make_widget;

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -423,10 +423,10 @@ impl WidgetConfig for Mandlebrot {
 
 impl Layout for Mandlebrot {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, a: AxisInfo) -> SizeRules {
-        let virt_size = if a.is_horizontal() { 300.0 } else { 200.0 };
-        let min_size = (virt_size * size_handle.scale_factor()).cast_floor();
-        let ideal_size = min_size * 10; // prefer big but not larger than screen size
-        SizeRules::new(min_size, ideal_size, (0, 0), StretchPolicy::Maximize)
+        let min = if a.is_horizontal() { 300.0 } else { 200.0 };
+        let ideal = min * 10.0; // prefer big but not larger than screen size
+        let sf = size_handle.scale_factor();
+        SizeRules::new_scaled(min, ideal, (0.0, 0.0), StretchPolicy::Maximize, sf)
     }
 
     #[inline]

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -426,7 +426,7 @@ impl Layout for Mandlebrot {
         let min = if a.is_horizontal() { 300.0 } else { 200.0 };
         let ideal = min * 10.0; // prefer big but not larger than screen size
         let sf = size_handle.scale_factor();
-        SizeRules::new_scaled(min, ideal, (0.0, 0.0), StretchPolicy::Maximize, sf)
+        SizeRules::new_scaled(min, ideal, 0.0, StretchPolicy::Maximize, sf)
     }
 
     #[inline]

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -578,7 +578,7 @@ impl<'a> Manager<'a> {
         let mut widget_stack = WidgetStack::new();
 
         if let Some(id) = self.state.popups.last().map(|(_, p)| p.id) {
-            if let Some(w) = widget.find_child(id) {
+            if let Some(w) = widget.find_leaf(id) {
                 widget = w;
             } else {
                 // This is a corner-case. Do nothing.

--- a/src/event/manager/mgr_shell.rs
+++ b/src/event/manager/mgr_shell.rs
@@ -231,9 +231,9 @@ impl ManagerState {
 
         self.nav_focus = self
             .nav_focus
-            .and_then(|id| widget.find_child(id).map(|w| w.id()));
+            .and_then(|id| widget.find_leaf(id).map(|w| w.id()));
         if let Some(id) = self.sel_focus {
-            if let Some(new_id) = widget.find_child(id).map(|w| w.id()) {
+            if let Some(new_id) = widget.find_leaf(id).map(|w| w.id()) {
                 self.sel_focus = Some(new_id);
             } else {
                 if self.char_focus {

--- a/src/event/response.rs
+++ b/src/event/response.rs
@@ -65,10 +65,9 @@ impl<M> Response<M> {
     #[inline]
     pub fn from<N>(r: Response<N>) -> Self
     where
-        M: From<N>,
+        N: Into<M>,
     {
-        r.try_into()
-            .unwrap_or_else(|msg| Response::Msg(M::from(msg)))
+        r.try_into().unwrap_or_else(|msg| Response::Msg(msg.into()))
     }
 
     /// Map one `Response` type into another
@@ -77,7 +76,7 @@ impl<M> Response<M> {
     #[inline]
     pub fn into<N>(self) -> Response<N>
     where
-        N: From<M>,
+        M: Into<N>,
     {
         Response::from(self)
     }

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -138,14 +138,13 @@ impl SizeRules {
     /// A fixed size, scaled from virtual pixels
     ///
     /// This is a shortcut to [`SizeRules::fixed`] using virtual-pixel sizes
-    /// and a scale factor.
+    /// and a scale factor. It also assumes both margins are equal.
     #[inline]
-    pub fn fixed_scaled(size: f32, margins: (f32, f32), scale_factor: f32) -> Self {
-        debug_assert!(size >= 0.0 && margins.0 >= 0.0 && margins.1 >= 0.0);
+    pub fn fixed_scaled(size: f32, margins: f32, scale_factor: f32) -> Self {
+        debug_assert!(size >= 0.0 && margins >= 0.0);
         let size = (scale_factor * size).cast_nearest();
-        let m0 = (scale_factor * margins.0).cast_nearest();
-        let m1 = (scale_factor * margins.1).cast_nearest();
-        SizeRules::fixed(size, (m0, m1))
+        let m = (scale_factor * margins).cast_nearest();
+        SizeRules::fixed(size, (m, m))
     }
 
     /// Construct fixed-size rules from given data
@@ -179,6 +178,9 @@ impl SizeRules {
 
     /// Construct with custom rules, scaled from virtual pixels
     ///
+    /// This is a shortcut aaround [`SizeRules::new`].
+    /// It assumes that both margins are equal.
+    ///
     /// Region size should meet the given `min`-imum size and has a given
     /// `ideal` size, plus a given `stretch` policy.
     ///
@@ -187,16 +189,15 @@ impl SizeRules {
     pub fn new_scaled(
         min: f32,
         ideal: f32,
-        margins: (f32, f32),
+        margins: f32,
         stretch: StretchPolicy,
         scale_factor: f32,
     ) -> Self {
-        debug_assert!(0.0 <= min && 0.0 <= ideal && margins.0 >= 0.0 && margins.1 >= 0.0);
+        debug_assert!(0.0 <= min && 0.0 <= ideal && margins >= 0.0);
         let min = (min * scale_factor).cast_nearest();
         let ideal = i32::conv_nearest(ideal * scale_factor).max(min);
-        let m0 = (scale_factor * margins.0).cast_nearest();
-        let m1 = (scale_factor * margins.1).cast_nearest();
-        SizeRules::new(min, ideal, (m0, m1), stretch)
+        let m = (scale_factor * margins).cast_nearest();
+        SizeRules::new(min, ideal, (m, m), stretch)
     }
 
     /// Get the minimum size

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -56,11 +56,14 @@ impl<M: 'static> WidgetChildren for Box<dyn Widget<Msg = M>> {
         self.as_mut().get_child_mut(index)
     }
 
-    fn find_child(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+    fn find_child(&self, id: WidgetId) -> Option<usize> {
         self.as_ref().find_child(id)
     }
-    fn find_child_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
-        self.as_mut().find_child_mut(id)
+    fn find_leaf(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+        self.as_ref().find_leaf(id)
+    }
+    fn find_leaf_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
+        self.as_mut().find_leaf_mut(id)
     }
 
     fn walk_children_dyn(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -458,20 +458,21 @@ pub trait Layout: WidgetChildren {
 
     /// Find a widget by coordinate
     ///
-    /// Returns the identifier of the widget containing this `coord`, if any.
-    /// Should only return `None` when `coord` is outside the widget's rect,
-    /// but this is not guaranteed.
+    /// Used to find the widget responsible for handling events at this `coord`
+    /// — usually the leaf-most widget containing the coordinate.
     ///
-    /// Implementations should:
+    /// The default implementation suffices for widgets without children;
+    /// otherwise this is usually implemented as follows:
     ///
     /// 1.  return `None` if `!self.rect().contains(coord)`
-    /// 2.  if, for any child (containing `coord`), `child.find_id(coord)`
-    ///     returns `Some(id)`, return that
+    /// 2.  for each `child`, check whether `child.find_id(coord)` returns
+    ///     `Some(id)`, and if so return this result (parents with many children
+    ///     might use a faster search strategy here)
     /// 3.  otherwise, return `Some(self.id())`
     ///
     /// Exceptionally, a widget may deviate from this behaviour, but only when
-    /// the coord is within the widget's rect (example: `CheckBox` contains an
-    /// embedded `CheckBoxBare` and always forwards this child's id).
+    /// the coord is within the widget's own rect (example: `CheckBox` contains
+    /// an embedded `CheckBoxBare` and always forwards this child's id).
     ///
     /// This must not be called before [`Layout::set_rect`].
     #[inline]

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -82,11 +82,14 @@ impl<M: 'static> WidgetChildren for Box<dyn Menu<Msg = M>> {
         self.as_mut().get_child_mut(index)
     }
 
-    fn find_child(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+    fn find_child(&self, id: WidgetId) -> Option<usize> {
         self.as_ref().find_child(id)
     }
-    fn find_child_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
-        self.as_mut().find_child_mut(id)
+    fn find_leaf(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+        self.as_ref().find_leaf(id)
+    }
+    fn find_leaf_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
+        self.as_mut().find_leaf_mut(id)
     }
 
     fn walk_children_dyn(&self, f: &mut dyn FnMut(&dyn WidgetConfig)) {

--- a/src/widget/menu/menubar.rs
+++ b/src/widget/menu/menubar.rs
@@ -97,7 +97,7 @@ impl<D: Directional, W: Menu<Msg = M>, M> event::Handler for MenuBar<D, W> {
                         && mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None)
                     {
                         mgr.set_grab_depress(source, Some(start_id));
-                        self.find_child(start_id)
+                        self.find_leaf(start_id)
                             .map(|w| mgr.next_nav_focus(w, false));
                         self.opening = false;
                         if self.rect().contains(coord) {
@@ -126,7 +126,7 @@ impl<D: Directional, W: Menu<Msg = M>, M> event::Handler for MenuBar<D, W> {
                 }
             }
             Event::PressMove { source, cur_id, .. } => {
-                if let Some(w) = cur_id.and_then(|id| self.find_child(id)) {
+                if let Some(w) = cur_id.and_then(|id| self.find_leaf(id)) {
                     if w.key_nav() {
                         let id = cur_id.unwrap();
                         mgr.set_grab_depress(source, Some(id));

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -16,7 +16,7 @@ use kas::{Future, WindowId};
 
 /// The main instantiation of the [`Window`] trait.
 #[derive(Widget)]
-#[handler(send=noauto, generics = <> where W: Widget<Msg = VoidMsg>)]
+#[handler(send=noauto, generics = <M: Into<VoidMsg>> where W: Widget<Msg = M>)]
 pub struct Window<W: Widget + 'static> {
     #[widget_core]
     core: CoreData,
@@ -157,16 +157,16 @@ impl<W: Widget> Layout for Window<W> {
     }
 }
 
-impl<W: Widget<Msg = VoidMsg> + 'static> event::SendEvent for Window<W> {
+impl<M: Into<VoidMsg>, W: Widget<Msg = M> + 'static> event::SendEvent for Window<W> {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         if !self.is_disabled() && id <= self.w.id() {
-            return self.w.send(mgr, id, event);
+            return self.w.send(mgr, id, event).into();
         }
         Response::Unhandled(event)
     }
 }
 
-impl<W: Widget<Msg = VoidMsg> + 'static> kas::Window for Window<W> {
+impl<M: Into<VoidMsg>, W: Widget<Msg = M> + 'static> kas::Window for Window<W> {
     fn title(&self) -> &str {
         &self.title
     }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -136,7 +136,7 @@ impl<W: Widget> Layout for Window<W> {
             return None;
         }
         for popup in self.popups.iter().rev() {
-            if let Some(id) = self.w.find_child(popup.1.id).and_then(|w| w.find_id(coord)) {
+            if let Some(id) = self.w.find_leaf(popup.1.id).and_then(|w| w.find_id(coord)) {
                 return Some(id);
             }
         }
@@ -150,7 +150,7 @@ impl<W: Widget> Layout for Window<W> {
         for popup in &self.popups {
             let class = ClipRegion::Popup;
             draw_handle.clip_region(self.core.rect, Offset::ZERO, class, &mut |draw_handle| {
-                self.find_child(popup.1.id)
+                self.find_leaf(popup.1.id)
                     .map(|w| w.draw(draw_handle, mgr, disabled));
             });
         }
@@ -234,7 +234,7 @@ impl<W: Widget> Window<W> {
         let popup = &mut self.popups[index].1;
 
         let c = find_rect(self.w.as_widget(), popup.parent).unwrap();
-        let widget = self.w.find_child_mut(popup.id).unwrap();
+        let widget = self.w.find_leaf_mut(popup.id).unwrap();
         let mut cache = mgr.size_handle(|sh| layout::SolveCache::find_constraints(widget, sh));
         let ideal = cache.ideal(false);
         let m = cache.margins();


### PR DESCRIPTION
This adds two examples (heavily inspired by Druid's examples), plus a few small changes:

- `WidgetChildren::find_child` was renamed to `find_leaf` since it finds the leaf-most descendant; a new `find_child` method was added, returning the index of the child which is an ancestor of the given id
- Setting a hover cursor icon for a widget now applies transitively to descendants, where those descendants' icons are `Default`. This simplifies the new example but it isn't clear if this is the right choice (or if `cursor_icon` should return `Option<CursorIcon>` so that children can force the default icon). It may be necessary to revisit this later.
- `SizeRules` has two new constructors to ease use with virtual pixels ~~(though given that these are purely convenience wrappers, possibly they should assume both margins are the same)~~ done.