### PR TITLE
Further revisions to draw API

### DIFF
--- a/kas-theme/src/draw_shaded.rs
+++ b/kas-theme/src/draw_shaded.rs
@@ -6,10 +6,10 @@
 //! Drawing APIs — shaded drawing
 
 use kas::draw::color::Rgba;
-use kas::draw::{Draw, Drawable, DrawableShared, PassId};
+use kas::draw::{DrawIface, Drawable, DrawableShared, PassId};
 use kas::geom::Quad;
 
-/// Extension trait providing shaded drawing over [`Draw`]
+/// Extension trait providing shaded drawing over [`DrawIface`]
 pub trait DrawableShadedExt {
     /// Add a shaded square to the draw buffer
     fn shaded_square(&mut self, rect: Quad, norm: (f32, f32), col: Rgba);
@@ -31,7 +31,7 @@ pub trait DrawableShadedExt {
     fn shaded_round_frame(&mut self, outer: Quad, inner: Quad, norm: (f32, f32), col: Rgba);
 }
 
-impl<'a, DS: DrawableShared> DrawableShadedExt for Draw<'a, DS>
+impl<'a, DS: DrawableShared> DrawableShadedExt for DrawIface<'a, DS>
 where
     DS::Draw: DrawableShaded,
 {

--- a/kas-theme/src/draw_shaded.rs
+++ b/kas-theme/src/draw_shaded.rs
@@ -10,7 +10,7 @@ use kas::draw::{DrawIface, DrawImpl, DrawSharedImpl, PassId};
 use kas::geom::Quad;
 
 /// Extension trait providing shaded drawing over [`DrawIface`]
-pub trait DrawableShadedExt {
+pub trait DrawShaded {
     /// Add a shaded square to the draw buffer
     fn shaded_square(&mut self, rect: Quad, norm: (f32, f32), col: Rgba);
 
@@ -31,7 +31,7 @@ pub trait DrawableShadedExt {
     fn shaded_round_frame(&mut self, outer: Quad, inner: Quad, norm: (f32, f32), col: Rgba);
 }
 
-impl<'a, DS: DrawSharedImpl> DrawableShadedExt for DrawIface<'a, DS>
+impl<'a, DS: DrawSharedImpl> DrawShaded for DrawIface<'a, DS>
 where
     DS::Draw: DrawShadedImpl,
 {

--- a/kas-theme/src/draw_shaded.rs
+++ b/kas-theme/src/draw_shaded.rs
@@ -6,7 +6,7 @@
 //! Drawing APIs — shaded drawing
 
 use kas::draw::color::Rgba;
-use kas::draw::{Draw, Drawable, PassId};
+use kas::draw::{Draw, Drawable, DrawableShared, PassId};
 use kas::geom::Quad;
 
 /// Extension trait providing shaded drawing over [`Draw`]
@@ -31,7 +31,10 @@ pub trait DrawableShadedExt {
     fn shaded_round_frame(&mut self, outer: Quad, inner: Quad, norm: (f32, f32), col: Rgba);
 }
 
-impl<'a, D: DrawableShaded + ?Sized> DrawableShadedExt for Draw<'a, D> {
+impl<'a, DS: DrawableShared> DrawableShadedExt for Draw<'a, DS>
+where
+    DS::Draw: DrawableShaded,
+{
     fn shaded_square(&mut self, rect: Quad, norm: (f32, f32), col: Rgba) {
         self.draw.shaded_square(self.pass(), rect, norm, col);
     }

--- a/kas-theme/src/draw_shaded.rs
+++ b/kas-theme/src/draw_shaded.rs
@@ -6,7 +6,7 @@
 //! Drawing APIs — shaded drawing
 
 use kas::draw::color::Rgba;
-use kas::draw::{DrawIface, Drawable, DrawableShared, PassId};
+use kas::draw::{DrawIface, DrawImpl, DrawSharedImpl, PassId};
 use kas::geom::Quad;
 
 /// Extension trait providing shaded drawing over [`DrawIface`]
@@ -31,9 +31,9 @@ pub trait DrawableShadedExt {
     fn shaded_round_frame(&mut self, outer: Quad, inner: Quad, norm: (f32, f32), col: Rgba);
 }
 
-impl<'a, DS: DrawableShared> DrawableShadedExt for DrawIface<'a, DS>
+impl<'a, DS: DrawSharedImpl> DrawableShadedExt for DrawIface<'a, DS>
 where
-    DS::Draw: DrawableShaded,
+    DS::Draw: DrawShadedImpl,
 {
     fn shaded_square(&mut self, rect: Quad, norm: (f32, f32), col: Rgba) {
         self.draw.shaded_square(self.pass, rect, norm, col);
@@ -63,7 +63,7 @@ where
 
 /// Drawing commands for shaded shapes
 ///
-/// This trait is an extension over [`Drawable`] providing solid shaded shapes.
+/// This trait is an extension over [`DrawImpl`] providing solid shaded shapes.
 ///
 /// Some drawing primitives (the "round" ones) are partially transparent.
 /// If the implementation buffers draw commands, it should draw these
@@ -74,7 +74,7 @@ where
 /// 0 is perpendicular to the screen towards the viewer, and 1 points outwards.
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-pub trait DrawableShaded: Drawable {
+pub trait DrawShadedImpl: DrawImpl {
     /// Add a shaded square to the draw buffer
     fn shaded_square(&mut self, pass: PassId, rect: Quad, norm: (f32, f32), col: Rgba);
 

--- a/kas-theme/src/draw_shaded.rs
+++ b/kas-theme/src/draw_shaded.rs
@@ -10,6 +10,12 @@ use kas::draw::{DrawIface, DrawImpl, DrawSharedImpl, PassId};
 use kas::geom::Quad;
 
 /// Extension trait providing shaded drawing over [`DrawIface`]
+///
+/// All methods draw some feature.
+///
+/// Methods are parameterised via a pair of normals, `(inner, outer)`. These may
+/// have values from the closed range `[-1, 1]`, where -1 points inwards,
+/// 0 is perpendicular to the screen towards the viewer, and 1 points outwards.
 pub trait DrawShaded {
     /// Add a shaded square to the draw buffer
     fn shaded_square(&mut self, rect: Quad, norm: (f32, f32), col: Rgba);
@@ -69,7 +75,7 @@ where
 /// If the implementation buffers draw commands, it should draw these
 /// primitives after solid primitives.
 ///
-/// These are parameterised via a pair of normals, `(inner, outer)`. These may
+/// Methods are parameterised via a pair of normals, `(inner, outer)`. These may
 /// have values from the closed range `[-1, 1]`, where -1 points inwards,
 /// 0 is perpendicular to the screen towards the viewer, and 1 points outwards.
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]

--- a/kas-theme/src/draw_shaded.rs
+++ b/kas-theme/src/draw_shaded.rs
@@ -36,11 +36,11 @@ where
     DS::Draw: DrawableShaded,
 {
     fn shaded_square(&mut self, rect: Quad, norm: (f32, f32), col: Rgba) {
-        self.draw.shaded_square(self.pass(), rect, norm, col);
+        self.draw.shaded_square(self.pass, rect, norm, col);
     }
 
     fn shaded_circle(&mut self, rect: Quad, norm: (f32, f32), col: Rgba) {
-        self.draw.shaded_circle(self.pass(), rect, norm, col);
+        self.draw.shaded_circle(self.pass, rect, norm, col);
     }
 
     fn shaded_square_frame(
@@ -52,12 +52,12 @@ where
         inner_col: Rgba,
     ) {
         self.draw
-            .shaded_square_frame(self.pass(), outer, inner, norm, outer_col, inner_col);
+            .shaded_square_frame(self.pass, outer, inner, norm, outer_col, inner_col);
     }
 
     fn shaded_round_frame(&mut self, outer: Quad, inner: Quad, norm: (f32, f32), col: Rgba) {
         self.draw
-            .shaded_round_frame(self.pass(), outer, inner, norm, col);
+            .shaded_round_frame(self.pass, outer, inner, norm, col);
     }
 }
 

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -256,7 +256,7 @@ where
         &mut self.draw
     }
 
-    fn new_draw_pass(
+    fn new_pass(
         &mut self,
         mut rect: Rect,
         offset: Offset,
@@ -266,7 +266,7 @@ where
         if class == PassType::Overlay {
             rect = rect.expand(self.window.dims.frame);
         }
-        let mut draw = self.draw.new_draw_pass(rect, offset, class);
+        let mut draw = self.draw.new_pass(rect, offset, class);
 
         if class == PassType::Overlay {
             let outer = draw.clip_rect();

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -136,7 +136,11 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+    unsafe fn draw_handle(
+        &self,
+        draw: DrawIface<DS>,
+        window: &mut Self::Window,
+    ) -> Self::DrawHandle {
         unsafe fn extend_lifetime<'b, T: ?Sized>(r: &'b T) -> &'static T {
             std::mem::transmute::<&'b T, &'static T>(r)
         }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -248,7 +248,7 @@ where
         self.window
     }
 
-    fn draw_device<'b>(&'b mut self) -> &mut dyn DrawT {
+    fn draw_device<'b>(&'b mut self) -> &mut dyn Draw {
         &mut self.draw
     }
 

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -144,11 +144,11 @@ where
             std::mem::transmute::<&'b mut T, &'static mut T>(r)
         }
         DrawHandle {
-            draw: Draw::new(
-                extend_lifetime_mut(draw.draw),
-                extend_lifetime_mut(draw.shared),
-                draw.pass(),
-            ),
+            draw: Draw {
+                draw: extend_lifetime_mut(draw.draw),
+                shared: extend_lifetime_mut(draw.shared),
+                pass: draw.pass,
+            },
             window: extend_lifetime_mut(window),
             cols: extend_lifetime(&self.cols),
         }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -83,15 +83,15 @@ const DIMS: dim::Parameters = dim::Parameters {
     progress_bar: Vec2::splat(12.0),
 };
 
-pub struct DrawHandle<'a, DS: DrawableShared> {
+pub struct DrawHandle<'a, DS: DrawSharedImpl> {
     pub(crate) draw: DrawIface<'a, DS>,
     pub(crate) window: &'a mut dim::Window,
     pub(crate) cols: &'a ColorsLinear,
 }
 
-impl<DS: DrawableShared> Theme<DS> for FlatTheme
+impl<DS: DrawSharedImpl> Theme<DS> for FlatTheme
 where
-    DS::Draw: DrawableRounded,
+    DS::Draw: DrawRoundedImpl,
 {
     type Config = Config;
     type Window = dim::Window;
@@ -196,9 +196,9 @@ impl ThemeApi for FlatTheme {
     }
 }
 
-impl<'a, DS: DrawableShared> DrawHandle<'a, DS>
+impl<'a, DS: DrawSharedImpl> DrawHandle<'a, DS>
 where
-    DS::Draw: DrawableRounded,
+    DS::Draw: DrawRoundedImpl,
 {
     /// Draw an edit box with optional navigation highlight.
     /// Return the inner rect.
@@ -240,9 +240,9 @@ where
     }
 }
 
-impl<'a, DS: DrawableShared> draw::DrawHandle for DrawHandle<'a, DS>
+impl<'a, DS: DrawSharedImpl> draw::DrawHandle for DrawHandle<'a, DS>
 where
-    DS::Draw: DrawableRounded,
+    DS::Draw: DrawRoundedImpl,
 {
     fn size_handle(&mut self) -> &mut dyn SizeHandle {
         self.window

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -324,13 +324,16 @@ where
     fn text(&mut self, pos: Coord, text: &TextDisplay, class: TextClass) {
         let pos = pos;
         let col = self.cols.text_class(class);
+        let pass = self.draw.pass();
         self.shared
-            .draw_text(self.draw.reborrow(), pos.into(), text, col);
+            .draw_text(&mut self.draw.draw, pass, pos.into(), text, col);
     }
 
     fn text_effects(&mut self, pos: Coord, text: &dyn TextApi, class: TextClass) {
+        let pass = self.draw.pass();
         self.shared.draw_text_col_effects(
-            self.draw.reborrow(),
+            &mut self.draw.draw,
+            pass,
             (pos).into(),
             text.display(),
             self.cols.text_class(class),
@@ -341,10 +344,12 @@ where
     fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
         let pos = Vec2::from(pos);
         let col = self.cols.text_class(class);
+        let pass = self.draw.pass();
         if state {
             let effects = text.text().effect_tokens();
             self.shared.draw_text_col_effects(
-                self.draw.reborrow(),
+                &mut self.draw.draw,
+                pass,
                 pos,
                 text.as_ref(),
                 col,
@@ -352,7 +357,7 @@ where
             );
         } else {
             self.shared
-                .draw_text(self.draw.reborrow(), pos, text.as_ref(), col);
+                .draw_text(&mut self.draw.draw, pass, pos, text.as_ref(), col);
         }
     }
 
@@ -391,8 +396,9 @@ where
                 aux: col,
             },
         ];
+        let pass = self.draw.pass();
         self.shared
-            .draw_text_effects(self.draw.reborrow(), pos, text, &effects);
+            .draw_text_effects(&mut self.draw.draw, pass, pos, text, &effects);
     }
 
     fn edit_marker(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
@@ -519,6 +525,7 @@ where
 
     fn image(&mut self, id: ImageId, rect: Rect) {
         let rect = Quad::from(rect);
-        self.shared.draw_image(self.draw.reborrow(), id, rect);
+        let pass = self.draw.pass();
+        self.shared.draw_image(&mut self.draw.draw, pass, id, rect);
     }
 }

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -269,7 +269,7 @@ where
         let mut draw = self.draw.new_pass(rect, offset, class);
 
         if class == PassType::Overlay {
-            let outer = draw.clip_rect();
+            let outer = draw.get_clip_rect();
             let inner = Quad::from(outer.shrink(self.window.dims.frame));
             let outer = Quad::from(outer);
             draw.rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
@@ -286,7 +286,7 @@ where
     }
 
     fn get_clip_rect(&self) -> Rect {
-        self.draw.clip_rect()
+        self.draw.get_clip_rect()
     }
 
     fn outer_frame(&mut self, rect: Rect) {

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -84,7 +84,7 @@ const DIMS: dim::Parameters = dim::Parameters {
 };
 
 pub struct DrawHandle<'a, DS: DrawableShared> {
-    pub(crate) draw: Draw<'a, DS>,
+    pub(crate) draw: DrawIface<'a, DS>,
     pub(crate) window: &'a mut dim::Window,
     pub(crate) cols: &'a ColorsLinear,
 }
@@ -136,7 +136,7 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: Draw<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle {
         unsafe fn extend_lifetime<'b, T: ?Sized>(r: &'b T) -> &'static T {
             std::mem::transmute::<&'b T, &'static T>(r)
         }
@@ -144,7 +144,7 @@ where
             std::mem::transmute::<&'b mut T, &'static mut T>(r)
         }
         DrawHandle {
-            draw: Draw {
+            draw: DrawIface {
                 draw: extend_lifetime_mut(draw.draw),
                 shared: extend_lifetime_mut(draw.shared),
                 pass: draw.pass,
@@ -156,7 +156,7 @@ where
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        draw: Draw<'a, DS>,
+        draw: DrawIface<'a, DS>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a> {
         DrawHandle {

--- a/kas-theme/src/flat_theme.rs
+++ b/kas-theme/src/flat_theme.rs
@@ -113,7 +113,7 @@ where
         action
     }
 
-    fn init(&mut self, _shared: &mut DrawShared<DS>) {
+    fn init(&mut self, _shared: &mut SharedState<DS>) {
         let fonts = fonts::fonts();
         if let Err(e) = fonts.select_default() {
             panic!("Error loading font: {}", e);

--- a/kas-theme/src/lib.rs
+++ b/kas-theme/src/lib.rs
@@ -45,7 +45,7 @@ pub use theme_dst::{MaybeBoxed, ThemeDst};
 pub use traits::{Theme, ThemeConfig, Window};
 
 #[cfg(feature = "stack_dst")]
-#[cfg_attr(doc_cfg, doc(cfg(stack_dst)))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "stack_dst")))]
 /// Fixed-size object of `Unsized` type
 ///
 /// This is a re-export of

--- a/kas-theme/src/lib.rs
+++ b/kas-theme/src/lib.rs
@@ -35,7 +35,7 @@ pub use kas;
 
 pub use colors::{Colors, ColorsLinear, ColorsSrgb};
 pub use config::{Config, RasterConfig};
-pub use draw_shaded::{DrawableShaded, DrawableShadedExt};
+pub use draw_shaded::{DrawShadedImpl, DrawableShadedExt};
 pub use flat_theme::FlatTheme;
 #[cfg(feature = "stack_dst")]
 pub use multi::{MultiTheme, MultiThemeBuilder};

--- a/kas-theme/src/lib.rs
+++ b/kas-theme/src/lib.rs
@@ -35,7 +35,7 @@ pub use kas;
 
 pub use colors::{Colors, ColorsLinear, ColorsSrgb};
 pub use config::{Config, RasterConfig};
-pub use draw_shaded::{DrawShadedImpl, DrawableShadedExt};
+pub use draw_shaded::{DrawShadedImpl, DrawShaded};
 pub use flat_theme::FlatTheme;
 #[cfg(feature = "stack_dst")]
 pub use multi::{MultiTheme, MultiThemeBuilder};

--- a/kas-theme/src/lib.rs
+++ b/kas-theme/src/lib.rs
@@ -35,7 +35,7 @@ pub use kas;
 
 pub use colors::{Colors, ColorsLinear, ColorsSrgb};
 pub use config::{Config, RasterConfig};
-pub use draw_shaded::{DrawShadedImpl, DrawShaded};
+pub use draw_shaded::{DrawShaded, DrawShadedImpl};
 pub use flat_theme::FlatTheme;
 #[cfg(feature = "stack_dst")]
 pub use multi::{MultiTheme, MultiThemeBuilder};

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -153,11 +153,11 @@ impl<DS: DrawableShared> Theme<DS> for MultiTheme<DS> {
             std::mem::transmute::<&'b mut T, &'static mut T>(r)
         }
         self.themes[self.active].draw_handle(
-            Draw::new(
-                extend_lifetime_mut(draw.draw),
-                extend_lifetime_mut(draw.shared),
-                draw.pass(),
-            ),
+            Draw {
+                draw: extend_lifetime_mut(draw.draw),
+                shared: extend_lifetime_mut(draw.shared),
+                pass: draw.pass,
+            },
             extend_lifetime_mut(window),
         )
     }

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::marker::Unsize;
 
 use crate::{Config, StackDst, Theme, ThemeDst, Window};
-use kas::draw::{color, DrawIface, DrawHandle, DrawShared, DrawableShared, ThemeApi};
+use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawableShared, ThemeApi};
 use kas::TkAction;
 
 #[cfg(feature = "unsize")]
@@ -129,7 +129,7 @@ impl<DS: DrawableShared> Theme<DS> for MultiTheme<DS> {
         action
     }
 
-    fn init(&mut self, shared: &mut DrawShared<DS>) {
+    fn init(&mut self, shared: &mut SharedState<DS>) {
         for theme in &mut self.themes {
             theme.init(shared);
         }

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::marker::Unsize;
 
 use crate::{Config, StackDst, Theme, ThemeDst, Window};
-use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawSharedImpl, ThemeApi};
+use kas::draw::{color, DrawHandle, DrawIface, DrawSharedImpl, SharedState, ThemeApi};
 use kas::TkAction;
 
 #[cfg(feature = "unsize")]

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -19,7 +19,7 @@ type DynTheme<DS> = StackDst<dyn ThemeDst<DS>>;
 type DynTheme<DS> = Box<dyn ThemeDst<DS>>;
 
 /// Wrapper around mutliple themes, supporting run-time switching
-#[cfg_attr(doc_cfg, doc(cfg(stack_dst)))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "stack_dst")))]
 pub struct MultiTheme<DS> {
     names: HashMap<String, usize>,
     themes: Vec<DynTheme<DS>>,
@@ -29,7 +29,7 @@ pub struct MultiTheme<DS> {
 /// Builder for [`MultiTheme`]
 ///
 /// Construct via [`MultiTheme::builder`].
-#[cfg_attr(doc_cfg, doc(cfg(stack_dst)))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "stack_dst")))]
 pub struct MultiThemeBuilder<DS> {
     names: HashMap<String, usize>,
     themes: Vec<DynTheme<DS>>,

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::marker::Unsize;
 
 use crate::{Config, StackDst, Theme, ThemeDst, Window};
-use kas::draw::{color, Draw, DrawHandle, DrawShared, DrawableShared, ThemeApi};
+use kas::draw::{color, DrawIface, DrawHandle, DrawShared, DrawableShared, ThemeApi};
 use kas::TkAction;
 
 #[cfg(feature = "unsize")]
@@ -146,14 +146,14 @@ impl<DS: DrawableShared> Theme<DS> for MultiTheme<DS> {
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        draw: Draw<DS>,
+        draw: DrawIface<DS>,
         window: &mut Self::Window,
     ) -> StackDst<dyn DrawHandle> {
         unsafe fn extend_lifetime_mut<'b, T: ?Sized>(r: &'b mut T) -> &'static mut T {
             std::mem::transmute::<&'b mut T, &'static mut T>(r)
         }
         self.themes[self.active].draw_handle(
-            Draw {
+            DrawIface {
                 draw: extend_lifetime_mut(draw.draw),
                 shared: extend_lifetime_mut(draw.shared),
                 pass: draw.pass,
@@ -165,7 +165,7 @@ impl<DS: DrawableShared> Theme<DS> for MultiTheme<DS> {
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        draw: Draw<'a, DS>,
+        draw: DrawIface<'a, DS>,
         window: &'a mut Self::Window,
     ) -> StackDst<dyn DrawHandle + 'a> {
         self.themes[self.active].draw_handle(draw, window)

--- a/kas-theme/src/multi.rs
+++ b/kas-theme/src/multi.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::marker::Unsize;
 
 use crate::{Config, StackDst, Theme, ThemeDst, Window};
-use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawableShared, ThemeApi};
+use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawSharedImpl, ThemeApi};
 use kas::TkAction;
 
 #[cfg(feature = "unsize")]
@@ -69,7 +69,7 @@ impl<DS> MultiThemeBuilder<DS> {
     #[cfg(not(feature = "unsize"))]
     pub fn add<S: ToString, T>(mut self, name: S, theme: T) -> Self
     where
-        DS: DrawableShared,
+        DS: DrawSharedImpl,
         T: ThemeDst<DS> + 'static,
     {
         let index = self.themes.len();
@@ -101,7 +101,7 @@ impl<DS> MultiThemeBuilder<DS> {
     }
 }
 
-impl<DS: DrawableShared> Theme<DS> for MultiTheme<DS> {
+impl<DS: DrawSharedImpl> Theme<DS> for MultiTheme<DS> {
     type Config = Config;
     type Window = StackDst<dyn Window>;
 

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -227,7 +227,7 @@ where
         &mut self.draw
     }
 
-    fn new_draw_pass(
+    fn new_pass(
         &mut self,
         mut rect: Rect,
         offset: Offset,
@@ -237,7 +237,7 @@ where
         if class == PassType::Overlay {
             rect = rect.expand(self.window.dims.frame);
         }
-        let mut draw = self.draw.new_draw_pass(rect, offset, class);
+        let mut draw = self.draw.new_pass(rect, offset, class);
 
         if class == PassType::Overlay {
             let outer = draw.clip_rect();

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -9,7 +9,7 @@ use std::f32;
 use std::ops::Range;
 
 use crate::{dim, ColorsLinear, Config, FlatTheme, Theme};
-use crate::{DrawShadedImpl, DrawShaded};
+use crate::{DrawShaded, DrawShadedImpl};
 use kas::dir::{Direction, Directional};
 use kas::draw::{self, color::Rgba, *};
 use kas::geom::*;
@@ -106,7 +106,11 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+    unsafe fn draw_handle(
+        &self,
+        draw: DrawIface<DS>,
+        window: &mut Self::Window,
+    ) -> Self::DrawHandle {
         unsafe fn extend_lifetime<'b, T: ?Sized>(r: &'b T) -> &'static T {
             std::mem::transmute::<&'b T, &'static T>(r)
         }

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -114,11 +114,11 @@ where
             std::mem::transmute::<&'b mut T, &'static mut T>(r)
         }
         DrawHandle {
-            draw: Draw::new(
-                extend_lifetime_mut(draw.draw),
-                extend_lifetime_mut(draw.shared),
-                draw.pass(),
-            ),
+            draw: Draw {
+                draw: extend_lifetime_mut(draw.draw),
+                shared: extend_lifetime_mut(draw.shared),
+                pass: draw.pass,
+            },
             window: extend_lifetime_mut(window),
             cols: extend_lifetime(&self.flat.cols),
         }

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -92,7 +92,7 @@ where
         <FlatTheme as Theme<DS>>::apply_config(&mut self.flat, config)
     }
 
-    fn init(&mut self, shared: &mut DrawShared<DS>) {
+    fn init(&mut self, shared: &mut SharedState<DS>) {
         <FlatTheme as Theme<DS>>::init(&mut self.flat, shared)
     }
 

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -9,7 +9,7 @@ use std::f32;
 use std::ops::Range;
 
 use crate::{dim, ColorsLinear, Config, FlatTheme, Theme};
-use crate::{DrawShadedImpl, DrawableShadedExt};
+use crate::{DrawShadedImpl, DrawShaded};
 use kas::dir::{Direction, Directional};
 use kas::draw::{self, color::Rgba, *};
 use kas::geom::*;

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -67,7 +67,7 @@ const DIMS: dim::Parameters = dim::Parameters {
 };
 
 pub struct DrawHandle<'a, DS: DrawableShared> {
-    draw: Draw<'a, DS>,
+    draw: DrawIface<'a, DS>,
     window: &'a mut dim::Window,
     cols: &'a ColorsLinear,
 }
@@ -106,7 +106,7 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: Draw<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle {
         unsafe fn extend_lifetime<'b, T: ?Sized>(r: &'b T) -> &'static T {
             std::mem::transmute::<&'b T, &'static T>(r)
         }
@@ -114,7 +114,7 @@ where
             std::mem::transmute::<&'b mut T, &'static mut T>(r)
         }
         DrawHandle {
-            draw: Draw {
+            draw: DrawIface {
                 draw: extend_lifetime_mut(draw.draw),
                 shared: extend_lifetime_mut(draw.shared),
                 pass: draw.pass,
@@ -126,7 +126,7 @@ where
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        draw: Draw<'a, DS>,
+        draw: DrawIface<'a, DS>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a> {
         DrawHandle {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -240,7 +240,7 @@ where
         let mut draw = self.draw.new_pass(rect, offset, class);
 
         if class == PassType::Overlay {
-            let outer = draw.clip_rect();
+            let outer = draw.get_clip_rect();
             let inner = Quad::from(outer.shrink(self.window.dims.frame));
             let outer = Quad::from(outer);
             let norm = (0.0, 0.0);
@@ -257,7 +257,7 @@ where
     }
 
     fn get_clip_rect(&self) -> Rect {
-        self.draw.clip_rect()
+        self.draw.get_clip_rect()
     }
 
     fn outer_frame(&mut self, rect: Rect) {

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -9,7 +9,7 @@ use std::f32;
 use std::ops::Range;
 
 use crate::{dim, ColorsLinear, Config, FlatTheme, Theme};
-use crate::{DrawableShaded, DrawableShadedExt};
+use crate::{DrawShadedImpl, DrawableShadedExt};
 use kas::dir::{Direction, Directional};
 use kas::draw::{self, color::Rgba, *};
 use kas::geom::*;
@@ -66,15 +66,15 @@ const DIMS: dim::Parameters = dim::Parameters {
     progress_bar: Vec2::splat(12.0),
 };
 
-pub struct DrawHandle<'a, DS: DrawableShared> {
+pub struct DrawHandle<'a, DS: DrawSharedImpl> {
     draw: DrawIface<'a, DS>,
     window: &'a mut dim::Window,
     cols: &'a ColorsLinear,
 }
 
-impl<DS: DrawableShared> Theme<DS> for ShadedTheme
+impl<DS: DrawSharedImpl> Theme<DS> for ShadedTheme
 where
-    DS::Draw: DrawableRounded + DrawableShaded,
+    DS::Draw: DrawRoundedImpl + DrawShadedImpl,
 {
     type Config = Config;
     type Window = dim::Window;
@@ -155,9 +155,9 @@ impl ThemeApi for ShadedTheme {
     }
 }
 
-impl<'a, DS: DrawableShared> DrawHandle<'a, DS>
+impl<'a, DS: DrawSharedImpl> DrawHandle<'a, DS>
 where
-    DS::Draw: DrawableRounded + DrawableShaded,
+    DS::Draw: DrawRoundedImpl + DrawShadedImpl,
 {
     // Type-cast to flat_theme's DrawHandle. Should be equivalent to transmute.
     fn as_flat<'b, 'c>(&'b mut self) -> super::flat_theme::DrawHandle<'c, DS>
@@ -211,9 +211,9 @@ where
     }
 }
 
-impl<'a, DS: DrawableShared> draw::DrawHandle for DrawHandle<'a, DS>
+impl<'a, DS: DrawSharedImpl> draw::DrawHandle for DrawHandle<'a, DS>
 where
-    DS::Draw: DrawableRounded + DrawableShaded,
+    DS::Draw: DrawRoundedImpl + DrawShadedImpl,
 {
     fn size_handle(&mut self) -> &mut dyn SizeHandle {
         self.window

--- a/kas-theme/src/shaded_theme.rs
+++ b/kas-theme/src/shaded_theme.rs
@@ -219,7 +219,7 @@ where
         self.window
     }
 
-    fn draw_device<'b>(&'b mut self) -> &mut dyn DrawT {
+    fn draw_device<'b>(&'b mut self) -> &mut dyn Draw {
         &mut self.draw
     }
 

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
 use super::{StackDst, Theme, Window};
-use kas::draw::{color, DrawIface, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
+use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawableShared, SizeHandle, ThemeApi};
 use kas::TkAction;
 
 /// An optionally-owning (boxed) reference
@@ -47,7 +47,7 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     /// Theme initialisation
     ///
     /// See also [`Theme::init`].
-    fn init(&mut self, shared: &mut DrawShared<DS>);
+    fn init(&mut self, shared: &mut SharedState<DS>);
 
     /// Construct per-window storage
     ///
@@ -111,7 +111,7 @@ where
         self.apply_config(config.downcast_ref().unwrap())
     }
 
-    fn init(&mut self, shared: &mut DrawShared<DS>) {
+    fn init(&mut self, shared: &mut SharedState<DS>) {
         self.init(shared);
     }
 
@@ -174,7 +174,7 @@ impl<'a, DS: DrawableShared, T: Theme<DS>> ThemeDst<DS> for T {
         self.apply_config(config.downcast_ref().unwrap())
     }
 
-    fn init(&mut self, shared: &mut DrawShared<DS>) {
+    fn init(&mut self, shared: &mut SharedState<DS>) {
         self.init(shared);
     }
 

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -16,7 +16,7 @@ use kas::TkAction;
 /// An optionally-owning (boxed) reference
 ///
 /// This is related but not identical to [`Cow`].
-#[cfg_attr(doc_cfg, doc(cfg(stack_dst)))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "stack_dst")))]
 pub enum MaybeBoxed<'a, B: 'a + ?Sized> {
     Borrowed(&'a B),
     Boxed(Box<B>),
@@ -36,7 +36,7 @@ impl<T: ?Sized> AsRef<T> for MaybeBoxed<'_, T> {
 /// This trait is implemented automatically for all implementations of
 /// [`Theme`]. It is intended only for use where a less parameterised
 /// trait is required.
-#[cfg_attr(doc_cfg, doc(cfg(stack_dst)))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "stack_dst")))]
 pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     /// Get current config
     fn config(&self) -> MaybeBoxed<dyn Any>;

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
 use super::{StackDst, Theme, Window};
-use kas::draw::{color, Draw, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
+use kas::draw::{color, DrawIface, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
 use kas::TkAction;
 
 /// An optionally-owning (boxed) reference
@@ -73,7 +73,7 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        draw: Draw<DS>,
+        draw: DrawIface<DS>,
         window: &mut dyn Window,
     ) -> StackDst<dyn DrawHandle>;
 
@@ -85,7 +85,7 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        draw: Draw<'a, DS>,
+        draw: DrawIface<'a, DS>,
         window: &'a mut dyn Window,
     ) -> StackDst<dyn DrawHandle + 'a>;
 
@@ -139,7 +139,7 @@ where
 
     unsafe fn draw_handle(
         &self,
-        draw: Draw<DS>,
+        draw: DrawIface<DS>,
         window: &mut dyn Window,
     ) -> StackDst<dyn DrawHandle> {
         let window = window.as_any_mut().downcast_mut().unwrap();
@@ -190,7 +190,7 @@ impl<'a, DS: DrawableShared, T: Theme<DS>> ThemeDst<DS> for T {
 
     fn draw_handle<'b>(
         &'b self,
-        draw: Draw<'b, DS>,
+        draw: DrawIface<'b, DS>,
         window: &'b mut dyn Window,
     ) -> StackDst<dyn DrawHandle + 'b> {
         let window = window.as_any_mut().downcast_mut().unwrap();

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
 use super::{StackDst, Theme, Window};
-use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawSharedImpl, SizeHandle, ThemeApi};
+use kas::draw::{color, DrawHandle, DrawIface, DrawSharedImpl, SharedState, SizeHandle, ThemeApi};
 use kas::TkAction;
 
 /// An optionally-owning (boxed) reference

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
 use super::{StackDst, Theme, Window};
-use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawableShared, SizeHandle, ThemeApi};
+use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawSharedImpl, SizeHandle, ThemeApi};
 use kas::TkAction;
 
 /// An optionally-owning (boxed) reference
@@ -37,7 +37,7 @@ impl<T: ?Sized> AsRef<T> for MaybeBoxed<'_, T> {
 /// [`Theme`]. It is intended only for use where a less parameterised
 /// trait is required.
 #[cfg_attr(doc_cfg, doc(cfg(feature = "stack_dst")))]
-pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
+pub trait ThemeDst<DS: DrawSharedImpl>: ThemeApi {
     /// Get current config
     fn config(&self) -> MaybeBoxed<dyn Any>;
 
@@ -96,7 +96,7 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
 }
 
 #[cfg(not(feature = "gat"))]
-impl<'a, DS: DrawableShared, T: Theme<DS>> ThemeDst<DS> for T
+impl<'a, DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T
 where
     <T as Theme<DS>>::DrawHandle: 'static,
 {
@@ -162,7 +162,7 @@ where
 }
 
 #[cfg(feature = "gat")]
-impl<'a, DS: DrawableShared, T: Theme<DS>> ThemeDst<DS> for T {
+impl<'a, DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T {
     fn config(&self) -> MaybeBoxed<dyn Any> {
         match self.config() {
             Cow::Borrowed(config) => MaybeBoxed::Borrowed(config),

--- a/kas-theme/src/theme_dst.rs
+++ b/kas-theme/src/theme_dst.rs
@@ -73,8 +73,7 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     #[cfg(not(feature = "gat"))]
     unsafe fn draw_handle(
         &self,
-        shared: &mut DrawShared<DS>,
-        draw: Draw<DS::Draw>,
+        draw: Draw<DS>,
         window: &mut dyn Window,
     ) -> StackDst<dyn DrawHandle>;
 
@@ -86,8 +85,7 @@ pub trait ThemeDst<DS: DrawableShared>: ThemeApi {
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        shared: &'a mut DrawShared<DS>,
-        draw: Draw<'a, DS::Draw>,
+        draw: Draw<'a, DS>,
         window: &'a mut dyn Window,
     ) -> StackDst<dyn DrawHandle + 'a>;
 
@@ -141,12 +139,11 @@ where
 
     unsafe fn draw_handle(
         &self,
-        shared: &mut DrawShared<DS>,
-        draw: Draw<DS::Draw>,
+        draw: Draw<DS>,
         window: &mut dyn Window,
     ) -> StackDst<dyn DrawHandle> {
         let window = window.as_any_mut().downcast_mut().unwrap();
-        let h = <T as Theme<DS>>::draw_handle(self, shared, draw, window);
+        let h = <T as Theme<DS>>::draw_handle(self, draw, window);
         #[cfg(feature = "unsize")]
         {
             StackDst::new_or_boxed(h)
@@ -193,12 +190,11 @@ impl<'a, DS: DrawableShared, T: Theme<DS>> ThemeDst<DS> for T {
 
     fn draw_handle<'b>(
         &'b self,
-        shared: &'b mut DrawShared<DS>,
-        draw: Draw<'b, DS::Draw>,
+        draw: Draw<'b, DS>,
         window: &'b mut dyn Window,
     ) -> StackDst<dyn DrawHandle + 'b> {
         let window = window.as_any_mut().downcast_mut().unwrap();
-        let h = <T as Theme<DS>>::draw_handle(self, shared, draw, window);
+        let h = <T as Theme<DS>>::draw_handle(self, draw, window);
         StackDst::new_or_boxed(h)
     }
 

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -5,7 +5,7 @@
 
 //! Theme traits
 
-use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawableShared, SizeHandle, ThemeApi};
+use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawSharedImpl, SizeHandle, ThemeApi};
 use kas::TkAction;
 use std::any::Any;
 use std::ops::{Deref, DerefMut};
@@ -41,7 +41,7 @@ pub trait ThemeConfig:
 ///
 /// Objects of this type are copied within each window's data structure. For
 /// large resources (e.g. fonts and icons) consider using external storage.
-pub trait Theme<DS: DrawableShared>: ThemeApi {
+pub trait Theme<DS: DrawSharedImpl>: ThemeApi {
     /// The associated config type
     type Config: ThemeConfig;
 
@@ -130,7 +130,7 @@ pub trait Window: 'static {
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
-impl<T: Theme<DS>, DS: DrawableShared> Theme<DS> for Box<T> {
+impl<T: Theme<DS>, DS: DrawSharedImpl> Theme<DS> for Box<T> {
     type Window = <T as Theme<DS>>::Window;
     type Config = <T as Theme<DS>>::Config;
 

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -105,17 +105,11 @@ pub trait Theme<DS: DrawableShared>: ThemeApi {
     ///
     /// All references passed into the method must outlive the returned object.
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
-        &self,
-        shared: &mut DrawShared<DS>,
-        draw: Draw<DS::Draw>,
-        window: &mut Self::Window,
-    ) -> Self::DrawHandle;
+    unsafe fn draw_handle(&self, draw: Draw<DS>, window: &mut Self::Window) -> Self::DrawHandle;
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        shared: &'a mut DrawShared<DS>,
-        draw: Draw<'a, DS::Draw>,
+        draw: Draw<'a, DS>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a>;
 
@@ -164,22 +158,16 @@ impl<T: Theme<DS>, DS: DrawableShared> Theme<DS> for Box<T> {
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
-        &self,
-        shared: &mut DrawShared<DS>,
-        draw: Draw<DS::Draw>,
-        window: &mut Self::Window,
-    ) -> Self::DrawHandle {
-        self.deref().draw_handle(shared, draw, window)
+    unsafe fn draw_handle(&self, draw: Draw<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+        self.deref().draw_handle(draw, window)
     }
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        shared: &'a mut DrawShared<DS>,
-        draw: Draw<'a, DS::Draw>,
+        draw: Draw<'a, DS>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a> {
-        self.deref().draw_handle(shared, draw, window)
+        self.deref().draw_handle(draw, window)
     }
 
     fn clear_color(&self) -> color::Rgba {

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -5,7 +5,7 @@
 
 //! Theme traits
 
-use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawSharedImpl, SizeHandle, ThemeApi};
+use kas::draw::{color, DrawHandle, DrawIface, DrawSharedImpl, SharedState, SizeHandle, ThemeApi};
 use kas::TkAction;
 use std::any::Any;
 use std::ops::{Deref, DerefMut};
@@ -105,7 +105,11 @@ pub trait Theme<DS: DrawSharedImpl>: ThemeApi {
     ///
     /// All references passed into the method must outlive the returned object.
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle;
+    unsafe fn draw_handle(
+        &self,
+        draw: DrawIface<DS>,
+        window: &mut Self::Window,
+    ) -> Self::DrawHandle;
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
@@ -158,7 +162,11 @@ impl<T: Theme<DS>, DS: DrawSharedImpl> Theme<DS> for Box<T> {
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+    unsafe fn draw_handle(
+        &self,
+        draw: DrawIface<DS>,
+        window: &mut Self::Window,
+    ) -> Self::DrawHandle {
         self.deref().draw_handle(draw, window)
     }
     #[cfg(feature = "gat")]

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -5,7 +5,7 @@
 
 //! Theme traits
 
-use kas::draw::{color, DrawIface, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
+use kas::draw::{color, DrawIface, DrawHandle, SharedState, DrawableShared, SizeHandle, ThemeApi};
 use kas::TkAction;
 use std::any::Any;
 use std::ops::{Deref, DerefMut};
@@ -67,7 +67,7 @@ pub trait Theme<DS: DrawableShared>: ThemeApi {
     ///
     /// At a minimum, a theme must load a font to [`kas::text::fonts`].
     /// The first font loaded (by any theme) becomes the default font.
-    fn init(&mut self, shared: &mut DrawShared<DS>);
+    fn init(&mut self, shared: &mut SharedState<DS>);
 
     /// Construct per-window storage
     ///
@@ -146,7 +146,7 @@ impl<T: Theme<DS>, DS: DrawableShared> Theme<DS> for Box<T> {
         self.deref_mut().apply_config(config)
     }
 
-    fn init(&mut self, shared: &mut DrawShared<DS>) {
+    fn init(&mut self, shared: &mut SharedState<DS>) {
         self.deref_mut().init(shared);
     }
 

--- a/kas-theme/src/traits.rs
+++ b/kas-theme/src/traits.rs
@@ -5,7 +5,7 @@
 
 //! Theme traits
 
-use kas::draw::{color, Draw, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
+use kas::draw::{color, DrawIface, DrawHandle, DrawShared, DrawableShared, SizeHandle, ThemeApi};
 use kas::TkAction;
 use std::any::Any;
 use std::ops::{Deref, DerefMut};
@@ -37,7 +37,7 @@ pub trait ThemeConfig:
 
 /// A *theme* provides widget sizing and drawing implementations.
 ///
-/// The theme is generic over some `Draw` type.
+/// The theme is generic over some `DrawIface`.
 ///
 /// Objects of this type are copied within each window's data structure. For
 /// large resources (e.g. fonts and icons) consider using external storage.
@@ -63,7 +63,7 @@ pub trait Theme<DS: DrawableShared>: ThemeApi {
     /// Theme initialisation
     ///
     /// The toolkit must call this method before [`Theme::new_window`]
-    /// to allow initialisation specific to the `Draw` device.
+    /// to allow initialisation specific to the `DrawIface`.
     ///
     /// At a minimum, a theme must load a font to [`kas::text::fonts`].
     /// The first font loaded (by any theme) becomes the default font.
@@ -105,11 +105,11 @@ pub trait Theme<DS: DrawableShared>: ThemeApi {
     ///
     /// All references passed into the method must outlive the returned object.
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: Draw<DS>, window: &mut Self::Window) -> Self::DrawHandle;
+    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle;
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        draw: Draw<'a, DS>,
+        draw: DrawIface<'a, DS>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a>;
 
@@ -158,13 +158,13 @@ impl<T: Theme<DS>, DS: DrawableShared> Theme<DS> for Box<T> {
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: Draw<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle {
         self.deref().draw_handle(draw, window)
     }
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        draw: Draw<'a, DS>,
+        draw: DrawIface<'a, DS>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a> {
         self.deref().draw_handle(draw, window)

--- a/kas-wgpu/examples/async-event.rs
+++ b/kas-wgpu/examples/async-event.rs
@@ -65,7 +65,7 @@ impl Layout for ColourSquare {
         SizeRules::fixed_scaled(100.0, 10.0, factor)
     }
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        let (mut draw, _shared) = draw_handle.draw_device();
+        let draw = draw_handle.draw_device();
         let col = *self.colour.lock().unwrap();
         draw.rect((self.rect()).into(), col);
     }

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -12,12 +12,12 @@ use log::info;
 use std::f32::consts::PI;
 use std::time::Duration;
 
-use kas::draw::{color, PassType, TextClass};
+use kas::draw::{color, Draw, DrawRoundedT, PassType, TextClass};
 use kas::geom::{Offset, Quad, Vec2};
 use kas::text::util::set_text_and_prepare;
 use kas::widget::Window;
 use kas::{event, prelude::*};
-use kas_wgpu::draw::DrawWindow;
+use kas_wgpu::draw::DrawPipe;
 
 #[derive(Clone, Debug, kas :: macros :: Widget)]
 #[handler(handle=noauto)]
@@ -71,8 +71,9 @@ impl Layout for Clock {
 
         // We use the low-level draw device to draw our clock. This means it is
         // not themeable, but gives us much more flexible draw routines.
-        let (mut draw, _shared) = draw_handle.draw_device();
-        let mut draw = draw.downcast::<DrawWindow<()>>().unwrap();
+        let draw = draw_handle.draw_device();
+        // Use use DrawRoundedT methods, thus must downcast:
+        let mut draw = Draw::<DrawPipe<()>>::downcast_from(draw).unwrap();
 
         let rect = self.core.rect;
         let quad = Quad::from(rect);

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -12,7 +12,7 @@ use log::info;
 use std::f32::consts::PI;
 use std::time::Duration;
 
-use kas::draw::{color, DrawIface, DrawRoundedT, PassType, TextClass};
+use kas::draw::{color, DrawIface, DrawRounded, PassType, TextClass};
 use kas::geom::{Offset, Quad, Vec2};
 use kas::text::util::set_text_and_prepare;
 use kas::widget::Window;
@@ -72,7 +72,7 @@ impl Layout for Clock {
         // We use the low-level draw device to draw our clock. This means it is
         // not themeable, but gives us much more flexible draw routines.
         let draw = draw_handle.draw_device();
-        // Use use DrawRoundedT methods, thus must downcast:
+        // Use use DrawRounded methods, thus must downcast:
         let mut draw = DrawIface::<DrawPipe<()>>::downcast_from(draw).unwrap();
 
         let rect = self.core.rect;

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -12,7 +12,7 @@ use log::info;
 use std::f32::consts::PI;
 use std::time::Duration;
 
-use kas::draw::{color, Draw, DrawRoundedT, PassType, TextClass};
+use kas::draw::{color, DrawIface, DrawRoundedT, PassType, TextClass};
 use kas::geom::{Offset, Quad, Vec2};
 use kas::text::util::set_text_and_prepare;
 use kas::widget::Window;
@@ -73,7 +73,7 @@ impl Layout for Clock {
         // not themeable, but gives us much more flexible draw routines.
         let draw = draw_handle.draw_device();
         // Use use DrawRoundedT methods, thus must downcast:
-        let mut draw = Draw::<DrawPipe<()>>::downcast_from(draw).unwrap();
+        let mut draw = DrawIface::<DrawPipe<()>>::downcast_from(draw).unwrap();
 
         let rect = self.core.rect;
         let quad = Quad::from(rect);

--- a/kas-wgpu/examples/clock.rs
+++ b/kas-wgpu/examples/clock.rs
@@ -93,7 +93,7 @@ impl Layout for Clock {
         }
 
         // We use a new pass to control the draw order (force in front).
-        let mut draw = draw.new_draw_pass(rect, Offset::ZERO, PassType::Clip);
+        let mut draw = draw.new_pass(rect, Offset::ZERO, PassType::Clip);
         let mut line_seg = |t: f32, r1: f32, r2: f32, w, col| {
             let v = Vec2(t.sin(), -t.cos());
             draw.rounded_line(centre + v * r1, centre + v * r2, w, col);

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -79,13 +79,13 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: Draw<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle {
         Theme::<DS>::draw_handle(&self.inner, draw, window)
     }
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        draw: Draw<'a, DS>,
+        draw: DrawIface<'a, DS>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a> {
         Theme::<DS>::draw_handle(&self.inner, draw, window)

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -79,22 +79,16 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
-        &self,
-        shared: &mut DrawShared<DS>,
-        draw: Draw<DS::Draw>,
-        window: &mut Self::Window,
-    ) -> Self::DrawHandle {
-        Theme::<DS>::draw_handle(&self.inner, shared, draw, window)
+    unsafe fn draw_handle(&self, draw: Draw<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+        Theme::<DS>::draw_handle(&self.inner, draw, window)
     }
     #[cfg(feature = "gat")]
     fn draw_handle<'a>(
         &'a self,
-        shared: &'a mut DrawShared<DS>,
-        draw: Draw<'a, DS::Draw>,
+        draw: Draw<'a, DS>,
         window: &'a mut Self::Window,
     ) -> Self::DrawHandle<'a> {
-        Theme::<DS>::draw_handle(&self.inner, shared, draw, window)
+        Theme::<DS>::draw_handle(&self.inner, draw, window)
     }
 
     fn clear_color(&self) -> Rgba {

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -66,7 +66,7 @@ where
         Theme::<DS>::apply_config(&mut self.inner, config)
     }
 
-    fn init(&mut self, shared: &mut DrawShared<DS>) {
+    fn init(&mut self, shared: &mut SharedState<DS>) {
         self.inner.init(shared);
     }
 

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -46,9 +46,9 @@ thread_local! {
     static BACKGROUND: Cell<Rgba> = Cell::new(Rgba::grey(1.0));
 }
 
-impl<DS: DrawableShared> Theme<DS> for CustomTheme
+impl<DS: DrawSharedImpl> Theme<DS> for CustomTheme
 where
-    DS::Draw: DrawableRounded,
+    DS::Draw: DrawRoundedImpl,
 {
     type Config = kas_theme::Config;
     type Window = <FlatTheme as Theme<DS>>::Window;

--- a/kas-wgpu/examples/custom-theme.rs
+++ b/kas-wgpu/examples/custom-theme.rs
@@ -79,7 +79,11 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(&self, draw: DrawIface<DS>, window: &mut Self::Window) -> Self::DrawHandle {
+    unsafe fn draw_handle(
+        &self,
+        draw: DrawIface<DS>,
+        window: &mut Self::Window,
+    ) -> Self::DrawHandle {
         Theme::<DS>::draw_handle(&self.inner, draw, window)
     }
     #[cfg(feature = "gat")]

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -12,7 +12,7 @@ use wgpu::util::DeviceExt;
 use wgpu::{include_spirv, Buffer, ShaderModule};
 
 use kas::adapter::ReserveP;
-use kas::draw::{DrawIface, DrawT, PassId};
+use kas::draw::{DrawIface, Draw, PassId};
 use kas::event::{self, Command};
 use kas::geom::{DVec2, Vec2, Vec3};
 use kas::prelude::*;

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -12,7 +12,7 @@ use wgpu::util::DeviceExt;
 use wgpu::{include_spirv, Buffer, ShaderModule};
 
 use kas::adapter::ReserveP;
-use kas::draw::{DrawIface, Draw, PassId};
+use kas::draw::{Draw, DrawIface, PassId};
 use kas::event::{self, Command};
 use kas::geom::{DVec2, Vec2, Vec3};
 use kas::prelude::*;

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -12,7 +12,7 @@ use wgpu::util::DeviceExt;
 use wgpu::{include_spirv, Buffer, ShaderModule};
 
 use kas::adapter::ReserveP;
-use kas::draw::{Draw, DrawT, PassId};
+use kas::draw::{DrawIface, DrawT, PassId};
 use kas::event::{self, Command};
 use kas::geom::{DVec2, Vec2, Vec3};
 use kas::prelude::*;
@@ -328,7 +328,7 @@ impl Layout for Mandlebrot {
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {
         let draw = draw_handle.draw_device();
-        let draw = Draw::<DrawPipe<Pipe>>::downcast_from(draw).unwrap();
+        let draw = DrawIface::<DrawPipe<Pipe>>::downcast_from(draw).unwrap();
         let p = (self.alpha, self.delta, self.rel_width, self.iter);
         draw.draw.custom(draw.pass(), self.core.rect, p);
     }

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -330,7 +330,7 @@ impl Layout for Mandlebrot {
         let draw = draw_handle.draw_device();
         let draw = DrawIface::<DrawPipe<Pipe>>::downcast_from(draw).unwrap();
         let p = (self.alpha, self.delta, self.rel_width, self.iter);
-        draw.draw.custom(draw.pass(), self.core.rect, p);
+        draw.draw.custom(draw.get_pass(), self.core.rect, p);
     }
 }
 

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -12,12 +12,12 @@ use wgpu::util::DeviceExt;
 use wgpu::{include_spirv, Buffer, ShaderModule};
 
 use kas::adapter::ReserveP;
-use kas::draw::PassId;
+use kas::draw::{Draw, PassId};
 use kas::event::{self, Command};
 use kas::geom::{DVec2, Vec2, Vec3};
 use kas::prelude::*;
 use kas::widget::{Label, Slider, Window};
-use kas_wgpu::draw::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom, DrawWindow};
+use kas_wgpu::draw::{CustomPipe, CustomPipeBuilder, CustomWindow, DrawCustom, DrawPipe};
 use kas_wgpu::Options;
 
 struct Shaders {
@@ -327,8 +327,8 @@ impl Layout for Mandlebrot {
     }
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {
-        let (mut draw, _shared) = draw_handle.draw_device();
-        let draw = draw.downcast::<DrawWindow<PipeWindow>>().unwrap();
+        let draw = draw_handle.draw_device();
+        let draw = Draw::<DrawPipe<Pipe>>::downcast_from(draw).unwrap();
         let pass = draw.pass();
         let p = (self.alpha, self.delta, self.rel_width, self.iter);
         draw.draw.custom(pass, self.core.rect, p);

--- a/kas-wgpu/examples/mandlebrot.rs
+++ b/kas-wgpu/examples/mandlebrot.rs
@@ -12,7 +12,7 @@ use wgpu::util::DeviceExt;
 use wgpu::{include_spirv, Buffer, ShaderModule};
 
 use kas::adapter::ReserveP;
-use kas::draw::{Draw, PassId};
+use kas::draw::{Draw, DrawT, PassId};
 use kas::event::{self, Command};
 use kas::geom::{DVec2, Vec2, Vec3};
 use kas::prelude::*;
@@ -329,9 +329,8 @@ impl Layout for Mandlebrot {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {
         let draw = draw_handle.draw_device();
         let draw = Draw::<DrawPipe<Pipe>>::downcast_from(draw).unwrap();
-        let pass = draw.pass();
         let p = (self.alpha, self.delta, self.rel_width, self.iter);
-        draw.draw.custom(pass, self.core.rect, p);
+        draw.draw.custom(draw.pass(), self.core.rect, p);
     }
 }
 

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -388,7 +388,7 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
 }
 
 impl<CW: CustomWindow> DrawImpl for DrawWindow<CW> {
-    fn new_draw_pass(
+    fn new_pass(
         &mut self,
         parent_pass: PassId,
         rect: Rect,

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -314,11 +314,6 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
     type Draw = DrawWindow<C::Window>;
 
     #[inline]
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
-
-    #[inline]
     fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
         self.images.alloc(size)
     }
@@ -393,16 +388,6 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
 }
 
 impl<CW: CustomWindow> Drawable for DrawWindow<CW> {
-    #[inline]
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
-
-    #[inline]
-    fn as_drawable_mut(&mut self) -> &mut dyn Drawable {
-        self
-    }
-
     fn new_draw_pass(
         &mut self,
         parent_pass: PassId,

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -14,7 +14,7 @@ use kas::draw::color::Rgba;
 use kas::draw::*;
 use kas::geom::{Coord, Quad, Rect, Size, Vec2};
 use kas::text::{Effect, TextDisplay};
-use kas_theme::DrawableShaded;
+use kas_theme::DrawShadedImpl;
 
 impl<C: CustomPipe> DrawPipe<C> {
     /// Construct
@@ -310,7 +310,7 @@ impl<C: CustomPipe> DrawPipe<C> {
     }
 }
 
-impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
+impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
     type Draw = DrawWindow<C::Window>;
 
     #[inline]
@@ -387,7 +387,7 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
     }
 }
 
-impl<CW: CustomWindow> Drawable for DrawWindow<CW> {
+impl<CW: CustomWindow> DrawImpl for DrawWindow<CW> {
     fn new_draw_pass(
         &mut self,
         parent_pass: PassId,
@@ -424,7 +424,7 @@ impl<CW: CustomWindow> Drawable for DrawWindow<CW> {
     }
 }
 
-impl<CW: CustomWindow> DrawableRounded for DrawWindow<CW> {
+impl<CW: CustomWindow> DrawRoundedImpl for DrawWindow<CW> {
     #[inline]
     fn rounded_line(&mut self, pass: PassId, p1: Vec2, p2: Vec2, radius: f32, col: Rgba) {
         self.flat_round.line(pass, p1, p2, radius, col);
@@ -449,7 +449,7 @@ impl<CW: CustomWindow> DrawableRounded for DrawWindow<CW> {
     }
 }
 
-impl<CW: CustomWindow> DrawableShaded for DrawWindow<CW> {
+impl<CW: CustomWindow> DrawShadedImpl for DrawWindow<CW> {
     #[inline]
     fn shaded_square(&mut self, pass: PassId, rect: Quad, norm: (f32, f32), col: Rgba) {
         self.shaded_square

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -340,53 +340,54 @@ impl<C: CustomPipe> DrawableShared for DrawPipe<C> {
     }
 
     #[inline]
-    fn draw_image(&self, target: Draw<Self::Draw>, id: ImageId, rect: Quad) {
+    fn draw_image(&self, draw: &mut Self::Draw, pass: PassId, id: ImageId, rect: Quad) {
         if let Some((atlas, tex)) = self.images.get_im_atlas_coords(id) {
-            target.draw.images.rect(target.pass(), atlas, tex, rect);
+            draw.images.rect(pass, atlas, tex, rect);
         };
     }
 
     #[inline]
-    fn draw_text(&mut self, target: Draw<Self::Draw>, pos: Vec2, text: &TextDisplay, col: Rgba) {
-        target
-            .draw
-            .text
-            .text(&mut self.text, target.pass(), pos, text, col);
+    fn draw_text(
+        &mut self,
+        draw: &mut Self::Draw,
+        pass: PassId,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+    ) {
+        draw.text.text(&mut self.text, pass, pos, text, col);
     }
 
     fn draw_text_col_effects(
         &mut self,
-        target: Draw<Self::Draw>,
+        draw: &mut Self::Draw,
+        pass: PassId,
         pos: Vec2,
         text: &TextDisplay,
         col: Rgba,
         effects: &[Effect<()>],
     ) {
-        let pass = target.pass();
-        let rects =
-            target
-                .draw
-                .text
-                .text_col_effects(&mut self.text, pass, pos, text, col, effects);
+        let rects = draw
+            .text
+            .text_col_effects(&mut self.text, pass, pos, text, col, effects);
         for rect in rects {
-            target.draw.shaded_square.rect(pass, rect, col);
+            draw.shaded_square.rect(pass, rect, col);
         }
     }
 
     fn draw_text_effects(
         &mut self,
-        target: Draw<Self::Draw>,
+        draw: &mut Self::Draw,
+        pass: PassId,
         pos: Vec2,
         text: &TextDisplay,
         effects: &[Effect<Rgba>],
     ) {
-        let pass = target.pass();
-        let rects = target
-            .draw
+        let rects = draw
             .text
             .text_effects(&mut self.text, pass, pos, text, effects);
         for (rect, col) in rects {
-            target.draw.shaded_square.rect(pass, rect, col);
+            draw.shaded_square.rect(pass, rect, col);
         }
     }
 }

--- a/kas-wgpu/src/draw/draw_pipe.rs
+++ b/kas-wgpu/src/draw/draw_pipe.rs
@@ -408,7 +408,7 @@ impl<CW: CustomWindow> DrawImpl for DrawWindow<CW> {
     }
 
     #[inline]
-    fn clip_rect(&self, pass: PassId) -> Rect {
+    fn get_clip_rect(&self, pass: PassId) -> Rect {
         let region = &self.clip_regions[pass.pass()];
         region.0 + region.1
     }

--- a/kas-wgpu/src/options.rs
+++ b/kas-wgpu/src/options.rs
@@ -6,7 +6,7 @@
 //! Options
 
 use super::Error;
-use kas::draw::DrawableShared;
+use kas::draw::DrawSharedImpl;
 use kas_theme::{Theme, ThemeConfig};
 use log::warn;
 use std::env::var;
@@ -179,7 +179,7 @@ impl Options {
     }
 
     /// Load/save theme config on start
-    pub fn theme_config<DS: DrawableShared, T: Theme<DS>>(
+    pub fn theme_config<DS: DrawSharedImpl, T: Theme<DS>>(
         &self,
         theme: &mut T,
     ) -> Result<(), Error> {
@@ -224,7 +224,7 @@ impl Options {
     }
 
     /// Save all config (on exit or after changes)
-    pub fn save_config<DS: DrawableShared, T: Theme<DS>>(
+    pub fn save_config<DS: DrawSharedImpl, T: Theme<DS>>(
         &self,
         config: &kas::event::Config,
         theme: &T,

--- a/kas-wgpu/src/shared.rs
+++ b/kas-wgpu/src/shared.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 
 use crate::draw::{CustomPipe, CustomPipeBuilder, DrawPipe, DrawWindow};
 use crate::{warn_about_error, Error, Options, WindowId};
-use kas::draw::DrawShared;
+use kas::draw;
 use kas::event::UpdateHandle;
 use kas::updatable::Updatable;
 use kas::TkAction;
@@ -28,7 +28,7 @@ pub struct SharedState<C: CustomPipe, T> {
     clipboard: Option<Clipboard>,
     data_updates: HashMap<UpdateHandle, Vec<Rc<dyn Updatable>>>,
     pub instance: wgpu::Instance,
-    pub draw: DrawShared<DrawPipe<C>>,
+    pub draw: draw::SharedState<DrawPipe<C>>,
     pub theme: T,
     pub config: Rc<RefCell<kas::event::Config>>,
     pub pending: Vec<PendingAction>,
@@ -65,7 +65,7 @@ where
         let device_and_queue = futures::executor::block_on(req)?;
 
         let pipe = DrawPipe::new(custom, device_and_queue, theme.config().raster());
-        let mut draw = DrawShared::new(pipe);
+        let mut draw = draw::SharedState::new(pipe);
 
         theme.init(&mut draw);
 

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use kas::cast::Cast;
-use kas::draw::{Draw, DrawSharedT, PassId, SizeHandle, ThemeApi};
+use kas::draw::{DrawIface, DrawSharedT, PassId, SizeHandle, ThemeApi};
 use kas::event::{CursorIcon, ManagerState, UpdateHandle};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
@@ -322,7 +322,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         let time = Instant::now();
 
         {
-            let draw = Draw {
+            let draw = DrawIface {
                 draw: &mut self.draw,
                 shared: &mut shared.draw,
                 pass: PassId::new(0),

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use kas::cast::Cast;
-use kas::draw::{DrawIface, DrawSharedT, PassId, SizeHandle, ThemeApi};
+use kas::draw::{DrawIface, DrawShared, PassId, SizeHandle, ThemeApi};
 use kas::event::{CursorIcon, ManagerState, UpdateHandle};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
@@ -466,7 +466,7 @@ where
         f(&mut size_handle);
     }
 
-    fn draw_shared(&mut self, f: &mut dyn FnMut(&mut dyn DrawSharedT)) {
+    fn draw_shared(&mut self, f: &mut dyn FnMut(&mut dyn DrawShared)) {
         f(&mut self.shared.draw);
     }
 

--- a/kas-wgpu/src/window.rs
+++ b/kas-wgpu/src/window.rs
@@ -324,23 +324,19 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         #[cfg(not(feature = "gat"))]
         unsafe {
             // Safety: lifetimes do not escape the returned draw_handle value.
-            let draw_shared = &mut shared.draw;
             let pass = PassId::new(0);
-            let draw = Draw::new(&mut self.draw, pass);
+            let draw = Draw::new(&mut self.draw, &mut shared.draw, pass);
             let window = &mut self.theme_window;
 
-            let mut draw_handle = shared.theme.draw_handle(draw_shared, draw, window);
+            let mut draw_handle = shared.theme.draw_handle(draw, window);
             self.widget.draw(&mut draw_handle, &self.mgr, false);
         }
 
         #[cfg(feature = "gat")]
         {
             let pass = PassId::new(0);
-            let draw = Draw::new(&mut self.draw, pass);
-            let mut draw_handle =
-                shared
-                    .theme
-                    .draw_handle(&mut shared.draw, draw, &mut self.theme_window);
+            let draw = Draw::new(&mut self.draw, &mut shared.draw, pass);
+            let mut draw_handle = shared.theme.draw_handle(draw, &mut self.theme_window);
             self.widget.draw(&mut draw_handle, &self.mgr, false);
         }
 

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -267,15 +267,6 @@ where
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 pub trait Drawable: Any {
-    /// Cast self to [`Any`] reference
-    ///
-    /// A downcast on this value may be used to obtain a reference to a
-    /// shell-specific API.
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-
-    /// Upcast to dyn drawable
-    fn as_drawable_mut(&mut self) -> &mut dyn Drawable;
-
     /// Add a draw pass
     ///
     /// Adds a new draw pass. Passes affect draw order (operations in new passes

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -8,7 +8,7 @@
 use super::color::Rgba;
 #[allow(unused)]
 use super::DrawHandle;
-use super::{SharedState, DrawSharedImpl, ImageId, PassId, PassType};
+use super::{DrawSharedImpl, ImageId, PassId, PassType, SharedState};
 use crate::geom::{Offset, Quad, Rect, Vec2};
 use crate::text::{Effect, TextDisplay};
 use std::any::Any;

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -195,6 +195,7 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
         (self.draw, self.shared)
     }
 
+    #[cfg(feature = "stack_dst")]
     fn new_dyn_pass<'b>(
         &'b mut self,
         rect: Rect,

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -6,8 +6,9 @@
 //! Drawing APIs — draw interface
 
 use super::color::Rgba;
-use super::{PassId, PassType};
+use super::{DrawShared, DrawableShared, ImageId, PassId, PassType};
 use crate::geom::{Offset, Quad, Rect, Vec2};
+use crate::text::{Effect, TextDisplay};
 use std::any::Any;
 
 /// Interface over a (local) draw object
@@ -29,74 +30,39 @@ use std::any::Any;
 /// "drawable" traits, for example one may use [`Draw::circle`] when
 /// [`DrawableRounded`] is implemented. In other cases one may directly use
 /// [`Draw::draw`], passing the result of [`Draw::pass`] as a parameter.
-pub struct Draw<'a, D: Any + ?Sized> {
+pub struct Draw<'a, DS: DrawableShared> {
+    pub draw: &'a mut DS::Draw,
+    pub shared: &'a mut DrawShared<DS>,
     pass: PassId,
-    pub draw: &'a mut D,
 }
 
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-impl<'a, D: Drawable + ?Sized> Draw<'a, D> {
+impl<'a, DS: DrawableShared> Draw<'a, DS> {
     /// Construct (this is only called by the shell)
-    pub fn new(draw: &'a mut D, pass: PassId) -> Self {
-        Draw { pass, draw }
+    pub fn new(draw: &'a mut DS::Draw, shared: &'a mut DrawShared<DS>, pass: PassId) -> Self {
+        Draw { draw, shared, pass }
+    }
+
+    /// Attempt to downcast a `&mut dyn DrawT` to a concrete [`Draw`] object
+    pub fn downcast_from(obj: &'a mut dyn DrawT) -> Option<Self> {
+        let pass = obj.pass();
+        let (draw, shared) = obj.fields_as_any_mut();
+        let draw = draw.downcast_mut()?;
+        let shared = shared.downcast_mut()?;
+        Some(Draw::new(draw, shared, pass))
     }
 }
 
-impl<'a> Draw<'a, dyn Any> {
-    /// Attempt to downcast to a derived type
-    ///
-    /// Rust does not (yet) support casting to trait object types (e.g.
-    /// `dyn Drawable`); instead we can only downcast to the shell's
-    /// implementing type, e.g. `kas_wgpu::draw::DrawWindow<()>`.
-    pub fn downcast<'b, D>(&'b mut self) -> Option<Draw<'b, D>>
-    where
-        'a: 'b,
-        D: Drawable,
-    {
-        let pass = self.pass;
-        self.draw.downcast_mut().map(|draw| Draw { pass, draw })
-    }
-}
-
-impl<'a> Draw<'a, dyn Drawable> {
-    /// Attempt to downcast to a derived type
-    ///
-    /// Rust does not (yet) support casting to trait object types (e.g.
-    /// `dyn Drawable`); instead we can only downcast to the shell's
-    /// implementing type, e.g. `kas_wgpu::draw::DrawWindow<()>`.
-    pub fn downcast<'b, D>(&'b mut self) -> Option<Draw<'b, D>>
-    where
-        'a: 'b,
-        D: Drawable,
-    {
-        let pass = self.pass;
-        self.draw
-            .as_any_mut()
-            .downcast_mut()
-            .map(|draw| Draw { pass, draw })
-    }
-}
-
-impl<'a, D: Drawable + ?Sized> Draw<'a, D> {
+impl<'a, DS: DrawableShared> Draw<'a, DS> {
     /// Reborrow with a new lifetime
-    pub fn reborrow<'b>(&'b mut self) -> Draw<'b, D>
+    pub fn reborrow<'b>(&'b mut self) -> Draw<'b, DS>
     where
         'a: 'b,
     {
         Draw {
             draw: &mut *self.draw,
-            pass: self.pass,
-        }
-    }
-
-    /// Upcast to `dyn Drawable` type
-    pub fn upcast_base<'b>(&'b mut self) -> Draw<'b, dyn Drawable>
-    where
-        'a: 'b,
-    {
-        Draw {
-            draw: self.draw.as_drawable_mut(),
+            shared: &mut *self.shared,
             pass: self.pass,
         }
     }
@@ -121,13 +87,23 @@ impl<'a, D: Drawable + ?Sized> Draw<'a, D> {
     /// Case `class == PassType::Overlay`: the new pass is derived from the
     /// base pass (i.e. the window). Draw operations still happen after those in
     /// `parent_pass`.
-    pub fn new_draw_pass(&mut self, rect: Rect, offset: Offset, class: PassType) -> Draw<D> {
+    pub fn new_draw_pass(&mut self, rect: Rect, offset: Offset, class: PassType) -> Draw<DS> {
         let pass = self.draw.new_draw_pass(self.pass, rect, offset, class);
         Draw {
             draw: &mut *self.draw,
+            shared: &mut *self.shared,
             pass,
         }
     }
+}
+
+/// Interface over [`Draw`]
+pub trait DrawT {
+    /// Get the current draw pass
+    fn pass(&self) -> PassId;
+
+    /// Cast fields to [`Any`] references
+    fn fields_as_any_mut(&mut self) -> (&mut dyn Any, &mut dyn Any);
 
     /// Get drawable rect for a draw `pass`
     ///
@@ -136,24 +112,93 @@ impl<'a, D: Drawable + ?Sized> Draw<'a, D> {
     ///
     /// (This is not guaranteed to equal the rect passed to
     /// [`Draw::new_draw_pass`].)
-    pub fn clip_rect(&self) -> Rect {
-        self.draw.clip_rect(self.pass)
-    }
+    fn clip_rect(&self) -> Rect;
 
     /// Draw a rectangle of uniform colour
-    pub fn rect(&mut self, rect: Quad, col: Rgba) {
-        self.draw.rect(self.pass, rect, col);
-    }
+    fn rect(&mut self, rect: Quad, col: Rgba);
 
     /// Draw a frame of uniform colour
     ///
     /// The frame is defined by the area inside `outer` and not inside `inner`.
-    pub fn frame(&mut self, outer: Quad, inner: Quad, col: Rgba) {
+    fn frame(&mut self, outer: Quad, inner: Quad, col: Rgba);
+
+    /// Draw the image in the given `rect`
+    fn image(&mut self, id: ImageId, rect: Quad);
+
+    /// Draw text with a colour
+    fn text(&mut self, pos: Vec2, text: &TextDisplay, col: Rgba);
+
+    /// Draw text with a colour and effects
+    ///
+    /// The effects list does not contain colour information, but may contain
+    /// underlining/strikethrough information. It may be empty.
+    fn text_col_effects(
+        &mut self,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+        effects: &[Effect<()>],
+    );
+
+    /// Draw text with effects
+    ///
+    /// The `effects` list provides both underlining and colour information.
+    /// If the `effects` list is empty or the first entry has `start > 0`, a
+    /// default entity will be assumed.
+    fn text_effects(&mut self, pos: Vec2, text: &TextDisplay, effects: &[Effect<Rgba>]);
+}
+
+impl<'a, DS: DrawableShared> DrawT for Draw<'a, DS> {
+    fn pass(&self) -> PassId {
+        self.pass
+    }
+
+    fn fields_as_any_mut(&mut self) -> (&mut dyn Any, &mut dyn Any) {
+        (self.draw, self.shared)
+    }
+
+    fn clip_rect(&self) -> Rect {
+        self.draw.clip_rect(self.pass)
+    }
+
+    fn rect(&mut self, rect: Quad, col: Rgba) {
+        self.draw.rect(self.pass, rect, col);
+    }
+    fn frame(&mut self, outer: Quad, inner: Quad, col: Rgba) {
         self.draw.frame(self.pass, outer, inner, col);
+    }
+
+    fn image(&mut self, id: ImageId, rect: Quad) {
+        self.shared.draw.draw_image(self.draw, self.pass, id, rect);
+    }
+
+    fn text(&mut self, pos: Vec2, text: &TextDisplay, col: Rgba) {
+        self.shared
+            .draw
+            .draw_text(self.draw, self.pass, pos, text, col);
+    }
+
+    fn text_col_effects(
+        &mut self,
+        pos: Vec2,
+        text: &TextDisplay,
+        col: Rgba,
+        effects: &[Effect<()>],
+    ) {
+        self.shared
+            .draw
+            .draw_text_col_effects(self.draw, self.pass, pos, text, col, effects);
+    }
+
+    fn text_effects(&mut self, pos: Vec2, text: &TextDisplay, effects: &[Effect<Rgba>]) {
+        self.shared
+            .draw
+            .draw_text_effects(self.draw, self.pass, pos, text, effects);
     }
 }
 
-impl<'a, D: DrawableRounded + ?Sized> Draw<'a, D> {
+/// Extension of [`DrawT`]
+pub trait DrawRoundedT: DrawT {
     /// Draw a line with rounded ends and uniform colour
     ///
     /// This command draws a line segment between the points `p1` and `p2`.
@@ -162,9 +207,7 @@ impl<'a, D: DrawableRounded + ?Sized> Draw<'a, D> {
     ///
     /// Note that for rectangular, axis-aligned lines, [`Drawable::rect`] should be
     /// preferred.
-    pub fn rounded_line(&mut self, p1: Vec2, p2: Vec2, radius: f32, col: Rgba) {
-        self.draw.rounded_line(self.pass, p1, p2, radius, col);
-    }
+    fn rounded_line(&mut self, p1: Vec2, p2: Vec2, radius: f32, col: Rgba);
 
     /// Draw a circle or oval of uniform colour
     ///
@@ -173,9 +216,7 @@ impl<'a, D: DrawableRounded + ?Sized> Draw<'a, D> {
     /// The `inner_radius` parameter gives the inner radius relative to the
     /// outer radius: a value of `0.0` will result in the whole shape being
     /// painted, while `1.0` will result in a zero-width line on the outer edge.
-    pub fn circle(&mut self, rect: Quad, inner_radius: f32, col: Rgba) {
-        self.draw.circle(self.pass, rect, inner_radius, col);
-    }
+    fn circle(&mut self, rect: Quad, inner_radius: f32, col: Rgba);
 
     /// Draw a frame with rounded corners and uniform colour
     ///
@@ -188,7 +229,20 @@ impl<'a, D: DrawableRounded + ?Sized> Draw<'a, D> {
     /// painted, while `1.0` will result in a zero-width line on the outer edge.
     /// When `inner_radius > 0`, the frame will be visually thinner than the
     /// allocated area.
-    pub fn rounded_frame(&mut self, outer: Quad, inner: Quad, inner_radius: f32, col: Rgba) {
+    fn rounded_frame(&mut self, outer: Quad, inner: Quad, inner_radius: f32, col: Rgba);
+}
+
+impl<'a, DS: DrawableShared> DrawRoundedT for Draw<'a, DS>
+where
+    DS::Draw: DrawableRounded,
+{
+    fn rounded_line(&mut self, p1: Vec2, p2: Vec2, radius: f32, col: Rgba) {
+        self.draw.rounded_line(self.pass, p1, p2, radius, col);
+    }
+    fn circle(&mut self, rect: Quad, inner_radius: f32, col: Rgba) {
+        self.draw.circle(self.pass, rect, inner_radius, col);
+    }
+    fn rounded_frame(&mut self, outer: Quad, inner: Quad, inner_radius: f32, col: Rgba) {
         self.draw
             .rounded_frame(self.pass, outer, inner, inner_radius, col);
     }

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -8,7 +8,7 @@
 use super::color::Rgba;
 #[allow(unused)]
 use super::DrawHandle;
-use super::{DrawShared, DrawableShared, ImageId, PassId, PassType};
+use super::{SharedState, DrawableShared, ImageId, PassId, PassType};
 use crate::geom::{Offset, Quad, Rect, Vec2};
 use crate::text::{Effect, TextDisplay};
 use std::any::Any;
@@ -50,7 +50,7 @@ pub struct DrawIface<'a, DS: DrawableShared> {
     pub draw: &'a mut DS::Draw,
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    pub shared: &'a mut DrawShared<DS>,
+    pub shared: &'a mut SharedState<DS>,
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
     pub pass: PassId,

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -31,30 +31,27 @@ use std::any::Any;
 /// [`DrawableRounded`] is implemented. In other cases one may directly use
 /// [`Draw::draw`], passing the result of [`Draw::pass`] as a parameter.
 pub struct Draw<'a, DS: DrawableShared> {
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
     pub draw: &'a mut DS::Draw,
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
     pub shared: &'a mut DrawShared<DS>,
-    pass: PassId,
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
+    pub pass: PassId,
 }
 
-#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-#[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 impl<'a, DS: DrawableShared> Draw<'a, DS> {
-    /// Construct (this is only called by the shell)
-    pub fn new(draw: &'a mut DS::Draw, shared: &'a mut DrawShared<DS>, pass: PassId) -> Self {
-        Draw { draw, shared, pass }
-    }
-
     /// Attempt to downcast a `&mut dyn DrawT` to a concrete [`Draw`] object
     pub fn downcast_from(obj: &'a mut dyn DrawT) -> Option<Self> {
         let pass = obj.pass();
         let (draw, shared) = obj.fields_as_any_mut();
         let draw = draw.downcast_mut()?;
         let shared = shared.downcast_mut()?;
-        Some(Draw::new(draw, shared, pass))
+        Some(Draw { draw, shared, pass })
     }
-}
 
-impl<'a, DS: DrawableShared> Draw<'a, DS> {
     /// Reborrow with a new lifetime
     pub fn reborrow<'b>(&'b mut self) -> Draw<'b, DS>
     where
@@ -65,11 +62,6 @@ impl<'a, DS: DrawableShared> Draw<'a, DS> {
             shared: &mut *self.shared,
             pass: self.pass,
         }
-    }
-
-    /// Get the current draw pass
-    pub fn pass(&self) -> PassId {
-        self.pass
     }
 
     /// Add a draw pass

--- a/src/draw/draw.rs
+++ b/src/draw/draw.rs
@@ -93,8 +93,8 @@ impl<'a, DS: DrawSharedImpl> DrawIface<'a, DS> {
     /// Case `class == PassType::Overlay`: the new pass is derived from the
     /// base pass (i.e. the window). Draw operations still happen after those in
     /// `parent_pass`.
-    pub fn new_draw_pass(&mut self, rect: Rect, offset: Offset, class: PassType) -> DrawIface<DS> {
-        let pass = self.draw.new_draw_pass(self.pass, rect, offset, class);
+    pub fn new_pass(&mut self, rect: Rect, offset: Offset, class: PassType) -> DrawIface<DS> {
+        let pass = self.draw.new_pass(self.pass, rect, offset, class);
         DrawIface {
             draw: &mut *self.draw,
             shared: &mut *self.shared,
@@ -146,7 +146,7 @@ pub trait Draw {
     /// `Rect::pos` is zero (but this is not guaranteed).
     ///
     /// (This is not guaranteed to equal the rect passed to
-    /// [`DrawIface::new_draw_pass`].)
+    /// [`DrawIface::new_pass`].)
     fn clip_rect(&self) -> Rect;
 
     /// Draw a rectangle of uniform colour
@@ -198,7 +198,7 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
         offset: Offset,
         class: PassType,
     ) -> stack_dst::ValueA<dyn Draw + 'b, [usize; 4]> {
-        let draw = self.new_draw_pass(rect, offset, class);
+        let draw = self.new_pass(rect, offset, class);
         stack_dst::ValueA::new_stable(draw, |d| d as &dyn Draw)
             .unwrap_or_else(|_| panic!("boxed window too big for StackDst!"))
     }
@@ -309,7 +309,7 @@ where
 ///
 /// Draw operations take place over multiple render passes, identified by a
 /// handle of type [`PassId`]. In general the user only needs to pass this value
-/// into methods as required. [`DrawImpl::new_draw_pass`] creates a new [`PassId`].
+/// into methods as required. [`DrawImpl::new_pass`] creates a new [`PassId`].
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 pub trait DrawImpl: Any {
@@ -328,7 +328,7 @@ pub trait DrawImpl: Any {
     /// Case `class == PassType::Overlay`: the new pass is derived from the
     /// base pass (i.e. the window). Draw operations still happen after those in
     /// `parent_pass`.
-    fn new_draw_pass(
+    fn new_pass(
         &mut self,
         parent_pass: PassId,
         rect: Rect,
@@ -342,7 +342,7 @@ pub trait DrawImpl: Any {
     /// `Rect::pos` is zero (but this is not guaranteed).
     ///
     /// (This is not guaranteed to equal the rect passed to
-    /// [`DrawImpl::new_draw_pass`].)
+    /// [`DrawImpl::new_pass`].)
     fn clip_rect(&self, pass: PassId) -> Rect;
 
     /// Draw a rectangle of uniform colour

--- a/src/draw/draw_rounded.rs
+++ b/src/draw/draw_rounded.rs
@@ -10,6 +10,8 @@ use super::{Draw, DrawIface, DrawImpl, DrawSharedImpl, PassId};
 use crate::geom::{Quad, Vec2};
 
 /// Extension over [`Draw`] for rounded shapes
+///
+/// All methods draw some feature.
 pub trait DrawRounded: Draw {
     /// Draw a line with rounded ends and uniform colour
     ///

--- a/src/draw/draw_rounded.rs
+++ b/src/draw/draw_rounded.rs
@@ -1,0 +1,88 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Drawing APIs — draw rounded
+
+use super::color::Rgba;
+use super::{Draw, DrawIface, DrawImpl, DrawSharedImpl, PassId};
+use crate::geom::{Quad, Vec2};
+
+/// Extension over [`Draw`] for rounded shapes
+pub trait DrawRounded: Draw {
+    /// Draw a line with rounded ends and uniform colour
+    ///
+    /// This command draws a line segment between the points `p1` and `p2`.
+    /// Pixels within the given `radius` of this segment are drawn, resulting
+    /// in rounded ends and width `2 * radius`.
+    ///
+    /// Note that for rectangular, axis-aligned lines, [`DrawImpl::rect`] should be
+    /// preferred.
+    fn rounded_line(&mut self, p1: Vec2, p2: Vec2, radius: f32, col: Rgba);
+
+    /// Draw a circle or oval of uniform colour
+    ///
+    /// More generally, this shape is an axis-aligned oval which may be hollow.
+    ///
+    /// The `inner_radius` parameter gives the inner radius relative to the
+    /// outer radius: a value of `0.0` will result in the whole shape being
+    /// painted, while `1.0` will result in a zero-width line on the outer edge.
+    fn circle(&mut self, rect: Quad, inner_radius: f32, col: Rgba);
+
+    /// Draw a frame with rounded corners and uniform colour
+    ///
+    /// All drawing occurs within the `outer` rect and outside of the `inner`
+    /// rect. Corners are circular (or more generally, ovular), centered on the
+    /// inner corners.
+    ///
+    /// The `inner_radius` parameter gives the inner radius relative to the
+    /// outer radius: a value of `0.0` will result in the whole shape being
+    /// painted, while `1.0` will result in a zero-width line on the outer edge.
+    /// When `inner_radius > 0`, the frame will be visually thinner than the
+    /// allocated area.
+    fn rounded_frame(&mut self, outer: Quad, inner: Quad, inner_radius: f32, col: Rgba);
+}
+
+impl<'a, DS: DrawSharedImpl> DrawRounded for DrawIface<'a, DS>
+where
+    DS::Draw: DrawRoundedImpl,
+{
+    fn rounded_line(&mut self, p1: Vec2, p2: Vec2, radius: f32, col: Rgba) {
+        self.draw.rounded_line(self.pass, p1, p2, radius, col);
+    }
+    fn circle(&mut self, rect: Quad, inner_radius: f32, col: Rgba) {
+        self.draw.circle(self.pass, rect, inner_radius, col);
+    }
+    fn rounded_frame(&mut self, outer: Quad, inner: Quad, inner_radius: f32, col: Rgba) {
+        self.draw
+            .rounded_frame(self.pass, outer, inner, inner_radius, col);
+    }
+}
+
+/// Drawing commands for rounded shapes
+///
+/// This trait is an extension over [`DrawImpl`] providing rounded shapes.
+///
+/// The primitives provided by this trait are partially transparent.
+/// If the implementation buffers draw commands, it should draw these
+/// primitives after solid primitives.
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+#[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
+pub trait DrawRoundedImpl: DrawImpl {
+    /// Draw a line with rounded ends and uniform colour
+    fn rounded_line(&mut self, pass: PassId, p1: Vec2, p2: Vec2, radius: f32, col: Rgba);
+
+    /// Draw a circle or oval of uniform colour
+    fn circle(&mut self, pass: PassId, rect: Quad, inner_radius: f32, col: Rgba);
+
+    /// Draw a frame with rounded corners and uniform colour
+    fn rounded_frame(
+        &mut self,
+        pass: PassId,
+        outer: Quad,
+        inner: Quad,
+        inner_radius: f32,
+        col: Rgba,
+    );
+}

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -12,7 +12,7 @@ use crate::text::{Effect, TextDisplay};
 use std::any::Any;
 use std::path::Path;
 
-/// Interface over a shared draw object
+/// Shared draw state
 ///
 /// A single [`SharedState`] instance is shared by all windows and draw contexts.
 /// This struct is built over a [`DrawSharedImpl`] object provided by the shell,

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -39,10 +39,9 @@ impl<DS: DrawSharedImpl> SharedState<DS> {
 }
 
 /// Interface over [`SharedState`]
+///
+/// All methods concern management of resources for drawing.
 pub trait DrawShared {
-    /// Access [`DrawSharedImpl`] object as `Any` to allow downcasting
-    fn drawable_as_any_mut(&mut self) -> &mut dyn Any;
-
     /// Allocate an image
     ///
     /// Use [`SharedState::image_upload`] to set contents of the new image.
@@ -63,20 +62,16 @@ pub trait DrawShared {
     /// Remove a loaded image, by path
     ///
     /// This reduces the reference count and frees if zero.
-    fn remove_image_from_path(&mut self, path: &Path);
+    fn image_free_from_path(&mut self, path: &Path);
 
     /// Free an image
-    fn remove_image(&mut self, id: ImageId);
+    fn image_free(&mut self, id: ImageId);
 
     /// Get the size of an image
     fn image_size(&self, id: ImageId) -> Option<Size>;
 }
 
 impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
-    fn drawable_as_any_mut(&mut self) -> &mut dyn Any {
-        &mut self.draw
-    }
-
     #[inline]
     fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError> {
         self.draw.image_alloc(size)
@@ -93,12 +88,12 @@ impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
     }
 
     #[inline]
-    fn remove_image_from_path(&mut self, path: &Path) {
+    fn image_free_from_path(&mut self, path: &Path) {
         self.images.remove_path(&mut self.draw, path);
     }
 
     #[inline]
-    fn remove_image(&mut self, id: ImageId) {
+    fn image_free(&mut self, id: ImageId) {
         self.images.remove_id(&mut self.draw, id);
     }
 

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -14,15 +14,15 @@ use std::path::Path;
 
 /// Interface over a shared draw object
 ///
-/// A single [`DrawShared`] instance is shared by all windows and draw contexts.
+/// A single [`SharedState`] instance is shared by all windows and draw contexts.
 /// This struct is built over a [`DrawableShared`] object provided by the shell,
 /// which may be accessed directly for a lower-level API (though most methods
-/// are available through [`DrawShared`] directly).
+/// are available through [`SharedState`] directly).
 ///
 /// Note: all functionality is implemented through the [`DrawSharedT`] trait to
 /// allow usage where the `DS` type parameter is unknown. Some functionality is
 /// also implemented directly to avoid the need for downcasting.
-pub struct DrawShared<DS: DrawableShared> {
+pub struct SharedState<DS: DrawableShared> {
     /// The shell's [`DrawableShared`] object
     pub draw: DS,
     images: images::Images,
@@ -30,22 +30,22 @@ pub struct DrawShared<DS: DrawableShared> {
 
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-impl<DS: DrawableShared> DrawShared<DS> {
+impl<DS: DrawableShared> SharedState<DS> {
     /// Construct (this is only called by the shell)
     pub fn new(draw: DS) -> Self {
         let images = images::Images::new();
-        DrawShared { draw, images }
+        SharedState { draw, images }
     }
 }
 
-/// Interface over [`DrawShared`]
+/// Interface over [`SharedState`]
 pub trait DrawSharedT {
     /// Access [`DrawableShared`] object as `Any` to allow downcasting
     fn drawable_as_any_mut(&mut self) -> &mut dyn Any;
 
     /// Allocate an image
     ///
-    /// Use [`DrawShared::image_upload`] to set contents of the new image.
+    /// Use [`SharedState::image_upload`] to set contents of the new image.
     fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, ImageError>;
 
     /// Upload an image to the GPU
@@ -72,7 +72,7 @@ pub trait DrawSharedT {
     fn image_size(&self, id: ImageId) -> Option<Size>;
 }
 
-impl<DS: DrawableShared> DrawSharedT for DrawShared<DS> {
+impl<DS: DrawableShared> DrawSharedT for SharedState<DS> {
     fn drawable_as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.draw
     }
@@ -110,7 +110,7 @@ impl<DS: DrawableShared> DrawSharedT for DrawShared<DS> {
 
 /// Trait over shared data of draw object
 ///
-/// This is typically used via [`DrawShared`].
+/// This is typically used via [`SharedState`].
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 pub trait DrawableShared: Any {

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -126,47 +126,6 @@ pub trait DrawSharedT {
 
     /// Get the size of an image
     fn image_size(&self, id: ImageId) -> Option<Size>;
-
-    /// Draw the image in the given `rect`
-    fn draw_image(&self, draw: &mut dyn Drawable, pass: PassId, id: ImageId, rect: Quad);
-
-    /// Draw text with a colour
-    fn draw_text(
-        &mut self,
-        draw: &mut dyn Drawable,
-        pass: PassId,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-    );
-
-    /// Draw text with a colour and effects
-    ///
-    /// The effects list does not contain colour information, but may contain
-    /// underlining/strikethrough information. It may be empty.
-    fn draw_text_col_effects(
-        &mut self,
-        draw: &mut dyn Drawable,
-        pass: PassId,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-        effects: &[Effect<()>],
-    );
-
-    /// Draw text with effects
-    ///
-    /// The `effects` list provides both underlining and colour information.
-    /// If the `effects` list is empty or the first entry has `start > 0`, a
-    /// default entity will be assumed.
-    fn draw_text_effects(
-        &mut self,
-        draw: &mut dyn Drawable,
-        pass: PassId,
-        pos: Vec2,
-        text: &TextDisplay,
-        effects: &[Effect<Rgba>],
-    );
 }
 
 impl<DS: DrawableShared> DrawSharedT for DrawShared<DS> {
@@ -202,53 +161,6 @@ impl<DS: DrawableShared> DrawSharedT for DrawShared<DS> {
     #[inline]
     fn image_size(&self, id: ImageId) -> Option<Size> {
         self.draw.image_size(id).map(|size| size.into())
-    }
-
-    fn draw_image(&self, draw: &mut dyn Drawable, pass: PassId, id: ImageId, rect: Quad) {
-        if let Some(draw) = draw.as_any_mut().downcast_mut() {
-            self.draw.draw_image(draw, pass, id, rect)
-        };
-    }
-
-    fn draw_text(
-        &mut self,
-        draw: &mut dyn Drawable,
-        pass: PassId,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-    ) {
-        if let Some(draw) = draw.as_any_mut().downcast_mut() {
-            self.draw.draw_text(draw, pass, pos, text, col)
-        };
-    }
-
-    fn draw_text_col_effects(
-        &mut self,
-        draw: &mut dyn Drawable,
-        pass: PassId,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-        effects: &[Effect<()>],
-    ) {
-        if let Some(draw) = draw.as_any_mut().downcast_mut() {
-            self.draw
-                .draw_text_col_effects(draw, pass, pos, text, col, effects)
-        };
-    }
-
-    fn draw_text_effects(
-        &mut self,
-        draw: &mut dyn Drawable,
-        pass: PassId,
-        pos: Vec2,
-        text: &TextDisplay,
-        effects: &[Effect<Rgba>],
-    ) {
-        if let Some(draw) = draw.as_any_mut().downcast_mut() {
-            self.draw.draw_text_effects(draw, pass, pos, text, effects)
-        };
     }
 }
 

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -38,62 +38,6 @@ impl<DS: DrawableShared> DrawShared<DS> {
     }
 }
 
-impl<DS: DrawableShared> DrawShared<DS> {
-    /// Draw the image in the given `rect`
-    #[inline]
-    pub fn draw_image(&self, draw: &mut DS::Draw, pass: PassId, id: ImageId, rect: Quad) {
-        self.draw.draw_image(draw, pass, id, rect)
-    }
-
-    /// Draw text with a colour
-    #[inline]
-    pub fn draw_text(
-        &mut self,
-        draw: &mut DS::Draw,
-        pass: PassId,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-    ) {
-        self.draw.draw_text(draw, pass, pos, text, col)
-    }
-
-    /// Draw text with a colour and effects
-    ///
-    /// The effects list does not contain colour information, but may contain
-    /// underlining/strikethrough information. It may be empty.
-    #[inline]
-    pub fn draw_text_col_effects(
-        &mut self,
-        draw: &mut DS::Draw,
-        pass: PassId,
-        pos: Vec2,
-        text: &TextDisplay,
-        col: Rgba,
-        effects: &[Effect<()>],
-    ) {
-        self.draw
-            .draw_text_col_effects(draw, pass, pos, text, col, effects)
-    }
-
-    /// Draw text with effects
-    ///
-    /// The `effects` list provides both underlining and colour information.
-    /// If the `effects` list is empty or the first entry has `start > 0`, a
-    /// default entity will be assumed.
-    #[inline]
-    pub fn draw_text_effects(
-        &mut self,
-        draw: &mut DS::Draw,
-        pass: PassId,
-        pos: Vec2,
-        text: &TextDisplay,
-        effects: &[Effect<Rgba>],
-    ) {
-        self.draw.draw_text_effects(draw, pass, pos, text, effects)
-    }
-}
-
 /// Interface over [`DrawShared`]
 pub trait DrawSharedT {
     /// Access [`DrawableShared`] object as `Any` to allow downcasting

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 /// which may be accessed directly for a lower-level API (though most methods
 /// are available through [`SharedState`] directly).
 ///
-/// Note: all functionality is implemented through the [`DrawSharedT`] trait to
+/// Note: all functionality is implemented through the [`DrawShared`] trait to
 /// allow usage where the `DS` type parameter is unknown. Some functionality is
 /// also implemented directly to avoid the need for downcasting.
 pub struct SharedState<DS: DrawSharedImpl> {
@@ -39,7 +39,7 @@ impl<DS: DrawSharedImpl> SharedState<DS> {
 }
 
 /// Interface over [`SharedState`]
-pub trait DrawSharedT {
+pub trait DrawShared {
     /// Access [`DrawSharedImpl`] object as `Any` to allow downcasting
     fn drawable_as_any_mut(&mut self) -> &mut dyn Any;
 
@@ -72,7 +72,7 @@ pub trait DrawSharedT {
     fn image_size(&self, id: ImageId) -> Option<Size>;
 }
 
-impl<DS: DrawSharedImpl> DrawSharedT for SharedState<DS> {
+impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
     fn drawable_as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.draw
     }

--- a/src/draw/draw_shared.rs
+++ b/src/draw/draw_shared.rs
@@ -116,9 +116,6 @@ impl<DS: DrawableShared> DrawSharedT for DrawShared<DS> {
 pub trait DrawableShared: Any {
     type Draw: Drawable;
 
-    /// Cast self to [`Any`] reference
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-
     /// Allocate an image
     ///
     /// Use [`DrawableShared::image_upload`] to set contents of the new image.

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -9,7 +9,7 @@ use std::convert::AsRef;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 
 use kas::dir::Direction;
-use kas::draw::{Draw, DrawSharedT, Drawable, ImageId};
+use kas::draw::{DrawT, ImageId};
 use kas::geom::{Coord, Offset, Rect, Size};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use kas::text::{AccelString, Text, TextApi, TextDisplay};
@@ -267,12 +267,7 @@ pub trait DrawHandle {
     fn size_handle(&mut self) -> &mut dyn SizeHandle;
 
     /// Access the low-level draw device
-    ///
-    /// Returns `(draw, shared)`.
-    ///
-    /// The `draw` object is over the [`Drawable`] interface which exposes only
-    /// minimal functionality. [`Draw::downcast`] will likely be of use.
-    fn draw_device(&mut self) -> (Draw<'_, dyn Drawable>, &mut dyn DrawSharedT);
+    fn draw_device(&mut self) -> &mut dyn DrawT;
 
     /// Add a draw pass
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
@@ -526,7 +521,7 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn size_handle(&mut self) -> &mut dyn SizeHandle {
         self.deref_mut().size_handle()
     }
-    fn draw_device(&mut self) -> (Draw<'_, dyn Drawable>, &mut dyn DrawSharedT) {
+    fn draw_device(&mut self) -> &mut dyn DrawT {
         self.deref_mut().draw_device()
     }
     fn new_draw_pass(
@@ -612,7 +607,7 @@ where
     fn size_handle(&mut self) -> &mut dyn SizeHandle {
         self.deref_mut().size_handle()
     }
-    fn draw_device(&'_ mut self) -> (Draw<'_, dyn Drawable>, &'_ mut dyn DrawSharedT) {
+    fn draw_device(&mut self) -> &mut dyn DrawT {
         self.deref_mut().draw_device()
     }
     fn new_draw_pass(

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -9,7 +9,7 @@ use std::convert::AsRef;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 
 use kas::dir::Direction;
-use kas::draw::{Draw, ImageId};
+use kas::draw::{Draw, ImageId, PassType};
 use kas::geom::{Coord, Offset, Rect, Size};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use kas::text::{AccelString, Text, TextApi, TextDisplay};
@@ -96,21 +96,6 @@ impl Default for TextClass {
     fn default() -> Self {
         TextClass::Label
     }
-}
-
-/// Type of draw pass
-#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-#[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub enum PassType {
-    /// New pass is clipped and offset relative to parent
-    Clip,
-    /// New pass is an overlay
-    ///
-    /// An overlay is a layer drawn over the base window, for example a tooltip
-    /// or combobox menu. The rect and offset are relative to the base window.
-    /// The theme may draw a shadow or border around this rect.
-    Overlay,
 }
 
 /// A handle to the active theme, used for sizing

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -9,7 +9,7 @@ use std::convert::AsRef;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 
 use kas::dir::Direction;
-use kas::draw::{DrawT, ImageId};
+use kas::draw::{Draw, ImageId};
 use kas::geom::{Coord, Offset, Rect, Size};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use kas::text::{AccelString, Text, TextApi, TextDisplay};
@@ -267,7 +267,7 @@ pub trait DrawHandle {
     fn size_handle(&mut self) -> &mut dyn SizeHandle;
 
     /// Access the low-level draw device
-    fn draw_device(&mut self) -> &mut dyn DrawT;
+    fn draw_device(&mut self) -> &mut dyn Draw;
 
     /// Add a draw pass
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
@@ -521,7 +521,7 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn size_handle(&mut self) -> &mut dyn SizeHandle {
         self.deref_mut().size_handle()
     }
-    fn draw_device(&mut self) -> &mut dyn DrawT {
+    fn draw_device(&mut self) -> &mut dyn Draw {
         self.deref_mut().draw_device()
     }
     fn new_draw_pass(
@@ -607,7 +607,7 @@ where
     fn size_handle(&mut self) -> &mut dyn SizeHandle {
         self.deref_mut().size_handle()
     }
-    fn draw_device(&mut self) -> &mut dyn DrawT {
+    fn draw_device(&mut self) -> &mut dyn Draw {
         self.deref_mut().draw_device()
     }
     fn new_draw_pass(

--- a/src/draw/handle.rs
+++ b/src/draw/handle.rs
@@ -242,7 +242,7 @@ pub trait SizeHandle {
 ///
 /// -   [`Self::size_handle`] provides access to a [`SizeHandle`]
 /// -   [`Self::draw_device`] provides a lower-level interface for draw operations
-/// -   [`Self::new_draw_pass`], [`DrawHandleExt::with_clip_region`],
+/// -   [`Self::new_pass`], [`DrawHandleExt::with_clip_region`],
 ///     [`DrawHandleExt::with_overlay`] construct new draw passes
 /// -   [`Self::get_clip_rect`] returns the clip rect
 ///
@@ -257,7 +257,7 @@ pub trait DrawHandle {
     /// Add a draw pass
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    fn new_draw_pass(
+    fn new_pass(
         &mut self,
         rect: Rect,
         offset: Offset,
@@ -391,7 +391,7 @@ pub trait DrawHandleExt: DrawHandle {
         offset: Offset,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     ) {
-        self.new_draw_pass(rect, offset, PassType::Clip, f);
+        self.new_pass(rect, offset, PassType::Clip, f);
     }
 
     /// Draw to a new pass as an overlay (e.g. for pop-up menus)
@@ -403,7 +403,7 @@ pub trait DrawHandleExt: DrawHandle {
     /// a frame or shadow around this overlay, thus the
     /// [`DrawHandle::get_clip_rect`] may be larger than expected.
     fn with_overlay(&mut self, rect: Rect, f: &mut dyn FnMut(&mut dyn DrawHandle)) {
-        self.new_draw_pass(rect, Offset::ZERO, PassType::Overlay, f);
+        self.new_pass(rect, Offset::ZERO, PassType::Overlay, f);
     }
 
     /// Draw some text using the standard font, with a subset selected
@@ -509,14 +509,14 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn draw_device(&mut self) -> &mut dyn Draw {
         self.deref_mut().draw_device()
     }
-    fn new_draw_pass(
+    fn new_pass(
         &mut self,
         rect: Rect,
         offset: Offset,
         class: PassType,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     ) {
-        self.deref_mut().new_draw_pass(rect, offset, class, f);
+        self.deref_mut().new_pass(rect, offset, class, f);
     }
     fn get_clip_rect(&self) -> Rect {
         self.deref().get_clip_rect()
@@ -595,14 +595,14 @@ where
     fn draw_device(&mut self) -> &mut dyn Draw {
         self.deref_mut().draw_device()
     }
-    fn new_draw_pass(
+    fn new_pass(
         &mut self,
         rect: Rect,
         offset: Offset,
         class: PassType,
         f: &mut dyn FnMut(&mut dyn DrawHandle),
     ) {
-        self.deref_mut().new_draw_pass(rect, offset, class, f);
+        self.deref_mut().new_pass(rect, offset, class, f);
     }
     fn get_clip_rect(&self) -> Rect {
         self.deref().get_clip_rect()

--- a/src/draw/images.rs
+++ b/src/draw/images.rs
@@ -5,7 +5,7 @@
 
 //! Image resource management
 
-use super::DrawableShared;
+use super::DrawSharedImpl;
 use image::RgbaImage;
 use std::collections::HashMap;
 use std::num::NonZeroU32;
@@ -67,7 +67,7 @@ impl Images {
     ///
     /// This deduplicates multiple loads of the same path, instead incrementing
     /// a reference count.
-    pub fn load_path<DS: DrawableShared>(
+    pub fn load_path<DS: DrawSharedImpl>(
         &mut self,
         draw: &mut DS,
         path: &Path,
@@ -95,7 +95,7 @@ impl Images {
     /// Remove a loaded image, by path
     ///
     /// This reduces the reference count and frees if zero.
-    pub fn remove_path<DS: DrawableShared>(&mut self, draw: &mut DS, path: &Path) {
+    pub fn remove_path<DS: DrawSharedImpl>(&mut self, draw: &mut DS, path: &Path) {
         let mut opt_id = None;
         self.paths.retain(|p, (id, _)| {
             if p == path {
@@ -116,7 +116,7 @@ impl Images {
     ///
     /// This reduces the reference count and frees if zero.
     /// (It also removes images not created through [`Images::load_path`].)
-    pub fn remove_id<DS: DrawableShared>(&mut self, draw: &mut DS, id: ImageId) {
+    pub fn remove_id<DS: DrawSharedImpl>(&mut self, draw: &mut DS, id: ImageId) {
         // We don't have a map from id to path, hence have to iterate. We can
         // however do a fast check that id is used.
         if !self.images.contains_key(&id) {

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -22,15 +22,11 @@
 //!
 //! ### Medium-level drawing interfaces
 //!
-//! The theme draws widget components over a [`Draw`] object (unique to the
-//! current draw context) plus a reference to [`DrawShared`] (for shared data
-//! related to drawing, e.g. loaded images). Widgets may access this same API
-//! via [`DrawHandle::draw_device`].
+//! The theme draws widget components over a [`Draw`] object.
+//! Widgets may access this same API via [`DrawHandle::draw_device`].
 //!
-//! Both [`Draw`] and [`DrawShared`] are wrappers over types provided by the
-//! shell implementing [`Drawable`] and [`DrawableShared`] respectively.
-//! Extension traits to [`Drawable`] (which may be defined elsewhere) cover
-//! further functionality.
+//! The traits [`DrawT`] and [`DrawRoundedT`] provide functinality over a
+//! [`Draw`] object. Additional interfaces may be defined in external crates.
 //!
 //! ### Low-level interface
 //!

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -22,11 +22,11 @@
 //!
 //! ### Medium-level drawing interfaces
 //!
-//! The theme draws widget components over a [`Draw`] object.
+//! The theme draws widget components over a [`DrawIface`] object.
 //! Widgets may access this same API via [`DrawHandle::draw_device`].
 //!
 //! The traits [`DrawT`] and [`DrawRoundedT`] provide functinality over a
-//! [`Draw`] object. Additional interfaces may be defined in external crates.
+//! [`DrawIface`] object. Additional interfaces may be defined in external crates.
 //!
 //! ### Low-level interface
 //!
@@ -40,7 +40,7 @@
 //!
 //! All draw operations happen within a "draw pass". The first pass corresponds
 //! to the window, while additional passes may be clipped and offset (see
-//! [`Draw::new_draw_pass`]). Draw passes are executed sequentially in the order
+//! [`DrawIface::new_draw_pass`]). Draw passes are executed sequentially in the order
 //! defined.
 //!
 //! Within each pass, draw operations may be batched by the shell, thus draw

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -65,7 +65,7 @@ mod theme;
 use crate::cast::Cast;
 
 pub use draw::*;
-pub use draw_shared::{SharedState, DrawSharedT, DrawableShared};
+pub use draw_shared::{SharedState, DrawSharedT, DrawSharedImpl};
 pub use handle::*;
 pub use images::{ImageError, ImageFormat, ImageId};
 pub use theme::*;

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -104,3 +104,16 @@ impl PassId {
         0.0
     }
 }
+
+/// Type of draw pass
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum PassType {
+    /// New pass is clipped and offset relative to parent
+    Clip,
+    /// New pass is an overlay
+    ///
+    /// An overlay is a layer drawn over the base window, for example a tooltip
+    /// or combobox menu. The rect and offset are relative to the base window.
+    /// The theme may draw a shadow or border around this rect.
+    Overlay,
+}

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -65,7 +65,7 @@ mod theme;
 use crate::cast::Cast;
 
 pub use draw::*;
-pub use draw_shared::{SharedState, DrawShared, DrawSharedImpl};
+pub use draw_shared::{DrawShared, DrawSharedImpl, SharedState};
 pub use handle::*;
 pub use images::{ImageError, ImageFormat, ImageId};
 pub use theme::*;

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -25,7 +25,7 @@
 //! The theme draws widget components over a [`DrawIface`] object.
 //! Widgets may access this same API via [`DrawHandle::draw_device`].
 //!
-//! The traits [`DrawT`] and [`DrawRoundedT`] provide functinality over a
+//! The traits [`Draw`] and [`DrawRounded`] provide functinality over a
 //! [`DrawIface`] object. Additional interfaces may be defined in external crates.
 //!
 //! ### Low-level interface
@@ -49,7 +49,7 @@
 //!
 //! 1.  Images
 //! 2.  Square-edged primitives (e.g. [`Draw::rect`])
-//! 3.  Rounded or other partially-transparent primitives (e.g. [`Draw::circle`])
+//! 3.  Rounded or other partially-transparent primitives (e.g. [`DrawRounded::circle`])
 //! 4.  Custom draw routines (`CustomPipe`)
 //! 5.  Text
 
@@ -65,7 +65,7 @@ mod theme;
 use crate::cast::Cast;
 
 pub use draw::*;
-pub use draw_shared::{SharedState, DrawSharedT, DrawSharedImpl};
+pub use draw_shared::{SharedState, DrawShared, DrawSharedImpl};
 pub use handle::*;
 pub use images::{ImageError, ImageFormat, ImageId};
 pub use theme::*;

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -40,7 +40,7 @@
 //!
 //! All draw operations happen within a "draw pass". The first pass corresponds
 //! to the window, while additional passes may be clipped and offset (see
-//! [`DrawIface::new_draw_pass`]). Draw passes are executed sequentially in the order
+//! [`DrawIface::new_pass`]). Draw passes are executed sequentially in the order
 //! defined.
 //!
 //! Within each pass, draw operations may be batched by the shell, thus draw
@@ -72,10 +72,7 @@ pub use theme::*;
 
 /// Draw pass identifier
 ///
-/// This is a small value passed by copy to identify which pass draw routines
-/// happen in. Draw passes allow control over draw order and clipping.
-///
-/// Custom render pipes should extract the pass number.
+/// This is a numerical identifier for the draw pass (see [`DrawIface::new_pass`]).
 #[derive(Copy, Clone)]
 pub struct PassId(u32);
 

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -57,6 +57,7 @@ pub mod color;
 
 #[allow(clippy::module_inception)]
 mod draw;
+mod draw_rounded;
 mod draw_shared;
 mod handle;
 mod images;
@@ -64,11 +65,12 @@ mod theme;
 
 use crate::cast::Cast;
 
-pub use draw::*;
+pub use draw::{Draw, DrawIface, DrawImpl};
+pub use draw_rounded::{DrawRounded, DrawRoundedImpl};
 pub use draw_shared::{DrawShared, DrawSharedImpl, SharedState};
-pub use handle::*;
+pub use handle::{DrawHandle, DrawHandleExt, InputState, SizeHandle, TextClass};
 pub use images::{ImageError, ImageFormat, ImageId};
-pub use theme::*;
+pub use theme::ThemeApi;
 
 /// Draw pass identifier
 ///

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -65,7 +65,7 @@ mod theme;
 use crate::cast::Cast;
 
 pub use draw::*;
-pub use draw_shared::{DrawShared, DrawSharedT, DrawableShared};
+pub use draw_shared::{SharedState, DrawSharedT, DrawableShared};
 pub use handle::*;
 pub use images::{ImageError, ImageFormat, ImageId};
 pub use theme::*;

--- a/src/event/manager/mgr_pub.rs
+++ b/src/event/manager/mgr_pub.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use std::u16;
 
 use super::*;
-use crate::draw::{DrawSharedT, SizeHandle, ThemeApi};
+use crate::draw::{DrawShared, SizeHandle, ThemeApi};
 use crate::geom::Coord;
 use crate::updatable::Updatable;
 #[allow(unused)]
@@ -337,10 +337,10 @@ impl<'a> Manager<'a> {
         result.expect("ShellWindow::size_handle impl failed to call function argument")
     }
 
-    /// Access a [`DrawSharedT`]
+    /// Access a [`DrawShared`]
     ///
     /// This can be accessed through [`Self::size_handle`]; this method is merely a shortcut.
-    pub fn draw_shared<F: FnMut(&mut dyn DrawSharedT) -> T, T>(&mut self, mut f: F) -> T {
+    pub fn draw_shared<F: FnMut(&mut dyn DrawShared) -> T, T>(&mut self, mut f: F) -> T {
         let mut result = None;
         self.shell.draw_shared(&mut |draw_shared| {
             result = Some(f(draw_shared));

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,7 +20,7 @@ pub use kas::class::*;
 #[doc(no_inline)]
 pub use kas::dir::{Direction, Directional};
 #[doc(no_inline)]
-pub use kas::draw::{DrawHandle, DrawHandleExt, DrawSharedT, ImageId, SizeHandle, ThemeApi};
+pub use kas::draw::{DrawHandle, DrawHandleExt, DrawShared, ImageId, SizeHandle, ThemeApi};
 #[doc(no_inline)]
 pub use kas::event::{
     Event, Handler, Manager, ManagerState, Response, SendEvent, UpdateHandle, VoidMsg,

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -15,7 +15,7 @@
 use std::num::NonZeroU32;
 use std::rc::Rc;
 
-use crate::draw::{DrawSharedT, SizeHandle, ThemeApi};
+use crate::draw::{DrawShared, SizeHandle, ThemeApi};
 use crate::event;
 use crate::event::UpdateHandle;
 use crate::updatable::Updatable;
@@ -151,12 +151,12 @@ pub trait ShellWindow {
     /// User-code *must not* depend on `f` being called for memory safety.
     fn size_handle(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle));
 
-    /// Access a [`DrawSharedT`]
+    /// Access a [`DrawShared`]
     ///
     /// Implementations should call the given function argument once; not doing
     /// so is memory-safe but will cause a panic when `draw_shared` is called.
     /// User-code *must not* depend on `f` being called for memory safety.
-    fn draw_shared(&mut self, f: &mut dyn FnMut(&mut dyn DrawSharedT));
+    fn draw_shared(&mut self, f: &mut dyn FnMut(&mut dyn DrawShared));
 
     /// Set the mouse cursor
     fn set_cursor_icon(&mut self, icon: event::CursorIcon);

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -161,7 +161,7 @@ impl<P: CanvasDrawable> Layout for Canvas<P> {
         let pm_size = self.pixmap.as_ref().map(|pm| (pm.width(), pm.height()));
         if pm_size.unwrap_or((0, 0)) != size {
             if let Some(id) = self.image_id {
-                mgr.draw_shared(|ds| ds.remove_image(id));
+                mgr.draw_shared(|ds| ds.image_free(id));
             }
             self.pixmap = Pixmap::new(size.0, size.1);
             let program = &self.program;

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -33,7 +33,7 @@ pub trait CanvasDrawable: std::fmt::Debug + 'static {
 /// The canvas (re)creates the backing pixmap when the size is set and draws
 /// to the new pixmap immediately. If the canvas program is modified then
 /// [`Canvas::redraw`] must be called to update the pixmap.
-#[cfg_attr(doc_cfg, doc(cfg(canvas)))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "canvas")))]
 #[derive(Clone, Debug, Widget)]
 pub struct Canvas<P: CanvasDrawable> {
     #[widget_core]

--- a/src/widget/sprite.rs
+++ b/src/widget/sprite.rs
@@ -142,7 +142,7 @@ impl Image {
         let mut size = Size::ZERO;
         mgr.draw_shared(|ds| {
             if let Some(id) = self.id {
-                ds.remove_image(id);
+                ds.image_free(id);
             }
             match ds.image_from_path(&self.path) {
                 Ok(id) => {
@@ -163,7 +163,7 @@ impl Image {
     pub fn clear(&mut self, mgr: &mut Manager) {
         if let Some(id) = self.id.take() {
             self.do_load = false;
-            mgr.draw_shared(|ds| ds.remove_image(id));
+            mgr.draw_shared(|ds| ds.image_free(id));
         }
     }
 

--- a/src/widget/svg.rs
+++ b/src/widget/svg.rs
@@ -164,7 +164,7 @@ impl Layout for Svg {
         let pm_size = self.pixmap.as_ref().map(|pm| (pm.width(), pm.height()));
         if pm_size.unwrap_or((0, 0)) != size {
             if let Some(id) = self.image_id {
-                mgr.draw_shared(|ds| ds.remove_image(id));
+                mgr.draw_shared(|ds| ds.image_free(id));
             }
             self.pixmap = Pixmap::new(size.0, size.1);
             if let Some(tree) = self.tree.as_ref() {

--- a/src/widget/svg.rs
+++ b/src/widget/svg.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use tiny_skia::Pixmap;
 
 /// An SVG image loaded from a path
-#[cfg_attr(doc_cfg, doc(cfg(svg)))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "svg")))]
 #[derive(Clone, Widget)]
 #[widget(config = noauto)]
 pub struct Svg {


### PR DESCRIPTION
This is the second part of #223, revisions to the draw API. Most of this PR concerns renaming methods and removing redundant methods, except for the first and third commits which include a reference to shared draw state within `Draw` (later renamed to `DrawIface`), providing users a much simpler API.