### PR TITLE
Drawable trait and Draw wrapper; casts; documentation

### DIFF
--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -247,8 +247,8 @@ where
         }
     }
 
-    fn draw_device(&mut self) -> (kas::draw::Pass, Offset, &mut dyn kas::draw::Drawable) {
-        (self.draw.pass(), self.offset, self.draw.draw)
+    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>) {
+        (self.offset, self.draw.upcast_base())
     }
 
     fn with_clip_region(

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -133,22 +133,17 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle<'a>(
-        &'a self,
-        shared: &'a mut DrawShared<DS>,
-        draw: &'a mut DS::Draw,
-        window: &'a mut Self::Window,
+    unsafe fn draw_handle(
+        &self,
+        shared: &'static mut DrawShared<DS>,
+        draw: &'static mut DS::Draw,
+        window: &'static mut Self::Window,
     ) -> Self::DrawHandle {
-        // We extend lifetimes (unsafe) due to the lack of associated type generics.
-        unsafe fn extend_lifetime<'b, T>(r: &'b mut T) -> &'static mut T {
-            std::mem::transmute::<&'b mut T, &'static mut T>(r)
-        }
-
         DrawHandle {
-            shared: extend_lifetime(shared),
-            draw: extend_lifetime(draw),
-            window: extend_lifetime(window),
-            cols: std::mem::transmute::<&'a ColorsLinear, &'static ColorsLinear>(&self.cols),
+            shared,
+            draw,
+            window,
+            cols: std::mem::transmute::<&ColorsLinear, &'static ColorsLinear>(&self.cols),
             offset: Offset::ZERO,
             pass: Pass::new(0),
         }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -8,6 +8,7 @@
 //! Widget size and appearance can be modified through themes.
 
 use linear_map::LinearMap;
+use std::any::Any;
 use std::f32;
 use std::ops::Range;
 use std::rc::Rc;
@@ -247,8 +248,12 @@ where
         }
     }
 
-    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>) {
-        (self.offset, self.draw.upcast_base())
+    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>, &mut dyn Any) {
+        (
+            self.offset,
+            self.draw.upcast_base(),
+            self.shared.draw.as_any_mut(),
+        )
     }
 
     fn with_clip_region(

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -144,11 +144,11 @@ impl<DS: DrawableShared> Theme<DS> for MultiTheme<DS> {
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle<'a>(
-        &'a self,
-        shared: &'a mut DrawShared<DS>,
-        draw: &'a mut DS::Draw,
-        window: &'a mut Self::Window,
+    unsafe fn draw_handle(
+        &self,
+        shared: &'static mut DrawShared<DS>,
+        draw: &'static mut DS::Draw,
+        window: &'static mut Self::Window,
     ) -> StackDst<dyn DrawHandle> {
         self.themes[self.active].draw_handle(shared, draw, window)
     }

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::marker::Unsize;
 
 use crate::{Config, StackDst, Theme, ThemeDst, WindowDst};
-use kas::draw::{color, DrawHandle, DrawShared, DrawableShared, ThemeApi};
+use kas::draw::{color, Draw, DrawHandle, DrawShared, DrawableShared, ThemeApi};
 use kas::TkAction;
 
 #[cfg(feature = "unsize")]
@@ -147,7 +147,7 @@ impl<DS: DrawableShared> Theme<DS> for MultiTheme<DS> {
     unsafe fn draw_handle(
         &self,
         shared: &'static mut DrawShared<DS>,
-        draw: &'static mut DS::Draw,
+        draw: Draw<'static, DS::Draw>,
         window: &'static mut Self::Window,
     ) -> StackDst<dyn DrawHandle> {
         self.themes[self.active].draw_handle(shared, draw, window)
@@ -157,7 +157,7 @@ impl<DS: DrawableShared> Theme<DS> for MultiTheme<DS> {
     fn draw_handle<'a>(
         &'a self,
         shared: &'a mut DrawShared<DS>,
-        draw: &'a mut DS::Draw,
+        draw: Draw<'a, DS::Draw>,
         window: &'a mut Self::Window,
     ) -> StackDst<dyn DrawHandle + 'a> {
         self.themes[self.active].draw_handle(shared, draw, window)

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -102,22 +102,17 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle<'a>(
-        &'a self,
-        shared: &'a mut DrawShared<DS>,
-        draw: &'a mut DS::Draw,
-        window: &'a mut Self::Window,
+    unsafe fn draw_handle(
+        &self,
+        shared: &'static mut DrawShared<DS>,
+        draw: &'static mut DS::Draw,
+        window: &'static mut Self::Window,
     ) -> Self::DrawHandle {
-        // We extend lifetimes (unsafe) due to the lack of associated type generics.
-        unsafe fn extend_lifetime<'b, T>(r: &'b mut T) -> &'static mut T {
-            std::mem::transmute::<&'b mut T, &'static mut T>(r)
-        }
-
         DrawHandle {
-            shared: extend_lifetime(shared),
-            draw: extend_lifetime(draw),
-            window: extend_lifetime(window),
-            cols: std::mem::transmute::<&'a ColorsLinear, &'static ColorsLinear>(&self.flat.cols),
+            shared,
+            draw,
+            window,
+            cols: std::mem::transmute::<&ColorsLinear, &'static ColorsLinear>(&self.flat.cols),
             offset: Offset::ZERO,
             pass: Pass::new(0),
         }

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -219,8 +219,8 @@ where
         }
     }
 
-    fn draw_device(&mut self) -> (kas::draw::Pass, Offset, &mut dyn kas::draw::Drawable) {
-        (self.draw.pass(), self.offset, self.draw.draw)
+    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>) {
+        (self.offset, self.draw.upcast_base())
     }
 
     fn with_clip_region(

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -5,6 +5,7 @@
 
 //! Shaded theme
 
+use std::any::Any;
 use std::f32;
 use std::ops::Range;
 
@@ -219,8 +220,12 @@ where
         }
     }
 
-    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>) {
-        (self.offset, self.draw.upcast_base())
+    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>, &mut dyn Any) {
+        (
+            self.offset,
+            self.draw.upcast_base(),
+            self.shared.draw.as_any_mut(),
+        )
     }
 
     fn with_clip_region(

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -72,9 +72,9 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &mut DrawShared<DS>,
-        draw: &mut DS::Draw,
-        window: &mut dyn WindowDst<DS>,
+        shared: &'static mut DrawShared<DS>,
+        draw: &'static mut DS::Draw,
+        window: &'static mut dyn WindowDst<DS>,
     ) -> StackDst<dyn DrawHandle>;
 
     /// Construct a [`DrawHandle`] object
@@ -141,9 +141,9 @@ where
 
     unsafe fn draw_handle(
         &self,
-        shared: &mut DrawShared<DS>,
-        draw: &mut DS::Draw,
-        window: &mut dyn WindowDst<DS>,
+        shared: &'static mut DrawShared<DS>,
+        draw: &'static mut DS::Draw,
+        window: &'static mut dyn WindowDst<DS>,
     ) -> StackDst<dyn DrawHandle> {
         let window = window.as_any_mut().downcast_mut().unwrap();
         let h = <T as Theme<DS>>::draw_handle(self, shared, draw, window);

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::ops::DerefMut;
 
 use super::{StackDst, Theme, Window};
-use kas::draw::{color, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
+use kas::draw::{color, Draw, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
 use kas::TkAction;
 
 /// An optionally-owning (boxed) reference
@@ -73,7 +73,7 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     unsafe fn draw_handle(
         &self,
         shared: &'static mut DrawShared<DS>,
-        draw: &'static mut DS::Draw,
+        draw: Draw<'static, DS::Draw>,
         window: &'static mut dyn WindowDst<DS>,
     ) -> StackDst<dyn DrawHandle>;
 
@@ -86,7 +86,7 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     fn draw_handle<'a>(
         &'a self,
         shared: &'a mut DrawShared<DS>,
-        draw: &'a mut DS::Draw,
+        draw: Draw<'a, DS::Draw>,
         window: &'a mut dyn WindowDst<DS>,
     ) -> StackDst<dyn DrawHandle + 'a>;
 
@@ -142,7 +142,7 @@ where
     unsafe fn draw_handle(
         &self,
         shared: &'static mut DrawShared<DS>,
-        draw: &'static mut DS::Draw,
+        draw: Draw<'static, DS::Draw>,
         window: &'static mut dyn WindowDst<DS>,
     ) -> StackDst<dyn DrawHandle> {
         let window = window.as_any_mut().downcast_mut().unwrap();
@@ -194,7 +194,7 @@ impl<'a, DS: DrawableShared, T: Theme<DS>> ThemeDst<DS> for T {
     fn draw_handle<'b>(
         &'b self,
         shared: &'b mut DrawShared<DS>,
-        draw: &'b mut DS::Draw,
+        draw: Draw<'b, DS::Draw>,
         window: &'b mut dyn WindowDst<DS>,
     ) -> StackDst<dyn DrawHandle + 'b> {
         let window = window.as_any_mut().downcast_mut().unwrap();

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -5,7 +5,7 @@
 
 //! Theme traits
 
-use kas::draw::{color, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
+use kas::draw::{color, Draw, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
 use kas::TkAction;
 use std::any::Any;
 use std::ops::{Deref, DerefMut};
@@ -108,14 +108,14 @@ pub trait Theme<DS: DrawableShared>: ThemeApi {
     unsafe fn draw_handle(
         &self,
         shared: &'static mut DrawShared<DS>,
-        draw: &'static mut DS::Draw,
+        draw: Draw<'static, DS::Draw>,
         window: &'static mut Self::Window,
     ) -> Self::DrawHandle;
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
         shared: &'a mut DrawShared<DS>,
-        draw: &'a mut DS::Draw,
+        draw: Draw<'a, DS::Draw>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a>;
 
@@ -180,7 +180,7 @@ impl<T: Theme<DS>, DS: DrawableShared> Theme<DS> for Box<T> {
     unsafe fn draw_handle(
         &self,
         shared: &'static mut DrawShared<DS>,
-        draw: &'static mut DS::Draw,
+        draw: Draw<'static, DS::Draw>,
         window: &'static mut Self::Window,
     ) -> Self::DrawHandle {
         self.deref().draw_handle(shared, draw, window)
@@ -189,7 +189,7 @@ impl<T: Theme<DS>, DS: DrawableShared> Theme<DS> for Box<T> {
     fn draw_handle<'a>(
         &'a self,
         shared: &'a mut DrawShared<DS>,
-        draw: &'a mut DS::Draw,
+        draw: Draw<'a, DS::Draw>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a> {
         self.deref().draw_handle(shared, draw, window)

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -99,15 +99,17 @@ pub trait Theme<DS: DrawableShared>: ThemeApi {
     /// [`Theme::new_window`] on `self`, and the `draw` reference is guaranteed
     /// to be identical to the one passed to [`Theme::new_window`].
     ///
-    /// This method is marked *unsafe* since a lifetime restriction is required
-    /// on the return value which can only be expressed with the unstable
-    /// feature Generic Associated Types (rust#44265).
+    /// Without the "gat" feature (Generic Associated Types; rust#44265), the
+    /// caller must unsafely extend the lifetime of references to `'static`.
+    /// These references shall not escape the lifetime of the return value.
+    /// The method is marked `unsafe` since sometimes it must extend the
+    /// lifetime of internal state.
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &mut DrawShared<DS>,
-        draw: &mut DS::Draw,
-        window: &mut Self::Window,
+        shared: &'static mut DrawShared<DS>,
+        draw: &'static mut DS::Draw,
+        window: &'static mut Self::Window,
     ) -> Self::DrawHandle;
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
@@ -177,9 +179,9 @@ impl<T: Theme<DS>, DS: DrawableShared> Theme<DS> for Box<T> {
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &mut DrawShared<DS>,
-        draw: &mut DS::Draw,
-        window: &mut Self::Window,
+        shared: &'static mut DrawShared<DS>,
+        draw: &'static mut DS::Draw,
+        window: &'static mut Self::Window,
     ) -> Self::DrawHandle {
         self.deref().draw_handle(shared, draw, window)
     }

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -45,7 +45,7 @@ bytemuck = "1.7.0"
 futures = "0.3"
 log = "0.4"
 smallvec = "1.6.1"
-wgpu = "0.8.0"
+wgpu = "0.9.0"
 winit = "0.25"
 thiserror = "1.0.23"
 window_clipboard = { version = "0.2.0", optional = true }

--- a/kas-wgpu/examples/async-event.rs
+++ b/kas-wgpu/examples/async-event.rs
@@ -65,9 +65,9 @@ impl Layout for ColourSquare {
         SizeRules::fixed_scaled(100.0, 10.0, factor)
     }
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        let (pass, offset, draw) = draw_handle.draw_device();
+        let (offset, mut draw) = draw_handle.draw_device();
         let col = *self.colour.lock().unwrap();
-        draw.rect(pass, (self.rect() + offset).into(), col);
+        draw.rect((self.rect() + offset).into(), col);
     }
 }
 impl Handler for ColourSquare {

--- a/kas-wgpu/examples/async-event.rs
+++ b/kas-wgpu/examples/async-event.rs
@@ -65,7 +65,7 @@ impl Layout for ColourSquare {
         SizeRules::fixed_scaled(100.0, 10.0, factor)
     }
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        let (offset, mut draw) = draw_handle.draw_device();
+        let (offset, mut draw, _shared) = draw_handle.draw_device();
         let col = *self.colour.lock().unwrap();
         draw.rect((self.rect() + offset).into(), col);
     }

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -12,7 +12,7 @@ use log::info;
 use std::f32::consts::PI;
 use std::time::Duration;
 
-use kas::draw::{color, DrawableRounded, TextClass};
+use kas::draw::{color, TextClass};
 use kas::geom::{Quad, Vec2};
 use kas::text::util::set_text_and_prepare;
 use kas::widget::Window;
@@ -75,18 +75,18 @@ impl Layout for Clock {
         //
         // Note: offset is used for scroll-regions, and should be zero here;
         // we add it anyway as is recommended.
-        let (pass, offset, draw) = draw_handle.draw_device();
-        let draw = draw.as_any_mut().downcast_mut::<DrawWindow<()>>().unwrap();
+        let (offset, mut draw) = draw_handle.draw_device();
+        let mut draw = draw.downcast::<DrawWindow<()>>().unwrap();
 
         let rect = Quad::from(self.core.rect + offset);
-        draw.circle(pass, rect, 0.95, col_face);
+        draw.circle(rect, 0.95, col_face);
 
         let half = (rect.b.1 - rect.a.1) / 2.0;
         let centre = rect.a + half;
 
         let mut line_seg = |t: f32, r1: f32, r2: f32, w, col| {
             let v = Vec2(t.sin(), -t.cos());
-            draw.rounded_line(pass, centre + v * r1, centre + v * r2, w, col);
+            draw.rounded_line(centre + v * r1, centre + v * r2, w, col);
         };
 
         let w = half * 0.015625;

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -12,7 +12,7 @@ use log::info;
 use std::f32::consts::PI;
 use std::time::Duration;
 
-use kas::draw::{color, DrawRounded, TextClass};
+use kas::draw::{color, DrawableRounded, TextClass};
 use kas::geom::{Quad, Vec2};
 use kas::text::util::set_text_and_prepare;
 use kas::widget::Window;

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -75,7 +75,7 @@ impl Layout for Clock {
         //
         // Note: offset is used for scroll-regions, and should be zero here;
         // we add it anyway as is recommended.
-        let (offset, mut draw) = draw_handle.draw_device();
+        let (offset, mut draw, _shared) = draw_handle.draw_device();
         let mut draw = draw.downcast::<DrawWindow<()>>().unwrap();
 
         let rect = self.core.rect + offset;

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -12,7 +12,7 @@ use log::info;
 use std::f32::consts::PI;
 use std::time::Duration;
 
-use kas::draw::{color, TextClass};
+use kas::draw::{color, RegionClass, TextClass};
 use kas::geom::{Quad, Vec2};
 use kas::text::util::set_text_and_prepare;
 use kas::widget::Window;
@@ -78,24 +78,29 @@ impl Layout for Clock {
         let (offset, mut draw) = draw_handle.draw_device();
         let mut draw = draw.downcast::<DrawWindow<()>>().unwrap();
 
-        let rect = Quad::from(self.core.rect + offset);
-        draw.circle(rect, 0.95, col_face);
+        let rect = self.core.rect + offset;
+        let quad = Quad::from(rect);
+        draw.circle(quad, 0.95, col_face);
 
-        let half = (rect.b.1 - rect.a.1) / 2.0;
-        let centre = rect.a + half;
-
-        let mut line_seg = |t: f32, r1: f32, r2: f32, w, col| {
-            let v = Vec2(t.sin(), -t.cos());
-            draw.rounded_line(centre + v * r1, centre + v * r2, w, col);
-        };
+        let half = (quad.b.1 - quad.a.1) / 2.0;
+        let centre = quad.a + half;
 
         let w = half * 0.015625;
         let l = w * 5.0;
         let r = half - w;
         for d in 0..12 {
             let l = if d % 3 == 0 { 2.0 * l } else { l };
-            line_seg(d as f32 * (PI / 6.0), r - l, r, w, col_face);
+            let t = d as f32 * (PI / 6.0);
+            let v = Vec2(t.sin(), -t.cos());
+            draw.rounded_line(centre + v * r - l, centre + v * r, w, col_face);
         }
+
+        // We use a new clip region to control the draw order (force in front).
+        let mut draw = draw.new_clip_region(rect, RegionClass::ScrollRegion);
+        let mut line_seg = |t: f32, r1: f32, r2: f32, w, col| {
+            let v = Vec2(t.sin(), -t.cos());
+            draw.rounded_line(centre + v * r1, centre + v * r2, w, col);
+        };
 
         let secs = self.now.time().num_seconds_from_midnight();
         let a_sec = f32::conv(secs % 60) * (PI / 30.0);

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -48,7 +48,7 @@ thread_local! {
 
 impl<DS: DrawableShared> Theme<DS> for CustomTheme
 where
-    DS::Draw: DrawRounded,
+    DS::Draw: DrawableRounded,
 {
     type Config = kas_theme::Config;
     type Window = <FlatTheme as Theme<DS>>::Window;
@@ -82,7 +82,7 @@ where
     unsafe fn draw_handle(
         &self,
         shared: &'static mut DrawShared<DS>,
-        draw: &'static mut DS::Draw,
+        draw: Draw<'static, DS::Draw>,
         window: &'static mut Self::Window,
     ) -> Self::DrawHandle {
         Theme::<DS>::draw_handle(&self.inner, shared, draw, window)
@@ -91,7 +91,7 @@ where
     fn draw_handle<'a>(
         &'a self,
         shared: &'a mut DrawShared<DS>,
-        draw: &'a mut DS::Draw,
+        draw: Draw<'a, DS::Draw>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a> {
         Theme::<DS>::draw_handle(&self.inner, shared, draw, window)

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -81,9 +81,9 @@ where
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &mut DrawShared<DS>,
-        draw: &mut DS::Draw,
-        window: &mut Self::Window,
+        shared: &'static mut DrawShared<DS>,
+        draw: &'static mut DS::Draw,
+        window: &'static mut Self::Window,
     ) -> Self::DrawHandle {
         Theme::<DS>::draw_handle(&self.inner, shared, draw, window)
     }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -327,17 +327,15 @@ impl Layout for Mandlebrot {
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {
-        let (pass, offset, draw) = draw_handle.draw_device();
+        let (offset, mut draw) = draw_handle.draw_device();
         // TODO: our view transform assumes that offset = 0.
         // Here it is but in general we should be able to handle an offset here!
         assert_eq!(offset, Offset::ZERO, "view transform assumption violated");
 
-        let draw = draw
-            .as_any_mut()
-            .downcast_mut::<DrawWindow<PipeWindow>>()
-            .unwrap();
+        let draw = draw.downcast::<DrawWindow<PipeWindow>>().unwrap();
+        let pass = draw.pass();
         let p = (self.alpha, self.delta, self.rel_width, self.iter);
-        draw.custom(pass, self.core.rect + offset, p);
+        draw.draw.custom(pass, self.core.rect + offset, p);
     }
 }
 

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -327,7 +327,7 @@ impl Layout for Mandlebrot {
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {
-        let (offset, mut draw) = draw_handle.draw_device();
+        let (offset, mut draw, _shared) = draw_handle.draw_device();
         // TODO: our view transform assumes that offset = 0.
         // Here it is but in general we should be able to handle an offset here!
         assert_eq!(offset, Offset::ZERO, "view transform assumption violated");

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -290,6 +290,11 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
     type Draw = DrawWindow<C::Window>;
 
     #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
     fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
         self.images.alloc(size)
     }

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -312,33 +312,29 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
     }
 
     #[inline]
-    fn draw_image(&self, target: Draw<Self::Draw>, pass: Pass, id: ImageId, rect: Quad) {
+    fn draw_image(&self, target: Draw<Self::Draw>, id: ImageId, rect: Quad) {
         if let Some((atlas, tex)) = self.images.get_im_atlas_coords(id) {
-            target.draw.images.rect(pass, atlas, tex, rect);
+            target.draw.images.rect(target.pass(), atlas, tex, rect);
         };
     }
 
     #[inline]
-    fn draw_text(
-        &mut self,
-        target: Draw<Self::Draw>,
-        pass: Pass,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-    ) {
-        target.draw.text.text(&mut self.text, pass, pos, text, col);
+    fn draw_text(&mut self, target: Draw<Self::Draw>, pos: Vec2, text: &TextDisplay, col: Rgba) {
+        target
+            .draw
+            .text
+            .text(&mut self.text, target.pass(), pos, text, col);
     }
 
     fn draw_text_col_effects(
         &mut self,
         target: Draw<Self::Draw>,
-        pass: Pass,
         pos: Vec2,
         text: &TextDisplay,
         col: Rgba,
         effects: &[Effect<()>],
     ) {
+        let pass = target.pass();
         let rects =
             target
                 .draw
@@ -352,11 +348,11 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
     fn draw_text_effects(
         &mut self,
         target: Draw<Self::Draw>,
-        pass: Pass,
         pos: Vec2,
         text: &TextDisplay,
         effects: &[Effect<Rgba>],
     ) {
+        let pass = target.pass();
         let rects = target
             .draw
             .text

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -5,7 +5,6 @@
 
 //! Drawing API for `kas_wgpu`
 
-use std::any::Any;
 use std::f32::consts::FRAC_PI_2;
 use wgpu::util::DeviceExt;
 
@@ -365,7 +364,12 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
 
 impl<CW: CustomWindow> Drawable for DrawWindow<CW> {
     #[inline]
-    fn as_any_mut(&mut self) -> &mut dyn Any {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn as_drawable_mut(&mut self) -> &mut dyn Drawable {
         self
     }
 

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -312,59 +312,62 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
     }
 
     #[inline]
-    fn draw_image(&self, window: &mut Self::Draw, pass: Pass, id: ImageId, rect: Quad) {
+    fn draw_image(&self, target: Draw<Self::Draw>, pass: Pass, id: ImageId, rect: Quad) {
         if let Some((atlas, tex)) = self.images.get_im_atlas_coords(id) {
-            window.images.rect(pass, atlas, tex, rect);
+            target.draw.images.rect(pass, atlas, tex, rect);
         };
     }
 
     #[inline]
     fn draw_text(
         &mut self,
-        window: &mut Self::Draw,
+        target: Draw<Self::Draw>,
         pass: Pass,
         pos: Vec2,
         text: &TextDisplay,
         col: Rgba,
     ) {
-        window.text.text(&mut self.text, pass, pos, text, col);
+        target.draw.text.text(&mut self.text, pass, pos, text, col);
     }
 
     fn draw_text_col_effects(
         &mut self,
-        window: &mut Self::Draw,
+        target: Draw<Self::Draw>,
         pass: Pass,
         pos: Vec2,
         text: &TextDisplay,
         col: Rgba,
         effects: &[Effect<()>],
     ) {
-        let rects = window
-            .text
-            .text_col_effects(&mut self.text, pass, pos, text, col, effects);
+        let rects =
+            target
+                .draw
+                .text
+                .text_col_effects(&mut self.text, pass, pos, text, col, effects);
         for rect in rects {
-            window.shaded_square.rect(pass, rect, col);
+            target.draw.shaded_square.rect(pass, rect, col);
         }
     }
 
     fn draw_text_effects(
         &mut self,
-        window: &mut Self::Draw,
+        target: Draw<Self::Draw>,
         pass: Pass,
         pos: Vec2,
         text: &TextDisplay,
         effects: &[Effect<Rgba>],
     ) {
-        let rects = window
+        let rects = target
+            .draw
             .text
             .text_effects(&mut self.text, pass, pos, text, effects);
         for (rect, col) in rects {
-            window.shaded_square.rect(pass, rect, col);
+            target.draw.shaded_square.rect(pass, rect, col);
         }
     }
 }
 
-impl<CW: CustomWindow> Draw for DrawWindow<CW> {
+impl<CW: CustomWindow> Drawable for DrawWindow<CW> {
     #[inline]
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
@@ -398,7 +401,7 @@ impl<CW: CustomWindow> Draw for DrawWindow<CW> {
     }
 }
 
-impl<CW: CustomWindow> DrawRounded for DrawWindow<CW> {
+impl<CW: CustomWindow> DrawableRounded for DrawWindow<CW> {
     #[inline]
     fn rounded_line(&mut self, pass: Pass, p1: Vec2, p2: Vec2, radius: f32, col: Rgba) {
         self.flat_round.line(pass, p1, p2, radius, col);
@@ -423,7 +426,7 @@ impl<CW: CustomWindow> DrawRounded for DrawWindow<CW> {
     }
 }
 
-impl<CW: CustomWindow> DrawShaded for DrawWindow<CW> {
+impl<CW: CustomWindow> DrawableShaded for DrawWindow<CW> {
     #[inline]
     fn shaded_square(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba) {
         self.shaded_square

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use kas::cast::Cast;
-use kas::draw::{SizeHandle, ThemeApi};
+use kas::draw::{Draw, SizeHandle, ThemeApi};
 use kas::event::{CursorIcon, ManagerState, UpdateHandle};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
@@ -329,7 +329,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
             // Safety: lifetimes do not escape the returned draw_handle value.
             let draw_shared = extend_lifetime(&mut shared.draw);
-            let draw = extend_lifetime(&mut self.draw);
+            let draw = Draw::new(extend_lifetime(&mut self.draw));
             let window = extend_lifetime(&mut self.theme_window);
 
             let mut draw_handle = shared.theme.draw_handle(draw_shared, draw, window);
@@ -338,10 +338,11 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
         #[cfg(feature = "gat")]
         {
+            let draw = Draw::new(&mut self.draw);
             let mut draw_handle =
                 shared
                     .theme
-                    .draw_handle(&mut shared.draw, &mut self.draw, &mut self.theme_window);
+                    .draw_handle(&mut shared.draw, draw, &mut self.theme_window);
             self.widget.draw(&mut draw_handle, &self.mgr, false);
         }
 

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use kas::cast::Cast;
-use kas::draw::{Draw, SizeHandle, ThemeApi};
+use kas::draw::{Draw, Pass, SizeHandle, ThemeApi};
 use kas::event::{CursorIcon, ManagerState, UpdateHandle};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
@@ -329,7 +329,8 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
             // Safety: lifetimes do not escape the returned draw_handle value.
             let draw_shared = extend_lifetime(&mut shared.draw);
-            let draw = Draw::new(extend_lifetime(&mut self.draw));
+            let pass = Pass::new(0);
+            let draw = Draw::new(extend_lifetime(&mut self.draw), pass);
             let window = extend_lifetime(&mut self.theme_window);
 
             let mut draw_handle = shared.theme.draw_handle(draw_shared, draw, window);
@@ -338,7 +339,8 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
         #[cfg(feature = "gat")]
         {
-            let draw = Draw::new(&mut self.draw);
+            let pass = Pass::new(0);
+            let draw = Draw::new(&mut self.draw, pass);
             let mut draw_handle =
                 shared
                     .theme

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -187,10 +187,8 @@ impl<'a, D: DrawableShaded + ?Sized> Draw<'a, D> {
 
 /// Base abstraction over drawing
 ///
-/// Unlike [`DrawHandle`], coordinates are specified via a [`Vec2`] and
-/// rectangular regions via [`Quad`]. The same coordinate system is used, hence
-/// type conversions can be performed with `from` and `into`. Integral
-/// coordinates align with pixels, non-integral coordinates may also be used.
+/// Coordinates are specified via a [`Vec2`] and rectangular regions via
+/// [`Quad`] allowing fractional positions.
 ///
 /// All draw operations may be batched; when drawn primitives overlap, the
 /// results are only loosely defined. Draw operations involving transparency

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -14,13 +14,14 @@ use crate::geom::{Quad, Rect, Vec2};
 /// Interface over a (local) draw object
 pub struct Draw<'a, D: Drawable> {
     pub draw: &'a mut D,
+    pass: Pass,
 }
 
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 impl<'a, D: Drawable> Draw<'a, D> {
     /// Construct
-    pub fn new(draw: &'a mut D) -> Self {
-        Draw { draw }
+    pub fn new(draw: &'a mut D, pass: Pass) -> Self {
+        Draw { draw, pass }
     }
 }
 
@@ -32,34 +33,44 @@ impl<'a, D: Drawable> Draw<'a, D> {
     {
         Draw {
             draw: &mut *self.draw,
+            pass: self.pass,
         }
     }
 
-    /// Add a clip region
+    /// Get current pass
+    pub fn pass(&self) -> Pass {
+        self.pass
+    }
+
+    /// Construct a clip region
     ///
     /// A clip region is a draw target within the same window with a new scissor
     /// rect (i.e. draw operations will be clipped to this `rect`).
-    pub fn add_clip_region(&mut self, pass: Pass, rect: Rect, class: RegionClass) -> Pass {
-        self.draw.add_clip_region(pass, rect, class)
+    pub fn new_clip_region<'b>(&'b mut self, rect: Rect, class: RegionClass) -> Draw<'b, D> {
+        let pass = self.draw.add_clip_region(self.pass, rect, class);
+        Draw {
+            draw: &mut *self.draw,
+            pass,
+        }
     }
 
-    /// Get drawable rect for a clip region
+    /// Get drawable rect for current target
     ///
     /// (This may be smaller than the rect passed to [`Drawable::add_clip_region`].)
-    pub fn get_clip_rect(&self, pass: Pass) -> Rect {
-        self.draw.get_clip_rect(pass)
+    pub fn clip_rect(&self) -> Rect {
+        self.draw.get_clip_rect(self.pass)
     }
 
     /// Draw a rectangle of uniform colour
-    pub fn rect(&mut self, pass: Pass, rect: Quad, col: Rgba) {
-        self.draw.rect(pass, rect, col);
+    pub fn rect(&mut self, rect: Quad, col: Rgba) {
+        self.draw.rect(self.pass, rect, col);
     }
 
     /// Draw a frame of uniform colour
     ///
     /// The frame is defined by the area inside `outer` and not inside `inner`.
-    pub fn frame(&mut self, pass: Pass, outer: Quad, inner: Quad, col: Rgba) {
-        self.draw.frame(pass, outer, inner, col);
+    pub fn frame(&mut self, outer: Quad, inner: Quad, col: Rgba) {
+        self.draw.frame(self.pass, outer, inner, col);
     }
 }
 
@@ -72,8 +83,8 @@ impl<'a, D: DrawableRounded> Draw<'a, D> {
     ///
     /// Note that for rectangular, axis-aligned lines, [`Drawable::rect`] should be
     /// preferred.
-    pub fn rounded_line(&mut self, pass: Pass, p1: Vec2, p2: Vec2, radius: f32, col: Rgba) {
-        self.draw.rounded_line(pass, p1, p2, radius, col);
+    pub fn rounded_line(&mut self, p1: Vec2, p2: Vec2, radius: f32, col: Rgba) {
+        self.draw.rounded_line(self.pass, p1, p2, radius, col);
     }
 
     /// Draw a circle or oval of uniform colour
@@ -83,8 +94,8 @@ impl<'a, D: DrawableRounded> Draw<'a, D> {
     /// The `inner_radius` parameter gives the inner radius relative to the
     /// outer radius: a value of `0.0` will result in the whole shape being
     /// painted, while `1.0` will result in a zero-width line on the outer edge.
-    pub fn circle(&mut self, pass: Pass, rect: Quad, inner_radius: f32, col: Rgba) {
-        self.draw.circle(pass, rect, inner_radius, col);
+    pub fn circle(&mut self, rect: Quad, inner_radius: f32, col: Rgba) {
+        self.draw.circle(self.pass, rect, inner_radius, col);
     }
 
     /// Draw a frame with rounded corners and uniform colour
@@ -98,34 +109,26 @@ impl<'a, D: DrawableRounded> Draw<'a, D> {
     /// painted, while `1.0` will result in a zero-width line on the outer edge.
     /// When `inner_radius > 0`, the frame will be visually thinner than the
     /// allocated area.
-    pub fn rounded_frame(
-        &mut self,
-        pass: Pass,
-        outer: Quad,
-        inner: Quad,
-        inner_radius: f32,
-        col: Rgba,
-    ) {
+    pub fn rounded_frame(&mut self, outer: Quad, inner: Quad, inner_radius: f32, col: Rgba) {
         self.draw
-            .rounded_frame(pass, outer, inner, inner_radius, col);
+            .rounded_frame(self.pass, outer, inner, inner_radius, col);
     }
 }
 
 impl<'a, D: DrawableShaded> Draw<'a, D> {
     /// Add a shaded square to the draw buffer
-    pub fn shaded_square(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba) {
-        self.draw.shaded_square(pass, rect, norm, col);
+    pub fn shaded_square(&mut self, rect: Quad, norm: (f32, f32), col: Rgba) {
+        self.draw.shaded_square(self.pass, rect, norm, col);
     }
 
     /// Add a shaded circle to the draw buffer
-    pub fn shaded_circle(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba) {
-        self.draw.shaded_circle(pass, rect, norm, col);
+    pub fn shaded_circle(&mut self, rect: Quad, norm: (f32, f32), col: Rgba) {
+        self.draw.shaded_circle(self.pass, rect, norm, col);
     }
 
     /// Add a square shaded frame to the draw buffer.
     pub fn shaded_square_frame(
         &mut self,
-        pass: Pass,
         outer: Quad,
         inner: Quad,
         norm: (f32, f32),
@@ -133,19 +136,13 @@ impl<'a, D: DrawableShaded> Draw<'a, D> {
         inner_col: Rgba,
     ) {
         self.draw
-            .shaded_square_frame(pass, outer, inner, norm, outer_col, inner_col);
+            .shaded_square_frame(self.pass, outer, inner, norm, outer_col, inner_col);
     }
 
     /// Add a rounded shaded frame to the draw buffer.
-    pub fn shaded_round_frame(
-        &mut self,
-        pass: Pass,
-        outer: Quad,
-        inner: Quad,
-        norm: (f32, f32),
-        col: Rgba,
-    ) {
-        self.draw.shaded_round_frame(pass, outer, inner, norm, col);
+    pub fn shaded_round_frame(&mut self, outer: Quad, inner: Quad, norm: (f32, f32), col: Rgba) {
+        self.draw
+            .shaded_round_frame(self.pass, outer, inner, norm, col);
     }
 }
 

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -46,9 +46,9 @@ impl<'a, D: Drawable + ?Sized> Draw<'a, D> {
 impl<'a> Draw<'a, dyn Any> {
     /// Attempt to downcast to a derived type
     ///
-    /// This method does not support casting to trait object types (e.g.
-    /// `dyn Drawable`); instead one must use the shell's implementing type,
-    /// e.g. `kas_wgpu::draw::DrawWindow<()>`.
+    /// Rust does not (yet) support casting to trait object types (e.g.
+    /// `dyn Drawable`); instead we can only downcast to the shell's
+    /// implementing type, e.g. `kas_wgpu::draw::DrawWindow<()>`.
     pub fn downcast<'b, D>(&'b mut self) -> Option<Draw<'b, D>>
     where
         'a: 'b,
@@ -57,16 +57,14 @@ impl<'a> Draw<'a, dyn Any> {
         let pass = self.pass;
         self.draw.downcast_mut().map(|draw| Draw { draw, pass })
     }
-
-    // TODO: support unsized (dyn trait) downcast to boxed value (unsafe)
 }
 
 impl<'a> Draw<'a, dyn Drawable> {
     /// Attempt to downcast to a derived type
     ///
-    /// This method does not support casting to trait object types (e.g.
-    /// `dyn Drawable`); instead one must use the shell's implementing type,
-    /// e.g. `kas_wgpu::draw::DrawWindow<()>`.
+    /// Rust does not (yet) support casting to trait object types (e.g.
+    /// `dyn Drawable`); instead we can only downcast to the shell's
+    /// implementing type, e.g. `kas_wgpu::draw::DrawWindow<()>`.
     pub fn downcast<'b, D>(&'b mut self) -> Option<Draw<'b, D>>
     where
         'a: 'b,

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -1,0 +1,133 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Drawing APIs — draw interface
+
+use std::any::Any;
+
+use super::color::Rgba;
+use super::{Pass, RegionClass};
+use crate::geom::{Quad, Rect, Vec2};
+
+/// Base abstraction over drawing
+///
+/// Unlike [`DrawHandle`], coordinates are specified via a [`Vec2`] and
+/// rectangular regions via [`Quad`]. The same coordinate system is used, hence
+/// type conversions can be performed with `from` and `into`. Integral
+/// coordinates align with pixels, non-integral coordinates may also be used.
+///
+/// All draw operations may be batched; when drawn primitives overlap, the
+/// results are only loosely defined. Draw operations involving transparency
+/// should be ordered after those without transparency.
+///
+/// Draw operations take place over multiple render passes, identified by a
+/// handle of type [`Pass`]. In general the user only needs to pass this value
+/// into methods as required. [`Draw::add_clip_region`] creates a new [`Pass`].
+pub trait Draw: Any {
+    /// Cast self to [`std::any::Any`] reference.
+    ///
+    /// A downcast on this value may be used to obtain a reference to a
+    /// shell-specific API.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+
+    /// Add a clip region
+    ///
+    /// Clip regions are cleared each frame and so must be recreated on demand.
+    fn add_clip_region(&mut self, pass: Pass, rect: Rect, class: RegionClass) -> Pass;
+
+    /// Get drawable rect for a clip region
+    ///
+    /// (This may be smaller than the rect passed to [`Draw::add_clip_region`].)
+    fn get_clip_rect(&self, pass: Pass) -> Rect;
+
+    /// Draw a rectangle of uniform colour
+    fn rect(&mut self, pass: Pass, rect: Quad, col: Rgba);
+
+    /// Draw a frame of uniform colour
+    ///
+    /// The frame is defined by the area inside `outer` and not inside `inner`.
+    fn frame(&mut self, pass: Pass, outer: Quad, inner: Quad, col: Rgba);
+}
+
+/// Drawing commands for rounded shapes
+///
+/// This trait is an extension over [`Draw`] providing rounded shapes.
+///
+/// The primitives provided by this trait are partially transparent.
+/// If the implementation buffers draw commands, it should draw these
+/// primitives after solid primitives.
+pub trait DrawRounded: Draw {
+    /// Draw a line with rounded ends and uniform colour
+    ///
+    /// This command draws a line segment between the points `p1` and `p2`.
+    /// Pixels within the given `radius` of this segment are drawn, resulting
+    /// in rounded ends and width `2 * radius`.
+    ///
+    /// Note that for rectangular, axis-aligned lines, [`Draw::rect`] should be
+    /// preferred.
+    fn rounded_line(&mut self, pass: Pass, p1: Vec2, p2: Vec2, radius: f32, col: Rgba);
+
+    /// Draw a circle or oval of uniform colour
+    ///
+    /// More generally, this shape is an axis-aligned oval which may be hollow.
+    ///
+    /// The `inner_radius` parameter gives the inner radius relative to the
+    /// outer radius: a value of `0.0` will result in the whole shape being
+    /// painted, while `1.0` will result in a zero-width line on the outer edge.
+    fn circle(&mut self, pass: Pass, rect: Quad, inner_radius: f32, col: Rgba);
+
+    /// Draw a frame with rounded corners and uniform colour
+    ///
+    /// All drawing occurs within the `outer` rect and outside of the `inner`
+    /// rect. Corners are circular (or more generally, ovular), centered on the
+    /// inner corners.
+    ///
+    /// The `inner_radius` parameter gives the inner radius relative to the
+    /// outer radius: a value of `0.0` will result in the whole shape being
+    /// painted, while `1.0` will result in a zero-width line on the outer edge.
+    /// When `inner_radius > 0`, the frame will be visually thinner than the
+    /// allocated area.
+    fn rounded_frame(&mut self, pass: Pass, outer: Quad, inner: Quad, inner_radius: f32, col: Rgba);
+}
+
+/// Drawing commands for shaded shapes
+///
+/// This trait is an extension over [`Draw`] providing solid shaded shapes.
+///
+/// Some drawing primitives (the "round" ones) are partially transparent.
+/// If the implementation buffers draw commands, it should draw these
+/// primitives after solid primitives.
+///
+/// These are parameterised via a pair of normals, `(inner, outer)`. These may
+/// have values from the closed range `[-1, 1]`, where -1 points inwards,
+/// 0 is perpendicular to the screen towards the viewer, and 1 points outwards.
+pub trait DrawShaded: Draw {
+    /// Add a shaded square to the draw buffer
+    fn shaded_square(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba);
+
+    /// Add a shaded circle to the draw buffer
+    fn shaded_circle(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba);
+
+    /// Add a square shaded frame to the draw buffer.
+    fn shaded_square_frame(
+        &mut self,
+        pass: Pass,
+        outer: Quad,
+        inner: Quad,
+        norm: (f32, f32),
+        outer_col: Rgba,
+        inner_col: Rgba,
+    );
+
+    /// Add a rounded shaded frame to the draw buffer.
+    fn shaded_round_frame(
+        &mut self,
+        pass: Pass,
+        outer: Quad,
+        inner: Quad,
+        norm: (f32, f32),
+        col: Rgba,
+    );
+}

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -228,7 +228,7 @@ impl<'a, D: DrawableShaded + ?Sized> Draw<'a, D> {
 /// into methods as required. [`Drawable::add_clip_region`] creates a new [`Pass`].
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 pub trait Drawable: Any {
-    /// Cast self to [`Any`] referfence
+    /// Cast self to [`Any`] reference
     ///
     /// A downcast on this value may be used to obtain a reference to a
     /// shell-specific API.

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -11,6 +11,144 @@ use super::color::Rgba;
 use super::{Pass, RegionClass};
 use crate::geom::{Quad, Rect, Vec2};
 
+/// Interface over a (local) draw object
+pub struct Draw<'a, D: Drawable> {
+    pub draw: &'a mut D,
+}
+
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+impl<'a, D: Drawable> Draw<'a, D> {
+    /// Construct
+    pub fn new(draw: &'a mut D) -> Self {
+        Draw { draw }
+    }
+}
+
+impl<'a, D: Drawable> Draw<'a, D> {
+    /// Reborrow with a new lifetime
+    pub fn reborrow<'b>(&'b mut self) -> Draw<'b, D>
+    where
+        'a: 'b,
+    {
+        Draw {
+            draw: &mut *self.draw,
+        }
+    }
+
+    /// Add a clip region
+    ///
+    /// A clip region is a draw target within the same window with a new scissor
+    /// rect (i.e. draw operations will be clipped to this `rect`).
+    pub fn add_clip_region(&mut self, pass: Pass, rect: Rect, class: RegionClass) -> Pass {
+        self.draw.add_clip_region(pass, rect, class)
+    }
+
+    /// Get drawable rect for a clip region
+    ///
+    /// (This may be smaller than the rect passed to [`Drawable::add_clip_region`].)
+    pub fn get_clip_rect(&self, pass: Pass) -> Rect {
+        self.draw.get_clip_rect(pass)
+    }
+
+    /// Draw a rectangle of uniform colour
+    pub fn rect(&mut self, pass: Pass, rect: Quad, col: Rgba) {
+        self.draw.rect(pass, rect, col);
+    }
+
+    /// Draw a frame of uniform colour
+    ///
+    /// The frame is defined by the area inside `outer` and not inside `inner`.
+    pub fn frame(&mut self, pass: Pass, outer: Quad, inner: Quad, col: Rgba) {
+        self.draw.frame(pass, outer, inner, col);
+    }
+}
+
+impl<'a, D: DrawableRounded> Draw<'a, D> {
+    /// Draw a line with rounded ends and uniform colour
+    ///
+    /// This command draws a line segment between the points `p1` and `p2`.
+    /// Pixels within the given `radius` of this segment are drawn, resulting
+    /// in rounded ends and width `2 * radius`.
+    ///
+    /// Note that for rectangular, axis-aligned lines, [`Drawable::rect`] should be
+    /// preferred.
+    pub fn rounded_line(&mut self, pass: Pass, p1: Vec2, p2: Vec2, radius: f32, col: Rgba) {
+        self.draw.rounded_line(pass, p1, p2, radius, col);
+    }
+
+    /// Draw a circle or oval of uniform colour
+    ///
+    /// More generally, this shape is an axis-aligned oval which may be hollow.
+    ///
+    /// The `inner_radius` parameter gives the inner radius relative to the
+    /// outer radius: a value of `0.0` will result in the whole shape being
+    /// painted, while `1.0` will result in a zero-width line on the outer edge.
+    pub fn circle(&mut self, pass: Pass, rect: Quad, inner_radius: f32, col: Rgba) {
+        self.draw.circle(pass, rect, inner_radius, col);
+    }
+
+    /// Draw a frame with rounded corners and uniform colour
+    ///
+    /// All drawing occurs within the `outer` rect and outside of the `inner`
+    /// rect. Corners are circular (or more generally, ovular), centered on the
+    /// inner corners.
+    ///
+    /// The `inner_radius` parameter gives the inner radius relative to the
+    /// outer radius: a value of `0.0` will result in the whole shape being
+    /// painted, while `1.0` will result in a zero-width line on the outer edge.
+    /// When `inner_radius > 0`, the frame will be visually thinner than the
+    /// allocated area.
+    pub fn rounded_frame(
+        &mut self,
+        pass: Pass,
+        outer: Quad,
+        inner: Quad,
+        inner_radius: f32,
+        col: Rgba,
+    ) {
+        self.draw
+            .rounded_frame(pass, outer, inner, inner_radius, col);
+    }
+}
+
+impl<'a, D: DrawableShaded> Draw<'a, D> {
+    /// Add a shaded square to the draw buffer
+    pub fn shaded_square(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba) {
+        self.draw.shaded_square(pass, rect, norm, col);
+    }
+
+    /// Add a shaded circle to the draw buffer
+    pub fn shaded_circle(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba) {
+        self.draw.shaded_circle(pass, rect, norm, col);
+    }
+
+    /// Add a square shaded frame to the draw buffer.
+    pub fn shaded_square_frame(
+        &mut self,
+        pass: Pass,
+        outer: Quad,
+        inner: Quad,
+        norm: (f32, f32),
+        outer_col: Rgba,
+        inner_col: Rgba,
+    ) {
+        self.draw
+            .shaded_square_frame(pass, outer, inner, norm, outer_col, inner_col);
+    }
+
+    /// Add a rounded shaded frame to the draw buffer.
+    pub fn shaded_round_frame(
+        &mut self,
+        pass: Pass,
+        outer: Quad,
+        inner: Quad,
+        norm: (f32, f32),
+        col: Rgba,
+    ) {
+        self.draw.shaded_round_frame(pass, outer, inner, norm, col);
+    }
+}
+
 /// Base abstraction over drawing
 ///
 /// Unlike [`DrawHandle`], coordinates are specified via a [`Vec2`] and
@@ -24,8 +162,9 @@ use crate::geom::{Quad, Rect, Vec2};
 ///
 /// Draw operations take place over multiple render passes, identified by a
 /// handle of type [`Pass`]. In general the user only needs to pass this value
-/// into methods as required. [`Draw::add_clip_region`] creates a new [`Pass`].
-pub trait Draw: Any {
+/// into methods as required. [`Drawable::add_clip_region`] creates a new [`Pass`].
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+pub trait Drawable: Any {
     /// Cast self to [`std::any::Any`] reference.
     ///
     /// A downcast on this value may be used to obtain a reference to a
@@ -33,21 +172,17 @@ pub trait Draw: Any {
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
     /// Add a clip region
-    ///
-    /// Clip regions are cleared each frame and so must be recreated on demand.
     fn add_clip_region(&mut self, pass: Pass, rect: Rect, class: RegionClass) -> Pass;
 
     /// Get drawable rect for a clip region
     ///
-    /// (This may be smaller than the rect passed to [`Draw::add_clip_region`].)
+    /// (This may be smaller than the rect passed to [`Drawable::add_clip_region`].)
     fn get_clip_rect(&self, pass: Pass) -> Rect;
 
     /// Draw a rectangle of uniform colour
     fn rect(&mut self, pass: Pass, rect: Quad, col: Rgba);
 
     /// Draw a frame of uniform colour
-    ///
-    /// The frame is defined by the area inside `outer` and not inside `inner`.
     fn frame(&mut self, pass: Pass, outer: Quad, inner: Quad, col: Rgba);
 }
 
@@ -58,43 +193,21 @@ pub trait Draw: Any {
 /// The primitives provided by this trait are partially transparent.
 /// If the implementation buffers draw commands, it should draw these
 /// primitives after solid primitives.
-pub trait DrawRounded: Draw {
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+pub trait DrawableRounded: Drawable {
     /// Draw a line with rounded ends and uniform colour
-    ///
-    /// This command draws a line segment between the points `p1` and `p2`.
-    /// Pixels within the given `radius` of this segment are drawn, resulting
-    /// in rounded ends and width `2 * radius`.
-    ///
-    /// Note that for rectangular, axis-aligned lines, [`Draw::rect`] should be
-    /// preferred.
     fn rounded_line(&mut self, pass: Pass, p1: Vec2, p2: Vec2, radius: f32, col: Rgba);
 
     /// Draw a circle or oval of uniform colour
-    ///
-    /// More generally, this shape is an axis-aligned oval which may be hollow.
-    ///
-    /// The `inner_radius` parameter gives the inner radius relative to the
-    /// outer radius: a value of `0.0` will result in the whole shape being
-    /// painted, while `1.0` will result in a zero-width line on the outer edge.
     fn circle(&mut self, pass: Pass, rect: Quad, inner_radius: f32, col: Rgba);
 
     /// Draw a frame with rounded corners and uniform colour
-    ///
-    /// All drawing occurs within the `outer` rect and outside of the `inner`
-    /// rect. Corners are circular (or more generally, ovular), centered on the
-    /// inner corners.
-    ///
-    /// The `inner_radius` parameter gives the inner radius relative to the
-    /// outer radius: a value of `0.0` will result in the whole shape being
-    /// painted, while `1.0` will result in a zero-width line on the outer edge.
-    /// When `inner_radius > 0`, the frame will be visually thinner than the
-    /// allocated area.
     fn rounded_frame(&mut self, pass: Pass, outer: Quad, inner: Quad, inner_radius: f32, col: Rgba);
 }
 
 /// Drawing commands for shaded shapes
 ///
-/// This trait is an extension over [`Draw`] providing solid shaded shapes.
+/// This trait is an extension over [`Drawable`] providing solid shaded shapes.
 ///
 /// Some drawing primitives (the "round" ones) are partially transparent.
 /// If the implementation buffers draw commands, it should draw these
@@ -103,7 +216,8 @@ pub trait DrawRounded: Draw {
 /// These are parameterised via a pair of normals, `(inner, outer)`. These may
 /// have values from the closed range `[-1, 1]`, where -1 points inwards,
 /// 0 is perpendicular to the screen towards the viewer, and 1 points outwards.
-pub trait DrawShaded: Draw {
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+pub trait DrawableShaded: Drawable {
     /// Add a shaded square to the draw buffer
     fn shaded_square(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba);
 

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -29,7 +29,7 @@ impl<DS: DrawableShared> DrawShared<DS> {
 impl<DS: DrawableShared> DrawShared<DS> {
     /// Allocate an image
     ///
-    /// Use [`DrawShared::upload`] to set contents of the new image.
+    /// Use [`DrawShared::image_upload`] to set contents of the new image.
     #[inline]
     pub fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
         self.draw.image_alloc(size)
@@ -120,7 +120,7 @@ pub trait DrawableShared: 'static {
 
     /// Allocate an image
     ///
-    /// Use [`DrawableShared::upload`] to set contents of the new image.
+    /// Use [`DrawableShared::image_upload`] to set contents of the new image.
     fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError>;
 
     /// Upload an image to the GPU

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -12,14 +12,20 @@ use crate::text::{Effect, TextDisplay};
 use std::path::Path;
 
 /// Interface over a shared draw object
+///
+/// A single [`DrawShared`] instance is shared by all windows and draw contexts.
+/// This struct is built over a [`DrawableShared`] object provided by the shell,
+/// which may be accessed directly for a lower-level API (though most methods
+/// are available through [`DrawShared`] directly).
 pub struct DrawShared<DS: DrawableShared> {
+    /// The shell's [`DrawableShared`] object
     pub draw: DS,
     images: images::Images,
 }
 
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 impl<DS: DrawableShared> DrawShared<DS> {
-    /// Construct
+    /// Construct (this is only called by the shell)
     pub fn new(draw: DS) -> Self {
         let images = images::Images::new();
         DrawShared { draw, images }

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -6,7 +6,7 @@
 //! Drawing APIs — shared draw state
 
 use super::color::Rgba;
-use super::{images, Draw, Drawable, ImageError, ImageFormat, ImageId, Pass};
+use super::{images, Draw, Drawable, ImageError, ImageFormat, ImageId};
 use crate::geom::{Quad, Size, Vec2};
 use crate::text::{Effect, TextDisplay};
 use std::path::Path;
@@ -70,20 +70,13 @@ impl<DS: DrawableShared> DrawShared<DS> {
     }
 
     /// Draw the image in the given `rect`
-    pub fn draw_image(&self, target: Draw<DS::Draw>, pass: Pass, id: ImageId, rect: Quad) {
-        self.draw.draw_image(target, pass, id, rect)
+    pub fn draw_image(&self, target: Draw<DS::Draw>, id: ImageId, rect: Quad) {
+        self.draw.draw_image(target, id, rect)
     }
 
     /// Draw text with a colour
-    pub fn draw_text(
-        &mut self,
-        target: Draw<DS::Draw>,
-        pass: Pass,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-    ) {
-        self.draw.draw_text(target, pass, pos, text, col)
+    pub fn draw_text(&mut self, target: Draw<DS::Draw>, pos: Vec2, text: &TextDisplay, col: Rgba) {
+        self.draw.draw_text(target, pos, text, col)
     }
 
     /// Draw text with a colour and effects
@@ -93,14 +86,13 @@ impl<DS: DrawableShared> DrawShared<DS> {
     pub fn draw_text_col_effects(
         &mut self,
         target: Draw<DS::Draw>,
-        pass: Pass,
         pos: Vec2,
         text: &TextDisplay,
         col: Rgba,
         effects: &[Effect<()>],
     ) {
         self.draw
-            .draw_text_col_effects(target, pass, pos, text, col, effects)
+            .draw_text_col_effects(target, pos, text, col, effects)
     }
 
     /// Draw text with effects
@@ -111,13 +103,11 @@ impl<DS: DrawableShared> DrawShared<DS> {
     pub fn draw_text_effects(
         &mut self,
         target: Draw<DS::Draw>,
-        pass: Pass,
         pos: Vec2,
         text: &TextDisplay,
         effects: &[Effect<Rgba>],
     ) {
-        self.draw
-            .draw_text_effects(target, pass, pos, text, effects)
+        self.draw.draw_text_effects(target, pos, text, effects)
     }
 }
 
@@ -146,17 +136,10 @@ pub trait DrawableShared: 'static {
     fn image_size(&self, id: ImageId) -> Option<(u32, u32)>;
 
     /// Draw the image in the given `rect`
-    fn draw_image(&self, target: Draw<Self::Draw>, pass: Pass, id: ImageId, rect: Quad);
+    fn draw_image(&self, target: Draw<Self::Draw>, id: ImageId, rect: Quad);
 
     /// Draw text with a colour
-    fn draw_text(
-        &mut self,
-        target: Draw<Self::Draw>,
-        pass: Pass,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-    );
+    fn draw_text(&mut self, target: Draw<Self::Draw>, pos: Vec2, text: &TextDisplay, col: Rgba);
 
     /// Draw text with a colour and effects
     ///
@@ -165,7 +148,6 @@ pub trait DrawableShared: 'static {
     fn draw_text_col_effects(
         &mut self,
         target: Draw<Self::Draw>,
-        pass: Pass,
         pos: Vec2,
         text: &TextDisplay,
         col: Rgba,
@@ -180,7 +162,6 @@ pub trait DrawableShared: 'static {
     fn draw_text_effects(
         &mut self,
         target: Draw<Self::Draw>,
-        pass: Pass,
         pos: Vec2,
         text: &TextDisplay,
         effects: &[Effect<Rgba>],

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -1,0 +1,186 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Drawing APIs — shared draw state
+
+use super::color::Rgba;
+use super::{images, Draw, ImageError, ImageFormat, ImageId, Pass};
+use crate::geom::{Quad, Size, Vec2};
+use crate::text::{Effect, TextDisplay};
+use std::path::Path;
+
+/// Interface over a shared draw object
+pub struct DrawShared<DS: DrawableShared> {
+    pub draw: DS,
+    images: images::Images,
+}
+
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+impl<DS: DrawableShared> DrawShared<DS> {
+    /// Construct
+    pub fn new(draw: DS) -> Self {
+        let images = images::Images::new();
+        DrawShared { draw, images }
+    }
+}
+
+impl<DS: DrawableShared> DrawShared<DS> {
+    /// Allocate an image
+    ///
+    /// Use [`DrawShared::upload`] to set contents of the new image.
+    pub fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
+        self.draw.image_alloc(size)
+    }
+
+    /// Upload an image to the GPU
+    ///
+    /// This should be called at least once on each image before display. May be
+    /// called again to update the image contents.
+    pub fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat) {
+        self.draw.image_upload(id, data, format);
+    }
+
+    /// Load an image from a path, autodetecting file type
+    ///
+    /// This deduplicates multiple loads of the same path, instead incrementing
+    /// a reference count.
+    pub fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError> {
+        self.images.load_path(&mut self.draw, path)
+    }
+
+    /// Remove a loaded image, by path
+    ///
+    /// This reduces the reference count and frees if zero.
+    pub fn remove_image_from_path(&mut self, path: &Path) {
+        self.images.remove_path(&mut self.draw, path);
+    }
+
+    /// Free an image
+    pub fn remove_image(&mut self, id: ImageId) {
+        self.images.remove_id(&mut self.draw, id);
+    }
+
+    /// Get the size of an image
+    pub fn image_size(&self, id: ImageId) -> Option<Size> {
+        self.draw.image_size(id).map(|size| size.into())
+    }
+
+    /// Draw the image in the given `rect`
+    pub fn draw_image(&self, window: &mut DS::Draw, pass: Pass, id: ImageId, rect: Quad) {
+        self.draw.draw_image(window, pass, id, rect)
+    }
+
+    /// Draw text with a colour
+    pub fn draw_text(
+        &mut self,
+        window: &mut DS::Draw,
+        pass: Pass,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+    ) {
+        self.draw.draw_text(window, pass, pos, text, col)
+    }
+
+    /// Draw text with a colour and effects
+    ///
+    /// The effects list does not contain colour information, but may contain
+    /// underlining/strikethrough information. It may be empty.
+    pub fn draw_text_col_effects(
+        &mut self,
+        window: &mut DS::Draw,
+        pass: Pass,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+        effects: &[Effect<()>],
+    ) {
+        self.draw
+            .draw_text_col_effects(window, pass, pos, text, col, effects)
+    }
+
+    /// Draw text with effects
+    ///
+    /// The `effects` list provides both underlining and colour information.
+    /// If the `effects` list is empty or the first entry has `start > 0`, a
+    /// default entity will be assumed.
+    pub fn draw_text_effects(
+        &mut self,
+        window: &mut DS::Draw,
+        pass: Pass,
+        pos: Vec2,
+        text: &TextDisplay,
+        effects: &[Effect<Rgba>],
+    ) {
+        self.draw
+            .draw_text_effects(window, pass, pos, text, effects)
+    }
+}
+
+/// Trait over shared data of draw object
+///
+/// This is typically used via [`DrawShared`].
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+pub trait DrawableShared: 'static {
+    type Draw: Draw;
+
+    /// Allocate an image
+    ///
+    /// Use [`DrawableShared::upload`] to set contents of the new image.
+    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError>;
+
+    /// Upload an image to the GPU
+    ///
+    /// This should be called at least once on each image before display. May be
+    /// called again to update the image contents.
+    fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat);
+
+    /// Free an image allocation
+    fn image_free(&mut self, id: ImageId);
+
+    /// Query an image's size
+    fn image_size(&self, id: ImageId) -> Option<(u32, u32)>;
+
+    /// Draw the image in the given `rect`
+    fn draw_image(&self, window: &mut Self::Draw, pass: Pass, id: ImageId, rect: Quad);
+
+    /// Draw text with a colour
+    fn draw_text(
+        &mut self,
+        window: &mut Self::Draw,
+        pass: Pass,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+    );
+
+    /// Draw text with a colour and effects
+    ///
+    /// The effects list does not contain colour information, but may contain
+    /// underlining/strikethrough information. It may be empty.
+    fn draw_text_col_effects(
+        &mut self,
+        window: &mut Self::Draw,
+        pass: Pass,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+        effects: &[Effect<()>],
+    );
+
+    /// Draw text with effects
+    ///
+    /// The `effects` list provides both underlining and colour information.
+    /// If the `effects` list is empty or the first entry has `start > 0`, a
+    /// default entity will be assumed.
+    fn draw_text_effects(
+        &mut self,
+        window: &mut Self::Draw,
+        pass: Pass,
+        pos: Vec2,
+        text: &TextDisplay,
+        effects: &[Effect<Rgba>],
+    );
+}

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -9,6 +9,7 @@ use super::color::Rgba;
 use super::{images, Draw, Drawable, ImageError, ImageFormat, ImageId};
 use crate::geom::{Quad, Size, Vec2};
 use crate::text::{Effect, TextDisplay};
+use std::any::Any;
 use std::path::Path;
 
 /// Interface over a shared draw object
@@ -121,8 +122,11 @@ impl<DS: DrawableShared> DrawShared<DS> {
 ///
 /// This is typically used via [`DrawShared`].
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-pub trait DrawableShared: 'static {
+pub trait DrawableShared: Any {
     type Draw: Drawable;
+
+    /// Cast self to [`Any`] reference
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 
     /// Allocate an image
     ///

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -295,7 +295,7 @@ pub trait DrawHandle {
     /// Add a clip region
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    fn add_clip_region(
+    fn with_clip_region(
         &mut self,
         rect: Rect,
         offset: Offset,
@@ -440,7 +440,7 @@ pub trait DrawHandleExt: DrawHandle {
     /// All content drawn by the new region is clipped to the intersection of
     /// `rect` and the current target ([`DrawHandle::target_rect`]).
     fn clip_region(&mut self, rect: Rect, offset: Offset, f: &mut dyn FnMut(&mut dyn DrawHandle)) {
-        self.add_clip_region(rect, offset, RegionClass::ScrollRegion, f);
+        self.with_clip_region(rect, offset, RegionClass::ScrollRegion, f);
     }
 
     /// Draw to an overlay (e.g. for pop-up menus)
@@ -454,7 +454,7 @@ pub trait DrawHandleExt: DrawHandle {
     /// beyond the bounds of the window, it will be silently reduced to that of
     /// the window.
     fn overlay(&mut self, rect: Rect, f: &mut dyn FnMut(&mut dyn DrawHandle)) {
-        self.add_clip_region(rect, Offset::ZERO, RegionClass::Overlay, f);
+        self.with_clip_region(rect, Offset::ZERO, RegionClass::Overlay, f);
     }
 
     /// Draw some text using the standard font, with a subset selected
@@ -653,14 +653,14 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Drawable) {
         self.deref_mut().draw_device()
     }
-    fn add_clip_region(
+    fn with_clip_region(
         &mut self,
         rect: Rect,
         offset: Offset,
         class: RegionClass,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     ) {
-        self.deref_mut().add_clip_region(rect, offset, class, f);
+        self.deref_mut().with_clip_region(rect, offset, class, f);
     }
     fn target_rect(&self) -> Rect {
         self.deref().target_rect()
@@ -739,14 +739,14 @@ where
     fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Drawable) {
         self.deref_mut().draw_device()
     }
-    fn add_clip_region(
+    fn with_clip_region(
         &mut self,
         rect: Rect,
         offset: Offset,
         class: RegionClass,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     ) {
-        self.deref_mut().add_clip_region(rect, offset, class, f);
+        self.deref_mut().with_clip_region(rect, offset, class, f);
     }
     fn target_rect(&self) -> Rect {
         self.deref().target_rect()

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -10,7 +10,7 @@ use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::path::Path;
 
 use kas::dir::Direction;
-use kas::draw::{Draw, ImageError, ImageId, Pass};
+use kas::draw::{Drawable, ImageError, ImageId, Pass};
 use kas::geom::{Coord, Offset, Rect, Size};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use kas::text::{AccelString, Text, TextApi, TextDisplay};
@@ -290,7 +290,7 @@ pub trait DrawHandle {
     /// # let rect = Rect::new(Coord::ZERO, Size::ZERO);
     /// let rect = rect + offset;
     /// ```
-    fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Draw);
+    fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Drawable);
 
     /// Add a clip region
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
@@ -650,7 +650,7 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
         self.deref_mut().size_handle_dyn(f)
     }
-    fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Draw) {
+    fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Drawable) {
         self.deref_mut().draw_device()
     }
     fn add_clip_region(
@@ -736,7 +736,7 @@ where
     fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
         self.deref_mut().size_handle_dyn(f)
     }
-    fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Draw) {
+    fn draw_device(&mut self) -> (Pass, Offset, &mut dyn Drawable) {
         self.deref_mut().draw_device()
     }
     fn add_clip_region(

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -15,16 +15,16 @@
 //!
 //! ### Medium-level drawing interfaces
 //!
-//! The [`Draw`] trait and its extensions are provided as the building-blocks
+//! The [`Drawable`] trait and its extensions are provided as the building-blocks
 //! used to implement themes, but may also be used directly (as in the `clock`
 //! example). These traits allow drawing of simple shapes, mostly in the form of
 //! an axis-aligned box or frame with several shading options.
 //!
-//! The [`Draw`] trait itself contains very little; extension traits
-//! [`DrawRounded`] and [`DrawShaded`] provide additional draw
-//! routines. Shells are only required to implement the base [`Draw`] trait,
+//! The [`Drawable`] trait itself contains very little; extension traits
+//! [`DrawableRounded`] and [`DrawableShaded`] provide additional draw
+//! routines. Shells are only required to implement the base [`Drawable`] trait,
 //! and may also provide their own extension traits. Themes may specify their
-//! own requirements, e.g. `D: Draw + DrawRounded + DrawText`.
+//! own requirements, e.g. `D: DrawableRounded`.
 //!
 //! The medium-level API will be extended in the future to support texturing
 //! (not yet supported) and potentially a more comprehensive path-based API

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -39,17 +39,15 @@
 
 pub mod color;
 
+mod draw;
 mod draw_shared;
 mod handle;
 mod images;
 mod theme;
 
-use std::any::Any;
-
 use crate::cast::Cast;
-use crate::geom::{Quad, Rect, Vec2};
-use color::Rgba;
 
+pub use draw::*;
 pub use draw_shared::{DrawShared, DrawableShared};
 pub use handle::*;
 pub use images::{ImageError, ImageFormat, ImageId};
@@ -87,125 +85,4 @@ impl Pass {
     pub fn depth(self) -> f32 {
         0.0
     }
-}
-
-/// Base abstraction over drawing
-///
-/// Unlike [`DrawHandle`], coordinates are specified via a [`Vec2`] and
-/// rectangular regions via [`Quad`]. The same coordinate system is used, hence
-/// type conversions can be performed with `from` and `into`. Integral
-/// coordinates align with pixels, non-integral coordinates may also be used.
-///
-/// All draw operations may be batched; when drawn primitives overlap, the
-/// results are only loosely defined. Draw operations involving transparency
-/// should be ordered after those without transparency.
-///
-/// Draw operations take place over multiple render passes, identified by a
-/// handle of type [`Pass`]. In general the user only needs to pass this value
-/// into methods as required. [`Draw::add_clip_region`] creates a new [`Pass`].
-pub trait Draw: Any {
-    /// Cast self to [`std::any::Any`] reference.
-    ///
-    /// A downcast on this value may be used to obtain a reference to a
-    /// shell-specific API.
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-
-    /// Add a clip region
-    ///
-    /// Clip regions are cleared each frame and so must be recreated on demand.
-    fn add_clip_region(&mut self, pass: Pass, rect: Rect, class: RegionClass) -> Pass;
-
-    /// Get drawable rect for a clip region
-    ///
-    /// (This may be smaller than the rect passed to [`Draw::add_clip_region`].)
-    fn get_clip_rect(&self, pass: Pass) -> Rect;
-
-    /// Draw a rectangle of uniform colour
-    fn rect(&mut self, pass: Pass, rect: Quad, col: Rgba);
-
-    /// Draw a frame of uniform colour
-    ///
-    /// The frame is defined by the area inside `outer` and not inside `inner`.
-    fn frame(&mut self, pass: Pass, outer: Quad, inner: Quad, col: Rgba);
-}
-
-/// Drawing commands for rounded shapes
-///
-/// This trait is an extension over [`Draw`] providing rounded shapes.
-///
-/// The primitives provided by this trait are partially transparent.
-/// If the implementation buffers draw commands, it should draw these
-/// primitives after solid primitives.
-pub trait DrawRounded: Draw {
-    /// Draw a line with rounded ends and uniform colour
-    ///
-    /// This command draws a line segment between the points `p1` and `p2`.
-    /// Pixels within the given `radius` of this segment are drawn, resulting
-    /// in rounded ends and width `2 * radius`.
-    ///
-    /// Note that for rectangular, axis-aligned lines, [`Draw::rect`] should be
-    /// preferred.
-    fn rounded_line(&mut self, pass: Pass, p1: Vec2, p2: Vec2, radius: f32, col: Rgba);
-
-    /// Draw a circle or oval of uniform colour
-    ///
-    /// More generally, this shape is an axis-aligned oval which may be hollow.
-    ///
-    /// The `inner_radius` parameter gives the inner radius relative to the
-    /// outer radius: a value of `0.0` will result in the whole shape being
-    /// painted, while `1.0` will result in a zero-width line on the outer edge.
-    fn circle(&mut self, pass: Pass, rect: Quad, inner_radius: f32, col: Rgba);
-
-    /// Draw a frame with rounded corners and uniform colour
-    ///
-    /// All drawing occurs within the `outer` rect and outside of the `inner`
-    /// rect. Corners are circular (or more generally, ovular), centered on the
-    /// inner corners.
-    ///
-    /// The `inner_radius` parameter gives the inner radius relative to the
-    /// outer radius: a value of `0.0` will result in the whole shape being
-    /// painted, while `1.0` will result in a zero-width line on the outer edge.
-    /// When `inner_radius > 0`, the frame will be visually thinner than the
-    /// allocated area.
-    fn rounded_frame(&mut self, pass: Pass, outer: Quad, inner: Quad, inner_radius: f32, col: Rgba);
-}
-
-/// Drawing commands for shaded shapes
-///
-/// This trait is an extension over [`Draw`] providing solid shaded shapes.
-///
-/// Some drawing primitives (the "round" ones) are partially transparent.
-/// If the implementation buffers draw commands, it should draw these
-/// primitives after solid primitives.
-///
-/// These are parameterised via a pair of normals, `(inner, outer)`. These may
-/// have values from the closed range `[-1, 1]`, where -1 points inwards,
-/// 0 is perpendicular to the screen towards the viewer, and 1 points outwards.
-pub trait DrawShaded: Draw {
-    /// Add a shaded square to the draw buffer
-    fn shaded_square(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba);
-
-    /// Add a shaded circle to the draw buffer
-    fn shaded_circle(&mut self, pass: Pass, rect: Quad, norm: (f32, f32), col: Rgba);
-
-    /// Add a square shaded frame to the draw buffer.
-    fn shaded_square_frame(
-        &mut self,
-        pass: Pass,
-        outer: Quad,
-        inner: Quad,
-        norm: (f32, f32),
-        outer_col: Rgba,
-        inner_col: Rgba,
-    );
-
-    /// Add a rounded shaded frame to the draw buffer.
-    fn shaded_round_frame(
-        &mut self,
-        pass: Pass,
-        outer: Quad,
-        inner: Quad,
-        norm: (f32, f32),
-        col: Rgba,
-    );
 }

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -39,18 +39,18 @@
 
 pub mod color;
 
+mod draw_shared;
 mod handle;
 mod images;
 mod theme;
 
 use std::any::Any;
-use std::path::Path;
 
 use crate::cast::Cast;
-use crate::geom::{Quad, Rect, Size, Vec2};
-use crate::text::{Effect, TextDisplay};
+use crate::geom::{Quad, Rect, Vec2};
 use color::Rgba;
 
+pub use draw_shared::{DrawShared, DrawableShared};
 pub use handle::*;
 pub use images::{ImageError, ImageFormat, ImageId};
 pub use theme::*;
@@ -87,180 +87,6 @@ impl Pass {
     pub fn depth(self) -> f32 {
         0.0
     }
-}
-
-/// Interface over a shared draw object
-pub struct DrawShared<DS: DrawableShared> {
-    pub draw: DS,
-    images: images::Images,
-}
-
-#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-impl<DS: DrawableShared> DrawShared<DS> {
-    /// Construct
-    pub fn new(draw: DS) -> Self {
-        let images = images::Images::new();
-        DrawShared { draw, images }
-    }
-}
-
-impl<DS: DrawableShared> DrawShared<DS> {
-    /// Allocate an image
-    ///
-    /// Use [`DrawShared::upload`] to set contents of the new image.
-    pub fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
-        self.draw.image_alloc(size)
-    }
-
-    /// Upload an image to the GPU
-    ///
-    /// This should be called at least once on each image before display. May be
-    /// called again to update the image contents.
-    pub fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat) {
-        self.draw.image_upload(id, data, format);
-    }
-
-    /// Load an image from a path, autodetecting file type
-    ///
-    /// This deduplicates multiple loads of the same path, instead incrementing
-    /// a reference count.
-    pub fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError> {
-        self.images.load_path(&mut self.draw, path)
-    }
-
-    /// Remove a loaded image, by path
-    ///
-    /// This reduces the reference count and frees if zero.
-    pub fn remove_image_from_path(&mut self, path: &Path) {
-        self.images.remove_path(&mut self.draw, path);
-    }
-
-    /// Free an image
-    pub fn remove_image(&mut self, id: ImageId) {
-        self.images.remove_id(&mut self.draw, id);
-    }
-
-    /// Get the size of an image
-    pub fn image_size(&self, id: ImageId) -> Option<Size> {
-        self.draw.image_size(id).map(|size| size.into())
-    }
-
-    /// Draw the image in the given `rect`
-    pub fn draw_image(&self, window: &mut DS::Draw, pass: Pass, id: ImageId, rect: Quad) {
-        self.draw.draw_image(window, pass, id, rect)
-    }
-
-    /// Draw text with a colour
-    pub fn draw_text(
-        &mut self,
-        window: &mut DS::Draw,
-        pass: Pass,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-    ) {
-        self.draw.draw_text(window, pass, pos, text, col)
-    }
-
-    /// Draw text with a colour and effects
-    ///
-    /// The effects list does not contain colour information, but may contain
-    /// underlining/strikethrough information. It may be empty.
-    pub fn draw_text_col_effects(
-        &mut self,
-        window: &mut DS::Draw,
-        pass: Pass,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-        effects: &[Effect<()>],
-    ) {
-        self.draw
-            .draw_text_col_effects(window, pass, pos, text, col, effects)
-    }
-
-    /// Draw text with effects
-    ///
-    /// The `effects` list provides both underlining and colour information.
-    /// If the `effects` list is empty or the first entry has `start > 0`, a
-    /// default entity will be assumed.
-    pub fn draw_text_effects(
-        &mut self,
-        window: &mut DS::Draw,
-        pass: Pass,
-        pos: Vec2,
-        text: &TextDisplay,
-        effects: &[Effect<Rgba>],
-    ) {
-        self.draw
-            .draw_text_effects(window, pass, pos, text, effects)
-    }
-}
-
-/// Trait over shared data of draw object
-///
-/// This is typically used via [`DrawShared`].
-#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-pub trait DrawableShared: 'static {
-    type Draw: Draw;
-
-    /// Allocate an image
-    ///
-    /// Use [`DrawableShared::upload`] to set contents of the new image.
-    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError>;
-
-    /// Upload an image to the GPU
-    ///
-    /// This should be called at least once on each image before display. May be
-    /// called again to update the image contents.
-    fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat);
-
-    /// Free an image allocation
-    fn image_free(&mut self, id: ImageId);
-
-    /// Query an image's size
-    fn image_size(&self, id: ImageId) -> Option<(u32, u32)>;
-
-    /// Draw the image in the given `rect`
-    fn draw_image(&self, window: &mut Self::Draw, pass: Pass, id: ImageId, rect: Quad);
-
-    /// Draw text with a colour
-    fn draw_text(
-        &mut self,
-        window: &mut Self::Draw,
-        pass: Pass,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-    );
-
-    /// Draw text with a colour and effects
-    ///
-    /// The effects list does not contain colour information, but may contain
-    /// underlining/strikethrough information. It may be empty.
-    fn draw_text_col_effects(
-        &mut self,
-        window: &mut Self::Draw,
-        pass: Pass,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-        effects: &[Effect<()>],
-    );
-
-    /// Draw text with effects
-    ///
-    /// The `effects` list provides both underlining and colour information.
-    /// If the `effects` list is empty or the first entry has `start > 0`, a
-    /// default entity will be assumed.
-    fn draw_text_effects(
-        &mut self,
-        window: &mut Self::Draw,
-        pass: Pass,
-        pos: Vec2,
-        text: &TextDisplay,
-        effects: &[Effect<Rgba>],
-    );
 }
 
 /// Base abstraction over drawing


### PR DESCRIPTION
This makes the "medium level" draw interface a little easier to use: the `pass` number is now bundled with the `draw` reference.

We could also bundle the `offset` parameter (thus making `DrawHandle::draw_device` easier to use); I opted not to do this since it would require applying the offset multiple times (as an `f32` value on each draw methods' parameters) instead of once (as an integer) in each `DrawHandle` method.

This PR includes some doc revision to the draw module and some minor code refactoring.