### PR TITLE
Fontdue rasterizer and other font adjustments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         run: cargo test --manifest-path kas-theme/Cargo.toml --all-features
       - name: test (kas-wgpu)
         run: |
-          cargo test --manifest-path kas-wgpu/Cargo.toml --no-default-features
+          cargo test --manifest-path kas-wgpu/Cargo.toml --no-default-features --features ab_glyph
           cargo test --manifest-path kas-wgpu/Cargo.toml --all-features
 
   test:
@@ -74,4 +74,4 @@ jobs:
       - name: test (kas-theme)
         run: cargo test --manifest-path kas-theme/Cargo.toml
       - name: test (kas-wgpu)
-        run: cargo test --manifest-path kas-wgpu/Cargo.toml --features clipboard
+        run: cargo test --manifest-path kas-wgpu/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,4 +89,4 @@ features = ["serde"]
 members = ["kas-macros", "kas-theme", "kas-wgpu"]
 
 [patch.crates-io]
-kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "448d07fc3290f011440d83af6d97901ebce9c72e" }
+kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "8e85e49df78f7908662d1356cacdf0b796274530" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,4 +89,4 @@ features = ["serde"]
 members = ["kas-macros", "kas-theme", "kas-wgpu"]
 
 [patch.crates-io]
-kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "05b50366a0a2fe7d1e611d93acbb2d9f83c52f0a" }
+kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "448d07fc3290f011440d83af6d97901ebce9c72e" }

--- a/example-config/theme.yaml
+++ b/example-config/theme.yaml
@@ -54,3 +54,7 @@ fonts:
     families:
       - sans-serif
     weight: 600
+raster:
+    mode: 0
+    subpixel_threshold: 0
+    subpixel_steps: 1

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -114,10 +114,10 @@ where
     }
 
     fn init(&mut self, _draw: &mut D) {
-        if let Err(e) = kas::text::fonts::fonts().select_default() {
+        let fonts = fonts::fonts();
+        if let Err(e) = fonts.select_default() {
             panic!("Error loading font: {}", e);
         }
-        let fonts = fonts::fonts();
         self.fonts = Some(Rc::new(
             self.config
                 .iter_fonts()

--- a/kas-theme/src/lib.rs
+++ b/kas-theme/src/lib.rs
@@ -32,7 +32,7 @@ mod traits;
 pub use kas;
 
 pub use colors::{Colors, ColorsLinear, ColorsSrgb};
-pub use config::Config;
+pub use config::{Config, RasterConfig};
 pub use dim::{Dimensions, DimensionsParams, DimensionsWindow};
 pub use flat_theme::FlatTheme;
 #[cfg(feature = "stack_dst")]

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -15,6 +15,9 @@ use std::ops::{Deref, DerefMut};
 pub trait ThemeConfig: Clone + std::fmt::Debug + 'static {
     /// Apply startup effects
     fn apply_startup(&self);
+
+    /// Get raster config
+    fn raster(&self) -> &crate::RasterConfig;
 }
 
 /// Requirements on theme config (with `config` feature)

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -27,6 +27,9 @@ pub trait ThemeConfig:
 
     /// Apply startup effects
     fn apply_startup(&self);
+
+    /// Get raster config
+    fn raster(&self) -> &crate::RasterConfig;
 }
 
 /// A *theme* provides widget sizing and drawing implementations.

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -18,7 +18,7 @@ no-default-features = true
 features = ["stack_dst"]
 
 [features]
-default = ["clipboard", "stack_dst"]
+default = ["ab_glyph", "clipboard", "stack_dst"]
 nightly = ["unsize", "kas/nightly", "kas-theme/nightly"]
 
 # Use Generic Associated Types (this is too unstable to include in nightly!)
@@ -34,7 +34,7 @@ stack_dst = ["kas-theme/stack_dst"]
 unsize = ["kas-theme/unsize"]
 
 # Also:
-# fontdue: use this for font rasterisation
+# ab_glyph, fontdue: enable at least one of these for text rasterisation
 
 [dependencies]
 kas = { path = "..", version = "0.7.0", features = ["config", "winit"] }
@@ -44,13 +44,14 @@ futures = "0.3"
 log = "0.4"
 smallvec = "1.6.1"
 wgpu = "0.8.0"
-ab_glyph = "0.2.10"
+ab_glyph = { version = "0.2.10", optional = true }
 winit = "0.25"
 thiserror = "1.0.23"
 window_clipboard = { version = "0.2.0", optional = true }
 image = "0.23.14"
 guillotiere = "0.6.0"
 fontdue = { version = "0.5.2", optional = true }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -33,6 +33,9 @@ stack_dst = ["kas-theme/stack_dst"]
 # Use kas-theme's unsize feature (nightly-only)
 unsize = ["kas-theme/unsize"]
 
+# Also:
+# fontdue: use this for font rasterisation
+
 [dependencies]
 kas = { path = "..", version = "0.7.0", features = ["config", "winit"] }
 kas-theme = { path = "../kas-theme", features = ["config"], version = "0.7.0" }
@@ -47,6 +50,7 @@ thiserror = "1.0.23"
 window_clipboard = { version = "0.2.0", optional = true }
 image = "0.23.14"
 guillotiere = "0.6.0"
+fontdue = { version = "0.5.2", optional = true }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/kas-wgpu/README.md
+++ b/kas-wgpu/README.md
@@ -31,11 +31,14 @@ Optional features
 This crate has the following feature flags:
 
 -   `clipboard` (enabled by default): clipboard integration
+-   `fontdue`: use [fontdue] library for font rasterisation (otherwise, `ab_glyph` is used)
 -   `stack_dst` (enabled by default): enables `kas-theme::MultiTheme`
 -   `gat`: enables usage of the Generic Associated Types feature (nightly only
     and currently unstable), allowing some usages of `unsafe` to be avoided.
     (The plan is to enable this by default once the feature is mature.)
 -   `unsize`: forwards this feature flag to `kas-theme`
+
+[fontdue]: https://github.com/mooman219/fontdue
 
 Copyright and Licence
 -------

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -24,6 +24,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         mut custom: CB,
         device: &wgpu::Device,
         shaders: &ShaderManager,
+        raster_config: &kas_theme::RasterConfig,
     ) -> Self {
         // Create staging belt and a local pool
         let staging_belt = wgpu::util::StagingBelt::new(1024);
@@ -60,7 +61,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         let shaded_round = shaded_round::Pipeline::new(device, shaders, &bgl_common);
         let flat_round = flat_round::Pipeline::new(device, shaders, &bgl_common);
         let custom = custom.build(&device, &bgl_common, RENDER_TEX_FORMAT);
-        let text = text_pipe::Pipeline::new(device, shaders, &bgl_common);
+        let text = text_pipe::Pipeline::new(device, shaders, &bgl_common, raster_config);
 
         DrawPipe {
             local_pool,

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -16,7 +16,7 @@ use crate::{warn_about_error, Error, Options, WindowId};
 use kas::event::UpdateHandle;
 use kas::updatable::Updatable;
 use kas::TkAction;
-use kas_theme::Theme;
+use kas_theme::{Theme, ThemeConfig};
 
 #[cfg(feature = "clipboard")]
 use window_clipboard::Clipboard;
@@ -67,7 +67,7 @@ where
         let (device, queue) = futures::executor::block_on(req)?;
 
         let shaders = ShaderManager::new(&device);
-        let mut draw = DrawPipe::new(custom, &device, &shaders);
+        let mut draw = DrawPipe::new(custom, &device, &shaders, theme.config().raster());
 
         theme.init(&mut draw);
 


### PR DESCRIPTION
Several improvments to text rendering, plus font raster configuration (under theme configuration).

Enables usage of the https://github.com/mooman219/fontdue rasterizer. Subjectively it may be a little better but still isn't perfect and noticably slows down start-up time.

Another option is to align to the horizontal side bearing using `ab_glyph`. In some ways this is better than sub-pixel alignment, in some ways not. Either way it's not close to [grid fitting](https://docs.microsoft.com/en-us/typography/opentype/spec/ttch01#grid-fitting-a-glyph-outline).

The biggest improvement to rendering was one of the simplest changes: vertically aligning text lines to the pixel grid during layout (in `kas-text`). This is enabled by default; other options (including sub-pixel positioning) are now disabled by default which seems to be the best *general* solution.