### PR TITLE
Use rustybuzz for shaping and enable by default; allow custom font aliases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,4 @@ jobs:
       - name: test (kas-theme)
         run: cargo test --manifest-path kas-theme/Cargo.toml
       - name: test (kas-wgpu)
-        run: |
-          cargo test --manifest-path kas-wgpu/Cargo.toml
-          cargo test --manifest-path kas-wgpu/Cargo.toml --features clipboard,shaping
+        run: cargo test --manifest-path kas-wgpu/Cargo.toml --features clipboard

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ markdown = ["kas-text/markdown"]
 # Enable config read/write
 #TODO(cargo): once weak-dep-features (cargo#8832) is stable, add "winit?/serde"
 # and remove the serde feature requirement under dependencies.winit.
-config = ["serde"]
+config = ["serde", "kas-text/serde"]
 
 # Enable support for YAML (de)serialisation
 yaml = ["config", "serde_yaml"]
@@ -89,4 +89,4 @@ features = ["serde"]
 members = ["kas-macros", "kas-theme", "kas-wgpu"]
 
 [patch.crates-io]
-kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "cfe73eceee41062db081421bae30d0c311f4fde9" }
+kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "c594569d5d8a4640c2b76865114453b2701d0c35" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,4 +87,4 @@ features = ["serde"]
 members = ["kas-macros", "kas-theme", "kas-wgpu"]
 
 [patch.crates-io]
-kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "df3fcc1b6a8f8644c0b799021045248bc29098c8" }
+kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "aa609b3fb4765f989bfa97e80e16f8adb8ab898e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 # RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --features=nightly,internal_doc,markdown,yaml,json --all --no-deps --open
 
 [features]
+default = ["shaping"]
+
 # Enables usage of unstable Rust features
 nightly = ["min_spec"]
 
@@ -34,10 +36,10 @@ min_spec = []
 # This flag does not change the API, only built documentation.
 internal_doc = []
 
-# Enables text shaping via HarfBuzz
-# Shaping is part of Complex Text Layout, used for ligatures and where form
-# depends on position and context (especially important for Arabic).
+# Enable shaping via rustybuzz
 shaping = ["kas-text/shaping"]
+# Force use of HarfBuzz for shaping
+harfbuzz = ["kas-text/harfbuzz"]
 
 # Enable Markdown parsing
 markdown = ["kas-text/markdown"]
@@ -87,4 +89,4 @@ features = ["serde"]
 members = ["kas-macros", "kas-theme", "kas-wgpu"]
 
 [patch.crates-io]
-kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "aa609b3fb4765f989bfa97e80e16f8adb8ab898e" }
+kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "cfe73eceee41062db081421bae30d0c311f4fde9" }

--- a/README.md
+++ b/README.md
@@ -132,12 +132,6 @@ Currently, KAS's only drawing method is [WebGPU] which requires DirectX 11/12,
 Vulkan or Metal.
 In the future, there may be support for OpenGL and software rendering.
 
-#### HarfBuzz (optional)
-
-This is only needed if the `shaping` feature is enabled. On my system, the
-following libraries are used: `libharfbuzz.so.0`, `libglib-2.0.so.0`,
-`libgraphite2.so.3` and `libpcre.so.1`.
-
 ### Quick-start
 
 Install dependencies:
@@ -184,8 +178,8 @@ and runs the UI.
 
 The `kas` crate has the following feature flags:
 
--   `shaping`: enables complex glyph forming for languages such as Arabic.
-    This requires that the HarfBuzz library is installed.
+-   `shaping` (enabled by default): enables complex glyph forming for languages such as Arabic.
+    Alternate: `harfbuzz` forces use of the HarfBuzz library for shaping.
 -   `markdown`: enables Markdown parsing for rich-text
 -   `config`: adds (de)serialisation support for configuration plus a few
     utility types (specifying `serde` instead only implements for utility types)

--- a/example-config/theme.yaml
+++ b/example-config/theme.yaml
@@ -1,0 +1,45 @@
+---
+font_size: 10.0
+active_scheme: dark
+color_schemes:
+  "":
+    background: "#FFFFFF"
+    frame: "#DADADA"
+    bg: "#FFFFFF"
+    bg_disabled: "#EDEDED"
+    bg_error: "#FFBCBC"
+    text: "#000000"
+    text_sel: "#FFFFFF"
+    text_sel_bg: "#6CC0E1"
+    label_text: "#000000"
+    button_text: "#FFFFFF"
+    nav_focus: "#F3D3AA"
+    button: "#7CDAFF"
+    button_disabled: "#BCBCBC"
+    button_highlighted: "#89E7FF"
+    button_depressed: "#6CC0E1"
+    checkbox: "#7CDAFF"
+  dark:
+    background: "#4d4f50"
+    frame: "#AAAAAA"
+    bg: "#595959"
+    bg_disabled: "#959595"
+    bg_error: "#FFBCBC"
+    text: "#FFFFFF"
+    text_sel: "#FFFFFF"
+    text_sel_bg: "#CB9559"
+    label_text: "#FFFFFF"
+    button_text: "#FFFFFF"
+    nav_focus: "#FFDABC"
+    button: "#BC5959"
+    button_disabled: "#DADADA"
+    button_highlighted: "#CB9559"
+    button_depressed: "#955959"
+    checkbox: "#BC5959"
+font_aliases:
+  sans-serif:
+    mode: Prepend
+    list: [Calibri]
+  Calibri:
+    mode: Append
+    list: [Carlito]

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -66,7 +66,11 @@ impl Dimensions {
         let font_id = Default::default();
         let dpp = scale_factor * (96.0 / 72.0);
         let dpem = dpp * pt_size;
-        let line_height = i32::conv_ceil(kas::text::fonts::fonts().get(font_id).height(dpem));
+        let line_height = i32::conv_ceil(
+            kas::text::fonts::fonts()
+                .get_first_face(font_id)
+                .height(dpem),
+        );
 
         let outer_margin = (params.outer_margin * scale_factor).cast_nearest();
         let inner_margin = (params.inner_margin * scale_factor).cast_nearest();

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -110,7 +110,7 @@ where
     }
 
     fn init(&mut self, _draw: &mut D) {
-        if let Err(e) = kas::text::fonts::fonts().load_default() {
+        if let Err(e) = kas::text::fonts::fonts().select_default() {
             panic!("Error loading font: {}", e);
         }
     }

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -99,7 +99,7 @@ where
     }
 
     fn init(&mut self, _draw: &mut D) {
-        if let Err(e) = kas::text::fonts::fonts().load_default() {
+        if let Err(e) = kas::text::fonts::fonts().select_default() {
             panic!("Error loading font: {}", e);
         }
     }

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -12,7 +12,10 @@ use std::ops::{Deref, DerefMut};
 
 /// Requirements on theme config (without `config` feature)
 #[cfg(not(feature = "config"))]
-pub trait ThemeConfig: Clone + std::fmt::Debug + 'static {}
+pub trait ThemeConfig: Clone + std::fmt::Debug + 'static {
+    /// Apply startup effects
+    fn apply_startup(&self);
+}
 
 /// Requirements on theme config (with `config` feature)
 #[cfg(feature = "config")]
@@ -21,6 +24,9 @@ pub trait ThemeConfig:
 {
     /// Has the config ever been updated?
     fn is_dirty(&self) -> bool;
+
+    /// Apply startup effects
+    fn apply_startup(&self);
 }
 
 /// A *theme* provides widget sizing and drawing implementations.

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -27,9 +27,6 @@ gat = ["kas-theme/gat"]
 # Enables clipboard read/write
 clipboard = ["window_clipboard"]
 
-# Enables text shaping
-shaping = ["kas/shaping"]
-
 # Use stack_dst crate for sized unsized types
 stack_dst = ["kas-theme/stack_dst"]
 

--- a/kas-wgpu/src/draw/text_pipe.rs
+++ b/kas-wgpu/src/draw/text_pipe.rs
@@ -113,6 +113,9 @@ impl atlases::Pipeline<Instance> {
         let size = to_vec2(bounds.max - bounds.min);
         let offset = to_vec2(bounds.min) - Vec2(fract_pos.0.round(), fract_pos.1.round());
         let size_u32 = (u32::conv_trunc(size.0), u32::conv_trunc(size.1));
+        if size_u32.0 == 0 || size_u32.1 == 0 {
+            return None; // nothing to draw
+        }
 
         let (atlas, _, origin, tex_quad) = match self.allocate(size_u32) {
             Ok(result) => result,

--- a/kas-wgpu/src/options.rs
+++ b/kas-wgpu/src/options.rs
@@ -196,6 +196,7 @@ impl Options {
                 }
             }
         }
+        theme.config().apply_startup();
         Ok(())
     }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -67,7 +67,7 @@ pub mod util {
     /// Note: an alternative approach would be to delay text preparation by
     /// adding TkAction::PREPARE and a new method, perhaps in Layout.
     fn prepare_if_needed<T: format::FormattableText>(text: &mut Text<T>, avail: Size) -> TkAction {
-        if fonts::fonts().num_fonts() == 0 {
+        if fonts::fonts().num_faces() == 0 {
             // Fonts not loaded yet: cannot prepare and can assume it will happen later anyway.
             return TkAction::empty();
         }


### PR DESCRIPTION
Mostly this concerns work done in `kas-text`:

- https://github.com/kas-gui/kas-text/pull/47
- https://github.com/kas-gui/kas-text/pull/48

Font resolution has been completely updated and no longer uses `font-kit` as a dependency. It is now configurable via aliases (see config example). Rustybuzz is supported and used by default for shaping; Harfbuzz and no shaping are still options.