### PR TITLE
Revise StretchPolicy → Stretch; shared data fixes + ListData::contrains_key

### DIFF
--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -13,7 +13,7 @@ use std::f32;
 use kas::conv::{Cast, CastFloat, ConvFloat};
 use kas::draw::{self, TextClass};
 use kas::geom::{Size, Vec2};
-use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, StretchPolicy};
+use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::text::{TextApi, TextApiExt};
 
 /// Parameterisation of [`Dimensions`]
@@ -207,9 +207,9 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
             // cause problems (e.g. edit boxes greedily consuming too much
             // space). This is a hard layout problem; for now don't do this.
             let stretch = match class {
-                TextClass::LabelFixed => StretchPolicy::Fixed,
-                TextClass::Button => StretchPolicy::Filler,
-                _ => StretchPolicy::LowUtility,
+                TextClass::LabelFixed => Stretch::None,
+                TextClass::Button => Stretch::Filler,
+                _ => Stretch::Low,
             };
             SizeRules::new(min, ideal, margins, stretch)
         } else {
@@ -222,9 +222,8 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
             };
             let ideal = i32::conv_ceil(required.1).max(min);
             let stretch = match class {
-                TextClass::Button | TextClass::Edit | TextClass::LabelFixed => StretchPolicy::Fixed,
-                TextClass::EditMulti => StretchPolicy::HighUtility,
-                _ => StretchPolicy::Filler,
+                TextClass::EditMulti => Stretch::Low,
+                _ => Stretch::None,
             };
             SizeRules::new(min, ideal, margins, stretch)
         }
@@ -257,12 +256,12 @@ impl<'a> draw::SizeHandle for SizeHandle<'a> {
 
     fn scrollbar(&self) -> (Size, i32) {
         let size = self.dims.scrollbar;
-        (size, 2 * size.0)
+        (size, 3 * size.0)
     }
 
     fn slider(&self) -> (Size, i32) {
         let size = self.dims.slider;
-        (size, 2 * size.0)
+        (size, 5 * size.0)
     }
 
     fn progress_bar(&self) -> Size {

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -35,7 +35,7 @@ struct Clock {
 impl Layout for Clock {
     fn size_rules(&mut self, _: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
         // We want a square shape and can resize freely. Numbers are arbitrary.
-        SizeRules::new(100, 200, (0, 0), StretchPolicy::HighUtility)
+        SizeRules::new(100, 200, (0, 0), Stretch::High)
     }
 
     #[inline]

--- a/kas-wgpu/examples/dynamic-view.rs
+++ b/kas-wgpu/examples/dynamic-view.rs
@@ -104,6 +104,10 @@ impl ListData for MyData {
         self.len
     }
 
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        *key < self.len
+    }
+
     fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
         Some(self.get(*key))
     }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -426,7 +426,7 @@ impl Layout for Mandlebrot {
         let min = if a.is_horizontal() { 300.0 } else { 200.0 };
         let ideal = min * 10.0; // prefer big but not larger than screen size
         let sf = size_handle.scale_factor();
-        SizeRules::new_scaled(min, ideal, 0.0, StretchPolicy::Maximize, sf)
+        SizeRules::new_scaled(min, ideal, 0.0, Stretch::High, sf)
     }
 
     #[inline]

--- a/kas-wgpu/examples/splitter.rs
+++ b/kas-wgpu/examples/splitter.rs
@@ -7,7 +7,7 @@
 
 use kas::event::{Manager, VoidMsg, VoidResponse};
 use kas::macros::{make_widget, VoidMsg};
-use kas::widget::{RowSplitter, StringLabel, TextButton, Window};
+use kas::widget::{EditField, RowSplitter, TextButton, Window};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Message {
@@ -26,8 +26,10 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[widget] _ = TextButton::new_msg("+", Message::Incr),
         }
     };
-    let mut panes = RowSplitter::<StringLabel>::default();
-    let _ = panes.resize_with(2, |n| StringLabel::new(format!("Pane {}", n)));
+    let mut panes = RowSplitter::<EditField>::default();
+    let _ = panes.resize_with(2, |n| {
+        EditField::new(format!("Pane {}", n)).multi_line(true)
+    });
 
     let window = Window::new(
         "Slitter panes",
@@ -37,7 +39,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget(handler = handle_button)] buttons -> Message = buttons,
-                #[widget] panes: RowSplitter<StringLabel> = panes,
+                #[widget] panes: RowSplitter<EditField> = panes,
                 counter: usize = 0,
             }
             impl {
@@ -50,7 +52,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                         }
                         Message::Incr => {
                             let n = self.panes.len() + 1;
-                            *mgr |= self.panes.push(StringLabel::new(format!("Pane {}", n)));
+                            *mgr |= self.panes.push(EditField::new(format!("Pane {}", n)).multi_line(true));
                         }
                     };
                     VoidResponse::None

--- a/src/data.rs
+++ b/src/data.rs
@@ -100,6 +100,9 @@ pub trait ListData: SharedDataRec {
 
     // TODO(gat): add get<'a>(&self) -> Self::ItemRef<'a> and get_mut
 
+    /// Check whether a key has data
+    fn contains_key(&self, key: &Self::Key) -> bool;
+
     /// Get data by key (clone)
     fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item>;
 
@@ -153,6 +156,10 @@ impl<T: Clone + Debug> ListData for [T] {
         (*self).len()
     }
 
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        *key < self.len()
+    }
+
     fn get_cloned(&self, key: &usize) -> Option<Self::Item> {
         self.get(*key).cloned()
     }
@@ -198,6 +205,10 @@ impl<K: Ord + Eq + Clone + Debug, T: Clone + Debug> ListData for std::collection
 
     fn len(&self) -> usize {
         (*self).len()
+    }
+
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        (*self).contains_key(key)
     }
 
     fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
@@ -262,6 +273,9 @@ macro_rules! impl_via_deref {
 
             fn len(&self) -> usize {
                 self.deref().len()
+            }
+            fn contains_key(&self, key: &Self::Key) -> bool {
+                self.deref().contains_key(key)
             }
             fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
                 self.deref().get_cloned(key)

--- a/src/layout/align.rs
+++ b/src/layout/align.rs
@@ -6,7 +6,7 @@
 //! Alignment types
 
 #[allow(unused)]
-use super::StretchPolicy; // for doc-links
+use super::Stretch; // for doc-links
 use crate::geom::{Rect, Size};
 
 pub use crate::text::Align;
@@ -71,7 +71,7 @@ impl CompleteAlignment {
     /// Construct a rect of size `ideal` within `rect` using the given alignment
     ///
     /// Note: this does not stretch, even with [`Align::Stretch`], since widget
-    /// stretching should be determined by the [`StretchPolicy`] instead.
+    /// stretching should be determined by the [`Stretch`] priority instead.
     pub fn aligned_rect(&self, ideal: Size, rect: Rect) -> Rect {
         let mut pos = rect.pos;
         let mut size = rect.size;

--- a/src/layout/grid_solver.rs
+++ b/src/layout/grid_solver.rs
@@ -144,7 +144,7 @@ where
         ) -> SizeRules {
             // spans: &mut [(rules, begin, end)]
 
-            // To avoid losing StretchPolicy, we distribute this first
+            // To avoid losing Stretch, we distribute this first
             const BASE_WEIGHT: u32 = 100;
             const SPAN_WEIGHT: u32 = 10;
             let mut scores: Vec<u32> = (&widths[0..(widths.len() - 1)])

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -13,7 +13,7 @@
 //! size requirements. It provides various methods to compute derived rules
 //! and [`SizeRules::solve_seq`], the "muscle" of the layout engine.
 //!
-//! [`AxisInfo`], [`Margins`] and [`StretchPolicy`] are auxilliary data types.
+//! [`AxisInfo`], [`Margins`] and [`Stretch`] are auxilliary data types.
 //!
 //! ## Layout engines
 //!
@@ -49,7 +49,7 @@ pub use grid_solver::{GridChildInfo, GridSetter, GridSolver};
 pub use row_solver::{RowPositionSolver, RowSetter, RowSolver};
 pub use single_solver::{SingleSetter, SingleSolver};
 pub use size_rules::SizeRules;
-pub use size_types::{FrameRules, Margins, StretchPolicy};
+pub use size_types::{FrameRules, Margins, Stretch};
 pub use sizer::{solve_size_rules, RulesSetter, RulesSolver, SolveCache};
 pub use storage::{
     DynGridStorage, DynRowStorage, FixedGridStorage, FixedRowStorage, GridStorage, RowStorage,

--- a/src/layout/size_types.rs
+++ b/src/layout/size_types.rs
@@ -67,24 +67,30 @@ impl Margins {
     }
 }
 
-/// Policy for stretching widgets beyond ideal size
+/// Priority for stretching widgets beyond ideal size
+///
+/// Space is allocated based on priority, with extra space (beyond the minimum)
+/// shared between widgets in the highest priority class.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub enum StretchPolicy {
-    /// Do not exceed ideal size
-    Fixed,
-    /// Can be stretched to fill space but without utility
+pub enum Stretch {
+    /// No expectations beyond the minimum
+    ///
+    /// Note: this does not prevent stretching (specifically, it can happen with
+    /// other widgets in the same row/column wishing more size).
+    None,
+    /// Fill unwanted space
     Filler,
-    /// Extra space has low utility
-    LowUtility,
-    /// Extra space has high utility
-    HighUtility,
+    /// Extra space is considered of low utility (but higher than `Filler`)
+    Low,
+    /// Extra space is considered of high utility
+    High,
     /// Greedily consume as much space as possible
     Maximize,
 }
 
-impl Default for StretchPolicy {
+impl Default for Stretch {
     fn default() -> Self {
-        StretchPolicy::Fixed
+        Stretch::None
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,7 +26,7 @@ pub use kas::event::{Event, Handler, Manager, ManagerState, Response, SendEvent,
 #[doc(no_inline)]
 pub use kas::geom::{Coord, Offset, Rect, Size};
 #[doc(no_inline)]
-pub use kas::layout::{Align, AlignHints, AxisInfo, FrameRules, Margins, SizeRules, StretchPolicy};
+pub use kas::layout::{Align, AlignHints, AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 #[doc(no_inline)]
 pub use kas::macros::*;
 #[doc(no_inline)]

--- a/src/widget/filler.rs
+++ b/src/widget/filler.rs
@@ -10,38 +10,57 @@ use kas::{event, prelude::*};
 /// A space filler
 ///
 /// This widget has zero minimum size but can expand according to the given
-/// stretch policy.
+/// stretch priority.
 #[derive(Clone, Debug, Default, Widget)]
 pub struct Filler {
     #[widget_core]
     core: CoreData,
-    policy: StretchPolicy,
+    horiz: Stretch,
+    vert: Stretch,
 }
 
 impl Layout for Filler {
-    fn size_rules(&mut self, _: &mut dyn SizeHandle, _: AxisInfo) -> SizeRules {
-        SizeRules::empty(self.policy)
+    fn size_rules(&mut self, _: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        let stretch = if axis.is_horizontal() {
+            self.horiz
+        } else {
+            self.vert
+        };
+        SizeRules::empty(stretch)
     }
 
     fn draw(&self, _: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {}
 }
 
 impl Filler {
-    /// Construct a filler with policy [`StretchPolicy::Filler`]
+    /// Construct a filler with priority [`Stretch::Filler`]
     pub fn new() -> Self {
-        Filler::with_policy(StretchPolicy::Filler)
+        Filler::with(Stretch::Filler)
     }
 
-    /// Construct a filler with policy [`StretchPolicy::Maximize`]
+    /// Construct a filler with priority [`Stretch::Low`]
+    pub fn low() -> Self {
+        Filler::with(Stretch::Low)
+    }
+
+    /// Construct a filler with priority [`Stretch::High`]
+    pub fn high() -> Self {
+        Filler::with(Stretch::High)
+    }
+
+    /// Construct a filler with priority [`Stretch::Maximize`]
     pub fn maximize() -> Self {
-        Filler::with_policy(StretchPolicy::Maximize)
+        Filler::with(Stretch::Maximize)
     }
 
-    /// Construct with a custom stretch policy
-    pub fn with_policy(policy: StretchPolicy) -> Self {
-        Filler {
-            core: Default::default(),
-            policy,
-        }
+    /// Construct with a custom stretch priority
+    pub fn with(stretch: Stretch) -> Self {
+        Filler::with_hv(stretch, stretch)
+    }
+
+    /// Construct with custom horizontal and vertical priorities
+    pub fn with_hv(horiz: Stretch, vert: Stretch) -> Self {
+        let core = Default::default();
+        Filler { core, horiz, vert }
     }
 }

--- a/src/widget/progress.rs
+++ b/src/widget/progress.rs
@@ -78,7 +78,7 @@ impl<D: Directional> Layout for ProgressBar<D> {
         }
         let margins = (0, 0);
         if self.direction.is_vertical() == axis.is_vertical() {
-            SizeRules::new(size.0, size.0, margins, StretchPolicy::LowUtility)
+            SizeRules::new(size.0, size.0, margins, Stretch::High)
         } else {
             SizeRules::fixed(size.1, margins)
         }

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -205,7 +205,7 @@ impl<D: Directional> Layout for ScrollBar<D> {
         self.min_handle_len = size.0;
         let margins = (0, 0);
         if self.direction.is_vertical() == axis.is_vertical() {
-            SizeRules::new(min_len, min_len, margins, StretchPolicy::HighUtility)
+            SizeRules::new(min_len, min_len, margins, Stretch::High)
         } else {
             SizeRules::fixed(size.1, margins)
         }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -220,7 +220,7 @@ impl<T: SliderType, D: Directional> Layout for Slider<T, D> {
         let (size, min_len) = size_handle.slider();
         let margins = (0, 0);
         if self.direction.is_vertical() == axis.is_vertical() {
-            SizeRules::new(min_len, min_len, margins, StretchPolicy::HighUtility)
+            SizeRules::new(min_len, min_len, margins, Stretch::High)
         } else {
             SizeRules::fixed(size.1, margins)
         }

--- a/src/widget/view/filter.rs
+++ b/src/widget/view/filter.rs
@@ -169,6 +169,10 @@ impl<T: ListData + 'static, F: Filter<T::Item>> ListData for Rc<FilteredList<T, 
         self.cell.borrow().1.len()
     }
 
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        self.get_cloned(key).is_some()
+    }
+
     fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
         // Check the item against our filter (probably O(1)) instead of using
         // our filtered list (O(n) where n=self.len()).

--- a/src/widget/view/list_view.rs
+++ b/src/widget/view/list_view.rs
@@ -411,7 +411,7 @@ impl<D: Directional, T: ListData, V: View<T::Key, T::Item>> Layout for ListView<
             let m = rules.margins_i32();
             self.child_inter_margin = (m.0 + m.1).max(inner_margin);
             rules.multiply_with_margin(2, self.ideal_visible);
-            rules.set_stretch(rules.stretch().max(StretchPolicy::HighUtility));
+            rules.set_stretch(rules.stretch().max(Stretch::High));
         }
         let (rules, offset, size) = frame.surround(rules);
         self.offset.set_component(axis, offset);

--- a/src/widget/view/list_view.rs
+++ b/src/widget/view/list_view.rs
@@ -229,15 +229,26 @@ impl<D: Directional, T: ListData, V: View<T::Key, T::Item>> ListView<D, T, V> {
     /// Directly select an item
     ///
     /// Returns `true` if selected, `false` if already selected.
+    /// Fails if selection mode does not permit selection or if the key is
+    /// invalid.
     ///
     /// Does not send [`ListMsg`] responses.
-    pub fn select(&mut self, key: T::Key) -> bool {
-        self.selection.insert(key)
+    pub fn select(&mut self, key: T::Key) -> Result<bool, ()> {
+        match self.sel_mode {
+            SelectionMode::None => return Err(()),
+            SelectionMode::Single => self.selection.clear(),
+            _ => (),
+        }
+        if !self.data.contains_key(&key) {
+            return Err(());
+        }
+        Ok(self.selection.insert(key))
     }
 
     /// Directly deselect an item
     ///
     /// Returns `true` if deselected, `false` if not previously selected.
+    /// Also returns `false` on invalid keys.
     ///
     /// Does not send [`ListMsg`] responses.
     pub fn deselect(&mut self, key: &T::Key) -> bool {
@@ -246,6 +257,8 @@ impl<D: Directional, T: ListData, V: View<T::Key, T::Item>> ListView<D, T, V> {
 
     /// Manually trigger an update to handle changed data
     pub fn update_view(&mut self, mgr: &mut Manager) {
+        let data = &self.data;
+        self.selection.retain(|key| data.contains_key(key));
         for w in &mut self.widgets {
             w.key = None;
         }

--- a/src/widget/view/shared_data.rs
+++ b/src/widget/view/shared_data.rs
@@ -66,6 +66,10 @@ impl<T: ListDataMut> ListData for SharedRc<T> {
         (self.0).1.borrow().len()
     }
 
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        (self.0).1.borrow().contains_key(key)
+    }
+
     fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
         (self.0).1.borrow().get_cloned(key)
     }


### PR DESCRIPTION
The `StretchPolicy` type was revised, mostly to make clear that what was `StretchPolicy::Fixed` does not actually fix the size. Text types no longer use `Filler` policy (except buttons horizontally) since this may have unintended consequences.

`FilteredList` now applies the filter to all methods, not just to iteration. `ListData` has an extra method.

`ListView` will now deselect data which is no longer visible.