### PR TITLE
DrawSharedT trait

### DIFF
--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -10,11 +10,10 @@
 use linear_map::LinearMap;
 use std::any::Any;
 use std::f32;
-use std::path::Path;
 use std::rc::Rc;
 
 use kas::cast::{Cast, CastFloat, ConvFloat};
-use kas::draw::{self, DrawShared, DrawSharedT, DrawableShared, ImageError, ImageId, TextClass};
+use kas::draw::{self, DrawShared, DrawSharedT, DrawableShared, TextClass};
 use kas::geom::{Size, Vec2};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::text::{fonts::FontId, TextApi, TextApiExt};
@@ -156,6 +155,10 @@ impl<'a, DS: DrawableShared> SizeHandle<'a, DS> {
 }
 
 impl<'a, DS: DrawableShared> draw::SizeHandle for SizeHandle<'a, DS> {
+    fn draw_shared(&mut self) -> &mut dyn DrawSharedT {
+        self.shared
+    }
+
     fn scale_factor(&self) -> f32 {
         self.w.dims.scale_factor
     }
@@ -298,16 +301,5 @@ impl<'a, DS: DrawableShared> draw::SizeHandle for SizeHandle<'a, DS> {
 
     fn progress_bar(&self) -> Size {
         self.w.dims.progress_bar
-    }
-
-    fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError> {
-        self.shared.image_from_path(path)
-    }
-    fn remove_image(&mut self, id: ImageId) {
-        self.shared.remove_image(id);
-    }
-
-    fn image(&self, id: ImageId) -> Option<Size> {
-        self.shared.image_size(id)
     }
 }

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::rc::Rc;
 
 use kas::cast::{Cast, CastFloat, ConvFloat};
-use kas::draw::{self, DrawShared, DrawableShared, ImageError, ImageId, TextClass};
+use kas::draw::{self, DrawShared, DrawSharedT, DrawableShared, ImageError, ImageId, TextClass};
 use kas::geom::{Size, Vec2};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::text::{fonts::FontId, TextApi, TextApiExt};

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -8,7 +8,6 @@
 //! Widget size and appearance can be modified through themes.
 
 use linear_map::LinearMap;
-use std::any::Any;
 use std::f32;
 use std::ops::Range;
 use std::rc::Rc;
@@ -248,12 +247,8 @@ where
         }
     }
 
-    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>, &mut dyn Any) {
-        (
-            self.offset,
-            self.draw.upcast_base(),
-            self.shared.draw.as_any_mut(),
-        )
+    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>, &mut dyn DrawSharedT) {
+        (self.offset, self.draw.upcast_base(), self.shared)
     }
 
     fn with_clip_region(

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -5,7 +5,6 @@
 
 //! Shaded theme
 
-use std::any::Any;
 use std::f32;
 use std::ops::Range;
 
@@ -220,12 +219,8 @@ where
         }
     }
 
-    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>, &mut dyn Any) {
-        (
-            self.offset,
-            self.draw.upcast_base(),
-            self.shared.draw.as_any_mut(),
-        )
+    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>, &mut dyn DrawSharedT) {
+        (self.offset, self.draw.upcast_base(), self.shared)
     }
 
     fn with_clip_region(

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -18,6 +18,10 @@ use std::path::Path;
 /// This struct is built over a [`DrawableShared`] object provided by the shell,
 /// which may be accessed directly for a lower-level API (though most methods
 /// are available through [`DrawShared`] directly).
+///
+/// Note: all functionality is implemented through the [`DrawSharedT`] trait to
+/// allow usage where the `DS` type parameter is unknown. Some functionality is
+/// also implemented directly to avoid the need for downcasting.
 pub struct DrawShared<DS: DrawableShared> {
     /// The shell's [`DrawableShared`] object
     pub draw: DS,
@@ -34,54 +38,14 @@ impl<DS: DrawableShared> DrawShared<DS> {
 }
 
 impl<DS: DrawableShared> DrawShared<DS> {
-    /// Allocate an image
-    ///
-    /// Use [`DrawShared::image_upload`] to set contents of the new image.
-    #[inline]
-    pub fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
-        self.draw.image_alloc(size)
-    }
-
-    /// Upload an image to the GPU
-    ///
-    /// This should be called at least once on each image before display. May be
-    /// called again to update the image contents.
-    #[inline]
-    pub fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat) {
-        self.draw.image_upload(id, data, format);
-    }
-
-    /// Load an image from a path, autodetecting file type
-    ///
-    /// This deduplicates multiple loads of the same path, instead incrementing
-    /// a reference count.
-    pub fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError> {
-        self.images.load_path(&mut self.draw, path)
-    }
-
-    /// Remove a loaded image, by path
-    ///
-    /// This reduces the reference count and frees if zero.
-    pub fn remove_image_from_path(&mut self, path: &Path) {
-        self.images.remove_path(&mut self.draw, path);
-    }
-
-    /// Free an image
-    pub fn remove_image(&mut self, id: ImageId) {
-        self.images.remove_id(&mut self.draw, id);
-    }
-
-    /// Get the size of an image
-    pub fn image_size(&self, id: ImageId) -> Option<Size> {
-        self.draw.image_size(id).map(|size| size.into())
-    }
-
     /// Draw the image in the given `rect`
+    #[inline]
     pub fn draw_image(&self, target: Draw<DS::Draw>, id: ImageId, rect: Quad) {
         self.draw.draw_image(target, id, rect)
     }
 
     /// Draw text with a colour
+    #[inline]
     pub fn draw_text(&mut self, target: Draw<DS::Draw>, pos: Vec2, text: &TextDisplay, col: Rgba) {
         self.draw.draw_text(target, pos, text, col)
     }
@@ -90,6 +54,7 @@ impl<DS: DrawableShared> DrawShared<DS> {
     ///
     /// The effects list does not contain colour information, but may contain
     /// underlining/strikethrough information. It may be empty.
+    #[inline]
     pub fn draw_text_col_effects(
         &mut self,
         target: Draw<DS::Draw>,
@@ -107,6 +72,7 @@ impl<DS: DrawableShared> DrawShared<DS> {
     /// The `effects` list provides both underlining and colour information.
     /// If the `effects` list is empty or the first entry has `start > 0`, a
     /// default entity will be assumed.
+    #[inline]
     pub fn draw_text_effects(
         &mut self,
         target: Draw<DS::Draw>,
@@ -115,6 +81,152 @@ impl<DS: DrawableShared> DrawShared<DS> {
         effects: &[Effect<Rgba>],
     ) {
         self.draw.draw_text_effects(target, pos, text, effects)
+    }
+}
+
+/// Interface over [`DrawShared`]
+pub trait DrawSharedT {
+    /// Access [`DrawableShared`] object as `Any` to allow downcasting
+    fn drawable_as_any_mut(&mut self) -> &mut dyn Any;
+
+    /// Allocate an image
+    ///
+    /// Use [`DrawShared::image_upload`] to set contents of the new image.
+    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError>;
+
+    /// Upload an image to the GPU
+    ///
+    /// This should be called at least once on each image before display. May be
+    /// called again to update the image contents.
+    fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat);
+
+    /// Load an image from a path, autodetecting file type
+    ///
+    /// This deduplicates multiple loads of the same path, instead incrementing
+    /// a reference count.
+    fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError>;
+
+    /// Remove a loaded image, by path
+    ///
+    /// This reduces the reference count and frees if zero.
+    fn remove_image_from_path(&mut self, path: &Path);
+
+    /// Free an image
+    fn remove_image(&mut self, id: ImageId);
+
+    /// Get the size of an image
+    fn image_size(&self, id: ImageId) -> Option<Size>;
+
+    /// Draw the image in the given `rect`
+    fn draw_image(&self, target: Draw<dyn Drawable>, id: ImageId, rect: Quad);
+
+    /// Draw text with a colour
+    fn draw_text(&mut self, target: Draw<dyn Drawable>, pos: Vec2, text: &TextDisplay, col: Rgba);
+
+    /// Draw text with a colour and effects
+    ///
+    /// The effects list does not contain colour information, but may contain
+    /// underlining/strikethrough information. It may be empty.
+    fn draw_text_col_effects(
+        &mut self,
+        target: Draw<dyn Drawable>,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+        effects: &[Effect<()>],
+    );
+
+    /// Draw text with effects
+    ///
+    /// The `effects` list provides both underlining and colour information.
+    /// If the `effects` list is empty or the first entry has `start > 0`, a
+    /// default entity will be assumed.
+    fn draw_text_effects(
+        &mut self,
+        target: Draw<dyn Drawable>,
+        pos: Vec2,
+        text: &TextDisplay,
+        effects: &[Effect<Rgba>],
+    );
+}
+
+impl<DS: DrawableShared> DrawSharedT for DrawShared<DS> {
+    fn drawable_as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.draw
+    }
+
+    #[inline]
+    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
+        self.draw.image_alloc(size)
+    }
+
+    #[inline]
+    fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat) {
+        self.draw.image_upload(id, data, format);
+    }
+
+    #[inline]
+    fn image_from_path(&mut self, path: &Path) -> Result<ImageId, ImageError> {
+        self.images.load_path(&mut self.draw, path)
+    }
+
+    #[inline]
+    fn remove_image_from_path(&mut self, path: &Path) {
+        self.images.remove_path(&mut self.draw, path);
+    }
+
+    #[inline]
+    fn remove_image(&mut self, id: ImageId) {
+        self.images.remove_id(&mut self.draw, id);
+    }
+
+    #[inline]
+    fn image_size(&self, id: ImageId) -> Option<Size> {
+        self.draw.image_size(id).map(|size| size.into())
+    }
+
+    fn draw_image(&self, mut target: Draw<dyn Drawable>, id: ImageId, rect: Quad) {
+        target
+            .downcast()
+            .map(|target| self.draw.draw_image(target, id, rect));
+    }
+
+    fn draw_text(
+        &mut self,
+        mut target: Draw<dyn Drawable>,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+    ) {
+        target
+            .downcast()
+            .map(|target| self.draw.draw_text(target, pos, text, col));
+    }
+
+    fn draw_text_col_effects(
+        &mut self,
+        mut target: Draw<dyn Drawable>,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+        effects: &[Effect<()>],
+    ) {
+        target.downcast().map(|target| {
+            self.draw
+                .draw_text_col_effects(target, pos, text, col, effects)
+        });
+    }
+
+    fn draw_text_effects(
+        &mut self,
+        mut target: Draw<dyn Drawable>,
+        pos: Vec2,
+        text: &TextDisplay,
+        effects: &[Effect<Rgba>],
+    ) {
+        target
+            .downcast()
+            .map(|target| self.draw.draw_text_effects(target, pos, text, effects));
     }
 }
 

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -5,13 +5,12 @@
 
 //! "Handle" types used by themes
 
-use std::any::Any;
 use std::convert::AsRef;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::path::Path;
 
 use kas::dir::Direction;
-use kas::draw::{Draw, Drawable, ImageError, ImageId};
+use kas::draw::{Draw, DrawSharedT, Drawable, ImageError, ImageId};
 use kas::geom::{Coord, Offset, Rect, Size};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use kas::text::{AccelString, Text, TextApi, TextDisplay};
@@ -283,10 +282,7 @@ pub trait DrawHandle {
     ///
     /// The `draw` object is over the [`Drawable`] interface which exposes only
     /// minimal functionality. [`Draw::downcast`] will likely be of use.
-    ///
-    /// The `shared` reference has type `dyn Any`; one must downcast to the
-    /// shell's type (e.g. `kas_wgpu::draw::DrawPipe<()>`).
-    fn draw_device<'a>(&'a mut self) -> (Offset, Draw<'a, dyn Drawable>, &'a mut dyn Any);
+    fn draw_device<'a>(&'a mut self) -> (Offset, Draw<'a, dyn Drawable>, &'a mut dyn DrawSharedT);
 
     /// Add a clip region
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
@@ -646,7 +642,7 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
         self.deref_mut().size_handle_dyn(f)
     }
-    fn draw_device<'a>(&'a mut self) -> (Offset, Draw<'a, dyn Drawable>, &'a mut dyn Any) {
+    fn draw_device<'a>(&'a mut self) -> (Offset, Draw<'a, dyn Drawable>, &'a mut dyn DrawSharedT) {
         self.deref_mut().draw_device()
     }
     fn with_clip_region(
@@ -732,7 +728,7 @@ where
     fn size_handle_dyn(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle)) {
         self.deref_mut().size_handle_dyn(f)
     }
-    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>, &'b mut dyn Any) {
+    fn draw_device<'b>(&'b mut self) -> (Offset, Draw<'b, dyn Drawable>, &'b mut dyn DrawSharedT) {
         self.deref_mut().draw_device()
     }
     fn with_clip_region(

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -67,7 +67,7 @@ mod theme;
 use crate::cast::Cast;
 
 pub use draw::*;
-pub use draw_shared::{DrawShared, DrawableShared};
+pub use draw_shared::{DrawShared, DrawSharedT, DrawableShared};
 pub use handle::*;
 pub use images::{ImageError, ImageFormat, ImageId};
 pub use theme::*;

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use std::u16;
 
 use super::*;
-use crate::draw::{SizeHandle, ThemeApi};
+use crate::draw::{DrawSharedT, SizeHandle, ThemeApi};
 use crate::geom::Coord;
 use crate::updatable::Updatable;
 #[allow(unused)]
@@ -335,6 +335,13 @@ impl<'a> Manager<'a> {
             result = Some(f(size_handle));
         });
         result.expect("ShellWindow::size_handle impl failed to call function argument")
+    }
+
+    /// Access a [`DrawSharedT`]
+    ///
+    /// This can be accessed through [`Self::size_handle`]; this method is merely a shortcut.
+    pub fn draw_shared<F: FnMut(&mut dyn DrawSharedT) -> T, T>(&mut self, mut f: F) -> T {
+        self.size_handle(|sh| f(sh.draw_shared()))
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,7 +20,7 @@ pub use kas::class::*;
 #[doc(no_inline)]
 pub use kas::dir::{Direction, Directional};
 #[doc(no_inline)]
-pub use kas::draw::{DrawHandle, DrawHandleExt, ImageId, SizeHandle, ThemeApi};
+pub use kas::draw::{DrawHandle, DrawHandleExt, DrawSharedT, ImageId, SizeHandle, ThemeApi};
 #[doc(no_inline)]
 pub use kas::event::{
     Event, Handler, Manager, ManagerState, Response, SendEvent, UpdateHandle, VoidMsg,


### PR DESCRIPTION
Following #206, this abstracts over a `DrawShared<DS>` object allowing usage where `DS = dyn Drawable`.

Adds `SizeHandle::draw_shared`, replacing image management methods.