### PR TITLE
Add kas/macros_log feature; prepare 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] — 2021-08-03
+
+Add `kas/macros_log` feature, disabled by default.
+
 ## [0.9.0] — 2021-08-03
 
 Version 0.8 added image support without much thought to the API, leaving image

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -61,6 +61,10 @@ canvas = ["tiny-skia"]
 # Support SVG images
 svg = ["tiny-skia", "resvg", "usvg"]
 
+# Inject logging into macro-generated code.
+# Requires that all crates using these macros depend on the log crate.
+macros_log = ["kas-macros/log"]
+
 [dependencies]
 easy-cast = "0.4.2"
 log = "0.4"
@@ -80,7 +84,7 @@ resvg = { version = "0.15.0", optional = true }
 usvg = { version = "0.15.0", optional = true }
 
 [dependencies.kas-macros]
-version = "0.9.0"
+version = "0.9.1"
 path = "kas-macros"
 
 [dependencies.kas-text]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ The `kas` crate has the following feature flags:
 -   `stack_dst`: some compatibility impls (see `kas-theme`'s documentation)
 -   `internal_doc`: turns on some extra documentation intended for internal
     usage but not for end users. (This only affects generated documentation.)
+-   `macros_log`: enable logging in macro-generated code. Requires that all
+    crates using `derive(Widget)` or `make_widget` depend on the `log` crate.
 
 Additionally, the following flags require a nightly compiler:
 

--- a/kas-macros/Cargo.toml
+++ b/kas-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-macros"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,6 +14,11 @@ build = "build.rs"
 
 [lib]
 proc-macro = true
+
+[features]
+# Inject logging into macro-generated code.
+# Requires that all crates using these macros depend on the log crate.
+log = []
 
 [dependencies]
 quote = "1.0"

--- a/kas-macros/src/lib.rs
+++ b/kas-macros/src/lib.rs
@@ -365,6 +365,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                 for child in args.children.iter() {
                     let ident = &child.ident;
                     let handler = if let Some(ref h) = child.args.handler {
+                        #[cfg(feature = "log")]
                         quote! {
                             r.try_into().unwrap_or_else(|msg| {
                                 log::trace!(
@@ -376,6 +377,8 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                                 self.#h(mgr, msg)
                             })
                         }
+                        #[cfg(not(feature = "log"))]
+                        quote! { r.try_into().unwrap_or_else(|msg| self.#h(mgr, msg)) }
                     } else {
                         quote! { r.into() }
                     };


### PR DESCRIPTION
Some recently added logging inadvertently required users to depend on the `log` crate. This PR makes that behaviour opt-in.