### PR TITLE
Extend derive(Widget) macro

### DIFF
--- a/kas-macros/src/args.rs
+++ b/kas-macros/src/args.rs
@@ -256,6 +256,8 @@ mod kw {
     custom_keyword!(HasString);
     custom_keyword!(SetAccel);
     custom_keyword!(class_traits);
+    custom_keyword!(Deref);
+    custom_keyword!(DerefMut);
 }
 
 #[derive(Debug, Default)]
@@ -264,6 +266,8 @@ pub struct WidgetDerive {
     pub has_str: bool,
     pub has_string: bool,
     pub set_accel: bool,
+    pub deref: bool,
+    pub deref_mut: bool,
 }
 
 impl Parse for WidgetDerive {
@@ -298,6 +302,12 @@ impl Parse for WidgetDerive {
                 derive.has_str = true;
                 derive.has_string = true;
                 derive.set_accel = true;
+            } else if !derive.deref && lookahead.peek(kw::Deref) {
+                let _: kw::Deref = content.parse()?;
+                derive.deref = true;
+            } else if !derive.deref_mut && lookahead.peek(kw::DerefMut) {
+                let _: kw::DerefMut = content.parse()?;
+                derive.deref_mut = true;
             } else {
                 return Err(lookahead.error());
             }

--- a/kas-macros/src/args.rs
+++ b/kas-macros/src/args.rs
@@ -252,11 +252,18 @@ mod kw {
     custom_keyword!(column);
     custom_keyword!(draw);
     custom_keyword!(HasBool);
+    custom_keyword!(HasStr);
+    custom_keyword!(HasString);
+    custom_keyword!(SetAccel);
+    custom_keyword!(class_traits);
 }
 
 #[derive(Debug, Default)]
 pub struct WidgetDerive {
     pub has_bool: bool,
+    pub has_str: bool,
+    pub has_string: bool,
+    pub set_accel: bool,
 }
 
 impl Parse for WidgetDerive {
@@ -271,6 +278,26 @@ impl Parse for WidgetDerive {
             if !derive.has_bool && lookahead.peek(kw::HasBool) {
                 let _: kw::HasBool = content.parse()?;
                 derive.has_bool = true;
+            } else if !derive.has_str && lookahead.peek(kw::HasStr) {
+                let _: kw::HasStr = content.parse()?;
+                derive.has_str = true;
+            } else if !derive.has_string && lookahead.peek(kw::HasString) {
+                let _: kw::HasString = content.parse()?;
+                derive.has_string = true;
+            } else if !derive.set_accel && lookahead.peek(kw::SetAccel) {
+                let _: kw::SetAccel = content.parse()?;
+                derive.set_accel = true;
+            } else if !derive.has_bool
+                && !derive.has_str
+                && !derive.has_string
+                && !derive.set_accel
+                && lookahead.peek(kw::class_traits)
+            {
+                let _: kw::class_traits = content.parse()?;
+                derive.has_bool = true;
+                derive.has_str = true;
+                derive.has_string = true;
+                derive.set_accel = true;
             } else {
                 return Err(lookahead.error());
             }

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -327,6 +327,29 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     }
 
     if let Some((member, ty)) = args.inner {
+        if args.derive.deref {
+            toks.append_all(quote! {
+                impl #impl_generics std::ops::Deref for #name #ty_generics #where_clause {
+                    type Target = #ty;
+                    #[inline]
+                    fn deref(&self) -> &Self::Target {
+                        &self.#member
+                    }
+                }
+            });
+        }
+
+        if args.derive.deref_mut {
+            toks.append_all(quote! {
+                impl #impl_generics std::ops::DerefMut for #name #ty_generics #where_clause {
+                    #[inline]
+                    fn deref_mut(&mut self) -> &mut Self::Target {
+                        &mut self.#member
+                    }
+                }
+            });
+        }
+
         let extended_where_clause = move |pred: WherePredicate| {
             if let Some(ref clause) = where_clause {
                 let mut clauses: WhereClause = (*clause).clone();

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -359,6 +359,52 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                 }
             });
         }
+
+        if args.derive.has_str {
+            let wc = extended_where_clause(parse_quote! { #ty: kas::class::HasStr });
+            toks.append_all(quote! {
+                impl #impl_generics kas::class::HasStr for #name #ty_generics #wc {
+                    #[inline]
+                    fn get_str(&self) -> &str {
+                        self.#member.get_str()
+                    }
+
+                    #[inline]
+                    fn get_string(&self) -> String {
+                        self.#member.get_string()
+                    }
+                }
+            });
+        }
+
+        if args.derive.has_string {
+            let wc = extended_where_clause(parse_quote! { #ty: kas::class::HasString });
+            toks.append_all(quote! {
+                impl #impl_generics kas::class::HasString for #name #ty_generics #wc {
+                    #[inline]
+                    fn set_str(&mut self, text: &str) -> kas::TkAction {
+                        self.#member.set_str(text)
+                    }
+
+                    #[inline]
+                    fn set_string(&mut self, text: String) -> kas::TkAction {
+                        self.#member.set_string(text)
+                    }
+                }
+            });
+        }
+
+        if args.derive.set_accel {
+            let wc = extended_where_clause(parse_quote! { #ty: kas::class::SetAccel });
+            toks.append_all(quote! {
+                impl #impl_generics kas::class::SetAccel for #name #ty_generics #wc {
+                    #[inline]
+                    fn set_accel_string(&mut self, accel: AccelString) -> kas::TkAction {
+                        self.#member.set_accel_string(accel)
+                    }
+                }
+            });
+        }
     }
 
     toks.into()

--- a/kas-wgpu/examples/data-list.rs
+++ b/kas-wgpu/examples/data-list.rs
@@ -140,7 +140,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget] display: StringLabel = Label::from("Entry #0"),
                 #[widget] _ = Separator::new(),
                 #[widget(handler = set_radio)] list: ScrollBarRegion<Column<ListEntry>> =
-                    ScrollBarRegion::new2(Column::new(entries)).with_bars(false, true),
+                    ScrollBarRegion::new(Column::new(entries)).with_bars(false, true),
                 #[widget] _ = Filler::maximize(),
                 active: usize = 0,
             }

--- a/kas-wgpu/examples/gallery.rs
+++ b/kas-wgpu/examples/gallery.rs
@@ -275,7 +275,7 @@ fn main() -> Result<(), kas_wgpu::Error> {
                 #[widget(halign = centre)] _ = Frame::new(head),
                 #[widget(handler = activations)] gallery:
                     for<W: Widget<Msg = Item>> ScrollBarRegion<W> =
-                        ScrollBarRegion::new2(widgets),
+                        ScrollBarRegion::new(widgets),
             }
             impl {
                 fn menu(&mut self, mgr: &mut Manager, msg: Menu) -> VoidResponse {

--- a/kas-wgpu/examples/markdown.rs
+++ b/kas-wgpu/examples/markdown.rs
@@ -46,7 +46,7 @@ It also supports lists:
                 #[widget(row=0, col=0, rspan=2)] editor: EditBox =
                     EditBox::new(doc).multi_line(true),
                 #[widget(row=0, col=1)] label: ScrollBarRegion<Label<Markdown>> =
-                    ScrollBarRegion::new2(Label::new(Markdown::new(doc)?)),
+                    ScrollBarRegion::new(Label::new(Markdown::new(doc)?)),
                 #[widget(row=1, col=1, handler=update)] _ = TextButton::new_msg("&Update", ()),
             }
             impl {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -43,12 +43,13 @@
 //! The behaviour of this macro is controlled by attributes on struct fields and
 //! on the widget struct itself.
 //!
-//! These attributes may be used on the struct: `widget`, `layout`, `handler`.
+//! These attributes may be used on the struct: `widget`, `widget_derive`, `layout`, `handler`.
 //! These may each appear zero or once (except `handler`; see below).
 //! They support multiple parameters, e.g. `#[widget(config=noauto, children=noauto)]`.
 //!
 //! These attributes may be used on fields: `widget`, `widget_core`,
-//! `layout_data`. The `widget` attribute supports multiple parameters,
+//! `widget_derive`,  `layout_data`.
+//! The `widget` attribute supports multiple parameters,
 //! discussed below (e.g. `#[widget(row=1, handler=f)]`).
 //! Fields without attributes (plain data fields) are fine too.
 //!
@@ -245,6 +246,33 @@
 //! A handler is bound to a child via the `widget` attribute, for example
 //! `#[widget(handler = f)] child: ChildType`.
 //!
+//! ### widget_derive
+//!
+//! The `#[widget_derive]` attribute may optionally appear on a field, and may
+//! also appear on the struct. The attribute has two possible effects:
+//!
+//! 1.  If used on a field *instead of* a field marked with `#[widget_core]`,
+//!     this field must implement [`Widget`] and the widget traits are
+//!     implemented for the struct as wrappers around this field. This
+//!     may be useful to implement a wrapper struct as a widget, for example
+//!     [`kas::widget::ScrollBarRegion`] (shown below).
+//! 2.  If used on the struct *and* on a field, the attribute allows deriving
+//!     various traits: [`std::ops::Deref`], [`std::ops::DerefMut`], and the
+//!     "class traits": [`kas::class`]. The traits to derive must be specified
+//!     as parameters to the attribute applied to the struct. The parameter
+//!     `class_traits` may be used to imply all [`kas::class`] traits, where
+//!     available. These traits will be derived to refer to the marked field.
+//!
+//! An example showing both effects simultaneously to implement [`Widget`],
+//! [`std::ops::Deref`], [`std::ops::DerefMut`] and the [`kas::class`] traits:
+//! ```
+//! # use kas::prelude::*;
+//! # use kas::widget::{ScrollBars, ScrollRegion};
+//! #[derive(Clone, Debug, Default, Widget)]
+//! #[widget_derive(class_traits, Deref, DerefMut)]
+//! #[handler(msg = <W as Handler>::Msg)]
+//! pub struct ScrollBarRegion<W: Widget>(#[widget_derive] ScrollBars<ScrollRegion<W>>);
+//! ```
 //!
 //! ### Examples
 //!

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -147,7 +147,7 @@ pub struct CheckBox<M: 'static> {
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,
-    #[inner_widget]
+    #[widget_derive]
     #[widget]
     checkbox: CheckBoxBare<M>,
     #[widget]

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -141,11 +141,13 @@ impl<M: 'static> event::Handler for CheckBoxBare<M> {
 #[layout(row, area=checkbox)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[widget(config=noauto)]
+#[widget_derive(HasBool)]
 pub struct CheckBox<M: 'static> {
     #[widget_core]
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,
+    #[inner_widget]
     #[widget]
     checkbox: CheckBoxBare<M>,
     #[widget]
@@ -226,17 +228,5 @@ impl<M: 'static> CheckBox<M> {
 impl<M: 'static> WidgetConfig for CheckBox<M> {
     fn configure(&mut self, mgr: &mut Manager) {
         mgr.add_accel_keys(self.checkbox.id(), self.label.keys());
-    }
-}
-
-impl<M: 'static> HasBool for CheckBox<M> {
-    #[inline]
-    fn get_bool(&self) -> bool {
-        self.checkbox.get_bool()
-    }
-
-    #[inline]
-    fn set_bool(&mut self, state: bool) -> TkAction {
-        self.checkbox.set_bool(state)
     }
 }

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -137,7 +137,6 @@ impl<M: 'static> event::Handler for CheckBoxBare<M> {
 }
 
 /// A checkable box with optional label
-// TODO: use a generic wrapper for CheckBox and RadioBox?
 #[derive(Clone, Default, Widget)]
 #[layout(row, area=checkbox)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -17,7 +17,7 @@ use kas::{event, prelude::*};
 pub struct Frame<W: Widget> {
     #[widget_core]
     core: CoreData,
-    #[inner_widget]
+    #[widget_derive]
     #[widget]
     pub inner: W,
     offset: Offset,

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -13,7 +13,7 @@ use kas::{event, prelude::*};
 /// contents.
 #[derive(Clone, Debug, Default, Widget)]
 #[handler(msg = <W as Handler>::Msg)]
-#[widget_derive(class_traits)]
+#[widget_derive(class_traits, Deref, DerefMut)]
 pub struct Frame<W: Widget> {
     #[widget_core]
     core: CoreData,
@@ -66,18 +66,5 @@ impl<W: Widget> Layout for Frame<W> {
         draw_handle.outer_frame(self.core_data().rect);
         let disabled = disabled || self.is_disabled();
         self.inner.draw(draw_handle, mgr, disabled);
-    }
-}
-
-impl<W: Widget> std::ops::Deref for Frame<W> {
-    type Target = W;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<W: Widget> std::ops::DerefMut for Frame<W> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
     }
 }

--- a/src/widget/frame.rs
+++ b/src/widget/frame.rs
@@ -13,9 +13,11 @@ use kas::{event, prelude::*};
 /// contents.
 #[derive(Clone, Debug, Default, Widget)]
 #[handler(msg = <W as Handler>::Msg)]
+#[widget_derive(class_traits)]
 pub struct Frame<W: Widget> {
     #[widget_core]
     core: CoreData,
+    #[inner_widget]
     #[widget]
     pub inner: W,
     offset: Offset,
@@ -64,36 +66,6 @@ impl<W: Widget> Layout for Frame<W> {
         draw_handle.outer_frame(self.core_data().rect);
         let disabled = disabled || self.is_disabled();
         self.inner.draw(draw_handle, mgr, disabled);
-    }
-}
-
-impl<W: HasBool + Widget> HasBool for Frame<W> {
-    fn get_bool(&self) -> bool {
-        self.inner.get_bool()
-    }
-
-    fn set_bool(&mut self, state: bool) -> TkAction {
-        self.inner.set_bool(state)
-    }
-}
-
-impl<W: HasStr + Widget> HasStr for Frame<W> {
-    fn get_str(&self) -> &str {
-        self.inner.get_str()
-    }
-}
-
-impl<W: HasString + Widget> HasString for Frame<W> {
-    fn set_string(&mut self, text: String) -> TkAction {
-        self.inner.set_string(text)
-    }
-}
-
-// TODO: HasFormatted
-
-impl<W: SetAccel + Widget> SetAccel for Frame<W> {
-    fn set_accel_string(&mut self, accel: AccelString) -> TkAction {
-        self.inner.set_accel_string(accel)
     }
 }
 

--- a/src/widget/nav_frame.rs
+++ b/src/widget/nav_frame.rs
@@ -14,9 +14,11 @@ use kas::{event, prelude::*};
 #[derive(Clone, Debug, Default, Widget)]
 #[handler(handle=noauto)]
 #[widget(config(key_nav = true))]
+#[widget_derive(class_traits)]
 pub struct NavFrame<W: Widget> {
     #[widget_core]
     core: CoreData,
+    #[inner_widget]
     #[widget]
     pub inner: W,
     offset: Offset,
@@ -76,36 +78,6 @@ impl<W: Widget> event::Handler for NavFrame<W> {
             Event::Activate => Response::Select,
             _ => Response::Unhandled,
         }
-    }
-}
-
-impl<W: HasBool + Widget> HasBool for NavFrame<W> {
-    fn get_bool(&self) -> bool {
-        self.inner.get_bool()
-    }
-
-    fn set_bool(&mut self, state: bool) -> TkAction {
-        self.inner.set_bool(state)
-    }
-}
-
-impl<W: HasStr + Widget> HasStr for NavFrame<W> {
-    fn get_str(&self) -> &str {
-        self.inner.get_str()
-    }
-}
-
-impl<W: HasString + Widget> HasString for NavFrame<W> {
-    fn set_string(&mut self, text: String) -> TkAction {
-        self.inner.set_string(text)
-    }
-}
-
-// TODO: HasFormatted
-
-impl<W: SetAccel + Widget> SetAccel for NavFrame<W> {
-    fn set_accel_string(&mut self, accel: AccelString) -> TkAction {
-        self.inner.set_accel_string(accel)
     }
 }
 

--- a/src/widget/nav_frame.rs
+++ b/src/widget/nav_frame.rs
@@ -14,7 +14,7 @@ use kas::{event, prelude::*};
 #[derive(Clone, Debug, Default, Widget)]
 #[handler(handle=noauto)]
 #[widget(config(key_nav = true))]
-#[widget_derive(class_traits)]
+#[widget_derive(class_traits, Deref, DerefMut)]
 pub struct NavFrame<W: Widget> {
     #[widget_core]
     core: CoreData,
@@ -78,18 +78,5 @@ impl<W: Widget> event::Handler for NavFrame<W> {
             Event::Activate => Response::Select,
             _ => Response::Unhandled,
         }
-    }
-}
-
-impl<W: Widget> std::ops::Deref for NavFrame<W> {
-    type Target = W;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<W: Widget> std::ops::DerefMut for NavFrame<W> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
     }
 }

--- a/src/widget/nav_frame.rs
+++ b/src/widget/nav_frame.rs
@@ -18,7 +18,7 @@ use kas::{event, prelude::*};
 pub struct NavFrame<W: Widget> {
     #[widget_core]
     core: CoreData,
-    #[inner_widget]
+    #[widget_derive]
     #[widget]
     pub inner: W,
     offset: Offset,

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -184,11 +184,13 @@ impl<M: 'static> HasBool for RadioBoxBare<M> {
 #[layout(row, area=radiobox)]
 #[handler(msg = M, generics = <> where M: From<VoidMsg>)]
 #[widget(config=noauto)]
+#[widget_derive(HasBool)]
 pub struct RadioBox<M: 'static> {
     #[widget_core]
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,
+    #[inner_widget]
     #[widget]
     radiobox: RadioBoxBare<M>,
     #[widget]
@@ -299,17 +301,5 @@ impl<M: 'static> RadioBox<M> {
 impl<M: 'static> WidgetConfig for RadioBox<M> {
     fn configure(&mut self, mgr: &mut Manager) {
         mgr.add_accel_keys(self.radiobox.id(), self.label.keys());
-    }
-}
-
-impl<M: 'static> HasBool for RadioBox<M> {
-    #[inline]
-    fn get_bool(&self) -> bool {
-        self.radiobox.get_bool()
-    }
-
-    #[inline]
-    fn set_bool(&mut self, state: bool) -> TkAction {
-        self.radiobox.set_bool(state)
     }
 }

--- a/src/widget/radiobox.rs
+++ b/src/widget/radiobox.rs
@@ -190,7 +190,7 @@ pub struct RadioBox<M: 'static> {
     core: CoreData,
     #[layout_data]
     layout_data: <Self as kas::LayoutData>::Data,
-    #[inner_widget]
+    #[widget_derive]
     #[widget]
     radiobox: RadioBoxBare<M>,
     #[widget]

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -244,7 +244,7 @@ impl ScrollComponent {
 #[derive(Clone, Debug, Default, Widget)]
 #[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
-#[widget_derive(class_traits)]
+#[widget_derive(class_traits, Deref, DerefMut)]
 pub struct ScrollRegion<W: Widget> {
     #[widget_core]
     core: CoreData,
@@ -409,18 +409,5 @@ impl<W: Widget> event::SendEvent for ScrollRegion<W> {
         } else {
             response.void_into()
         }
-    }
-}
-
-impl<W: Widget> std::ops::Deref for ScrollRegion<W> {
-    type Target = W;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<W: Widget> std::ops::DerefMut for ScrollRegion<W> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
     }
 }

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -244,6 +244,7 @@ impl ScrollComponent {
 #[derive(Clone, Debug, Default, Widget)]
 #[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
+#[widget_derive(class_traits)]
 pub struct ScrollRegion<W: Widget> {
     #[widget_core]
     core: CoreData,
@@ -251,6 +252,7 @@ pub struct ScrollRegion<W: Widget> {
     offset: Offset,
     frame_size: Size,
     scroll: ScrollComponent,
+    #[inner_widget]
     #[widget]
     inner: W,
 }

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -252,7 +252,7 @@ pub struct ScrollRegion<W: Widget> {
     offset: Offset,
     frame_size: Size,
     scroll: ScrollComponent,
-    #[inner_widget]
+    #[widget_derive]
     #[widget]
     inner: W,
 }

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -327,6 +327,7 @@ pub type ScrollBarRegion<W> = ScrollBars<ScrollRegion<W>>;
 #[derive(Clone, Debug, Default, Widget)]
 #[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
+#[widget_derive(class_traits)]
 pub struct ScrollBars<W: Scrollable> {
     #[widget_core]
     core: CoreData,
@@ -336,6 +337,7 @@ pub struct ScrollBars<W: Scrollable> {
     horiz_bar: ScrollBar<kas::dir::Right>,
     #[widget]
     vert_bar: ScrollBar<kas::dir::Down>,
+    #[inner_widget]
     #[widget]
     inner: W,
 }

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -327,7 +327,7 @@ pub type ScrollBarRegion<W> = ScrollBars<ScrollRegion<W>>;
 #[derive(Clone, Debug, Default, Widget)]
 #[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
-#[widget_derive(class_traits)]
+#[widget_derive(class_traits, Deref, DerefMut)]
 pub struct ScrollBars<W: Scrollable> {
     #[widget_core]
     core: CoreData,
@@ -557,18 +557,5 @@ impl<W: Scrollable> event::SendEvent for ScrollBars<W> {
             debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
             self.handle(mgr, event)
         }
-    }
-}
-
-impl<W: Scrollable> std::ops::Deref for ScrollBars<W> {
-    type Target = W;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<W: Scrollable> std::ops::DerefMut for ScrollBars<W> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
     }
 }


### PR DESCRIPTION
This can now derive for wrapper structs over an internal field, and derive class traits as well as `Deref`. I hope it's not too confusing.