### PR TITLE
Overlay borders / shadows

### DIFF
--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -14,8 +14,8 @@ use crate::{Dimensions, DimensionsParams, DimensionsWindow, Theme, ThemeColours,
 use kas::cast::Cast;
 use kas::dir::{Direction, Directional};
 use kas::draw::{
-    self, Colour, Draw, DrawRounded, DrawShared, ImageId, InputState, Pass, SizeHandle, TextClass,
-    ThemeAction, ThemeApi,
+    self, Colour, Draw, DrawRounded, DrawShared, ImageId, InputState, Pass, RegionClass,
+    SizeHandle, TextClass, ThemeAction, ThemeApi,
 };
 use kas::geom::*;
 use kas::text::format::FormattableText;
@@ -220,14 +220,15 @@ where
         (self.pass, self.offset, self.draw)
     }
 
-    fn clip_region(
+    fn add_clip_region(
         &mut self,
         rect: Rect,
         offset: Offset,
+        class: RegionClass,
         f: &mut dyn FnMut(&mut dyn draw::DrawHandle),
     ) {
         let rect = rect + self.offset;
-        let pass = self.draw.add_clip_region(rect);
+        let pass = self.draw.add_clip_region(self.pass, rect, class);
         let mut handle = DrawHandle {
             shared: self.shared,
             draw: self.draw,

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -72,7 +72,6 @@ pub struct DrawHandle<'a, D: DrawShared> {
     pub(crate) draw: &'a mut D::Draw,
     pub(crate) window: &'a mut DimensionsWindow,
     pub(crate) cols: &'a ThemeColours,
-    pub(crate) rect: Rect,
     pub(crate) offset: Offset,
     pub(crate) pass: Pass,
 }
@@ -108,7 +107,6 @@ where
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle {
         // We extend lifetimes (unsafe) due to the lack of associated type generics.
         unsafe fn extend_lifetime<'b, T>(r: &'b mut T) -> &'static mut T {
@@ -120,7 +118,6 @@ where
             draw: extend_lifetime(draw),
             window: extend_lifetime(window),
             cols: std::mem::transmute::<&'a ThemeColours, &'static ThemeColours>(&self.cols),
-            rect,
             offset: Offset::ZERO,
             pass: Pass::new(0),
         }
@@ -131,14 +128,12 @@ where
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle<'a> {
         DrawHandle {
             shared,
             draw,
             window,
             cols: &self.cols,
-            rect,
             offset: Offset::ZERO,
             pass: Pass::new(0),
         }
@@ -238,7 +233,6 @@ where
             draw: self.draw,
             window: self.window,
             cols: self.cols,
-            rect,
             offset: self.offset - offset,
             pass,
         };
@@ -247,7 +241,7 @@ where
 
     fn target_rect(&self) -> Rect {
         // Translate to local coordinates
-        self.rect - self.offset
+        self.draw.get_clip_rect(self.pass) - self.offset
     }
 
     fn outer_frame(&mut self, rect: Rect) {

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -252,15 +252,6 @@ where
             .rounded_frame(self.pass, outer, inner, 0.5, self.cols.frame);
     }
 
-    fn menu_frame(&mut self, rect: Rect) {
-        let outer = Quad::from(rect + self.offset);
-        let inner = outer.shrink(self.window.dims.frame as f32);
-        self.draw
-            .rounded_frame(self.pass, outer, inner, 0.5, self.cols.frame);
-        let inner = outer.shrink(self.window.dims.frame as f32 / 3.0);
-        self.draw.rect(self.pass, inner, self.cols.background);
-    }
-
     fn separator(&mut self, rect: Rect) {
         let outer = Quad::from(rect + self.offset);
         let inner = outer.shrink(outer.size().min_comp() / 2.0);

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -227,8 +227,22 @@ where
         class: RegionClass,
         f: &mut dyn FnMut(&mut dyn draw::DrawHandle),
     ) {
-        let rect = rect + self.offset;
-        let pass = self.draw.add_clip_region(self.pass, rect, class);
+        let inner_rect = rect + self.offset;
+        let outer_rect = match class {
+            RegionClass::ScrollRegion => inner_rect,
+            RegionClass::Overlay => inner_rect.expand(self.window.dims.frame),
+        };
+        let pass = self.draw.add_clip_region(self.pass, outer_rect, class);
+
+        if class == RegionClass::Overlay {
+            let outer = Quad::from(outer_rect);
+            let inner = Quad::from(inner_rect);
+            self.draw
+                .rounded_frame(pass, outer, inner, 0.5, self.cols.frame);
+            let inner = outer.shrink(self.window.dims.frame as f32 / 3.0);
+            self.draw.rect(pass, inner, self.cols.background);
+        }
+
         let mut handle = DrawHandle {
             shared: self.shared,
             draw: self.draw,

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -11,7 +11,6 @@ use std::marker::Unsize;
 
 use crate::{StackDst, Theme, ThemeDst, WindowDst};
 use kas::draw::{Colour, DrawHandle, DrawShared, ThemeAction, ThemeApi};
-use kas::geom::Rect;
 
 #[cfg(feature = "unsize")]
 type DynTheme<Draw> = StackDst<dyn ThemeDst<Draw>>;
@@ -129,9 +128,8 @@ impl<D: DrawShared> Theme<D> for MultiTheme<D> {
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
-        rect: Rect,
     ) -> StackDst<dyn DrawHandle> {
-        self.themes[self.active].draw_handle(shared, draw, window, rect)
+        self.themes[self.active].draw_handle(shared, draw, window)
     }
 
     #[cfg(feature = "gat")]
@@ -140,9 +138,8 @@ impl<D: DrawShared> Theme<D> for MultiTheme<D> {
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
-        rect: Rect,
     ) -> StackDst<dyn DrawHandle + 'a> {
-        self.themes[self.active].draw_handle(shared, draw, window, rect)
+        self.themes[self.active].draw_handle(shared, draw, window)
     }
 
     fn clear_color(&self) -> Colour {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -11,8 +11,8 @@ use std::ops::Range;
 use crate::{Dimensions, DimensionsParams, DimensionsWindow, Theme, ThemeColours, Window};
 use kas::dir::{Direction, Directional};
 use kas::draw::{
-    self, Colour, Draw, DrawRounded, DrawShaded, DrawShared, ImageId, InputState, Pass, SizeHandle,
-    TextClass, ThemeAction, ThemeApi,
+    self, Colour, Draw, DrawRounded, DrawShaded, DrawShared, ImageId, InputState, Pass,
+    RegionClass, SizeHandle, TextClass, ThemeAction, ThemeApi,
 };
 use kas::geom::*;
 use kas::text::{AccelString, Text, TextApi, TextDisplay};
@@ -231,14 +231,15 @@ where
         (self.pass, self.offset, self.draw)
     }
 
-    fn clip_region(
+    fn add_clip_region(
         &mut self,
         rect: Rect,
         offset: Offset,
+        class: RegionClass,
         f: &mut dyn FnMut(&mut dyn draw::DrawHandle),
     ) {
         let rect = rect + self.offset;
-        let pass = self.draw.add_clip_region(rect);
+        let pass = self.draw.add_clip_region(self.pass, rect, class);
         let mut handle = DrawHandle {
             shared: self.shared,
             draw: self.draw,

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -211,8 +211,7 @@ where
 
         if let Some(col) = self.cols.nav_region(state) {
             let outer = outer.shrink(thickness / 4.0);
-            self.draw
-                .rounded_frame(self.pass, outer, inner, 2.0 / 3.0, col);
+            self.draw.rounded_frame(self.pass, outer, inner, 0.6, col);
         }
     }
 }
@@ -344,7 +343,7 @@ where
 
         if let Some(col) = self.cols.nav_region(state) {
             let outer = outer.shrink(self.window.dims.inner_margin as f32);
-            self.draw.rounded_frame(self.pass, outer, inner, 0.5, col);
+            self.draw.rounded_frame(self.pass, outer, inner, 0.6, col);
         }
     }
 

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -68,7 +68,6 @@ pub struct DrawHandle<'a, D: DrawShared> {
     draw: &'a mut D::Draw,
     window: &'a mut DimensionsWindow,
     cols: &'a ThemeColours,
-    rect: Rect,
     offset: Offset,
     pass: Pass,
 }
@@ -104,7 +103,6 @@ where
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle {
         // We extend lifetimes (unsafe) due to the lack of associated type generics.
         unsafe fn extend_lifetime<'b, T>(r: &'b mut T) -> &'static mut T {
@@ -116,7 +114,6 @@ where
             draw: extend_lifetime(draw),
             window: extend_lifetime(window),
             cols: std::mem::transmute::<&'a ThemeColours, &'static ThemeColours>(&self.cols),
-            rect,
             offset: Offset::ZERO,
             pass: Pass::new(0),
         }
@@ -127,14 +124,12 @@ where
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle<'a> {
         DrawHandle {
             shared,
             draw,
             window,
             cols: &self.cols,
-            rect,
             offset: Offset::ZERO,
             pass: Pass::new(0),
         }
@@ -176,7 +171,6 @@ where
             draw: *&mut self.draw,
             window: *&mut self.window,
             cols: *&self.cols,
-            rect: self.rect,
             offset: self.offset,
             pass: self.pass,
         }
@@ -250,7 +244,6 @@ where
             draw: self.draw,
             window: self.window,
             cols: self.cols,
-            rect,
             offset: self.offset - offset,
             pass,
         };
@@ -259,7 +252,7 @@ where
 
     fn target_rect(&self) -> Rect {
         // Translate to local coordinates
-        self.rect - self.offset
+        self.draw.get_clip_rect(self.pass) - self.offset
     }
 
     fn outer_frame(&mut self, rect: Rect) {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -186,8 +186,9 @@ where
         let mut outer = Quad::from(outer);
         let mut inner = outer.shrink(self.window.dims.frame as f32);
 
+        let col = self.cols.background;
         self.draw
-            .shaded_square_frame(self.pass, outer, inner, (-0.6, 0.0), self.cols.background);
+            .shaded_square_frame(self.pass, outer, inner, (-0.6, 0.0), col, col);
 
         if let Some(col) = nav_col {
             outer = inner;
@@ -268,10 +269,15 @@ where
     fn menu_frame(&mut self, rect: Rect) {
         let outer = Quad::from(rect + self.offset);
         let inner = outer.shrink(self.window.dims.frame as f32);
-        let norm = (0.7, 0.0);
-        let col = self.cols.background;
-        self.draw
-            .shaded_round_frame(self.pass, outer, inner, norm, col);
+        let norm = (0.0, 0.0);
+        self.draw.shaded_square_frame(
+            self.pass,
+            outer,
+            inner,
+            norm,
+            Colour::TRANSPARENT,
+            Colour::BLACK,
+        );
         self.draw.rect(self.pass, inner, self.cols.background);
     }
 

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -266,21 +266,6 @@ where
             .shaded_round_frame(self.pass, outer, inner, norm, col);
     }
 
-    fn menu_frame(&mut self, rect: Rect) {
-        let outer = Quad::from(rect + self.offset);
-        let inner = outer.shrink(self.window.dims.frame as f32);
-        let norm = (0.0, 0.0);
-        self.draw.shaded_square_frame(
-            self.pass,
-            outer,
-            inner,
-            norm,
-            Colour::TRANSPARENT,
-            Colour::BLACK,
-        );
-        self.draw.rect(self.pass, inner, self.cols.background);
-    }
-
     fn separator(&mut self, rect: Rect) {
         let outer = Quad::from(rect + self.offset);
         let inner = outer.shrink(outer.size().min_comp() / 2.0);

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -10,7 +10,6 @@ use std::ops::DerefMut;
 
 use super::{StackDst, Theme, Window};
 use kas::draw::{Colour, DrawHandle, DrawShared, SizeHandle, ThemeApi};
-use kas::geom::Rect;
 
 /// As [`Theme`], but without associated types
 ///
@@ -51,7 +50,6 @@ pub trait ThemeDst<D: DrawShared>: ThemeApi {
         shared: &mut D,
         draw: &mut D::Draw,
         window: &mut dyn WindowDst<D>,
-        rect: Rect,
     ) -> StackDst<dyn DrawHandle>;
 
     /// Construct a [`DrawHandle`] object
@@ -65,7 +63,6 @@ pub trait ThemeDst<D: DrawShared>: ThemeApi {
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut dyn WindowDst<D>,
-        rect: Rect,
     ) -> StackDst<dyn DrawHandle + 'a>;
 
     /// Background colour
@@ -111,10 +108,9 @@ where
         shared: &mut D,
         draw: &mut D::Draw,
         window: &mut dyn WindowDst<D>,
-        rect: Rect,
     ) -> StackDst<dyn DrawHandle> {
         let window = window.as_any_mut().downcast_mut().unwrap();
-        let h = <T as Theme<D>>::draw_handle(self, shared, draw, window, rect);
+        let h = <T as Theme<D>>::draw_handle(self, shared, draw, window);
         #[cfg(feature = "unsize")]
         {
             StackDst::new_or_boxed(h)
@@ -153,10 +149,9 @@ impl<'a, D: DrawShared, T: Theme<D>> ThemeDst<D> for T {
         shared: &'b mut D,
         draw: &'b mut D::Draw,
         window: &'b mut dyn WindowDst<D>,
-        rect: Rect,
     ) -> StackDst<dyn DrawHandle + 'b> {
         let window = window.as_any_mut().downcast_mut().unwrap();
-        let h = <T as Theme<D>>::draw_handle(self, shared, draw, window, rect);
+        let h = <T as Theme<D>>::draw_handle(self, shared, draw, window);
         StackDst::new_or_boxed(h)
     }
 

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -9,7 +9,6 @@ use std::any::Any;
 use std::ops::{Deref, DerefMut};
 
 use kas::draw::{Colour, DrawHandle, DrawShared, SizeHandle, ThemeApi};
-use kas::geom::Rect;
 
 /// A *theme* provides widget sizing and drawing implementations.
 ///
@@ -75,7 +74,6 @@ pub trait Theme<D: DrawShared>: ThemeApi {
         shared: &mut D,
         draw: &mut D::Draw,
         window: &mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle;
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
@@ -83,7 +81,6 @@ pub trait Theme<D: DrawShared>: ThemeApi {
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle<'a>;
 
     /// Background colour
@@ -141,9 +138,8 @@ impl<T: Theme<D>, D: DrawShared> Theme<D> for Box<T> {
         shared: &mut D,
         draw: &mut D::Draw,
         window: &mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle {
-        self.deref().draw_handle(shared, draw, window, rect)
+        self.deref().draw_handle(shared, draw, window)
     }
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
@@ -151,9 +147,8 @@ impl<T: Theme<D>, D: DrawShared> Theme<D> for Box<T> {
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle<'a> {
-        self.deref().draw_handle(shared, draw, window, rect)
+        self.deref().draw_handle(shared, draw, window)
     }
 
     fn clear_color(&self) -> Colour {

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -10,7 +10,6 @@ use std::cell::Cell;
 
 use kas::draw::*;
 use kas::event::{Manager, VoidMsg, VoidResponse};
-use kas::geom::Rect;
 use kas::macros::{make_widget, VoidMsg};
 use kas::widget::*;
 use kas_theme::Theme;
@@ -76,9 +75,8 @@ where
         shared: &mut D,
         draw: &mut D::Draw,
         window: &mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle {
-        Theme::<D>::draw_handle(&self.inner, shared, draw, window, rect)
+        Theme::<D>::draw_handle(&self.inner, shared, draw, window)
     }
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
@@ -86,9 +84,8 @@ where
         shared: &'a mut D,
         draw: &'a mut D::Draw,
         window: &'a mut Self::Window,
-        rect: Rect,
     ) -> Self::DrawHandle<'a> {
-        Theme::<D>::draw_handle(&self.inner, shared, draw, window, rect)
+        Theme::<D>::draw_handle(&self.inner, shared, draw, window)
     }
 
     fn clear_color(&self) -> Colour {

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -351,6 +351,11 @@ impl<CW: CustomWindow> Draw for DrawWindow<CW> {
     }
 
     #[inline]
+    fn get_clip_rect(&self, pass: Pass) -> Rect {
+        self.clip_regions[pass.pass()]
+    }
+
+    #[inline]
     fn rect(&mut self, pass: Pass, rect: Quad, col: Colour) {
         self.shaded_square.rect(pass, rect, col);
     }

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -414,10 +414,11 @@ impl<CW: CustomWindow> DrawShaded for DrawWindow<CW> {
         outer: Quad,
         inner: Quad,
         norm: (f32, f32),
-        col: Colour,
+        outer_col: Colour,
+        inner_col: Colour,
     ) {
         self.shaded_square
-            .shaded_frame(pass, outer, inner, Vec2::from(norm), col);
+            .shaded_frame(pass, outer, inner, Vec2::from(norm), outer_col, inner_col);
     }
 
     #[inline]

--- a/kas-wgpu/src/draw/flat_round.rs
+++ b/kas-wgpu/src/draw/flat_round.rs
@@ -235,7 +235,8 @@ impl Window {
             dd = cc;
         }
 
-        let inner = inner_radius.max(0.0).min(1.0);
+        let inner = inner_radius.clamp(0.0, 1.0);
+        let inner = inner * inner; // shader compares to square
 
         let col = col.into();
 

--- a/kas-wgpu/src/draw/shaded_square.rs
+++ b/kas-wgpu/src/draw/shaded_square.rs
@@ -65,7 +65,7 @@ impl Pipeline {
                 entry_point: "main",
                 targets: &[wgpu::ColorTargetState {
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                    blend: None,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
                     write_mask: wgpu::ColorWrite::ALL,
                 }],
             }),
@@ -147,11 +147,11 @@ impl Window {
     #[inline]
     pub fn frame(&mut self, pass: Pass, outer: Quad, inner: Quad, col: Colour) {
         let norm = Vec2::splat(0.0);
-        self.shaded_frame(pass, outer, inner, norm, col);
+        self.shaded_frame(pass, outer, inner, norm, col, col);
     }
 
     /// Add a frame to the buffer, defined by two outer corners, `aa` and `bb`,
-    /// and two inner corners, `cc` and `dd` with colour `col`.
+    /// and two inner corners, `cc` and `dd` with colours `outer_col`, `inner_col`.
     ///
     /// Bounds on input: `aa < cc < dd < bb` and `-1 ≤ norm ≤ 1`.
     pub fn shaded_frame(
@@ -160,7 +160,8 @@ impl Window {
         outer: Quad,
         inner: Quad,
         mut norm: Vec2,
-        col: Colour,
+        outer_col: Colour,
+        inner_col: Colour,
     ) {
         let aa = outer.a;
         let bb = outer.b;
@@ -189,7 +190,8 @@ impl Window {
         let cd = Vec2(cc.0, dd.1);
         let dc = Vec2(dd.0, cc.1);
 
-        let col = col.into();
+        let outer_col = outer_col.into();
+        let inner_col = inner_col.into();
         let tt = (Vec2(0.0, -norm.1), Vec2(0.0, -norm.0));
         let tl = (Vec2(-norm.1, 0.0), Vec2(-norm.0, 0.0));
         let tb = (Vec2(0.0, norm.1), Vec2(0.0, norm.0));
@@ -198,17 +200,17 @@ impl Window {
         #[rustfmt::skip]
         self.add_vertices(pass.pass(), &[
             // top bar: ba - dc - cc - aa
-            Vertex(ba, col, tt.0), Vertex(dc, col, tt.1), Vertex(aa, col, tt.0),
-            Vertex(aa, col, tt.0), Vertex(dc, col, tt.1), Vertex(cc, col, tt.1),
+            Vertex(ba, outer_col, tt.0), Vertex(dc, inner_col, tt.1), Vertex(aa, outer_col, tt.0),
+            Vertex(aa, outer_col, tt.0), Vertex(dc, inner_col, tt.1), Vertex(cc, inner_col, tt.1),
             // left bar: aa - cc - cd - ab
-            Vertex(aa, col, tl.0), Vertex(cc, col, tl.1), Vertex(ab, col, tl.0),
-            Vertex(ab, col, tl.0), Vertex(cc, col, tl.1), Vertex(cd, col, tl.1),
+            Vertex(aa, outer_col, tl.0), Vertex(cc, inner_col, tl.1), Vertex(ab, outer_col, tl.0),
+            Vertex(ab, outer_col, tl.0), Vertex(cc, inner_col, tl.1), Vertex(cd, inner_col, tl.1),
             // bottom bar: ab - cd - dd - bb
-            Vertex(ab, col, tb.0), Vertex(cd, col, tb.1), Vertex(bb, col, tb.0),
-            Vertex(bb, col, tb.0), Vertex(cd, col, tb.1), Vertex(dd, col, tb.1),
+            Vertex(ab, outer_col, tb.0), Vertex(cd, inner_col, tb.1), Vertex(bb, outer_col, tb.0),
+            Vertex(bb, outer_col, tb.0), Vertex(cd, inner_col, tb.1), Vertex(dd, inner_col, tb.1),
             // right bar: bb - dd - dc - ba
-            Vertex(bb, col, tr.0), Vertex(dd, col, tr.1), Vertex(ba, col, tr.0),
-            Vertex(ba, col, tr.0), Vertex(dd, col, tr.1), Vertex(dc, col, tr.1),
+            Vertex(bb, outer_col, tr.0), Vertex(dd, inner_col, tr.1), Vertex(ba, outer_col, tr.0),
+            Vertex(ba, outer_col, tr.0), Vertex(dd, inner_col, tr.1), Vertex(dc, inner_col, tr.1),
         ]);
     }
 }

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -322,18 +322,15 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
     pub(crate) fn do_draw(&mut self, shared: &mut SharedState<C, T>) {
         let time = Instant::now();
-        let rect = Rect::new(Coord::ZERO, self.sc_size());
 
         shared.draw.text.prepare_fonts();
 
         unsafe {
             // Safety: we must drop draw_handle after draw call (wrong lifetime)
-            let mut draw_handle = shared.theme.draw_handle(
-                &mut shared.draw,
-                &mut self.draw,
-                &mut self.theme_window,
-                rect,
-            );
+            let mut draw_handle =
+                shared
+                    .theme
+                    .draw_handle(&mut shared.draw, &mut self.draw, &mut self.theme_window);
             self.widget.draw(&mut draw_handle, &self.mgr, false);
         }
 

--- a/src/draw/colour.rs
+++ b/src/draw/colour.rs
@@ -19,6 +19,18 @@ pub struct Colour {
 }
 
 impl Colour {
+    /// Transparent black
+    pub const TRANSPARENT: Colour = Colour {
+        r: 0.0,
+        g: 0.0,
+        b: 0.0,
+        a: 0.0,
+    };
+    /// Opaque white
+    pub const WHITE: Colour = Colour::grey(1.0);
+    /// Opaque black
+    pub const BLACK: Colour = Colour::grey(0.0);
+
     /// Constructor
     pub const fn new(r: f32, g: f32, b: f32) -> Self {
         Colour { r, g, b, a: 1.0 }

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -298,9 +298,9 @@ pub trait DrawHandle {
 
     /// Target area for drawing
     ///
-    /// If this instance of [`DrawHandle`] was created via
-    /// [`DrawHandle::clip_region`], then this returns the `rect` passed to
-    /// that method; otherwise this returns the window's `rect`.
+    /// Drawing is restricted to this [`Rect`], which is either the window or a
+    /// [clip region](DrawHandle::clip_region). This may be used to cull hidden
+    /// items from lists inside a scrollable view.
     fn target_rect(&self) -> Rect;
 
     /// Draw a frame inside the given `rect`

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -315,11 +315,6 @@ pub trait DrawHandle {
     /// The frame dimensions equal those of [`SizeHandle::frame`] on each side.
     fn outer_frame(&mut self, rect: Rect);
 
-    /// Draw a menu frame and background inside the given `rect`
-    ///
-    /// The frame dimensions equal those of [`SizeHandle::frame`] on each side.
-    fn menu_frame(&mut self, rect: Rect);
-
     /// Draw a separator in the given `rect`
     fn separator(&mut self, rect: Rect);
 
@@ -673,9 +668,6 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn outer_frame(&mut self, rect: Rect) {
         self.deref_mut().outer_frame(rect);
     }
-    fn menu_frame(&mut self, rect: Rect) {
-        self.deref_mut().menu_frame(rect);
-    }
     fn separator(&mut self, rect: Rect) {
         self.deref_mut().separator(rect);
     }
@@ -761,9 +753,6 @@ where
     }
     fn outer_frame(&mut self, rect: Rect) {
         self.deref_mut().outer_frame(rect);
-    }
-    fn menu_frame(&mut self, rect: Rect) {
-        self.deref_mut().menu_frame(rect);
     }
     fn separator(&mut self, rect: Rect) {
         self.deref_mut().separator(rect);

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -188,6 +188,11 @@ pub trait Draw: Any {
     /// Clip regions are cleared each frame and so must be recreated on demand.
     fn add_clip_region(&mut self, rect: Rect) -> Pass;
 
+    /// Get drawable rect for a clip region
+    ///
+    /// (This may be smaller than the rect passed to [`Draw::add_clip_region`].)
+    fn get_clip_rect(&self, pass: Pass) -> Rect;
+
     /// Draw a rectangle of uniform colour
     fn rect(&mut self, pass: Pass, rect: Quad, col: Colour);
 

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -275,7 +275,8 @@ pub trait DrawShaded: Draw {
         outer: Quad,
         inner: Quad,
         norm: (f32, f32),
-        col: Colour,
+        outer_col: Colour,
+        inner_col: Colour,
     );
 
     /// Add a rounded shaded frame to the draw buffer.

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -186,7 +186,7 @@ pub trait Draw: Any {
     /// Add a clip region
     ///
     /// Clip regions are cleared each frame and so must be recreated on demand.
-    fn add_clip_region(&mut self, rect: Rect) -> Pass;
+    fn add_clip_region(&mut self, pass: Pass, rect: Rect, class: RegionClass) -> Pass;
 
     /// Get drawable rect for a clip region
     ///

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -561,9 +561,12 @@ pub struct Rect {
 }
 
 impl Rect {
+    /// The empty rect (all fields zero)
+    pub const ZERO: Self = Self::new(Coord::ZERO, Size::ZERO);
+
     /// Construct from a [`Coord`] and [`Size`]
     #[inline]
-    pub fn new(pos: Coord, size: Size) -> Self {
+    pub const fn new(pos: Coord, size: Size) -> Self {
         Rect { pos, size }
     }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -606,6 +606,15 @@ impl Rect {
         let size = self.size.clamped_sub(Size::splat(n + n));
         Rect { pos, size }
     }
+
+    /// Expand self in all directions by the given `n`
+    #[inline]
+    pub fn expand(&self, n: i32) -> Rect {
+        debug_assert!(n >= 0);
+        let pos = self.pos - Offset::splat(n);
+        let size = self.size + Size::splat(n + n);
+        Rect { pos, size }
+    }
 }
 
 impl std::ops::Add<Offset> for Rect {

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 use std::rc::Rc;
 
-use super::{Column, MenuEntry, MenuFrame};
+use super::{Column, MenuEntry};
 use kas::draw::TextClass;
 use kas::event::{self, Command, GrabMode};
 use kas::prelude::*;
@@ -109,7 +109,7 @@ impl ComboBox<VoidMsg> {
             frame_size: Default::default(),
             popup: ComboPopup {
                 core: Default::default(),
-                inner: MenuFrame::new(Column::new(entries)),
+                inner: Column::new(entries),
             },
             active,
             opening: false,
@@ -185,7 +185,7 @@ impl<M: 'static> ComboBox<M> {
     ///
     /// Triggers a [reconfigure action](Manager::send_action).
     pub fn push<T: Into<AccelString>>(&mut self, label: T) -> TkAction {
-        let column = &mut self.popup.inner.inner;
+        let column = &mut self.popup.inner;
         column.push(MenuEntry::new(label, ()))
         // TODO: localised reconfigure
     }
@@ -194,7 +194,7 @@ impl<M: 'static> ComboBox<M> {
     ///
     /// Triggers a [reconfigure action](Manager::send_action).
     pub fn pop(&mut self) -> (Option<()>, TkAction) {
-        let r = self.popup.inner.inner.pop();
+        let r = self.popup.inner.pop();
         (r.0.map(|_| ()), r.1)
     }
 
@@ -204,7 +204,7 @@ impl<M: 'static> ComboBox<M> {
     ///
     /// Triggers a [reconfigure action](Manager::send_action).
     pub fn insert<T: Into<AccelString>>(&mut self, index: usize, label: T) -> TkAction {
-        let column = &mut self.popup.inner.inner;
+        let column = &mut self.popup.inner;
         column.insert(index, MenuEntry::new(label, ()))
         // TODO: localised reconfigure
     }
@@ -301,7 +301,7 @@ impl<M: 'static> event::Handler for ComboBox<M> {
                 parent: s.id(),
                 direction: Direction::Down,
             });
-            if let Some(id) = s.popup.inner.inner.get_child(s.active).map(|w| w.id()) {
+            if let Some(id) = s.popup.inner.get_child(s.active).map(|w| w.id()) {
                 mgr.set_nav_focus(id);
             }
         };
@@ -405,5 +405,5 @@ struct ComboPopup {
     #[widget_core]
     core: CoreData,
     #[widget]
-    inner: MenuFrame<Column<MenuEntry<()>>>,
+    inner: Column<MenuEntry<()>>,
 }

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -8,12 +8,10 @@
 use std::ops::{Deref, DerefMut};
 
 mod menu_entry;
-mod menu_frame;
 mod menubar;
 mod submenu;
 
 pub use menu_entry::{MenuEntry, MenuToggle};
-pub use menu_frame::MenuFrame;
 pub use menubar::MenuBar;
 pub use submenu::SubMenu;
 

--- a/src/widget/menu/submenu.rs
+++ b/src/widget/menu/submenu.rs
@@ -5,7 +5,7 @@
 
 //! Sub-menu
 
-use super::{Menu, MenuFrame};
+use super::Menu;
 use kas::draw::TextClass;
 use kas::event::{self, Command, ConfigureManager};
 use kas::prelude::*;
@@ -24,7 +24,7 @@ pub struct SubMenu<D: Directional, W: Menu> {
     label_off: Offset,
     frame_size: Size,
     #[widget]
-    pub list: MenuFrame<Column<W>>,
+    pub list: Column<W>,
     popup_id: Option<WindowId>,
 }
 
@@ -65,7 +65,7 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
             label: Text::new_single(label.into()),
             label_off: Offset::ZERO,
             frame_size: Size::ZERO,
-            list: MenuFrame::new(Column::new(list)),
+            list: Column::new(list),
             popup_id: None,
         }
     }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -28,7 +28,6 @@
 //! -   [`ComboBox`]: a simple pop-up selector
 //! -   [`MenuBar`], [`SubMenu`]: menu parent widgets
 //! -   [`MenuEntry`], [`MenuToggle`], [`Separator`]: menu entries
-//! -   [`MenuFrame`]: edges of a pop-up menu
 //!
 //! ## Controls
 //!

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -145,11 +145,12 @@ impl<W: Widget> Layout for Window<W> {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
         let disabled = disabled || self.is_disabled();
         self.w.draw(draw_handle, mgr, disabled);
-        for popup in &self.popups {
-            draw_handle.overlay(self.core.rect, &mut |draw_handle| {
-                self.find_leaf(popup.1.id)
-                    .map(|w| w.draw(draw_handle, mgr, disabled));
-            });
+        for (_, popup) in &self.popups {
+            if let Some(widget) = self.find_leaf(popup.id) {
+                draw_handle.overlay(widget.rect(), &mut |draw_handle| {
+                    widget.draw(draw_handle, mgr, disabled);
+                });
+            }
         }
     }
 }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -146,7 +146,7 @@ impl<W: Widget> Layout for Window<W> {
         let disabled = disabled || self.is_disabled();
         self.w.draw(draw_handle, mgr, disabled);
         for popup in &self.popups {
-            draw_handle.clip_region(self.core.rect, Offset::ZERO, &mut |draw_handle| {
+            draw_handle.overlay(self.core.rect, &mut |draw_handle| {
                 self.find_leaf(popup.1.id)
                     .map(|w| w.draw(draw_handle, mgr, disabled));
             });


### PR DESCRIPTION
Switching to our own glyph caching/drawing system fixed the clipping problems with overlays. This PR fixes clipping for embedded scroll regions and adds transparent shadows around popup menus (shaded theme only).

The `MenuFrame` widget is removed (no longer needed).

There are also a few small improvements to drawing code, plus some tweaks to rounded frame thickness.