### PR TITLE
Revise shared parts of draw pipe; move image loading up to KAS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ serde = { version = "1.0.123", features = ["derive"], optional = true }
 serde_json = { version = "1.0.61", optional = true }
 serde_yaml = { version = "0.8.16", optional = true }
 dep_ron = { version = "0.6.4", package = "ron", optional = true }
+image = "0.23.14"
 
 [dependencies.kas-macros]
 version = "0.8.0"

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::rc::Rc;
 
 use kas::cast::{Cast, CastFloat, ConvFloat};
-use kas::draw::{self, DrawShared, DrawableShared, ImageId, TextClass};
+use kas::draw::{self, DrawShared, DrawableShared, ImageError, ImageId, TextClass};
 use kas::geom::{Size, Vec2};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::text::{fonts::FontId, TextApi, TextApiExt};
@@ -300,8 +300,8 @@ impl<'a, DS: DrawableShared> draw::SizeHandle for SizeHandle<'a, DS> {
         self.w.dims.progress_bar
     }
 
-    fn load_image(&mut self, path: &Path) -> Result<ImageId, Box<dyn std::error::Error + 'static>> {
-        self.shared.load_image(path)
+    fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError> {
+        self.shared.image_from_path(path)
     }
     fn remove_image(&mut self, id: ImageId) {
         self.shared.remove_image(id);

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -49,7 +49,6 @@ wgpu = "0.8.0"
 winit = "0.25"
 thiserror = "1.0.23"
 window_clipboard = { version = "0.2.0", optional = true }
-image = "0.23.14"
 guillotiere = "0.6.0"
 
 [dev-dependencies]

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -46,55 +46,55 @@ thread_local! {
     static BACKGROUND: Cell<Rgba> = Cell::new(Rgba::grey(1.0));
 }
 
-impl<D: DrawShared> Theme<D> for CustomTheme
+impl<DS: DrawableShared> Theme<DS> for CustomTheme
 where
-    D::Draw: DrawRounded,
+    DS::Draw: DrawRounded,
 {
     type Config = kas_theme::Config;
-    type Window = <FlatTheme as Theme<D>>::Window;
+    type Window = <FlatTheme as Theme<DS>>::Window;
 
     #[cfg(not(feature = "gat"))]
-    type DrawHandle = <FlatTheme as Theme<D>>::DrawHandle;
+    type DrawHandle = <FlatTheme as Theme<DS>>::DrawHandle;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a> = <FlatTheme as Theme<D>>::DrawHandle<'a>;
+    type DrawHandle<'a> = <FlatTheme as Theme<DS>>::DrawHandle<'a>;
 
     fn config(&self) -> std::borrow::Cow<Self::Config> {
-        Theme::<D>::config(&self.inner)
+        Theme::<DS>::config(&self.inner)
     }
 
     fn apply_config(&mut self, config: &Self::Config) -> TkAction {
-        Theme::<D>::apply_config(&mut self.inner, config)
+        Theme::<DS>::apply_config(&mut self.inner, config)
     }
 
-    fn init(&mut self, draw: &mut D) {
-        self.inner.init(draw);
+    fn init(&mut self, shared: &mut DrawShared<DS>) {
+        self.inner.init(shared);
     }
 
     fn new_window(&self, dpi_factor: f32) -> Self::Window {
-        Theme::<D>::new_window(&self.inner, dpi_factor)
+        Theme::<DS>::new_window(&self.inner, dpi_factor)
     }
 
     fn update_window(&self, window: &mut Self::Window, dpi_factor: f32) {
-        Theme::<D>::update_window(&self.inner, window, dpi_factor);
+        Theme::<DS>::update_window(&self.inner, window, dpi_factor);
     }
 
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &mut D,
-        draw: &mut D::Draw,
+        shared: &mut DrawShared<DS>,
+        draw: &mut DS::Draw,
         window: &mut Self::Window,
     ) -> Self::DrawHandle {
-        Theme::<D>::draw_handle(&self.inner, shared, draw, window)
+        Theme::<DS>::draw_handle(&self.inner, shared, draw, window)
     }
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        shared: &'a mut D,
-        draw: &'a mut D::Draw,
+        shared: &'a mut DrawShared<DS>,
+        draw: &'a mut DS::Draw,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a> {
-        Theme::<D>::draw_handle(&self.inner, shared, draw, window)
+        Theme::<DS>::draw_handle(&self.inner, shared, draw, window)
     }
 
     fn clear_color(&self) -> Rgba {

--- a/kas-wgpu/src/draw/atlases.rs
+++ b/kas-wgpu/src/draw/atlases.rs
@@ -12,7 +12,7 @@ use std::ops::Range;
 use thiserror::Error;
 
 use kas::cast::{Cast, Conv};
-use kas::draw::Pass;
+use kas::draw::{ImageError, Pass};
 use kas::geom::{Quad, Size, Vec2};
 
 fn to_vec2(p: guillotiere::Point) -> Vec2 {
@@ -21,8 +21,14 @@ fn to_vec2(p: guillotiere::Point) -> Vec2 {
 
 /// Allocation failed: too large
 #[derive(Error, Debug)]
-#[error("allocation failed: image is too large")]
+#[error("failed to allocate texture space for image")]
 pub struct AllocError;
+
+impl From<AllocError> for ImageError {
+    fn from(_: AllocError) -> ImageError {
+        ImageError::Allocation
+    }
+}
 
 pub struct Atlas {
     alloc: AtlasAllocator,

--- a/kas-wgpu/src/draw/atlases.rs
+++ b/kas-wgpu/src/draw/atlases.rs
@@ -100,7 +100,7 @@ impl<I: bytemuck::Pod> Pipeline<I> {
         tex_size: i32,
         tex_format: wgpu::TextureFormat,
         vertex: wgpu::VertexState,
-        fragment_module: &wgpu::ShaderModule,
+        fragment: wgpu::FragmentState,
     ) -> Self {
         let bg_tex_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("atlas texture bind group layout"),
@@ -148,15 +148,7 @@ impl<I: bytemuck::Pod> Pipeline<I> {
             },
             depth_stencil: None,
             multisample: Default::default(),
-            fragment: Some(wgpu::FragmentState {
-                module: fragment_module,
-                entry_point: "main",
-                targets: &[wgpu::ColorTargetState {
-                    format: super::RENDER_TEX_FORMAT,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
-                    write_mask: wgpu::ColorWrite::ALL,
-                }],
-            }),
+            fragment: Some(fragment),
         });
 
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -22,11 +22,11 @@ impl<C: CustomPipe> DrawPipe<C> {
     /// Construct
     pub fn new<CB: CustomPipeBuilder<Pipe = C>>(
         mut custom: CB,
-        device: wgpu::Device,
-        queue: wgpu::Queue,
-        shaders: &ShaderManager,
+        (device, queue): (wgpu::Device, wgpu::Queue),
         raster_config: &kas_theme::RasterConfig,
     ) -> Self {
+        let shaders = ShaderManager::new(&device);
+
         // Create staging belt and a local pool
         let staging_belt = wgpu::util::StagingBelt::new(1024);
         let local_pool = futures::executor::LocalPool::new();
@@ -57,12 +57,12 @@ impl<C: CustomPipe> DrawPipe<C> {
             ],
         });
 
-        let images = images::Images::new(&device, shaders, &bgl_common);
-        let shaded_square = shaded_square::Pipeline::new(&device, shaders, &bgl_common);
-        let shaded_round = shaded_round::Pipeline::new(&device, shaders, &bgl_common);
-        let flat_round = flat_round::Pipeline::new(&device, shaders, &bgl_common);
+        let images = images::Images::new(&device, &shaders, &bgl_common);
+        let shaded_square = shaded_square::Pipeline::new(&device, &shaders, &bgl_common);
+        let shaded_round = shaded_round::Pipeline::new(&device, &shaders, &bgl_common);
+        let flat_round = flat_round::Pipeline::new(&device, &shaders, &bgl_common);
         let custom = custom.build(&device, &bgl_common, RENDER_TEX_FORMAT);
-        let text = text_pipe::Pipeline::new(&device, shaders, &bgl_common, raster_config);
+        let text = text_pipe::Pipeline::new(&device, &shaders, &bgl_common, raster_config);
 
         DrawPipe {
             device,

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -7,14 +7,12 @@
 
 use std::any::Any;
 use std::f32::consts::FRAC_PI_2;
-use std::path::Path;
 use wgpu::util::DeviceExt;
 
 use super::*;
 use kas::cast::Cast;
-use kas::draw::{
-    color::Rgba, Draw, DrawRounded, DrawShaded, DrawableShared, ImageId, Pass, RegionClass,
-};
+use kas::draw::color::Rgba;
+use kas::draw::*;
 use kas::geom::{Coord, Quad, Rect, Size, Vec2};
 use kas::text::{Effect, TextDisplay};
 
@@ -293,17 +291,23 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
     type Draw = DrawWindow<C::Window>;
 
     #[inline]
-    fn load_image(&mut self, path: &Path) -> Result<ImageId, Box<dyn std::error::Error + 'static>> {
-        self.images.load_path(&self.device, &self.queue, path)
+    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
+        self.images.alloc(size)
     }
 
     #[inline]
-    fn remove_image(&mut self, id: ImageId) {
-        self.images.remove(id);
+    fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat) {
+        self.images
+            .upload(&self.device, &self.queue, id, data, format);
     }
 
     #[inline]
-    fn image_size(&self, id: ImageId) -> Option<Size> {
+    fn image_free(&mut self, id: ImageId) {
+        self.images.free(id);
+    }
+
+    #[inline]
+    fn image_size(&self, id: ImageId) -> Option<(u32, u32)> {
         self.images.image_size(id)
     }
 

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -13,7 +13,7 @@ use wgpu::util::DeviceExt;
 use super::*;
 use kas::cast::Cast;
 use kas::draw::{
-    color::Rgba, Draw, DrawRounded, DrawShaded, DrawShared, ImageId, Pass, RegionClass,
+    color::Rgba, Draw, DrawRounded, DrawShaded, DrawableShared, ImageId, Pass, RegionClass,
 };
 use kas::geom::{Coord, Quad, Rect, Size, Vec2};
 use kas::text::{Effect, TextDisplay};
@@ -289,7 +289,7 @@ impl<C: CustomPipe> DrawPipe<C> {
     }
 }
 
-impl<C: CustomPipe> DrawShared for DrawPipe<C> {
+impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
     type Draw = DrawWindow<C::Window>;
 
     #[inline]

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -189,7 +189,6 @@ impl<C: CustomPipe> DrawPipe<C> {
         self.images.prepare(
             &mut window.images,
             &mut self.device,
-            &mut self.queue,
             &mut self.staging_belt,
             &mut encoder,
         );
@@ -295,7 +294,7 @@ impl<C: CustomPipe> DrawShared for DrawPipe<C> {
 
     #[inline]
     fn load_image(&mut self, path: &Path) -> Result<ImageId, Box<dyn std::error::Error + 'static>> {
-        self.images.load_path(path)
+        self.images.load_path(&self.device, &self.queue, path)
     }
 
     #[inline]

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -22,7 +22,8 @@ impl<C: CustomPipe> DrawPipe<C> {
     /// Construct
     pub fn new<CB: CustomPipeBuilder<Pipe = C>>(
         mut custom: CB,
-        device: &wgpu::Device,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
         shaders: &ShaderManager,
         raster_config: &kas_theme::RasterConfig,
     ) -> Self {
@@ -56,14 +57,16 @@ impl<C: CustomPipe> DrawPipe<C> {
             ],
         });
 
-        let images = images::Images::new(device, shaders, &bgl_common);
-        let shaded_square = shaded_square::Pipeline::new(device, shaders, &bgl_common);
-        let shaded_round = shaded_round::Pipeline::new(device, shaders, &bgl_common);
-        let flat_round = flat_round::Pipeline::new(device, shaders, &bgl_common);
+        let images = images::Images::new(&device, shaders, &bgl_common);
+        let shaded_square = shaded_square::Pipeline::new(&device, shaders, &bgl_common);
+        let shaded_round = shaded_round::Pipeline::new(&device, shaders, &bgl_common);
+        let flat_round = flat_round::Pipeline::new(&device, shaders, &bgl_common);
         let custom = custom.build(&device, &bgl_common, RENDER_TEX_FORMAT);
-        let text = text_pipe::Pipeline::new(device, shaders, &bgl_common, raster_config);
+        let text = text_pipe::Pipeline::new(&device, shaders, &bgl_common, raster_config);
 
         DrawPipe {
+            device,
+            queue,
             local_pool,
             staging_belt,
             bgl_common,
@@ -77,14 +80,16 @@ impl<C: CustomPipe> DrawPipe<C> {
     }
 
     /// Construct per-window state
-    pub fn new_window(&self, device: &wgpu::Device, size: Size) -> DrawWindow<C::Window> {
+    pub fn new_window(&self, size: Size) -> DrawWindow<C::Window> {
         type Scale = [f32; 2];
         let scale_factor: Scale = [2.0 / size.0 as f32, -2.0 / size.1 as f32];
-        let scale_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("SR scale_buf"),
-            contents: bytemuck::cast_slice(&scale_factor),
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-        });
+        let scale_buf = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("SR scale_buf"),
+                contents: bytemuck::cast_slice(&scale_factor),
+                usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            });
 
         // Light dir: `(a, b)` where `0 ≤ a < pi/2` is the angle to the screen
         // normal (i.e. `a = 0` is straight at the screen) and `b` is the bearing
@@ -97,13 +102,15 @@ impl<C: CustomPipe> DrawPipe<C> {
         let f = a.0 / a.1;
         let light_norm = [dir.1.sin() * f, -dir.1.cos() * f, 1.0];
 
-        let light_norm_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("SR light_norm_buf"),
-            contents: bytemuck::cast_slice(&light_norm),
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-        });
+        let light_norm_buf = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("SR light_norm_buf"),
+                contents: bytemuck::cast_slice(&light_norm),
+                usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            });
 
-        let bg_common = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        let bg_common = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("common bind group"),
             layout: &self.bgl_common,
             entries: &[
@@ -128,7 +135,7 @@ impl<C: CustomPipe> DrawPipe<C> {
 
         let rect = Rect::new(Coord::ZERO, size);
 
-        let custom = self.custom.new_window(device, size);
+        let custom = self.custom.new_window(&self.device, size);
 
         DrawWindow {
             scale_buf,
@@ -143,63 +150,68 @@ impl<C: CustomPipe> DrawPipe<C> {
         }
     }
 
-    /// Process window resize
-    pub fn resize(
+    /// Wraps [`wgpu::Device::create_swap_chain`]
+    pub fn create_swap_chain(
         &self,
-        window: &mut DrawWindow<C::Window>,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        size: Size,
-    ) {
+        surface: &wgpu::Surface,
+        desc: &wgpu::SwapChainDescriptor,
+    ) -> wgpu::SwapChain {
+        self.device.create_swap_chain(surface, desc)
+    }
+
+    /// Process window resize
+    pub fn resize(&self, window: &mut DrawWindow<C::Window>, size: Size) {
         window.clip_regions[0].size = size;
 
         let scale_factor = [2.0 / size.0 as f32, -2.0 / size.1 as f32];
-        queue.write_buffer(&window.scale_buf, 0, bytemuck::cast_slice(&scale_factor));
+        self.queue
+            .write_buffer(&window.scale_buf, 0, bytemuck::cast_slice(&scale_factor));
 
-        self.custom.resize(&mut window.custom, device, queue, size);
+        self.custom
+            .resize(&mut window.custom, &self.device, &self.queue, size);
 
-        queue.submit(std::iter::empty());
+        self.queue.submit(std::iter::empty());
     }
 
     /// Render batched draw instructions via `rpass`
     pub fn render(
         &mut self,
         window: &mut DrawWindow<C::Window>,
-        device: &mut wgpu::Device,
-        queue: &mut wgpu::Queue,
         frame_view: &wgpu::TextureView,
         clear_color: wgpu::Color,
     ) {
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("render"),
-        });
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("render"),
+            });
 
         self.images.prepare(
             &mut window.images,
-            device,
-            queue,
+            &mut self.device,
+            &mut self.queue,
             &mut self.staging_belt,
             &mut encoder,
         );
         window
             .shaded_square
-            .write_buffers(device, &mut self.staging_belt, &mut encoder);
+            .write_buffers(&mut self.device, &mut self.staging_belt, &mut encoder);
         window
             .shaded_round
-            .write_buffers(device, &mut self.staging_belt, &mut encoder);
+            .write_buffers(&mut self.device, &mut self.staging_belt, &mut encoder);
         window
             .flat_round
-            .write_buffers(device, &mut self.staging_belt, &mut encoder);
+            .write_buffers(&mut self.device, &mut self.staging_belt, &mut encoder);
         self.custom.prepare(
             &mut window.custom,
-            device,
+            &mut self.device,
             &mut self.staging_belt,
             &mut encoder,
         );
-        self.text.prepare(device, queue);
+        self.text.prepare(&mut self.device, &mut self.queue);
         window
             .text
-            .write_buffers(device, &mut self.staging_belt, &mut encoder);
+            .write_buffers(&mut self.device, &mut self.staging_belt, &mut encoder);
 
         let mut color_attachments = [wgpu::RenderPassColorAttachment {
             view: frame_view,
@@ -238,8 +250,13 @@ impl<C: CustomPipe> DrawPipe<C> {
                     .render(&window.shaded_round, pass, &mut rpass, bg_common);
                 self.flat_round
                     .render(&window.flat_round, pass, &mut rpass, bg_common);
-                self.custom
-                    .render_pass(&mut window.custom, device, pass, &mut rpass, bg_common);
+                self.custom.render_pass(
+                    &mut window.custom,
+                    &mut self.device,
+                    pass,
+                    &mut rpass,
+                    bg_common,
+                );
                 self.text
                     .render(&mut window.text, pass, &mut rpass, bg_common);
             }
@@ -250,14 +267,19 @@ impl<C: CustomPipe> DrawPipe<C> {
         // Fonts and custom pipes use their own render pass(es).
         let size = window.clip_regions[0].size;
 
-        self.custom
-            .render_final(&mut window.custom, device, &mut encoder, frame_view, size);
+        self.custom.render_final(
+            &mut window.custom,
+            &mut self.device,
+            &mut encoder,
+            frame_view,
+            size,
+        );
 
         // Keep only first clip region (which is the entire window)
         window.clip_regions.truncate(1);
 
         self.staging_belt.finish();
-        queue.submit(std::iter::once(encoder.finish()));
+        self.queue.submit(std::iter::once(encoder.finish()));
 
         use futures::task::SpawnExt;
         self.local_pool

--- a/kas-wgpu/src/draw/images.rs
+++ b/kas-wgpu/src/draw/images.rs
@@ -156,7 +156,15 @@ impl Images {
                     ],
                 }],
             },
-            &shaders.frag_image,
+            wgpu::FragmentState {
+                module: &shaders.frag_image,
+                entry_point: "main",
+                targets: &[wgpu::ColorTargetState {
+                    format: super::RENDER_TEX_FORMAT,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrite::ALL,
+                }],
+            },
         );
         Images {
             atlas_pipe,

--- a/kas-wgpu/src/draw/images.rs
+++ b/kas-wgpu/src/draw/images.rs
@@ -24,8 +24,8 @@ pub enum ImageError {
     IOError(#[from] std::io::Error),
     #[error(transparent)]
     Image(#[from] image::ImageError),
-    #[error("allocation failed: insufficient space in image atlas")]
-    Allocation,
+    #[error(transparent)]
+    Allocation(#[from] atlases::AllocError),
 }
 
 #[derive(Debug)]

--- a/kas-wgpu/src/draw/images.rs
+++ b/kas-wgpu/src/draw/images.rs
@@ -186,7 +186,8 @@ impl Images {
         queue: &wgpu::Queue,
         path: &Path,
     ) -> Result<ImageId, Box<dyn std::error::Error + 'static>> {
-        if let Some((id, _)) = self.paths.get(path) {
+        if let Some((id, ref mut count)) = self.paths.get_mut(path) {
+            *count += 1;
             return Ok(*id);
         }
 

--- a/kas-wgpu/src/draw/images.rs
+++ b/kas-wgpu/src/draw/images.rs
@@ -6,91 +6,43 @@
 //! Images pipeline
 
 use guillotiere::AllocId;
-use image::RgbaImage;
 use std::collections::HashMap;
 use std::mem::size_of;
 use std::num::NonZeroU32;
-use std::path::{Path, PathBuf};
-use thiserror::Error;
 
 use super::{atlases, ShaderManager};
-use kas::draw::{ImageId, Pass};
-use kas::geom::{Quad, Size, Vec2};
-
-/// Image loading errors
-#[derive(Error, Debug)]
-pub enum ImageError {
-    #[error("IO error")]
-    IOError(#[from] std::io::Error),
-    #[error(transparent)]
-    Image(#[from] image::ImageError),
-    #[error(transparent)]
-    Allocation(#[from] atlases::AllocError),
-}
+use kas::draw::{ImageError, ImageFormat, ImageId, Pass};
+use kas::geom::{Quad, Vec2};
 
 #[derive(Debug)]
-pub struct Image {
-    image: RgbaImage,
+struct Image {
     atlas: u32,
     alloc: AllocId,
+    size: (u32, u32),
+    origin: (u32, u32),
     tex_quad: Quad,
 }
 
 impl Image {
-    /// Load an image
-    pub fn load_path(
-        atlas_pipe: &mut atlases::Pipeline<Instance>,
-        path: &Path,
-    ) -> Result<(Self, (u32, u32)), ImageError> {
-        let image = image::io::Reader::open(path)?.decode()?;
-        // TODO(opt): we convert to RGBA8 since this is the only format common
-        // to both the image crate and WGPU. It may not be optimal however.
-        // It also assumes that the image colour space is sRGB.
-        let image = image.into_rgba8();
-        let size = image.dimensions();
-
-        let (atlas, alloc, origin, tex_quad) = atlas_pipe.allocate(size)?;
-
-        let image = Image {
-            image,
-            atlas: atlas,
-            alloc,
-            tex_quad,
-        };
-        log::debug!(
-            "Image: atlas={}, alloc={:?}, tex_quad={:?}",
-            image.atlas,
-            image.alloc,
-            image.tex_quad
-        );
-        Ok((image, origin))
-    }
-
-    /// Query image size
-    pub fn size(&self) -> (u32, u32) {
-        self.image.dimensions()
-    }
-
-    /// Prepare textures
-    pub fn write_to_tex(
+    fn upload(
         &mut self,
         atlas_pipe: &atlases::Pipeline<Instance>,
-        origin: (u32, u32),
         queue: &wgpu::Queue,
+        data: &[u8],
     ) {
         // TODO(opt): use StagingBelt for upload (when supported)? Or our own equivalent.
-        let size = self.image.dimensions();
+        let size = self.size;
         queue.write_texture(
             wgpu::ImageCopyTexture {
                 texture: atlas_pipe.get_texture(self.atlas),
                 mip_level: 0,
                 origin: wgpu::Origin3d {
-                    x: origin.0,
-                    y: origin.1,
+                    x: self.origin.0,
+                    y: self.origin.1,
                     z: 0,
                 },
             },
-            &self.image,
+            data,
             wgpu::ImageDataLayout {
                 offset: 0,
                 bytes_per_row: NonZeroU32::new(4 * size.0),
@@ -102,10 +54,6 @@ impl Image {
                 depth_or_array_layers: 1,
             },
         );
-    }
-
-    pub fn tex_quad(&self) -> Quad {
-        self.tex_quad
     }
 }
 
@@ -125,7 +73,6 @@ unsafe impl bytemuck::Pod for Instance {}
 pub struct Images {
     atlas_pipe: atlases::Pipeline<Instance>,
     last_image_n: u32,
-    paths: HashMap<PathBuf, (ImageId, u32)>,
     images: HashMap<ImageId, Image>,
 }
 
@@ -168,7 +115,6 @@ impl Images {
         Images {
             atlas_pipe,
             last_image_n: 0,
-            paths: Default::default(),
             images: Default::default(),
         }
     }
@@ -179,61 +125,52 @@ impl Images {
         ImageId::try_new(n).expect("exhausted image IDs")
     }
 
-    /// Load an image from the file-system
-    pub fn load_path(
-        &mut self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        path: &Path,
-    ) -> Result<ImageId, Box<dyn std::error::Error + 'static>> {
-        if let Some((id, ref mut count)) = self.paths.get_mut(path) {
-            *count += 1;
-            return Ok(*id);
-        }
-
+    /// Allocate an image
+    pub fn alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
         let id = self.next_image_id();
-        let (image, origin) = Image::load_path(&mut self.atlas_pipe, path)?;
+        let (atlas, alloc, origin, tex_quad) = self.atlas_pipe.allocate(size)?;
+        let image = Image {
+            atlas,
+            alloc,
+            size,
+            origin,
+            tex_quad,
+        };
         self.images.insert(id, image);
-
-        self.atlas_pipe.prepare(device);
-        if let Some(image) = self.images.get_mut(&id) {
-            image.write_to_tex(&self.atlas_pipe, origin, queue);
-        }
-
-        self.paths.insert(path.to_owned(), (id, 1));
-
         Ok(id)
     }
 
-    /// Reduce usage count for `id` and free if zero
-    pub fn remove(&mut self, id: ImageId) {
-        // We don't have a map from id to path, hence have to iterate. We can
-        // however do a fast check that id is used.
-        if !self.images.contains_key(&id) {
-            return;
+    /// Upload an image to the GPU
+    pub fn upload(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        id: ImageId,
+        data: &[u8],
+        format: ImageFormat,
+    ) {
+        // The atlas pipe allocates textures lazily. Ensure ours is ready:
+        self.atlas_pipe.prepare(device);
+
+        match format {
+            ImageFormat::Rgba8 => (),
         }
 
-        let mut ref_count = 0;
-        self.paths.retain(|_, obj| {
-            if obj.0 == id {
-                obj.1 -= 1;
-                ref_count = obj.1;
-                ref_count != 0
-            } else {
-                true
-            }
-        });
+        if let Some(image) = self.images.get_mut(&id) {
+            image.upload(&self.atlas_pipe, queue, data);
+        }
+    }
 
-        if ref_count == 0 {
-            if let Some(im) = self.images.remove(&id) {
-                self.atlas_pipe.deallocate(im.atlas, im.alloc);
-            }
+    /// Free an image allocation
+    pub fn free(&mut self, id: ImageId) {
+        if let Some(im) = self.images.remove(&id) {
+            self.atlas_pipe.deallocate(im.atlas, im.alloc);
         }
     }
 
     /// Query image size
-    pub fn image_size(&self, id: ImageId) -> Option<Size> {
-        self.images.get(&id).map(|im| im.size().into())
+    pub fn image_size(&self, id: ImageId) -> Option<(u32, u32)> {
+        self.images.get(&id).map(|im| im.size)
     }
 
     /// Write to textures
@@ -249,7 +186,7 @@ impl Images {
 
     /// Get atlas and texture coordinates for an image
     pub fn get_im_atlas_coords(&self, id: ImageId) -> Option<(u32, Quad)> {
-        self.images.get(&id).map(|im| (im.atlas, im.tex_quad()))
+        self.images.get(&id).map(|im| (im.atlas, im.tex_quad))
     }
 
     /// Enqueue render commands

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -19,9 +19,8 @@ mod shaders;
 mod text_pipe;
 
 use kas::geom::Rect;
-use wgpu::TextureFormat;
-
 use shaders::ShaderManager;
+use wgpu::TextureFormat;
 
 pub use custom::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom};
 

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -22,7 +22,7 @@ use kas::geom::Rect;
 use wgpu::TextureFormat;
 
 pub(crate) use images::ImageError;
-pub(crate) use shaders::ShaderManager;
+use shaders::ShaderManager;
 
 pub use custom::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom};
 

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -21,7 +21,6 @@ mod text_pipe;
 use kas::geom::Rect;
 use wgpu::TextureFormat;
 
-pub(crate) use images::ImageError;
 use shaders::ShaderManager;
 
 pub use custom::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom};

--- a/kas-wgpu/src/draw/mod.rs
+++ b/kas-wgpu/src/draw/mod.rs
@@ -34,6 +34,8 @@ pub(crate) const RENDER_TEX_FORMAT: TextureFormat = TextureFormat::Bgra8UnormSrg
 
 /// Shared pipeline data
 pub struct DrawPipe<C> {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
     local_pool: futures::executor::LocalPool,
     staging_belt: wgpu::util::StagingBelt,
     bgl_common: wgpu::BindGroupLayout,

--- a/kas-wgpu/src/draw/text_pipe.rs
+++ b/kas-wgpu/src/draw/text_pipe.rs
@@ -78,7 +78,15 @@ impl Pipeline {
                     ],
                 }],
             },
-            &shaders.frag_glyph,
+            wgpu::FragmentState {
+                module: &shaders.frag_glyph,
+                entry_point: "main",
+                targets: &[wgpu::ColorTargetState {
+                    format: super::RENDER_TEX_FORMAT,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrite::ALL,
+                }],
+            },
         );
         Pipeline {
             config: Config::new(

--- a/kas-wgpu/src/options.rs
+++ b/kas-wgpu/src/options.rs
@@ -6,7 +6,7 @@
 //! Options
 
 use super::Error;
-use kas::draw::DrawShared;
+use kas::draw::DrawableShared;
 use kas_theme::{Theme, ThemeConfig};
 use log::warn;
 use std::env::var;
@@ -179,7 +179,10 @@ impl Options {
     }
 
     /// Load/save theme config on start
-    pub fn theme_config<D: DrawShared, T: Theme<D>>(&self, theme: &mut T) -> Result<(), Error> {
+    pub fn theme_config<DS: DrawableShared, T: Theme<DS>>(
+        &self,
+        theme: &mut T,
+    ) -> Result<(), Error> {
         if !self.theme_config_path.as_os_str().is_empty() {
             match self.config_mode {
                 ConfigMode::Read | ConfigMode::ReadWrite => {
@@ -221,7 +224,7 @@ impl Options {
     }
 
     /// Save all config (on exit or after changes)
-    pub fn save_config<D: DrawShared, T: Theme<D>>(
+    pub fn save_config<DS: DrawableShared, T: Theme<DS>>(
         &self,
         config: &kas::event::Config,
         theme: &T,

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -27,8 +27,6 @@ pub struct SharedState<C: CustomPipe, T> {
     clipboard: Option<Clipboard>,
     data_updates: HashMap<UpdateHandle, Vec<Rc<dyn Updatable>>>,
     pub instance: wgpu::Instance,
-    pub device: wgpu::Device,
-    pub queue: wgpu::Queue,
     pub shaders: ShaderManager,
     pub draw: DrawPipe<C>,
     pub theme: T,
@@ -67,7 +65,7 @@ where
         let (device, queue) = futures::executor::block_on(req)?;
 
         let shaders = ShaderManager::new(&device);
-        let mut draw = DrawPipe::new(custom, &device, &shaders, theme.config().raster());
+        let mut draw = DrawPipe::new(custom, device, queue, &shaders, theme.config().raster());
 
         theme.init(&mut draw);
 
@@ -76,8 +74,6 @@ where
             clipboard: None,
             data_updates: Default::default(),
             instance,
-            device,
-            queue,
             shaders,
             draw,
             theme,
@@ -114,13 +110,7 @@ where
         frame_view: &wgpu::TextureView,
         clear_color: wgpu::Color,
     ) {
-        self.draw.render(
-            window,
-            &mut self.device,
-            &mut self.queue,
-            frame_view,
-            clear_color,
-        );
+        self.draw.render(window, frame_view, clear_color);
     }
 
     #[inline]

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -55,7 +55,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
         // Create draw immediately (with Size::ZERO) to find ideal window size
         let scale_factor = shared.scale_factor as f32;
-        let mut draw = shared.draw.new_window(Size::ZERO);
+        let mut draw = shared.draw.draw.new_window(Size::ZERO);
         let mut theme_window = shared.theme.new_window(scale_factor);
 
         let mut mgr = ManagerState::new(shared.config.clone());
@@ -86,7 +86,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         info!("Constucted new window with size {:?}", size);
 
         // draw was initially created with Size::ZERO; we must resize
-        shared.draw.resize(&mut draw, size);
+        shared.draw.draw.resize(&mut draw, size);
 
         let surface = unsafe { shared.instance.create_surface(&window) };
         let sc_desc = wgpu::SwapChainDescriptor {
@@ -96,7 +96,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
             height: size.1.cast(),
             present_mode: wgpu::PresentMode::Mailbox,
         };
-        let swap_chain = shared.draw.create_swap_chain(&surface, &sc_desc);
+        let swap_chain = shared.draw.draw.create_swap_chain(&surface, &sc_desc);
 
         let mut r = Window {
             widget,
@@ -299,11 +299,14 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
             return;
         }
 
-        shared.draw.resize(&mut self.draw, size);
+        shared.draw.draw.resize(&mut self.draw, size);
 
         self.sc_desc.width = size.0.cast();
         self.sc_desc.height = size.1.cast();
-        self.swap_chain = shared.draw.create_swap_chain(&self.surface, &self.sc_desc);
+        self.swap_chain = shared
+            .draw
+            .draw
+            .create_swap_chain(&self.surface, &self.sc_desc);
 
         // Note that on resize, width adjustments may affect height
         // requirements; we therefore refresh size restrictions.

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -55,7 +55,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
         // Create draw immediately (with Size::ZERO) to find ideal window size
         let scale_factor = shared.scale_factor as f32;
-        let mut draw = shared.draw.new_window(&mut shared.device, Size::ZERO);
+        let mut draw = shared.draw.new_window(Size::ZERO);
         let mut theme_window = shared.theme.new_window(scale_factor);
 
         let mut mgr = ManagerState::new(shared.config.clone());
@@ -86,9 +86,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         info!("Constucted new window with size {:?}", size);
 
         // draw was initially created with Size::ZERO; we must resize
-        shared
-            .draw
-            .resize(&mut draw, &shared.device, &shared.queue, size);
+        shared.draw.resize(&mut draw, size);
 
         let surface = unsafe { shared.instance.create_surface(&window) };
         let sc_desc = wgpu::SwapChainDescriptor {
@@ -98,7 +96,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
             height: size.1.cast(),
             present_mode: wgpu::PresentMode::Mailbox,
         };
-        let swap_chain = shared.device.create_swap_chain(&surface, &sc_desc);
+        let swap_chain = shared.draw.create_swap_chain(&surface, &sc_desc);
 
         let mut r = Window {
             widget,
@@ -301,15 +299,11 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
             return;
         }
 
-        shared
-            .draw
-            .resize(&mut self.draw, &shared.device, &shared.queue, size);
+        shared.draw.resize(&mut self.draw, size);
 
         self.sc_desc.width = size.0.cast();
         self.sc_desc.height = size.1.cast();
-        self.swap_chain = shared
-            .device
-            .create_swap_chain(&self.surface, &self.sc_desc);
+        self.swap_chain = shared.draw.create_swap_chain(&self.surface, &self.sc_desc);
 
         // Note that on resize, width adjustments may affect height
         // requirements; we therefore refresh size restrictions.

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -10,7 +10,7 @@ use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::path::Path;
 
 use kas::dir::Direction;
-use kas::draw::{Draw, ImageId, Pass};
+use kas::draw::{Draw, ImageError, ImageId, Pass};
 use kas::geom::{Coord, Offset, Rect, Size};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use kas::text::{AccelString, Text, TextApi, TextDisplay};
@@ -240,7 +240,7 @@ pub trait SizeHandle {
     ///
     /// Image resources are deduplicated through the path lookup and have a
     /// use count. This method increments the use-count.
-    fn load_image(&mut self, path: &Path) -> Result<ImageId, Box<dyn std::error::Error + 'static>>;
+    fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError>;
 
     /// Remove image usage
     ///
@@ -250,7 +250,7 @@ pub trait SizeHandle {
 
     /// Get image size
     ///
-    /// If loading is in progress (see [`SizeHandle::load_image`]), this blocks
+    /// If loading is in progress (see [`SizeHandle::image_from_path`]), this blocks
     /// until done.
     ///
     /// Returns `None` if the resource is not found or failed to load.
@@ -553,8 +553,8 @@ impl<S: SizeHandle> SizeHandle for Box<S> {
     fn progress_bar(&self) -> Size {
         self.deref().progress_bar()
     }
-    fn load_image(&mut self, path: &Path) -> Result<ImageId, Box<dyn std::error::Error + 'static>> {
-        self.deref_mut().load_image(path)
+    fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError> {
+        self.deref_mut().image_from_path(path)
     }
     fn remove_image(&mut self, id: ImageId) {
         self.deref_mut().remove_image(id);
@@ -635,8 +635,8 @@ where
     fn progress_bar(&self) -> Size {
         self.deref().progress_bar()
     }
-    fn load_image(&mut self, path: &Path) -> Result<ImageId, Box<dyn std::error::Error + 'static>> {
-        self.deref_mut().load_image(path)
+    fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError> {
+        self.deref_mut().image_from_path(path)
     }
     fn remove_image(&mut self, id: ImageId) {
         self.deref_mut().remove_image(id);

--- a/src/draw/images.rs
+++ b/src/draw/images.rs
@@ -1,0 +1,141 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Image resource management
+
+use super::DrawableShared;
+use image::RgbaImage;
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ImageId(NonZeroU32);
+
+impl ImageId {
+    /// Construct a new identifier from `u32` value not equal to 0
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
+    #[inline]
+    pub const fn try_new(n: u32) -> Option<Self> {
+        // We can't use ? or .map in a const fn so do it the tedious way:
+        if let Some(nz) = NonZeroU32::new(n) {
+            Some(ImageId(nz))
+        } else {
+            None
+        }
+    }
+}
+
+/// Image formats available for upload
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum ImageFormat {
+    /// 8-bit RGBA values
+    Rgba8,
+}
+
+/// Image loading errors
+#[derive(Error, Debug)]
+pub enum ImageError {
+    #[error("IO error")]
+    IOError(#[from] std::io::Error),
+    #[error(transparent)]
+    Image(#[from] image::ImageError),
+    #[error("failed to allocate texture space for image")]
+    Allocation,
+}
+
+pub struct Images {
+    paths: HashMap<PathBuf, (ImageId, u32)>,
+    images: HashMap<ImageId, RgbaImage>,
+}
+
+impl Images {
+    /// Construct
+    pub fn new() -> Self {
+        Images {
+            paths: HashMap::new(),
+            images: HashMap::new(),
+        }
+    }
+
+    /// Load an image from the file-system
+    ///
+    /// This deduplicates multiple loads of the same path, instead incrementing
+    /// a reference count.
+    pub fn load_path<DS: DrawableShared>(
+        &mut self,
+        draw: &mut DS,
+        path: &Path,
+    ) -> Result<ImageId, ImageError> {
+        if let Some((id, ref mut count)) = self.paths.get_mut(path) {
+            *count += 1;
+            return Ok(*id);
+        }
+
+        let image = image::io::Reader::open(path)?.decode()?;
+        // TODO(opt): we convert to RGBA8 since this is the only format common
+        // to both the image crate and WGPU. It may not be optimal however.
+        // It also assumes that the image colour space is sRGB.
+        let image = image.into_rgba8();
+        let size = image.dimensions();
+
+        let id = draw.image_alloc(size)?;
+        draw.image_upload(id, &image, ImageFormat::Rgba8);
+        self.images.insert(id, image);
+        self.paths.insert(path.to_owned(), (id, 1));
+
+        Ok(id)
+    }
+
+    /// Remove a loaded image, by path
+    ///
+    /// This reduces the reference count and frees if zero.
+    pub fn remove_path<DS: DrawableShared>(&mut self, draw: &mut DS, path: &Path) {
+        let mut opt_id = None;
+        self.paths.retain(|p, (id, _)| {
+            if p == path {
+                opt_id = Some(*id);
+                false
+            } else {
+                true
+            }
+        });
+
+        if let Some(id) = opt_id {
+            self.images.remove(&id);
+            draw.image_free(id);
+        }
+    }
+
+    /// Remove a loaded image, by id
+    ///
+    /// This reduces the reference count and frees if zero.
+    /// (It also removes images not created through [`Images::load_path`].)
+    pub fn remove_id<DS: DrawableShared>(&mut self, draw: &mut DS, id: ImageId) {
+        // We don't have a map from id to path, hence have to iterate. We can
+        // however do a fast check that id is used.
+        if !self.images.contains_key(&id) {
+            return;
+        }
+
+        let mut ref_count = 0;
+        self.paths.retain(|_, obj| {
+            if obj.0 == id {
+                obj.1 -= 1;
+                ref_count = obj.1;
+                ref_count != 0
+            } else {
+                true
+            }
+        });
+
+        if ref_count == 0 {
+            self.images.remove(&id);
+            draw.image_free(id);
+        }
+    }
+}

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -403,6 +403,12 @@ impl From<(u32, u32)> for Size {
     }
 }
 
+impl From<Size> for (u32, u32) {
+    fn from(size: Size) -> (u32, u32) {
+        (size.0.cast(), size.1.cast())
+    }
+}
+
 impl From<Size> for kas_text::Vec2 {
     fn from(size: Size) -> kas_text::Vec2 {
         debug_assert!(size.0 >= 0 && size.1 >= 0);

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -405,7 +405,7 @@ impl From<(u32, u32)> for Size {
 
 impl From<Size> for (u32, u32) {
     fn from(size: Size) -> (u32, u32) {
-        (size.0.cast(), size.1.cast())
+        (u32::conv(size.0), u32::conv(size.1))
     }
 }
 

--- a/src/widget/image.rs
+++ b/src/widget/image.rs
@@ -89,12 +89,12 @@ impl Image {
             if let Some(id) = self.id {
                 sh.remove_image(id);
             }
-            match sh.load_image(&self.path) {
+            match sh.image_from_path(&self.path) {
                 Ok(id) => {
                     self.id = Some(id);
                     img_size = sh.image(id).unwrap_or(Size::ZERO);
                 }
-                Err(error) => self.handle_load_fail(&*error),
+                Err(error) => self.handle_load_fail(&error),
             };
         });
         mgr.redraw(self.id());
@@ -129,9 +129,9 @@ impl WidgetConfig for Image {
     fn configure(&mut self, mgr: &mut Manager) {
         if self.do_load {
             self.do_load = false;
-            match mgr.size_handle(|sh| sh.load_image(&self.path)) {
+            match mgr.size_handle(|sh| sh.image_from_path(&self.path)) {
                 Ok(id) => self.id = Some(id),
-                Err(error) => self.handle_load_fail(&*error),
+                Err(error) => self.handle_load_fail(&error),
             }
         }
     }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -77,6 +77,7 @@ mod window;
 
 pub mod view;
 
+pub use self::image::{Image, ImageScaling};
 pub use button::TextButton;
 pub use checkbox::{CheckBox, CheckBoxBare};
 pub use combobox::ComboBox;
@@ -85,7 +86,6 @@ pub use drag::DragHandle;
 pub use editbox::{EditBox, EditField, EditGuard};
 pub use filler::Filler;
 pub use frame::Frame;
-pub use image::{Image, ImageScaling};
 pub use label::{AccelLabel, Label, StrLabel, StringLabel};
 pub use list::*;
 pub use menu::*;


### PR DESCRIPTION
The API around the shared parts of the draw machinery now looks significantly different:

- `wgpu::{Device, Queue}` handles were moved into `DrawPipe`, allowing referencing within its API
- Image loading was split into *allocate* and *upload* steps
- Image upload is now immediate, avoiding the need to store the (or another) buffer within the draw pipe
- The `DrawShared` trait was renamed `DrawableShared` and hidden from public docs
- A new `DrawShared` struct was introduced as a wrapper around `DrawableShared`, allowing different API
- Image loading code was moved to `kas::draw::images::Images`, adding `Images` as a field to `DrawShared`

Rationales:

- Image loading code may now be shared with other potential toolkit backends
- We can offer users of the draw machinery a nice API (image from path) without complicating back-end code
- This enables image upload from other sources (without requiring an extra copy inside the image pipeline)