### PR TITLE
Release v0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] — 2021-04-??
+## [0.7.0] — 2021-04-03
 
 The major focus of this release is "view widgets": the ability to construct a
 synchronised view over shared data.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -64,7 +64,7 @@ serde_json = { version = "1.0.61", optional = true }
 serde_yaml = { version = "0.8.16", optional = true }
 
 [dependencies.kas-macros]
-version = "0.6.0"
+version = "0.7.0"
 path = "kas-macros"
 
 [dependencies.kas-text]

--- a/kas-macros/Cargo.toml
+++ b/kas-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-macros"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/kas-theme/Cargo.toml
+++ b/kas-theme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-theme"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -30,7 +30,7 @@ stack_dst_ = { version = "0.6", package = "stack_dst", optional = true }
 
 [dependencies.kas]
 path = ".."
-version = "0.6.0"
+version = "0.7.0"
 
 [package.metadata.docs.rs]
 features = ["stack_dst"]

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-wgpu"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -37,8 +37,8 @@ stack_dst = ["kas-theme/stack_dst"]
 unsize = ["kas-theme/unsize"]
 
 [dependencies]
-kas = { path = "..", version = "0.6.0", features = ["winit"] }
-kas-theme = { path = "../kas-theme", version = "0.6.0" }
+kas = { path = "..", version = "0.7.0", features = ["winit"] }
+kas-theme = { path = "../kas-theme", version = "0.7.0" }
 bytemuck = "1.5.1"
 futures = "0.3"
 log = "0.4"

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -138,7 +138,6 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
         let mut setter = layout::RowSetter::<D, Vec<i32>, _>::new(rect, dim, align, &mut self.data);
 
         for (n, child) in self.widgets.iter_mut().enumerate() {
-            let align = AlignHints::default();
             child.set_rect(mgr, setter.child_rect(&mut self.data, n), align);
         }
     }

--- a/src/widget/view/matrix_view.rs
+++ b/src/widget/view/matrix_view.rs
@@ -53,6 +53,7 @@ pub struct MatrixView<
     view: V,
     data: T,
     widgets: Vec<WidgetData<T::Key, V::Widget>>,
+    align_hints: AlignHints,
     // TODO: the following three all have units of "the number of rows/cols"
     ideal_len: Size,
     alloc_len: Size,
@@ -86,6 +87,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> MatrixVie
             view,
             data,
             widgets: Default::default(),
+            align_hints: Default::default(),
             ideal_len: Size(5, 3),
             alloc_len: Size::ZERO,
             cur_len: Size::ZERO,
@@ -279,7 +281,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> MatrixVie
                 }
                 rect.pos = pos_start + skip.cwise_mul(Size(ci.cast(), ri.cast()));
                 if w.widget.rect() != rect {
-                    w.widget.set_rect(mgr, rect, Default::default());
+                    w.widget.set_rect(mgr, rect, self.align_hints);
                 }
             }
         }
@@ -380,7 +382,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Layout fo
         rules
     }
 
-    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, _align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
 
         let mut child_size = rect.size - self.frame_size;
@@ -395,6 +397,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Layout fo
             child_size.1 = self.child_size_min.1;
         }
         self.child_size = child_size;
+        self.align_hints = align;
 
         let skip = child_size + self.child_inter_margin;
         let vis_len = (rect.size + skip - Size::splat(1)).cwise_div(skip) + Size::splat(1);


### PR DESCRIPTION
It's ready.

The major focus of this release is "view widgets": the ability to construct a
synchronised view over shared data.

The new view widgets allow completion of the "CRUD" (Create, Read, Update,
Delete) [7GUIs challenge app](https://github.com/kas-gui/7guis/). The use of
view widgets allows data-UI separation and scaling to larger data sets (mainly
limited by the `O(n)` filter in this example). Work also started on the Cells
challenge (mini-spreadsheet), though many details of the app and of the
`MatrixView` widget still need addressing, especially drawing, multi-cell
selection and keyboard handling.

Additionally, this version saw development of a new mini-library, `kas::conv`,
which spun off into its own lib [easy-cast](https://crates.io/crates/easy-cast).

[Read the full CHANGELOG here.](https://github.com/kas-gui/kas/blob/441d1e061a4031314e5df63887f51038b5544135/CHANGELOG.md#070--2021-04-03)