### PR TITLE
Apply Clippy suggestions

### DIFF
--- a/kas-theme/src/config.rs
+++ b/kas-theme/src/config.rs
@@ -176,6 +176,7 @@ impl Config {
 /// Other functions
 impl Config {
     /// Currently this is just "set". Later, maybe some type of merge.
+    #[allow(clippy::float_cmp)]
     pub fn apply_config(&mut self, other: &Config) -> TkAction {
         let action = if self.font_size != other.font_size {
             TkAction::RESIZE | TkAction::THEME_UPDATE

--- a/kas-theme/src/dim.rs
+++ b/kas-theme/src/dim.rs
@@ -226,10 +226,10 @@ impl<'a, DS: DrawableShared> draw::SizeHandle for SizeHandle<'a, DS> {
             }
             env.set_bounds(bounds);
 
-            env.set_wrap(match class {
-                TextClass::Label | TextClass::EditMulti | TextClass::LabelScroll => true,
-                _ => false,
-            });
+            env.set_wrap(matches!(
+                class,
+                TextClass::Label | TextClass::EditMulti | TextClass::LabelScroll
+            ));
         });
 
         let margin = self.w.dims.text_margin;

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -140,15 +140,21 @@ where
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &'static mut DrawShared<DS>,
-        draw: Draw<'static, DS::Draw>,
-        window: &'static mut Self::Window,
+        shared: &mut DrawShared<DS>,
+        draw: Draw<DS::Draw>,
+        window: &mut Self::Window,
     ) -> Self::DrawHandle {
+        unsafe fn extend_lifetime<'b, T: ?Sized>(r: &'b T) -> &'static T {
+            std::mem::transmute::<&'b T, &'static T>(r)
+        }
+        unsafe fn extend_lifetime_mut<'b, T: ?Sized>(r: &'b mut T) -> &'static mut T {
+            std::mem::transmute::<&'b mut T, &'static mut T>(r)
+        }
         DrawHandle {
-            shared,
-            draw,
-            window,
-            cols: std::mem::transmute::<&ColorsLinear, &'static ColorsLinear>(&self.cols),
+            shared: extend_lifetime_mut(shared),
+            draw: Draw::new(extend_lifetime_mut(draw.draw), draw.pass()),
+            window: extend_lifetime_mut(window),
+            cols: extend_lifetime(&self.cols),
             offset: Offset::ZERO,
         }
     }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -33,6 +33,12 @@ pub struct FlatTheme {
     pub(crate) fonts: Option<Rc<LinearMap<TextClass, fonts::FontId>>>,
 }
 
+impl Default for FlatTheme {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FlatTheme {
     /// Construct
     #[inline]
@@ -117,13 +123,13 @@ where
         self.fonts = Some(Rc::new(
             self.config
                 .iter_fonts()
-                .filter_map(|(c, s)| fonts.select_font(&s).ok().map(|id| (*c, id)))
+                .filter_map(|(c, s)| fonts.select_font(s).ok().map(|id| (*c, id)))
                 .collect(),
         ));
     }
 
     fn new_window(&self, dpi_factor: f32) -> Self::Window {
-        let fonts = self.fonts.as_ref().clone().unwrap().clone();
+        let fonts = self.fonts.as_ref().unwrap().clone();
         DimensionsWindow::new(DIMS, self.config.font_size(), dpi_factor, fonts)
     }
 

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -80,12 +80,12 @@ impl<DS> MultiThemeBuilder<DS> {
 
     /// Build
     ///
-    /// Fails if no themes were added.
-    pub fn try_build(self) -> Result<MultiTheme<DS>, ()> {
+    /// Returns `None` if no themes were added.
+    pub fn try_build(self) -> Option<MultiTheme<DS>> {
         if self.themes.is_empty() {
-            return Err(());
+            return None;
         }
-        Ok(MultiTheme {
+        Some(MultiTheme {
             names: self.names,
             themes: self.themes,
             active: 0,
@@ -97,7 +97,7 @@ impl<DS> MultiThemeBuilder<DS> {
     /// Panics if no themes were added.
     pub fn build(self) -> MultiTheme<DS> {
         self.try_build()
-            .unwrap_or_else(|_| panic!("MultiThemeBuilder: no themes added"))
+            .unwrap_or_else(|| panic!("MultiThemeBuilder: no themes added"))
     }
 }
 

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -82,7 +82,7 @@ impl<DS> MultiThemeBuilder<DS> {
     ///
     /// Fails if no themes were added.
     pub fn try_build(self) -> Result<MultiTheme<DS>, ()> {
-        if self.themes.len() == 0 {
+        if self.themes.is_empty() {
             return Err(());
         }
         Ok(MultiTheme {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -21,6 +21,12 @@ pub struct ShadedTheme {
     flat: FlatTheme,
 }
 
+impl Default for ShadedTheme {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ShadedTheme {
     /// Construct
     pub fn new() -> Self {
@@ -92,7 +98,7 @@ where
     }
 
     fn new_window(&self, dpi_factor: f32) -> Self::Window {
-        let fonts = self.flat.fonts.as_ref().clone().unwrap().clone();
+        let fonts = self.flat.fonts.as_ref().unwrap().clone();
         DimensionsWindow::new(DIMS, self.flat.config.font_size(), dpi_factor, fonts)
     }
 
@@ -161,10 +167,10 @@ where
         'b: 'c,
     {
         super::flat_theme::DrawHandle {
-            shared: *&mut self.shared,
+            shared: self.shared,
             draw: self.draw.reborrow(),
-            window: *&mut self.window,
-            cols: *&self.cols,
+            window: self.window,
+            cols: self.cols,
             offset: self.offset,
         }
     }

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -67,14 +67,15 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     ///
     /// See also [`Theme::draw_handle`].
     ///
-    /// This function is **unsafe** because the returned object requires a
-    /// lifetime bound not exceeding that of all three pointers passed in.
+    /// # Safety
+    ///
+    /// All references passed into the method must outlive the returned object.
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &'static mut DrawShared<DS>,
-        draw: Draw<'static, DS::Draw>,
-        window: &'static mut dyn WindowDst<DS>,
+        shared: &mut DrawShared<DS>,
+        draw: Draw<DS::Draw>,
+        window: &mut dyn WindowDst<DS>,
     ) -> StackDst<dyn DrawHandle>;
 
     /// Construct a [`DrawHandle`] object
@@ -141,9 +142,9 @@ where
 
     unsafe fn draw_handle(
         &self,
-        shared: &'static mut DrawShared<DS>,
-        draw: Draw<'static, DS::Draw>,
-        window: &'static mut dyn WindowDst<DS>,
+        shared: &mut DrawShared<DS>,
+        draw: Draw<DS::Draw>,
+        window: &mut dyn WindowDst<DS>,
     ) -> StackDst<dyn DrawHandle> {
         let window = window.as_any_mut().downcast_mut().unwrap();
         let h = <T as Theme<DS>>::draw_handle(self, shared, draw, window);
@@ -220,8 +221,9 @@ pub trait WindowDst<DS: DrawableShared> {
     /// The `shared` reference is guaranteed to be identical to the one used to
     /// construct this object.
     ///
-    /// This function is **unsafe** because the returned object requires a
-    /// lifetime bound not exceeding that of all three pointers passed in.
+    /// # Safety
+    ///
+    /// All references passed into the method must outlive the returned object.
     #[cfg(not(feature = "gat"))]
     unsafe fn size_handle(&mut self, shared: &mut DrawShared<DS>) -> StackDst<dyn SizeHandle>;
 

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -105,7 +105,7 @@ where
     fn config(&self) -> MaybeBoxed<dyn Any> {
         match self.config() {
             Cow::Borrowed(config) => MaybeBoxed::Borrowed(config),
-            Cow::Owned(config) => MaybeBoxed::Boxed(Box::new(config.to_owned())),
+            Cow::Owned(config) => MaybeBoxed::Boxed(Box::new(config)),
         }
     }
 

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -99,17 +99,17 @@ pub trait Theme<DS: DrawableShared>: ThemeApi {
     /// [`Theme::new_window`] on `self`, and the `draw` reference is guaranteed
     /// to be identical to the one passed to [`Theme::new_window`].
     ///
-    /// Without the "gat" feature (Generic Associated Types; rust#44265), the
-    /// caller must unsafely extend the lifetime of references to `'static`.
-    /// These references shall not escape the lifetime of the return value.
-    /// The method is marked `unsafe` since sometimes it must extend the
-    /// lifetime of internal state.
+    /// # Safety
+    ///
+    /// (This section only applies when not using the `gat` feature.)
+    ///
+    /// All references passed into the method must outlive the returned object.
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &'static mut DrawShared<DS>,
-        draw: Draw<'static, DS::Draw>,
-        window: &'static mut Self::Window,
+        shared: &mut DrawShared<DS>,
+        draw: Draw<DS::Draw>,
+        window: &mut Self::Window,
     ) -> Self::DrawHandle;
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
@@ -141,6 +141,10 @@ pub trait Window<DS: DrawableShared>: 'static {
     ///
     /// The `shared` reference is guaranteed to be identical to the one used to
     /// construct this object.
+    ///
+    /// # Safety
+    ///
+    /// All references passed into the method must outlive the returned object.
     #[cfg(not(feature = "gat"))]
     unsafe fn size_handle(&mut self, shared: &mut DrawShared<DS>) -> Self::SizeHandle;
     #[cfg(feature = "gat")]
@@ -179,9 +183,9 @@ impl<T: Theme<DS>, DS: DrawableShared> Theme<DS> for Box<T> {
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &'static mut DrawShared<DS>,
-        draw: Draw<'static, DS::Draw>,
-        window: &'static mut Self::Window,
+        shared: &mut DrawShared<DS>,
+        draw: Draw<DS::Draw>,
+        window: &mut Self::Window,
     ) -> Self::DrawHandle {
         self.deref().draw_handle(shared, draw, window)
     }

--- a/kas-wgpu/build.rs
+++ b/kas-wgpu/build.rs
@@ -36,7 +36,7 @@ fn main() {
         Err(e) => panic!("failed to read env var SHADERC: {}", e),
     };
 
-    let mut pat = String::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let mut pat = env::var("CARGO_MANIFEST_DIR").unwrap();
     pat.push_str("/**/*.vert");
     walk(&pat, &shaderc, &mut runners);
     pat.replace_range((pat.len() - 4).., "frag");

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -81,9 +81,9 @@ where
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &'static mut DrawShared<DS>,
-        draw: Draw<'static, DS::Draw>,
-        window: &'static mut Self::Window,
+        shared: &mut DrawShared<DS>,
+        draw: Draw<DS::Draw>,
+        window: &mut Self::Window,
     ) -> Self::DrawHandle {
         Theme::<DS>::draw_handle(&self.inner, shared, draw, window)
     }

--- a/kas-wgpu/src/draw/atlases.rs
+++ b/kas-wgpu/src/draw/atlases.rs
@@ -215,7 +215,7 @@ impl<I: bytemuck::Pod> Pipeline<I> {
 
         self.new_aa.push(Atlas::new_alloc(tex_size));
         match self.new_aa.last_mut().unwrap().allocate(size2d) {
-            Some(alloc) => return Ok((atlas.cast(), alloc, tex_size)),
+            Some(alloc) => Ok((atlas.cast(), alloc, tex_size)),
             None => unreachable!(),
         }
     }

--- a/kas-wgpu/src/draw/custom.rs
+++ b/kas-wgpu/src/draw/custom.rs
@@ -157,7 +157,6 @@ impl CustomPipeBuilder for () {
         _: &wgpu::BindGroupLayout,
         _: wgpu::TextureFormat,
     ) -> Self::Pipe {
-        ()
     }
 }
 
@@ -166,9 +165,7 @@ pub enum Void {}
 /// A dummy implementation (does nothing)
 impl CustomPipe for () {
     type Window = ();
-    fn new_window(&self, _: &wgpu::Device, _: Size) -> Self::Window {
-        ()
-    }
+    fn new_window(&self, _: &wgpu::Device, _: Size) -> Self::Window {}
     fn resize(&self, _: &mut Self::Window, _: &wgpu::Device, _: &wgpu::Queue, _: Size) {}
 }
 

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -185,29 +185,29 @@ impl<C: CustomPipe> DrawPipe<C> {
 
         self.images.prepare(
             &mut window.images,
-            &mut self.device,
+            &self.device,
             &mut self.staging_belt,
             &mut encoder,
         );
         window
             .shaded_square
-            .write_buffers(&mut self.device, &mut self.staging_belt, &mut encoder);
+            .write_buffers(&self.device, &mut self.staging_belt, &mut encoder);
         window
             .shaded_round
-            .write_buffers(&mut self.device, &mut self.staging_belt, &mut encoder);
+            .write_buffers(&self.device, &mut self.staging_belt, &mut encoder);
         window
             .flat_round
-            .write_buffers(&mut self.device, &mut self.staging_belt, &mut encoder);
+            .write_buffers(&self.device, &mut self.staging_belt, &mut encoder);
         self.custom.prepare(
             &mut window.custom,
-            &mut self.device,
+            &self.device,
             &mut self.staging_belt,
             &mut encoder,
         );
-        self.text.prepare(&mut self.device, &mut self.queue);
+        self.text.prepare(&self.device, &self.queue);
         window
             .text
-            .write_buffers(&mut self.device, &mut self.staging_belt, &mut encoder);
+            .write_buffers(&self.device, &mut self.staging_belt, &mut encoder);
 
         let mut color_attachments = [wgpu::RenderPassColorAttachment {
             view: frame_view,
@@ -248,13 +248,12 @@ impl<C: CustomPipe> DrawPipe<C> {
                     .render(&window.flat_round, pass, &mut rpass, bg_common);
                 self.custom.render_pass(
                     &mut window.custom,
-                    &mut self.device,
+                    &self.device,
                     pass,
                     &mut rpass,
                     bg_common,
                 );
-                self.text
-                    .render(&mut window.text, pass, &mut rpass, bg_common);
+                self.text.render(&window.text, pass, &mut rpass, bg_common);
             }
 
             color_attachments[0].ops.load = wgpu::LoadOp::Load;
@@ -265,7 +264,7 @@ impl<C: CustomPipe> DrawPipe<C> {
 
         self.custom.render_final(
             &mut window.custom,
-            &mut self.device,
+            &self.device,
             &mut encoder,
             frame_view,
             size,

--- a/kas-wgpu/src/draw/images.rs
+++ b/kas-wgpu/src/draw/images.rs
@@ -85,7 +85,7 @@ impl Images {
     ) -> Self {
         let atlas_pipe = atlases::Pipeline::new(
             device,
-            &bgl_common,
+            bgl_common,
             2048,
             wgpu::TextureFormat::Rgba8UnormSrgb,
             wgpu::VertexState {

--- a/kas-wgpu/src/draw/text_pipe.rs
+++ b/kas-wgpu/src/draw/text_pipe.rs
@@ -48,6 +48,7 @@ pub struct Pipeline {
     config: Config,
     atlas_pipe: atlases::Pipeline<Instance>,
     glyphs: HashMap<SpriteDescriptor, Option<Sprite>>,
+    #[allow(clippy::type_complexity)]
     prepare: Vec<(u32, (u32, u32), (u32, u32), Vec<u8>)>,
 }
 
@@ -60,7 +61,7 @@ impl Pipeline {
     ) -> Self {
         let atlas_pipe = atlases::Pipeline::new(
             device,
-            &bgl_common,
+            bgl_common,
             512,
             wgpu::TextureFormat::R8Unorm,
             wgpu::VertexState {

--- a/kas-wgpu/src/event_loop.rs
+++ b/kas-wgpu/src/event_loop.rs
@@ -72,7 +72,7 @@ where
             UserEvent(action) => match action {
                 ProxyAction::Close(id) => {
                     if let Some(id) = self.id_map.get(&id) {
-                        if let Some(window) = self.windows.get_mut(&id) {
+                        if let Some(window) = self.windows.get_mut(id) {
                             window.send_action(TkAction::CLOSE);
                         }
                     }
@@ -224,7 +224,7 @@ where
                 }
                 PendingAction::CloseWindow(id) => {
                     if let Some(wwid) = self.id_map.get(&id) {
-                        if let Some(window) = self.windows.get_mut(&wwid) {
+                        if let Some(window) = self.windows.get_mut(wwid) {
                             window.send_close(&mut self.shared, id);
                         }
                         self.id_map.remove(&id);

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -323,15 +323,11 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
         #[cfg(not(feature = "gat"))]
         unsafe {
-            unsafe fn extend_lifetime<'b, T>(r: &'b mut T) -> &'static mut T {
-                std::mem::transmute::<&'b mut T, &'static mut T>(r)
-            }
-
             // Safety: lifetimes do not escape the returned draw_handle value.
-            let draw_shared = extend_lifetime(&mut shared.draw);
+            let draw_shared = &mut shared.draw;
             let pass = Pass::new(0);
-            let draw = Draw::new(extend_lifetime(&mut self.draw), pass);
-            let window = extend_lifetime(&mut self.theme_window);
+            let draw = Draw::new(&mut self.draw, pass);
+            let window = &mut self.theme_window;
 
             let mut draw_handle = shared.theme.draw_handle(draw_shared, draw, window);
             self.widget.draw(&mut draw_handle, &self.mgr, false);

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -134,7 +134,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
                 self.solve_cache.invalidate_rule_cache();
                 self.do_resize(shared, *new_inner_size);
             }
-            event @ _ => {
+            event => {
                 let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
                 let widget = &mut *self.widget;
                 self.mgr.with(&mut tkw, |mgr| {

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -58,6 +58,7 @@
 
 pub mod color;
 
+#[allow(clippy::module_inception)]
 mod draw;
 mod draw_shared;
 mod handle;

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -173,7 +173,7 @@ impl<'a> Manager<'a> {
         self.state
             .handle_updates
             .entry(handle)
-            .or_insert(Default::default())
+            .or_insert_with(Default::default)
             .insert(w_id);
     }
 

--- a/src/event/shortcuts.rs
+++ b/src/event/shortcuts.rs
@@ -24,7 +24,7 @@ pub struct Shortcuts {
 impl Shortcuts {
     /// Construct, with no bindings
     #[inline]
-    pub fn new() -> Self {
+    pub fn empty() -> Self {
         Shortcuts {
             map: Default::default(),
         }
@@ -33,7 +33,7 @@ impl Shortcuts {
     /// Construct, with default bindings
     #[inline]
     pub fn platform_defaults() -> Self {
-        let mut s = Self::new();
+        let mut s = Self::empty();
         s.load_platform_defaults();
         s
     }

--- a/src/layout/row_solver.rs
+++ b/src/layout/row_solver.rs
@@ -343,8 +343,7 @@ impl<D: Directional> RowPositionSolver<D> {
             Err(_) => 0,
         };
 
-        for i in start..widgets.len() {
-            let child = &widgets[i];
+        for child in widgets[start..].iter() {
             let do_break = match self.direction.as_direction() {
                 Direction::Right => child.rect().pos.0 >= end.0,
                 Direction::Down => child.rect().pos.1 >= end.1,

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -392,7 +392,11 @@ impl SizeRules {
     /// is passed explicitly.
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    #[allow(clippy::comparison_chain, clippy::needless_range_loop)]
+    #[allow(
+        clippy::comparison_chain,
+        clippy::needless_range_loop,
+        clippy::needless_return
+    )]
     #[inline]
     pub fn solve_seq_total(out: &mut [i32], rules: &[Self], total: Self, target: i32) {
         type Targets = SmallVec<[i32; 16]>;

--- a/src/layout/size_rules.rs
+++ b/src/layout/size_rules.rs
@@ -392,6 +392,7 @@ impl SizeRules {
     /// is passed explicitly.
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
+    #[allow(clippy::comparison_chain, clippy::needless_range_loop)]
     #[inline]
     pub fn solve_seq_total(out: &mut [i32], rules: &[Self], total: Self, target: i32) {
         type Targets = SmallVec<[i32; 16]>;
@@ -710,20 +711,20 @@ impl SizeRules {
         let b_per_elt = excess_b / count;
         let mut extra_a = excess_a - count * a_per_elt;
         let mut extra_b = excess_b - count * b_per_elt;
-        for i in 0..len {
-            if rules[i].stretch == highest_stretch {
-                rules[i].a += a_per_elt;
-                rules[i].b += b_per_elt;
+        for rules in rules.iter_mut() {
+            if rules.stretch == highest_stretch {
+                rules.a += a_per_elt;
+                rules.b += b_per_elt;
                 if extra_a > 0 {
-                    rules[i].a += 1;
+                    rules.a += 1;
                     extra_a -= 1;
                 }
                 if extra_b > 0 {
-                    rules[i].b += 1;
+                    rules.b += 1;
                     extra_b -= 1;
                 }
                 if highest_stretch < self.stretch {
-                    rules[i].stretch = self.stretch;
+                    rules.stretch = self.stretch;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,6 @@
     clippy::identity_op,
     clippy::or_fun_call,
     clippy::never_loop,
-    clippy::module_inception,
-    clippy::needless_return,
-    clippy::neg_cmp_op_on_partial_ord,
     clippy::comparison_chain
 )]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@
     clippy::module_inception,
     clippy::len_zero,
     clippy::needless_return,
-    clippy::neg_cmp_op_on_partial_ord
+    clippy::neg_cmp_op_on_partial_ord,
+    clippy::comparison_chain
 )]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(feature = "gat", feature(generic_associated_types))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
     clippy::or_fun_call,
     clippy::never_loop,
     clippy::module_inception,
-    clippy::len_zero,
     clippy::needless_return,
     clippy::neg_cmp_op_on_partial_ord,
     clippy::comparison_chain

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 
 // Use ``never_loop`` until: https://github.com/rust-lang/rust-clippy/issues/7397 is fixed
 #![allow(
+    clippy::identity_op,
     clippy::or_fun_call,
     clippy::never_loop,
     clippy::module_inception,

--- a/src/text/selection.rs
+++ b/src/text/selection.rs
@@ -110,15 +110,13 @@ impl SelectionHelper {
                 .next_back()
                 .map(|(index, _)| index)
                 .unwrap_or(0);
-            end = 'a: loop {
-                for (index, _) in string[start..].split_word_bound_indices() {
+            end = string[start..]
+                .split_word_bound_indices()
+                .find_map(|(index, _)| {
                     let pos = start + index;
-                    if pos >= range.end {
-                        break 'a pos;
-                    }
-                }
-                break 'a string.len();
-            };
+                    (pos >= range.end).then(|| pos)
+                })
+                .unwrap_or_else(|| string.len());
         } else {
             start = text.find_line(range.start).map(|r| r.1.start).unwrap_or(0);
             end = text

--- a/src/widget/combobox.rs
+++ b/src/widget/combobox.rs
@@ -177,6 +177,12 @@ impl<M: 'static> ComboBox<M> {
         self.popup.inner.len()
     }
 
+    /// True if the box contains no entries
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.popup.inner.is_empty()
+    }
+
     /// Remove all choices
     ///
     /// Triggers a [reconfigure action](Manager::send_action).

--- a/src/widget/progress.rs
+++ b/src/widget/progress.rs
@@ -59,6 +59,7 @@ impl<D: Directional> ProgressBar<D> {
     /// Set the value
     ///
     /// Returns [`TkAction::REDRAW`] if a redraw is required.
+    #[allow(clippy::float_cmp)]
     pub fn set_value(&mut self, value: f32) -> TkAction {
         let value = value.max(0.0).min(1.0);
         if value == self.value {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -189,6 +189,7 @@ impl<T: SliderType, D: Directional> Slider<T, D> {
     }
 
     // true if not equal to old value
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     fn set_offset(&mut self, offset: Offset) -> bool {
         let b = self.range.1 - self.range.0;
         let max_offset = self.handle.max_offset();

--- a/src/widget/splitter.rs
+++ b/src/widget/splitter.rs
@@ -115,7 +115,7 @@ impl<D: Directional, W: Widget> WidgetChildren for Splitter<D, W> {
 
 impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        if self.widgets.len() == 0 {
+        if self.widgets.is_empty() {
             return SizeRules::EMPTY;
         }
         assert_eq!(self.handles.len() + 1, self.widgets.len());
@@ -146,7 +146,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
 
     fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core.rect = rect;
-        if self.widgets.len() == 0 {
+        if self.widgets.is_empty() {
             return;
         }
         assert!(self.handles.len() + 1 == self.widgets.len());
@@ -220,7 +220,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
 
 impl<D: Directional, W: Widget> event::SendEvent for Splitter<D, W> {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
-        if !self.is_disabled() && self.widgets.len() > 0 {
+        if !self.is_disabled() && !self.widgets.is_empty() {
             assert!(self.handles.len() + 1 == self.widgets.len());
             let mut n = 0;
             loop {

--- a/src/widget/view/data_traits.rs
+++ b/src/widget/view/data_traits.rs
@@ -49,6 +49,7 @@ pub trait SingleDataMut: SingleData {
 }
 
 /// Trait for viewable data lists
+#[allow(clippy::len_without_is_empty)]
 pub trait ListData: Debug {
     /// Key type
     type Key: Clone + Debug + PartialEq + Eq;

--- a/src/widget/view/list_view.rs
+++ b/src/widget/view/list_view.rs
@@ -5,7 +5,7 @@
 
 //! List view widget
 
-use super::{driver, Driver, ListData, SelectionMode};
+use super::{driver, Driver, ListData, SelectionError, SelectionMode};
 use kas::event::{ChildMsg, Command, CursorIcon, GrabMode, PressSource};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
@@ -223,14 +223,14 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
     /// invalid.
     ///
     /// Does not send [`ChildMsg`] responses.
-    pub fn select(&mut self, key: T::Key) -> Result<bool, ()> {
+    pub fn select(&mut self, key: T::Key) -> Result<bool, SelectionError> {
         match self.sel_mode {
-            SelectionMode::None => return Err(()),
+            SelectionMode::None => return Err(SelectionError::Disabled),
             SelectionMode::Single => self.selection.clear(),
             _ => (),
         }
         if !self.data.contains_key(&key) {
-            return Err(());
+            return Err(SelectionError::Key);
         }
         Ok(self.selection.insert(key))
     }

--- a/src/widget/view/matrix_view.rs
+++ b/src/widget/view/matrix_view.rs
@@ -5,7 +5,7 @@
 
 //! List view widget
 
-use super::{driver, Driver, MatrixData, SelectionMode};
+use super::{driver, Driver, MatrixData, SelectionError, SelectionMode};
 use kas::event::{ChildMsg, Command, CursorIcon, GrabMode, PressSource};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
@@ -196,14 +196,14 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> MatrixVie
     /// invalid.
     ///
     /// Does not send [`ChildMsg`] responses.
-    pub fn select(&mut self, key: T::Key) -> Result<bool, ()> {
+    pub fn select(&mut self, key: T::Key) -> Result<bool, SelectionError> {
         match self.sel_mode {
-            SelectionMode::None => return Err(()),
+            SelectionMode::None => return Err(SelectionError::Disabled),
             SelectionMode::Single => self.selection.clear(),
             _ => (),
         }
         if !self.data.contains(&key) {
-            return Err(());
+            return Err(SelectionError::Key);
         }
         Ok(self.selection.insert(key))
     }

--- a/src/widget/view/mod.rs
+++ b/src/widget/view/mod.rs
@@ -71,6 +71,7 @@
 #[allow(unused)]
 use kas::event::UpdateHandle;
 use kas::macros::VoidMsg;
+use thiserror::Error;
 
 mod data_impls;
 mod data_traits;
@@ -103,4 +104,13 @@ impl Default for SelectionMode {
     fn default() -> Self {
         SelectionMode::None
     }
+}
+
+/// Selection errors
+#[derive(Error, Debug)]
+pub enum SelectionError {
+    #[error("selection disabled")]
+    Disabled,
+    #[error("invalid key or index")]
+    Key,
 }


### PR DESCRIPTION
Some are ignored:

- `float_cmp` when used to avoid work on unchanged values
- several suggestions to `solve_seq_total` which is an over-complex method where consistency and reduced indentation is more important than the style suggestions
- `identity_op` since, where applicable, it's purely for consistent styling
- `or_fun_call` since all cases should inline anyway
- `never_loop` (https://github.com/rust-lang/rust-clippy/issues/7397)
- `comparison_chain` because in my opinion the suggested alternative is less readable

The `draw_handle` method (non-GAT version) now does not take `'static` inputs but extends lifetimes internally (which was already required in one case).