### PR TITLE
Add canvas widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ json = ["config", "serde_json"]
 # Enable support for RON (de)serialisation
 ron = ["config", "dep_ron"]
 
+# Support canvas widget
+canvas = ["tiny-skia"]
+
 # Support SVG images
 svg = ["tiny-skia", "resvg", "usvg"]
 

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -55,7 +55,7 @@ rustc-hash = "1.0"
 [dev-dependencies]
 chrono = "0.4"
 env_logger = "0.8"
-kas = { path = "..", features = ["markdown", "winit", "json", "yaml", "ron", "svg"] }
+kas = { path = "..", features = ["markdown", "winit", "json", "yaml", "ron", "svg", "canvas"] }
 
 [build-dependencies]
 glob = "0.3"

--- a/kas-wgpu/Cargo.toml
+++ b/kas-wgpu/Cargo.toml
@@ -50,6 +50,7 @@ winit = "0.25"
 thiserror = "1.0.23"
 window_clipboard = { version = "0.2.0", optional = true }
 guillotiere = "0.6.0"
+rustc-hash = "1.0"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/kas-wgpu/examples/canvas.rs
+++ b/kas-wgpu/examples/canvas.rs
@@ -1,0 +1,67 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Canvas example
+
+use kas::cast::Conv;
+use kas::geom::Size;
+use kas::widget::tiny_skia::*;
+use kas::widget::{Canvas, CanvasDrawable, Window};
+
+#[derive(Debug)]
+struct Program;
+impl CanvasDrawable for Program {
+    fn draw(&self, pixmap: &mut Pixmap) {
+        let size = (200.0, 200.0);
+        let scale = Transform::from_scale(
+            f32::conv(pixmap.width()) / size.0,
+            f32::conv(pixmap.height()) / size.1,
+        );
+
+        let paint = Paint {
+            shader: LinearGradient::new(
+                Point::from_xy(0.0, 0.0),
+                Point::from_xy(size.0, size.1),
+                vec![
+                    GradientStop::new(0.0, Color::BLACK),
+                    GradientStop::new(1.0, Color::from_rgba8(0, 255, 200, 255)),
+                ],
+                SpreadMode::Pad,
+                Transform::identity(),
+            )
+            .unwrap(),
+            ..Default::default()
+        };
+
+        let mut path = PathBuilder::new();
+        path.push_circle(120.0, 90.0, 100.0);
+        path.push_circle(110.0, 90.0, 50.0);
+        let path = path.finish().unwrap();
+        pixmap.fill_path(&path, &paint, FillRule::EvenOdd, scale, None);
+
+        let path = PathBuilder::from_circle(30.0, 180.0, 20.0).unwrap();
+        pixmap.fill_path(&path, &paint, FillRule::Winding, scale, None);
+
+        let mut paint = Paint::default();
+        paint.set_color_rgba8(230, 90, 50, 255);
+        let mut path = PathBuilder::new();
+        path.move_to(20.0, 50.0);
+        path.quad_to(60.0, 60.0, 80.0, 110.0);
+        path.quad_to(80.0, 85.0, 100.0, 60.0);
+        path.quad_to(60.0, 40.0, 20.0, 50.0);
+        let path = path.finish().unwrap();
+        pixmap.fill_path(&path, &paint, FillRule::Winding, scale, None);
+    }
+}
+
+fn main() -> Result<(), kas_wgpu::Error> {
+    env_logger::init();
+
+    let canvas = Canvas::new(Program, Size(400, 400));
+    let window = Window::new("Canvas", canvas);
+
+    let theme = kas_theme::FlatTheme::new();
+    kas_wgpu::Toolkit::new(theme)?.with(window)?.run()
+}

--- a/kas-wgpu/src/draw/text_pipe.rs
+++ b/kas-wgpu/src/draw/text_pipe.rs
@@ -13,7 +13,7 @@ use kas::text::fonts::FaceId;
 use kas::text::{Effect, Glyph, TextDisplay};
 use kas_text::raster::{raster, Config, SpriteDescriptor};
 use kas_theme::RasterConfig;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 use std::mem::size_of;
 use std::num::NonZeroU32;
 

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -1,0 +1,185 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Canvas widget
+
+use kas::draw::{ImageFormat, ImageId};
+use kas::layout::MarginSelector;
+use kas::{event, prelude::*};
+use tiny_skia::{Color, Pixmap};
+
+/// Draws to a [`Canvas`]'s [`Pixmap`]
+pub trait CanvasDrawable: std::fmt::Debug + 'static {
+    /// Draw
+    ///
+    /// This is called whenever the [`Pixmap`] is resized. One should check the
+    /// pixmap's dimensions and scale the contents appropriately.
+    fn draw(&self, pixmap: &mut Pixmap);
+}
+
+/// A canvas widget over the `tiny-skia` library
+///
+/// Note that the `tiny-skia` API is re-exported as [`kas::widget::tiny_skia`].
+///
+/// Canvas size is controlled by the sizing arguments passed to the constructor,
+/// as well as the `stretch` factor and the display's scale factor `sf`.
+/// Minimum size is `min_size * sf`. Ideal size is `ideal_size * sf` except that
+/// if `fix_aspect` is true, then the ideal height is the one that preserves
+/// aspect ratio for the given width. The canvas may also exceed the ideal size
+/// if a [`Stretch`] factor greater than `None` is used.
+///
+/// The canvas (re)creates the backing pixmap when the size is set and draws
+/// to the new pixmap immediately. If the canvas program is modified then
+/// [`Canvas::redraw`] must be called to update the pixmap.
+#[cfg_attr(doc_cfg, doc(cfg(canvas)))]
+#[derive(Clone, Debug, Widget)]
+pub struct Canvas<P: CanvasDrawable> {
+    #[widget_core]
+    core: CoreData,
+    margins: MarginSelector,
+    fix_aspect: bool,
+    min_size: Size,
+    ideal_size: Size,
+    stretch: Stretch,
+    pixmap: Option<Pixmap>,
+    image_id: Option<ImageId>,
+    /// The program drawing to the canvas
+    pub program: P,
+}
+
+impl<P: CanvasDrawable> Canvas<P> {
+    /// Construct with given size
+    ///
+    /// Creates a new canvas with `min_size = ideal_size = size` and
+    /// `fix_aspect = true`. Use [`Canvas::new_sizes`] for more control.
+    /// Sizes are multiplied by the display's scale factor.
+    #[inline]
+    pub fn new(program: P, size: Size) -> Self {
+        Self::new_sizes(program, size, size, true)
+    }
+
+    /// Construct with given sizes and optional aspect ratio fixing
+    ///
+    /// Sizes are multiplied by the display's scale factor. See [`Canvas`]
+    /// documentation for more details on sizing.
+    pub fn new_sizes(program: P, min_size: Size, ideal_size: Size, fix_aspect: bool) -> Self {
+        Canvas {
+            core: Default::default(),
+            margins: MarginSelector::Outer,
+            fix_aspect,
+            min_size,
+            ideal_size,
+            stretch: Stretch::None,
+            pixmap: None,
+            image_id: None,
+            program,
+        }
+    }
+
+    /// Set margins
+    pub fn with_margins(mut self, margins: MarginSelector) -> Self {
+        self.margins = margins;
+        self
+    }
+
+    /// Set stretch policy
+    pub fn with_stretch(mut self, stretch: Stretch) -> Self {
+        self.stretch = stretch;
+        self
+    }
+
+    /// Set margins
+    pub fn set_margins(&mut self, margins: MarginSelector) {
+        self.margins = margins;
+    }
+
+    /// Set stretch policy
+    pub fn set_stretch(&mut self, stretch: Stretch) {
+        self.stretch = stretch;
+    }
+
+    /// Redraw immediately
+    ///
+    /// Other than this, the canvas is only drawn when the backing pixmap is
+    /// (re)created: on start and on resizing.
+    ///
+    /// This method does nothing before a backing pixmap has been created.
+    pub fn redraw(&mut self, mgr: &mut Manager) {
+        if let Some((pm, id)) = self.pixmap.as_mut().zip(self.image_id) {
+            pm.fill(Color::TRANSPARENT);
+            self.program.draw(pm);
+            mgr.draw_shared(|ds| ds.image_upload(id, pm.data(), ImageFormat::Rgba8));
+        }
+    }
+}
+
+impl<P: CanvasDrawable> Layout for Canvas<P> {
+    fn size_rules(&mut self, sh: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+        let margins = self.margins.select(sh);
+        if axis.is_horizontal() {
+            let mut ideal_w = self.ideal_size.0;
+            if let Some(height) = axis.other() {
+                ideal_w = i32::conv(
+                    i64::conv(height) * i64::conv(ideal_w) / i64::conv(self.ideal_size.1),
+                );
+            }
+            SizeRules::new(self.min_size.0, ideal_w, margins.horiz, self.stretch)
+        } else {
+            let mut ideal_h = self.ideal_size.1;
+            if let Some(width) = axis.other() {
+                ideal_h =
+                    i32::conv(i64::conv(width) * i64::conv(ideal_h) / i64::conv(self.ideal_size.0));
+            }
+            SizeRules::new(self.min_size.1, ideal_h, margins.vert, self.stretch)
+        }
+    }
+
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
+        let size = if self.fix_aspect {
+            match self.ideal_size.aspect_scale_to(rect.size) {
+                Some(size) => {
+                    self.core_data_mut().rect = align
+                        .complete(Align::Centre, Align::Centre)
+                        .aligned_rect(size, rect);
+                    size
+                }
+                None => {
+                    self.core_data_mut().rect = rect;
+                    self.pixmap = None;
+                    self.image_id = None;
+                    return;
+                }
+            }
+        } else {
+            self.core_data_mut().rect = rect;
+            rect.size
+        };
+        let size: (u32, u32) = size.into();
+
+        let pm_size = self.pixmap.as_ref().map(|pm| (pm.width(), pm.height()));
+        if pm_size.unwrap_or((0, 0)) != size {
+            if let Some(id) = self.image_id {
+                mgr.draw_shared(|ds| ds.remove_image(id));
+            }
+            self.pixmap = Pixmap::new(size.0, size.1);
+            let program = &self.program;
+            self.image_id = self.pixmap.as_mut().map(|pm| {
+                program.draw(pm);
+                mgr.draw_shared(|ds| {
+                    let (w, h) = (pm.width(), pm.height());
+                    let id = ds.image_alloc((w, h)).unwrap();
+                    ds.image_upload(id, pm.data(), ImageFormat::Rgba8);
+                    id
+                })
+            });
+        }
+    }
+
+    fn draw(&self, draw: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {
+        if let Some(id) = self.image_id {
+            draw.image(id, self.rect());
+        }
+    }
+}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -52,6 +52,8 @@
 //! -   [`DragHandle`]: a handle (e.g. for a slider, splitter or scrollbar)
 
 mod button;
+#[cfg(feature = "canvas")]
+mod canvas;
 mod checkbox;
 mod combobox;
 mod dialog;
@@ -80,6 +82,8 @@ mod window;
 pub mod view;
 
 pub use button::{Button, TextButton};
+#[cfg(feature = "canvas")]
+pub use canvas::{Canvas, CanvasDrawable};
 pub use checkbox::{CheckBox, CheckBoxBare};
 pub use combobox::ComboBox;
 pub use dialog::MessageBox;
@@ -104,3 +108,6 @@ pub use stack::{BoxStack, RefStack, Stack};
 #[cfg(feature = "svg")]
 pub use svg::Svg;
 pub use window::Window;
+
+#[cfg(feature = "canvas")]
+pub use tiny_skia;

--- a/src/widget/svg.rs
+++ b/src/widget/svg.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use tiny_skia::Pixmap;
 
 /// An SVG image loaded from a path
+#[cfg_attr(doc_cfg, doc(cfg(svg)))]
 #[derive(Clone, Widget)]
 #[widget(config = noauto)]
 pub struct Svg {
@@ -88,7 +89,7 @@ impl Svg {
     }
 
     /// Set margins
-    pub fn margins(&mut self, margins: MarginSelector) {
+    pub fn set_margins(&mut self, margins: MarginSelector) {
         self.margins = margins;
     }
 


### PR DESCRIPTION
This is built over the [tiny-skia API](https://docs.rs/tiny-skia) (which is already used by the `Svg` widget).
The canvas has a built-in cache since it is rendered on the CPU then uploaded as a GPU texture.

Potentially we could add other canvas widgets over other draw APIs in the future, in which case this widget should be renamed.

Note there is already another option for drawing: constructing a new widget with code in the `Layout::draw` implementation (not cached); see e.g. `clock` or `mandlebrot` examples.

Also: some optimisations to text drawing.