### PR TITLE
Prepare 0.8 release; doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0] — unreleased
+## [0.8.0] — 2021-06-17
 
 This release sees basic support for images, improved text rendering,
 replacements for all non-Rust dependencies, and theme configuration support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] — unreleased
+
+This release sees basic support for images, improved text rendering,
+replacements for all non-Rust dependencies, and theme configuration support.
+
+### Themes and text style/layout
+
+-   Support theme configuration (#196, #198)
+-   Support write-on-exit for updated configuration files (#196, #197)
+-   Revise colour types: replace `Colour` with `Rgba` and `Rgba8Srgb` (#198)
+
+### Text layout and configuration
+
+-   Use rustybuzz for text shaping, enabled by default (#199)
+-   Allow custom font aliases in config (#199)
+-   Allow assigning a custom font per text class; new `TextClass::MenuLabel`,
+    use (by default) serif fonts for edit fields (#200)
+-   Vertically-align text lines (#201)
+-   Configuration for text rastering (#201)
+
+### Images and (text) rendering
+
+-   Support raster images loaded from the file-system (#185)
+-   Use dynamic image atlases (#186) created on demand (#187)
+-   Replace `wgpu_glyph` and `glyph_brush` with our own glyph caching (#190)
+-   Add transparent shadows to pop-up layers (#194)
+-   Support `fontdue` for glyph rastering (#201)
+-   Move glyph raster code to KAS-text (#202)
+
+Details:
+
+-   Use push constants (#184)
+-   Remove depth-buffer (#185)
+-   Use common bind group for graphics pipes (#187)
+-   Use a staging belt for vertex uploads (#189)
+-   Significant code revision (#184 - #190)
+-   Update `wgpu-rs` to 0.8 (#193)
+
+### Other
+
+-   Fix (or work-around) hang-on-exit with multiple windows open (#184)
+-   Better scrolling for widgets not receiving the initial event (#192)
+-   Avoid unnecessary redraws on mouse-movement while a mouse-grab is in
+    effect (#196)
+
 ## [0.7.1] — 2021-05-03
 
 -   Fix for spans in grids (landed in master in #184)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -68,7 +68,7 @@ serde_yaml = { version = "0.8.16", optional = true }
 dep_ron = { version = "0.6.4", package = "ron", optional = true }
 
 [dependencies.kas-macros]
-version = "0.7.0"
+version = "0.8.0"
 path = "kas-macros"
 
 [dependencies.kas-text]
@@ -82,6 +82,3 @@ features = ["serde"]
 
 [workspace]
 members = ["kas-macros", "kas-theme", "kas-wgpu"]
-
-[patch.crates-io]
-kas-text = { git = "https://github.com/kas-gui/kas-text.git", rev = "fe480966daad0c17f5b7d0a956189e2f3823faf2" }

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ KAS's design provides:
 -   concise, partially declarative specification of widgets
 -   type-safe, widget-local event handlers
 -   simple ownership with no retained pointers into widget state
--   widgets embed state and handlers (easy reuse of complex components)
--   scalability to millions of widgets
+-   fast, efficient, responsive UI
 
 ## Documentation
 
@@ -31,85 +30,19 @@ Further examples can be found in [kas-gui/7guis](https://github.com/kas-gui/7gui
 
 ![Gallery](https://github.com/kas-gui/data-dump/blob/master/video/gallery.png)
 
-## Status and Features
+## Features
 
 The below should give a rough idea of what's done and what's not. See also the
 [ROADMAP].
 
-We aim to make new minor releases (0.x.0) every couple of months and patch
-releases (0.x.y) only for minor fixes where required.
-Before 1.0 (which will *not* be the release after 0.9), some breaking changes
-should be expected in each minor release.
-
-### Layout
-
-**Widget layout:** works well but not perfectly; automatic sizing according to
-content or specified size for custom widgets; automatic position and stretching
-within row/column or grid layouts. Some tweaking still needed.  
-**Text layout:** custom engine handles shaping, bidi and line-wrapping (some
-bugs). Several features missing: font fallbacks, emoticons, large-text support.
-See separate [KAS-text] repository.  
-**DPI scaling:** done.  
-**Performance/scalability:** pretty fast. Exception: text layout of larger
-documents (not done). Scalability is okay to at least thousands of widgets and
-even usable to a million since many operations are `O(log n)` or better.  
-
-### Graphics
-
-**Support:** uses [WebGPU] for DirectX/Vulkan/Metal and (maybe) OpenGL
-acceleration. Currently no CPU fallback.  
-**Themes:** theme engine supports sizing and drawing many common widget parts
-(not yet comprehensive), with two example themes (not especially good ones).  
-**DPI scaling:** perfect stepless scaling for text and most drawables; images may be sized according to pixels  
-**Anti-aliased:** yes for "rounded" shapes, no for simple blocks and images.  
-**API:** limited high-level widget graphics via theme plus simple shapes via low-level API; not yet comprehensive.  
-**Custom accelerated widgets:** yes (see [Mandlebrot example](kas-wgpu/examples/README.md#Mandlebrot)).  
-**Textures/images:** done in master branch (currently only for raster images from path)
-
-### Event handling
-
-**Mouse interactions:** most left-click actions implemented for existing
-widgets, including double-click and delayed responses. Context-menus missing.  
-**Keyboard interactions:** tab-navigation, arrow-key navigation and accelerator
-keys all done. Menus navigable with arrows and Alt+Key combos. Widgets may
-respond to Home, PageUp, etc.  
-**Touch interactions:** most single-touch gestures done. Minimal support for
-multi-touch gestures (see Mandlebrot demo app).  
-**Text-editing:** most expected keyboard/mouse behaviours done. Basic touch
-interactions supported but less complete and no virtual keyboard.  
-**Shortcuts:** widget-local and some navigation shortcuts supported; global
-shortcuts are missing. Several platform-specific bindings.  
-**Configuration:** shortcuts and some event-handling behaviour configurable.
-Serialisation to/from JSON and YAML. [See below](#Configuration).
-
-### Platform integration
-
-**Font discovery:** basic.  
-**Platform-specific default config:** yes (but probably needs tuning).  
-**Windowing:** uses [winit] which supports basic windows but lacks a few things,
-including pop-up/modal windows and good text input support.
-In theory a back-end could directly target Windows/X11/... instead but this has
-not been done.  
-**Platform-native menus:** no; waiting on [winit] support (see above).  
-**Platform-native dialogs:** no; waiting on [winit] support (see above).  
-**Embedding (within a game):** not supported; only really requires graphics
-([WebGPU] or implementing basics over another backend) plus input binding
-(currently only [winit] events are supported).  
-
-### Data handling
-
-**Embedded state in widgets:** yes.  
-**Shared state:** yes (in progress). Used by the `sync-counter`, `filter-list`
-and `dynamic-view` examples; allows custom widgets within a data-sharing "view"
-over a single datum or list of data. Missing a few common widgets (tree-view,
-table, spreadsheet).  
-**Multi-thread communication:** yes (at least basic support). See the
-`async-event` example.  
-
-### Widget library
-
-This is ad-hoc: it contains only the things wanted so far. See:
-[available widgets (latest release)](https://docs.rs/kas/latest/kas/widget/).
+-   Stepless DPI scaling
+-   Texts supporting bidirectional languages and font fallback
+-   Accelerated graphics via [WebGPU] (via DirectX/Vulkan/Metal or possibly
+    OpenGL); currently no CPU fallback
+-   Shaders in custom widgets (see [Mandlebrot example](kas-wgpu/examples/README.md#Mandlebrot))
+-   Support themes, colour schemes and end-user configuration
+-   Keyboard navigation and control
+-   View widgets over shared state
 
 
 Installation and dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,22 +7,22 @@ The past
 First, lets summarise KAS's journey so far.
 For details, see the [CHANGELOG](CHANGELOG.md).
 
-### 0.0.x — Jan 2019
+### 0.0.x — January 2019
 
 Early releases, built over GTK.
 
-### 0.1.0 — Dec 2019
+### 0.1.0 — December 2019
 
 A restart, replacing GTK with direct widget implementations including rendering
 via the `rgx` crate. Initial theme traits, event-handling revision.
 
-### 0.2.0 — Feb 2020
+### 0.2.0 — February 2020
 
 Lots of small but significant changes, including the introduction of the
 `Manager` handle, user-defined `configure` code, scheduled updates (animation),
 a scrollable region with scrollbars and addition of `ToolkitProxy`.
 
-### 0.3.0 — Feb 2020
+### 0.3.0 — February 2020
 
 Only three weeks later, this delivered two new levels of draw API (portrayed by
 `clock` and `mandlebrot` examples respectively), a "flat" theme, run-time theme
@@ -53,7 +53,7 @@ Small additions included recursive disabled states for all widgets and an error
 state for `EditBox` (set via a user-defined input guard). Widgets included a
 `Slider`, a resizable `Splitter`, a `ComboBox` and menu widgets.
 
-### 0.5.0 — Aug 2020
+### 0.5.0 — August 2020
 
 This release focussed on text presentation and editing with a new library,
 [kas-text](https://github.com/kas-gui/kas-text/). The text editing experience
@@ -68,7 +68,7 @@ short-cuts, double-click tracking and separate inner and outer margins.
 Additionally, a [CONTRIBUTING](CONTRIBUTING.md) guide and this `ROADMAP`
 have been added.
 
-### 0.6.0 — Nov 2020
+### 0.6.0 — November 2020
 
 A continuation of the work on text, with intial support for rich text,
 exemplified via a Markdown parser. Underline and strike-through may be applied
@@ -80,10 +80,10 @@ To allow retrieval of data from temporary (dialog) windows, the
 
 This release also simplifies distribution by bundling pre-compiled GLSL shaders.
 
-### 0.7.0 — unreleased (March 2021?)
+### 0.7.0 — April 2021
 
-This release focusses on one of the remaining hard problems: data sharing. A new
-framework for "view widgets" is introduced, allowing (interactive) views over
+This release focussed on one of the remaining hard problems: data sharing. A new
+framework for "view widgets" was introduced, allowing (interactive) views over
 shared data.
 
 View widgets enable synchronised access to shared data from multiple locations.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,14 +93,24 @@ are scalable to large data sets.
 Also included are several improvements to sizing, widget construction and event
 handling, as well as a new type-conversion library.
 
-### 0.8.0 — unreleased
+### 0.8.0 — June 2021
 
-This version will likely (finally) add support for images and textures, as well
-as some related work:
+This release finally addressed one of the most obvious missing features of KAS:
+images. At least, in their most basic form: static raster images loaded from
+file sources. This new raster-image rendering system was then tweaked and used
+as a replacement for the `glyph_brush` library, giving us better control over
+glyph rendering and caching, and allowing a choice of font glyph rasterer.
 
--   generalised buttons: support at least image or text contents
--   SVG support?
--   Better drawing APIs?
+The work on fonts and text did not stop there: as part of KAS-text 0.3, the
+(rather large and mostly unused) dependency `font-kit` was replaced with
+`fontdb` (plus a collection of custom aliases), extended to support font
+fallbacks and run-time configuration, meanwhile `rustybuzz` was integrated as
+a pure-Rust alternative to HarfBuzz for text shaping. These changes removed
+all non-Rust dependencies from the text system.
+
+Partially related to the above was the work on theme configuration, covering
+colour schemes, font size, font family (per font class and global), and glyph
+rastering.
 
 
 Future work

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -128,8 +128,6 @@ types instead. See [#95](https://github.com/kas-gui/kas/issues/95).
 
 Support display of images in the GUI:
 
--   fixed-size raster images sized to the pixel count without scaling
--   scaling of fixed raster images
 -   image display using a target size and multiple rastered versions, with
     the option of scaling to the target size or using the nearest size
 -   vector images rastered to a target size
@@ -137,29 +135,6 @@ Support display of images in the GUI:
 
 Possibly as part of this topic, implement colour management
 [#59](https://github.com/kas-gui/kas/issues/59).
-
-### Text: glyph caching and rasterisation
-
-Currently we use `wgpu_glyph` for glyph rasterisation and caching (which uses
-`glyph_brush` which uses `ab_glyph`). We already do our own glyph layout, so
-could perhaps move up the dependency tree or rewrite part of it. A few steps are
-involved, from font loading (already part of `kas-text`) to rasterising (several
-existing crates do this) to cache and texture management.
-
-Alongside this we could enable some extra features: sub-pixel precision for more
-accurate layout at low DPI, rotated and flipped text, fade-out where text is
-partially obscured.
-
-### Configuration and resource management
-
-Currently KAS has an ad-hoc font loader and fixed colour-schemes and shortcuts.
-This work item includes:
-
--   discovery of resources (fonts, icons, colour-schemes) from the system and
-    from user-local directories
--   configuration for e.g. fonts, colour schemes, icon sets
--   overriding the scale factor
--   shortcuts (e.g. Ctrl+Z), including configuration and maybe some localisation
 
 ### Standard resource sets
 
@@ -180,7 +155,20 @@ perhaps selecting a special context menu).
 At the same time, the undo history should probably be removed from widgets and
 stored in some shared state.
 
-This may also be a good time to review clipboard integration (see below).
+Slightly related to this is support for global and standard shortcuts such as
+undo, copy selection, save file, quit app.
+
+### Script-driven UIs
+
+So far, KAS only supports statically defined widgets and (more limited, without
+event handlers) programmatically added widgets. We should aim to support
+script-driven UIs: support all layouts with dynamic containers, add direct
+integration with a Rust-centric scripting language for building UIs, and add
+support for event handlers using dynamic typing.
+
+This should aim both to allow rapid prototyping of UIs and to make KAS easier
+to use (especially for those less familiar with Rust's traits, generics and
+macros).
 
 ### Widget identifiers
 
@@ -217,24 +205,6 @@ available.
 External dependencies
 ----------------------
 
-### Rust
-
-KAS currently *does* support stable `rustc`, but with feature limitations.
-Getting everything working well on stable Rust *requires* some new Rust
-features, though not all of these issues have a clear solution:
-
--   [#25](https://github.com/kas-gui/kas/issues/25) lists existing (optional)
-    usage of Rust nightly features; all of these
-    would be great to have in stable Rust but must are not essential
--   [#15](https://github.com/kas-gui/kas/issues/15) documents a major limitation
-    of `make_widget!`; Rust's
-    [RFC 2524](https://github.com/rust-lang/rfcs/pull/2524) provides
-    a solution but has neither been accepted nor implemented
--   [#11](https://github.com/kas-gui/kas/issues/11) documents one example of a
-    bad error message; another case of bad error messages is
-    [the sole reason `msg` does not have a default type within `make_widget!`](https://github.com/kas-gui/kas/blob/master/src/macros.rs#L381);
-    it is not clear (to me) how best to solve these issues
-
 ### WebGPU and CPU rasterisation
 
 Currently, KAS can only draw via `wgpu`, which currently does not support OpenGL
@@ -247,17 +217,9 @@ Additionally, KAS should provide a CPU-based renderer. See
 
 ### Clipboard support
 
-The current clipboard dependency is sub-par.
-[window_clipboard](https://github.com/hecrj/window_clipboard) may be the path
-forward, but still needs a lot of work (even copy-to-clipboard support).
-
-This includes support for formats other than plain text, e.g. images and HTML.
-
-This is not a trivial topic, especially considering that platforms have very
-different approaches to this (e.g. both X11 and Wayland expect apps to publish
-a list of available formats by mime type, then send contents in the window's
-event handler, while other platforms usually have more restricted formats and
-expect data to be sent to the clipboard provider in all formats up front).
+We have plain text clipboard support via
+[window_clipboard](https://github.com/hecrj/window_clipboard), but lack support
+for formatted text, images, etc.
 
 ### (winit) pop-up window support
 
@@ -274,8 +236,8 @@ receiving a drop or under a hovered drop.
 See [#98](https://github.com/kas-gui/kas/issues/98) and
 [winit#1550](https://github.com/rust-windowing/winit/issues/1550).
 
-### (winit) full key-bindings
+### (winit) key-bindings and text input
 
-Winit's `VirtualKeyCode` enum is rather limited. See
-[#27](https://github.com/kas-gui/kas/issues/27) (and *several* winit issues) on
-this topic.
+This needs revision, allowing more generic key bindings and supporting Input
+Method Editors (IME). Winit has an on-going effort here which will require
+support in KAS: <https://github.com/rust-windowing/winit/issues/1806>.

--- a/kas-macros/Cargo.toml
+++ b/kas-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-macros"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/kas-theme/Cargo.toml
+++ b/kas-theme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-theme"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -35,7 +35,7 @@ stack_dst_ = { version = "0.6", package = "stack_dst", optional = true }
 
 [dependencies.kas]
 path = ".."
-version = "0.7.0"
+version = "0.8.0"
 
 [package.metadata.docs.rs]
 features = ["stack_dst"]

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-wgpu"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -38,10 +38,10 @@ stack_dst = ["kas-theme/stack_dst"]
 unsize = ["kas-theme/unsize"]
 
 [dependencies]
-kas = { path = "..", version = "0.7.0", features = ["config", "winit"] }
-kas-theme = { path = "../kas-theme", features = ["config"], version = "0.7.0" }
+kas = { path = "..", version = "0.8.0", features = ["config", "winit"] }
+kas-theme = { path = "../kas-theme", features = ["config"], version = "0.8.0" }
 kas-text = { version = "0.3.0" }
-bytemuck = "1.5.1"
+bytemuck = "1.7.0"
 futures = "0.3"
 log = "0.4"
 smallvec = "1.6.1"

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -28,7 +28,13 @@ struct Shaders {
 impl Shaders {
     fn new(device: &wgpu::Device) -> Self {
         let vertex = device.create_shader_module(&include_spirv!("mandlebrot/shader.vert.spv"));
-        let fragment = device.create_shader_module(&include_spirv!("mandlebrot/shader.frag.spv"));
+        // Note: we don't use wgpu::include_spirv since it forces validation,
+        // which cannot currently deal with double precision floats (dvec2).
+        let fragment = device.create_shader_module(&wgpu::ShaderModuleDescriptor {
+            label: Some("fragment shader"),
+            source: wgpu::util::make_spirv(include_bytes!("mandlebrot/shader.frag.spv")),
+            flags: Default::default(),
+        });
 
         Shaders { vertex, fragment }
     }


### PR DESCRIPTION
Updates the CHANGELOG, README and ROADMAP for this release.

Also fixes the mandlebrot example.

No new screenshots/clips because I'm lazy and the only obvious change is the addition of a couple of images.