### PR TITLE
Arrow and tab navigation for views; EditGuard::focus_gained

### DIFF
--- a/kas-wgpu/examples/data-list-view.rs
+++ b/kas-wgpu/examples/data-list-view.rs
@@ -239,7 +239,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget] display: StringLabel = Label::from("Entry #0"),
                 #[widget] _ = Separator::new(),
                 #[widget(handler = set_radio)] list: ScrollBars<MyList> =
-                    ScrollBars::new(ListView::new_with_view(driver, data)).with_bars(false, true),
+                    ScrollBars::new(ListView::new_with_driver(driver, data)).with_bars(false, true),
             }
             impl {
                 fn set_len(&mut self, mgr: &mut Manager, len: usize) -> Response<VoidMsg> {

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -672,15 +672,9 @@ impl<'a> Manager<'a> {
         // Breaks to given lifetime on error.
         macro_rules! do_child {
             ($lt:lifetime, $nav_stack:ident, $widget:ident, $widget_stack:ident) => {{
-                let range = $widget.spatial_range();
-                if $widget.is_disabled() || range.1 == std::usize::MAX {
+                if $widget.is_disabled() {
                     false
-                } else {
-                    // We have a child; the first is range.0 unless reverse
-                    let index = match reverse {
-                        false => range.0,
-                        true => range.1,
-                    };
+                } else if let Some(index) = $widget.spatial_nav(reverse, None) {
                     let new = match $widget.get_child(index) {
                         None => break $lt,
                         Some(w) => w,
@@ -689,6 +683,8 @@ impl<'a> Manager<'a> {
                     $widget_stack.push($widget);
                     $widget = new;
                     true
+                } else {
+                    false
                 }
             }};
         }
@@ -698,7 +694,7 @@ impl<'a> Manager<'a> {
         // Breaks to given lifetime on error.
         macro_rules! do_sibling_or_pop {
             ($lt:lifetime, $nav_stack:ident, $widget:ident, $widget_stack:ident) => {{
-                let mut index;
+                let index;
                 match ($nav_stack.pop(), $widget_stack.pop()) {
                     (Some(i), Some(w)) => {
                         index = i.cast();
@@ -706,39 +702,19 @@ impl<'a> Manager<'a> {
                     }
                     _ => break $lt,
                 };
-                let mut range = $widget.spatial_range();
-                if $widget.is_disabled() || range.1 == std::usize::MAX {
-                    break $lt;
-                }
-
-                let reverse = (range.1 < range.0) ^ reverse;
-                if range.1 < range.0 {
-                    std::mem::swap(&mut range.0, &mut range.1);
-                }
-
-                // Look for next sibling
-                let have_sibling = match reverse {
-                    false if index < range.1 => {
-                        index += 1;
-                        true
-                    }
-                    true if range.0 < index => {
-                        index -= 1;
+                match $widget.spatial_nav(reverse, Some(index)) {
+                    Some(index) if !$widget.is_disabled() => {
+                        let new = match $widget.get_child(index) {
+                            None => break $lt,
+                            Some(w) => w,
+                        };
+                        $nav_stack.push(index.cast());
+                        $widget_stack.push($widget);
+                        $widget = new;
                         true
                     }
                     _ => false,
-                };
-
-                if have_sibling {
-                    let new = match $widget.get_child(index) {
-                        None => break $lt,
-                        Some(w) => w,
-                    };
-                    $nav_stack.push(index.cast());
-                    $widget_stack.push($widget);
-                    $widget = new;
                 }
-                have_sibling
             }};
         }
 

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -430,12 +430,16 @@ impl<'a> Manager<'a> {
     /// Character data is sent to the widget with char focus via
     /// [`Event::ReceivedCharacter`] and [`Event::Command`].
     ///
-    /// Currently, this method always succeeds. Focus persists until either
-    /// another widget requests focus or the widget's event handler returns
-    /// `Response::Unhandled(Event::Control(ControlKey::Escape))`.
-    pub fn request_char_focus(&mut self, id: WidgetId) {
+    /// This method returns true on success, false if focus is unavailable.
+    /// When granted, focus persists until either another widget requests focus
+    /// or the widget's event handler returns `Response::Unhandled` on event
+    /// `Event::Control(ControlKey::Escape)`.
+    pub fn request_char_focus(&mut self, id: WidgetId) -> bool {
         if !self.read_only {
             self.set_char_focus(Some(id));
+            true
+        } else {
+            false
         }
     }
 

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -62,9 +62,9 @@ impl<M: 'static> kas::Layout for ComboBox<M> {
         });
     }
 
-    fn spatial_range(&self) -> (usize, usize) {
-        // We have no child within our rect; return an empty range
-        (0, std::usize::MAX)
+    fn spatial_nav(&self, _: bool, _: Option<usize>) -> Option<usize> {
+        // We have no child within our rect
+        None
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -143,11 +143,25 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
         }
     }
 
-    fn spatial_range(&self) -> (usize, usize) {
-        let last = self.num_children().wrapping_sub(1);
-        match self.direction.is_reversed() {
-            false => (0, last),
-            true => (last, 0),
+    fn spatial_nav(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
+        if self.num_children() == 0 {
+            return None;
+        }
+
+        let last = self.num_children() - 1;
+        let reverse = reverse ^ self.direction.is_reversed();
+
+        if let Some(index) = from {
+            match reverse {
+                false if index < last => Some(index + 1),
+                true if 0 < index => Some(index - 1),
+                _ => None,
+            }
+        } else {
+            match reverse {
+                false => Some(0),
+                true => Some(last),
+            }
         }
     }
 

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -125,9 +125,9 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
         });
     }
 
-    fn spatial_range(&self) -> (usize, usize) {
-        // We have no child within our rect; return an empty range
-        (0, std::usize::MAX)
+    fn spatial_nav(&self, _: bool, _: Option<usize>) -> Option<usize> {
+        // We have no child within our rect
+        None
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {

--- a/src/widget/view/list_view.rs
+++ b/src/widget/view/list_view.rs
@@ -82,7 +82,7 @@ impl<
     /// type: for `D: Directional + Default`. In other cases, use
     /// [`ListView::new_with_direction`].
     pub fn new(data: T) -> Self {
-        Self::new_with_dir_view(D::default(), <V as Default>::default(), data)
+        Self::new_with_dir_driver(D::default(), <V as Default>::default(), data)
     }
 }
 impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item> + Default>
@@ -90,22 +90,22 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
 {
     /// Construct a new instance with explicit direction
     pub fn new_with_direction(direction: D, data: T) -> Self {
-        Self::new_with_dir_view(direction, <V as Default>::default(), data)
+        Self::new_with_dir_driver(direction, <V as Default>::default(), data)
     }
 }
 impl<D: Directional + Default, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>>
     ListView<D, T, V>
 {
     /// Construct a new instance with explicit view
-    pub fn new_with_view(view: V, data: T) -> Self {
-        Self::new_with_dir_view(D::default(), view, data)
+    pub fn new_with_driver(view: V, data: T) -> Self {
+        Self::new_with_dir_driver(D::default(), view, data)
     }
 }
 impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>>
     ListView<D, T, V>
 {
     /// Construct a new instance with explicit direction and view
-    pub fn new_with_dir_view(direction: D, view: V, data: T) -> Self {
+    pub fn new_with_dir_driver(direction: D, view: V, data: T) -> Self {
         ListView {
             first_id: Default::default(),
             core: Default::default(),

--- a/src/widget/view/list_view.rs
+++ b/src/widget/view/list_view.rs
@@ -6,7 +6,7 @@
 //! List view widget
 
 use super::{driver, Driver, ListData, SelectionMode};
-use kas::event::{ChildMsg, CursorIcon, GrabMode, PressSource};
+use kas::event::{ChildMsg, Command, CursorIcon, GrabMode, PressSource};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
 use kas::updatable::UpdatableAll;
@@ -49,7 +49,7 @@ pub struct ListView<
     first_id: WidgetId,
     #[widget_core]
     core: CoreData,
-    offset: Offset,
+    frame_offset: Offset,
     frame_size: Size,
     view: V,
     data: T,
@@ -109,7 +109,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
         ListView {
             first_id: Default::default(),
             core: Default::default(),
-            offset: Default::default(),
+            frame_offset: Default::default(),
             frame_size: Default::default(),
             view,
             data,
@@ -296,7 +296,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
         let offset = u64::conv(self.scroll_offset().extract(self.direction));
         let first_data = usize::conv(offset / u64::conv(skip.extract(self.direction)));
 
-        let mut pos_start = self.core.rect.pos + self.offset;
+        let mut pos_start = self.core.rect.pos + self.frame_offset;
         if self.direction.is_reversed() {
             pos_start += skip * i32::conv(len - 1);
             skip = skip * -1;
@@ -417,7 +417,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
             rules.set_stretch(rules.stretch().max(Stretch::High));
         }
         let (rules, offset, size) = frame.surround(rules);
-        self.offset.set_component(axis, offset);
+        self.frame_offset.set_component(axis, offset);
         self.frame_size.set_component(axis, size);
         rules
     }
@@ -657,14 +657,63 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
         };
 
         let id = self.id();
-        let (action, response) =
+        let (action, response) = if let Event::Command(cmd, _) = event {
+            // Simplified version of logic in update_widgets
+            let len = usize::conv(self.cur_len);
+            let skip = self.child_size.extract(self.direction) + self.child_inter_margin;
+            let offset = u64::conv(self.scroll_offset().extract(self.direction));
+            let first_data = usize::conv(offset / u64::conv(skip));
+            let data_start = (first_data / len) * len;
+
+            let cur = mgr
+                .nav_focus()
+                .and_then(|id| self.find_child(id))
+                .map(|index| {
+                    let mut data = data_start + index;
+                    if data < first_data {
+                        data += len;
+                    }
+                    data
+                });
+            let last = self.data.len().wrapping_sub(1);
+            let is_vert = self.direction.is_vertical();
+
+            let data = match (cmd, cur) {
+                _ if last == usize::MAX => None,
+                _ if !self.widgets[0].widget.key_nav() => None,
+                (Command::Home, _) => Some(0),
+                (Command::End, _) => Some(last),
+                (Command::Left, Some(cur)) if !is_vert && cur > 0 => Some(cur - 1),
+                (Command::Up, Some(cur)) if is_vert && cur > 0 => Some(cur - 1),
+                (Command::Right, Some(cur)) if !is_vert && cur < last => Some(cur + 1),
+                (Command::Down, Some(cur)) if is_vert && cur < last => Some(cur + 1),
+                (Command::PageUp, Some(cur)) if cur > 0 => Some(cur.saturating_sub(len / 2)),
+                (Command::PageDown, Some(cur)) if cur < last => Some((cur + len / 2).min(last)),
+                _ => None,
+            };
+            let action = if let Some(index) = data {
+                // Set nav focus to index and update scroll position
+                // Note: we update nav focus before updating widgets; this is fine
+                mgr.set_nav_focus(self.widgets[index % len].widget.id());
+
+                let mut skip_off = Offset::ZERO;
+                skip_off.set_component(self.direction, skip);
+                let pos = self.core.rect.pos + self.frame_offset + skip_off * i32::conv(index);
+                let item_rect = Rect::new(pos, self.child_size);
+                self.scroll.focus_rect(item_rect, self.core.rect).1
+            } else {
+                TkAction::empty()
+            };
+            (action, Response::None)
+        } else {
             self.scroll
                 .scroll_by_event(event, self.core.rect.size, |source, _, coord| {
                     if source.is_primary() && mgr.config_enable_mouse_pan() {
                         let icon = Some(CursorIcon::Grabbing);
                         mgr.request_grab(id, source, coord, GrabMode::Grab, icon);
                     }
-                });
+                })
+        };
         if !action.is_empty() {
             *mgr |= action;
             self.update_widgets(mgr);

--- a/src/widget/view/matrix_view.rs
+++ b/src/widget/view/matrix_view.rs
@@ -266,7 +266,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> MatrixVie
             let ci = first_col + cn;
             for (rn, row) in rows.iter().enumerate() {
                 let ri = first_row + rn;
-                let i = (ci % cols.len()) * rows.len() + (ri % rows.len());
+                let i = (ci % cols.len()) + (ri % rows.len()) * cols.len();
                 let w = &mut self.widgets[i];
                 let key = T::make_key(&col, &row);
                 if w.key.as_ref() != Some(&key) {

--- a/src/widget/view/matrix_view.rs
+++ b/src/widget/view/matrix_view.rs
@@ -72,12 +72,12 @@ pub struct MatrixView<
 impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item> + Default> MatrixView<T, V> {
     /// Construct a new instance
     pub fn new(data: T) -> Self {
-        Self::new_with_view(<V as Default>::default(), data)
+        Self::new_with_driver(<V as Default>::default(), data)
     }
 }
 impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> MatrixView<T, V> {
     /// Construct a new instance with explicit view
-    pub fn new_with_view(view: V, data: T) -> Self {
+    pub fn new_with_driver(view: V, data: T) -> Self {
         MatrixView {
             first_id: Default::default(),
             core: Default::default(),

--- a/src/widget/view/matrix_view.rs
+++ b/src/widget/view/matrix_view.rs
@@ -48,7 +48,7 @@ pub struct MatrixView<
     first_id: WidgetId,
     #[widget_core]
     core: CoreData,
-    offset: Offset,
+    frame_offset: Offset,
     frame_size: Size,
     view: V,
     data: T,
@@ -81,7 +81,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> MatrixVie
         MatrixView {
             first_id: Default::default(),
             core: Default::default(),
-            offset: Default::default(),
+            frame_offset: Default::default(),
             frame_size: Default::default(),
             view,
             data,
@@ -258,7 +258,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> MatrixVie
             .row_iter_vec_from(first_row, self.alloc_len.1.cast());
         self.cur_len = Size(cols.len().cast(), rows.len().cast());
 
-        let pos_start = self.core.rect.pos + self.offset;
+        let pos_start = self.core.rect.pos + self.frame_offset;
         let mut rect = Rect::new(pos_start, self.child_size);
 
         let mut action = TkAction::empty();
@@ -375,7 +375,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Layout fo
         rules.set_stretch(rules.stretch().max(Stretch::High));
 
         let (rules, offset, size) = frame.surround(rules);
-        self.offset.set_component(axis, offset);
+        self.frame_offset.set_component(axis, offset);
         self.frame_size.set_component(axis, size);
         rules
     }

--- a/src/widget/view/single_view.rs
+++ b/src/widget/view/single_view.rs
@@ -52,12 +52,12 @@ impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item> + De
 {
     /// Construct a new instance
     pub fn new(data: T) -> Self {
-        Self::new_with_view(<V as Default>::default(), data)
+        Self::new_with_driver(<V as Default>::default(), data)
     }
 }
 impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> SingleView<T, V> {
     /// Construct a new instance with explicit view
-    pub fn new_with_view(view: V, data: T) -> Self {
+    pub fn new_with_driver(view: V, data: T) -> Self {
         let mut child = view.new();
         let _ = view.set(&mut child, data.get_cloned());
         SingleView {


### PR DESCRIPTION
`EditGuard` now has a `focus_gained` method, allowing custom actions on gaining text-input focus.

Replace `Layout::spatial_range` with `spatial_nav`, fixing iteration order for elements in `ListView` and `MatrixView` (but not changing the odd behaviour that sometimes tab scrolls to new elements and sometimes it doesn't).

Implement arrow-key and page up/down, home and end key navigation for `ListView` and for `MatrixView` where the immediate widget supports key-navigation.