### PR TITLE
Improve keyboard navigation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,13 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install -y libxkbcommon-dev libxcb-shape0-dev libxcb-xfixes0-dev
       - name: Build examples
-        run: cargo build --manifest-path kas-wgpu/Cargo.toml --release --example calculator --example gallery --example mandlebrot
+        run: |
+          cargo build --release --example calculator --example gallery
+          cargo build --release --manifest-path examples/mandlebrot/Cargo.toml
       - name: Prepare
         run: |
-          strip target/release/examples/calculator target/release/examples/gallery target/release/examples/mandlebrot
+          strip target/release/examples/calculator target/release/examples/gallery target/release/mandlebrot
+          mv target/release/mandlebrot target/release/examples/
           cp -a kas-wgpu/res target/release/examples/
       - name: Upload
         uses: actions/upload-artifact@v2
@@ -49,10 +52,13 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.7
           WINIT_LINK_COLORSYNC: 1
-        run: cargo build --manifest-path kas-wgpu/Cargo.toml --release --example calculator --example gallery --example mandlebrot
+        run: |
+          cargo build --release --example calculator --example gallery
+          cargo build --release --manifest-path examples/mandlebrot/Cargo.toml
       - name: Prepare
         run: |
-          strip target/release/examples/calculator target/release/examples/gallery target/release/examples/mandlebrot
+          strip target/release/examples/calculator target/release/examples/gallery target/release/mandlebrot
+          mv target/release/mandlebrot target/release/examples/
           cp -a kas-wgpu/res target/release/examples/
       - name: Upload
         uses: actions/upload-artifact@v2
@@ -76,10 +82,13 @@ jobs:
           toolchain: stable
           override: true
       - name: Build examples
-        run: cargo build --manifest-path kas-wgpu/Cargo.toml --release --example calculator --example gallery --example mandlebrot
+        run: |
+          cargo build --release --example calculator --example gallery
+          cargo build --release --manifest-path examples/mandlebrot/Cargo.toml
       - name: Prepare
         run: |
-          strip target/release/examples/calculator target/release/examples/gallery target/release/examples/mandlebrot
+          strip target/release/examples/calculator target/release/examples/gallery target/release/mandlebrot
+          mv target/release/mandlebrot target/release/examples/
           xcopy kas-wgpu\res target\release\examples\res /e/k/c/i/y
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,11 @@ jobs:
         run: sudo apt-get install -y libxkbcommon-dev libxcb-shape0-dev libxcb-xfixes0-dev
       - name: Build examples
         run: |
-          cargo build --release --example calculator --example gallery
+          cargo build --release --example layout --example gallery
           cargo build --release --manifest-path examples/mandlebrot/Cargo.toml
       - name: Prepare
         run: |
-          strip target/release/examples/calculator target/release/examples/gallery target/release/mandlebrot
+          strip target/release/examples/layout target/release/examples/gallery target/release/mandlebrot
           mv target/release/mandlebrot target/release/examples/
           cp -a kas-wgpu/res target/release/examples/
       - name: Upload
@@ -32,7 +32,7 @@ jobs:
         with:
           name: examples-ubuntu
           path: |
-            target/release/examples/calculator
+            target/release/examples/layout
             target/release/examples/gallery
             target/release/examples/mandlebrot
             target/release/examples/res/
@@ -53,11 +53,11 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.7
           WINIT_LINK_COLORSYNC: 1
         run: |
-          cargo build --release --example calculator --example gallery
+          cargo build --release --example layout --example gallery
           cargo build --release --manifest-path examples/mandlebrot/Cargo.toml
       - name: Prepare
         run: |
-          strip target/release/examples/calculator target/release/examples/gallery target/release/mandlebrot
+          strip target/release/examples/layout target/release/examples/gallery target/release/mandlebrot
           mv target/release/mandlebrot target/release/examples/
           cp -a kas-wgpu/res target/release/examples/
       - name: Upload
@@ -65,7 +65,7 @@ jobs:
         with:
           name: examples-macOS
           path: |
-            target/release/examples/calculator
+            target/release/examples/layout
             target/release/examples/gallery
             target/release/examples/mandlebrot
             target/release/examples/res/
@@ -83,11 +83,11 @@ jobs:
           override: true
       - name: Build examples
         run: |
-          cargo build --release --example calculator --example gallery
+          cargo build --release --example layout --example gallery
           cargo build --release --manifest-path examples/mandlebrot/Cargo.toml
       - name: Prepare
         run: |
-          strip target/release/examples/calculator target/release/examples/gallery target/release/mandlebrot
+          strip target/release/examples/layout target/release/examples/gallery target/release/mandlebrot
           mv target/release/mandlebrot target/release/examples/
           xcopy kas-wgpu\res target\release\examples\res /e/k/c/i/y
       - name: Upload
@@ -95,7 +95,7 @@ jobs:
         with:
           name: examples-windows
           path: |
-            target/release/examples/calculator.exe
+            target/release/examples/layout.exe
             target/release/examples/gallery.exe
             target/release/examples/mandlebrot.exe
             target/release/examples/res/

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -130,7 +130,7 @@ pub trait WidgetCore: Any + fmt::Debug {
     /// returns true.
     fn input_state(&self, mgr: &ManagerState, disabled: bool) -> InputState {
         let id = self.core_data().id;
-        let (char_focus, sel_focus) = mgr.char_focus(id);
+        let (char_focus, sel_focus) = mgr.has_char_focus(id);
         InputState {
             disabled: self.core_data().disabled || disabled,
             error: false,

--- a/crates/kas-core/src/event/config.rs
+++ b/crates/kas-core/src/event/config.rs
@@ -33,6 +33,11 @@ pub struct Config {
     #[cfg_attr(feature = "config", serde(default = "defaults::mouse_text_pan"))]
     mouse_text_pan: MousePan,
 
+    #[cfg_attr(feature = "config", serde(default = "defaults::mouse_nav_focus"))]
+    mouse_nav_focus: bool,
+    #[cfg_attr(feature = "config", serde(default = "defaults::touch_nav_focus"))]
+    touch_nav_focus: bool,
+
     #[cfg_attr(feature = "config", serde(default = "Shortcuts::platform_defaults"))]
     shortcuts: Shortcuts,
 }
@@ -45,6 +50,8 @@ impl Default for Config {
             pan_dist_thresh: defaults::pan_dist_thresh(),
             mouse_pan: defaults::mouse_pan(),
             mouse_text_pan: defaults::mouse_text_pan(),
+            mouse_nav_focus: defaults::mouse_nav_focus(),
+            touch_nav_focus: defaults::touch_nav_focus(),
             shortcuts: Shortcuts::platform_defaults(),
         }
     }
@@ -84,6 +91,18 @@ impl Config {
     #[inline]
     pub fn mouse_text_pan(&self) -> MousePan {
         self.mouse_text_pan
+    }
+
+    /// Whether mouse clicks set keyboard navigation focus
+    #[inline]
+    pub fn mouse_nav_focus(&self) -> bool {
+        self.mouse_nav_focus
+    }
+
+    /// Whether touchscreen events set keyboard navigation focus
+    #[inline]
+    pub fn touch_nav_focus(&self) -> bool {
+        self.touch_nav_focus
     }
 
     /// Read shortcut config
@@ -159,5 +178,11 @@ mod defaults {
         {
             MousePan::WithCtrl
         }
+    }
+    pub fn mouse_nav_focus() -> bool {
+        true
+    }
+    pub fn touch_nav_focus() -> bool {
+        true
     }
 }

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -372,15 +372,13 @@ impl Command {
     /// Convert to selection-focus command
     ///
     /// Certain limited commands may be sent to widgets with selection focus but
-    /// not character or navigation focus. This is limited to: `Deselect`,
-    /// `Copy`.
-    pub fn as_select(self) -> Option<Self> {
+    /// not character or navigation focus.
+    pub fn suitable_for_sel_focus(self) -> bool {
         use Command::*;
-        Some(match self {
-            Deselect | Escape => Deselect,
-            Cut | Copy => Copy,
-            _ => return None,
-        })
+        match self {
+            Escape | Cut | Copy | Deselect => true,
+            _ => false,
+        }
     }
 }
 

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -160,7 +160,9 @@ pub enum Event {
     PopupRemoved(WindowId),
     /// Sent when a widget receives keyboard navigation focus
     ///
-    /// The widget should reply with [`Response::Focus`].
+    /// The widget should reply with [`Response::Focus`] (this is done by
+    /// [`Manager::handle_generic`]). It may also be used as an opportunity to
+    /// request char focus.
     NavFocus,
 }
 

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -365,6 +365,20 @@ impl Command {
             _ => return None,
         })
     }
+
+    /// Convert to selection-focus command
+    ///
+    /// Certain limited commands may be sent to widgets with selection focus but
+    /// not character or navigation focus. This is limited to: `Deselect`,
+    /// `Copy`.
+    pub fn as_select(self) -> Option<Self> {
+        use Command::*;
+        Some(match self {
+            Deselect | Escape => Deselect,
+            Cut | Copy => Copy,
+            _ => return None,
+        })
+    }
 }
 
 /// Source of `EventChild::Press`

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -146,7 +146,7 @@ impl<'a> Manager<'a> {
         }
         let is_nav_focus = event == Event::NavFocus;
         match widget.handle(mgr, event) {
-            Response::None if is_nav_focus => Response::Focus(widget.rect()),
+            Response::Unhandled | Response::None if is_nav_focus => Response::Focus(widget.rect()),
             r => r,
         }
     }

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -144,9 +144,10 @@ impl<'a> Manager<'a> {
                 _ => (),
             };
         }
-        if event == Event::NavFocus {
-            return Response::Focus(widget.rect());
+        let is_nav_focus = event == Event::NavFocus;
+        match widget.handle(mgr, event) {
+            Response::None if is_nav_focus => Response::Focus(widget.rect()),
+            r => r,
         }
-        widget.handle(mgr, event)
     }
 }

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -382,6 +382,7 @@ impl<'a> Manager<'a> {
         }
 
         if let Some(id) = target {
+            self.set_nav_focus(id, true);
             self.add_key_depress(scancode, id);
             if !self.try_send_event(widget, id, Event::Activate) {
                 if vkey == VK::Escape {

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -304,9 +304,7 @@ impl<'a> Manager<'a> {
 
         if vkey == VK::Tab {
             self.clear_char_focus();
-            if !self.next_nav_focus(widget.as_widget(), shift, true) {
-                self.clear_nav_focus();
-            }
+            self.next_nav_focus(widget.as_widget(), shift, true);
             return;
         }
 

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -351,12 +351,10 @@ impl<'a> Manager<'a> {
                 }
             }
 
-            if self.state.sel_focus != self.state.nav_focus {
+            if self.state.sel_focus != self.state.nav_focus && cmd.suitable_for_sel_focus() {
                 if let Some(id) = self.state.sel_focus {
-                    if let Some(cmd) = cmd.as_select() {
-                        if self.try_send_event(widget, id, Event::Command(cmd, shift)) {
-                            return;
-                        }
+                    if self.try_send_event(widget, id, Event::Command(cmd, shift)) {
+                        return;
                     }
                 }
             }

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -321,15 +321,14 @@ impl<'a> Manager<'a> {
 
         // First priority goes to the widget with char focus and/or with nav
         // focus (note: char focus implies nav focus).
-        if let Some(id) = self.state.char_focus() {
+        if let Some(id) = self.state.sel_focus {
             if let Some(cmd) = opt_command {
-                let event = Event::Command(cmd, shift);
-                if self.try_send_event(widget, id, event) {
+                if self.try_send_event(widget, id, Event::Command(cmd, shift)) {
                     return;
                 }
             }
         } else if !self.state.modifiers.alt() {
-            if let Some(id) = self.state.nav_focus {
+            if let Some(id) = self.state.sel_focus.or(self.state.nav_focus) {
                 if vkey == VK::Space || vkey == VK::Return || vkey == VK::NumpadEnter {
                     self.add_key_depress(scancode, id);
                     self.send_event(widget, id, Event::Activate);
@@ -343,16 +342,15 @@ impl<'a> Manager<'a> {
         }
 
         if let Some(cmd) = opt_command {
-            let ev = Event::Command(cmd, shift);
             // Next priority goes to any popup present
             if let Some(id) = self.state.popups.last().map(|popup| popup.1.parent) {
-                if self.try_send_event(widget, id, ev.clone()) {
+                if self.try_send_event(widget, id, Event::Command(cmd, shift)) {
                     return;
                 }
             }
             // Then to the nav fallback
             if let Some(id) = self.state.nav_fallback {
-                if self.try_send_event(widget, id, ev) {
+                if self.try_send_event(widget, id, Event::Command(cmd, shift)) {
                     return;
                 }
             }

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -282,6 +282,13 @@ impl<'a> Manager<'a> {
     where
         W: Widget<Msg = VoidMsg> + ?Sized,
     {
+        trace!(
+            "Manager::start_key_event: widget={}, vkey={:?}, scancode={}",
+            widget.id(),
+            vkey,
+            scancode
+        );
+
         use VirtualKeyCode as VK;
         let config = self.state.config.borrow();
         let opt_command = config.shortcuts().get(self.state.modifiers, vkey);

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -77,6 +77,7 @@ struct PanGrab {
 enum Pending {
     LostCharFocus(WidgetId),
     LostSelFocus(WidgetId),
+    SetNavFocus(WidgetId),
 }
 
 /// Event manager state
@@ -303,11 +304,8 @@ impl<'a> Manager<'a> {
 
         if vkey == VK::Tab {
             self.clear_char_focus();
-            if !self.next_nav_focus(widget.as_widget(), shift) {
+            if !self.next_nav_focus(widget.as_widget(), shift, true) {
                 self.clear_nav_focus();
-            }
-            if let Some(id) = self.state.nav_focus {
-                self.send_event(widget, id, Event::NavFocus);
             }
             return;
         }
@@ -464,7 +462,7 @@ impl<'a> Manager<'a> {
             wid,
             char_focus
         );
-        self.set_nav_focus(wid);
+        self.set_nav_focus(wid, false);
 
         if self.state.sel_focus == Some(wid) {
             self.state.char_focus = self.state.char_focus || char_focus;

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -237,7 +237,6 @@ impl ManagerState {
 /// from documentation unless the `internal_doc` feature is enabled.
 #[must_use]
 pub struct Manager<'a> {
-    read_only: bool,
     state: &'a mut ManagerState,
     shell: &'a mut dyn ShellWindow,
     action: TkAction,

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -288,6 +288,17 @@ impl<'a> Manager<'a> {
         drop(config);
         let shift = self.state.modifiers.shift();
 
+        if vkey == VK::Tab {
+            self.set_char_focus(None);
+            if !self.next_nav_focus(widget.as_widget(), shift) {
+                self.clear_nav_focus();
+            }
+            if let Some(id) = self.state.nav_focus {
+                self.send_event(widget, id, Event::NavFocus);
+            }
+            return;
+        }
+
         if self.state.char_focus {
             if let Some(id) = self.state.sel_focus {
                 if let Some(cmd) = opt_command {
@@ -301,16 +312,6 @@ impl<'a> Manager<'a> {
                 }
                 return;
             }
-        }
-
-        if vkey == VK::Tab {
-            if !self.next_nav_focus(widget.as_widget(), shift) {
-                self.clear_nav_focus();
-            }
-            if let Some(id) = self.state.nav_focus {
-                self.send_event(widget, id, Event::NavFocus);
-            }
-            return;
         }
 
         let mut id_action = None;

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -43,7 +43,7 @@ impl ManagerState {
     ///
     /// Note that `char_focus` implies `sel_focus`.
     #[inline]
-    pub fn char_focus(&self, w_id: WidgetId) -> (bool, bool) {
+    pub fn has_char_focus(&self, w_id: WidgetId) -> (bool, bool) {
         if let Some(id) = self.sel_focus {
             if id == w_id {
                 return (self.char_focus, true);
@@ -458,7 +458,7 @@ impl<'a> Manager<'a> {
             self.set_sel_focus(id, true);
             true
         } else {
-            self.state.sel_focus == Some(id) && self.state.char_focus
+            self.state.char_focus() == Some(id)
         }
     }
 

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -680,9 +680,8 @@ impl<'a> Manager<'a> {
     /// returns true; otherwise this will give focus to the first (or last)
     /// such widget.
     ///
-    /// This method returns true when the navigation focus has been updated,
-    /// otherwise leaves the focus unchanged. The caller may (optionally) choose
-    /// to call [`Manager::clear_nav_focus`] when this method returns false.
+    /// Returns true on success, false if there are no navigable widgets or
+    /// some error occurred.
     ///
     /// If `notify` is true, then [`Event::NavFocus`] will be sent to the new
     /// widget if focus is changed. This may cause UI adjustments such as

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -432,11 +432,9 @@ impl<'a> Manager<'a> {
     // TODO(type safety): consider only implementing on ConfigureManager
     #[inline]
     pub fn add_accel_keys(&mut self, id: WidgetId, keys: &[VirtualKeyCode]) {
-        if !self.read_only {
-            if let Some(last) = self.state.accel_stack.last_mut() {
-                for key in keys {
-                    last.1.insert(*key, id);
-                }
+        if let Some(last) = self.state.accel_stack.last_mut() {
+            for key in keys {
+                last.1.insert(*key, id);
             }
         }
     }
@@ -454,12 +452,8 @@ impl<'a> Manager<'a> {
     /// When char focus is lost, [`Event::LostCharFocus`] is sent.
     #[inline]
     pub fn request_char_focus(&mut self, id: WidgetId) -> bool {
-        if !self.read_only {
-            self.set_sel_focus(id, true);
-            true
-        } else {
-            self.state.char_focus() == Some(id)
-        }
+        self.set_sel_focus(id, true);
+        true
     }
 
     /// Request selection focus
@@ -477,12 +471,8 @@ impl<'a> Manager<'a> {
     /// When char focus is lost, [`Event::LostSelFocus`] is sent.
     #[inline]
     pub fn request_sel_focus(&mut self, id: WidgetId) -> bool {
-        if !self.read_only {
-            self.set_sel_focus(id, false);
-            true
-        } else {
-            self.state.sel_focus == Some(id)
-        }
+        self.set_sel_focus(id, false);
+        true
     }
 
     /// Request a grab on the given input `source`
@@ -526,10 +516,6 @@ impl<'a> Manager<'a> {
         mode: GrabMode,
         cursor: Option<CursorIcon>,
     ) -> bool {
-        if self.read_only {
-            return false;
-        }
-
         let start_id = id;
         let mut pan_grab = (u16::MAX, 0);
         match source {

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -653,11 +653,17 @@ impl<'a> Manager<'a> {
     ///
     /// [`WidgetConfig::key_nav`] *should* return true for the given widget,
     /// otherwise navigation behaviour may not be correct.
+    ///
+    /// Note: this method does *not* send [`Event::NavFocus`] to notify the
+    /// widget of navigation focus and ensure the widget's visibility. Only
+    /// navigation via the <kbd>Tab</kbd> key does that.
     pub fn set_nav_focus(&mut self, id: WidgetId) {
-        self.redraw(id);
-        self.state.nav_focus = Some(id);
-        self.state.nav_stack.clear();
-        trace!("Manager: nav_focus = Some({})", id);
+        if self.state.nav_focus != Some(id) {
+            self.redraw(id);
+            self.state.nav_focus = Some(id);
+            self.state.nav_stack.clear();
+            trace!("Manager: nav_focus = Some({})", id);
+        }
     }
 
     /// Advance the keyboard navigation focus

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -218,6 +218,14 @@ impl ManagerState {
                     false
                 }
             }
+            Pending::SetNavFocus(id) => {
+                if let Some(new_id) = renames.get(id) {
+                    *item = Pending::SetNavFocus(*new_id);
+                    true
+                } else {
+                    false
+                }
+            }
         });
     }
 
@@ -368,6 +376,7 @@ impl ManagerState {
             let (id, event) = match item {
                 Pending::LostCharFocus(id) => (id, Event::LostCharFocus),
                 Pending::LostSelFocus(id) => (id, Event::LostSelFocus),
+                Pending::SetNavFocus(id) => (id, Event::NavFocus),
             };
             mgr.send_event(widget, id, event);
         }
@@ -584,7 +593,7 @@ impl<'a> Manager<'a> {
                                 .map(|w| w.key_nav())
                                 .unwrap_or(false)
                         {
-                            self.set_nav_focus(start_id);
+                            self.set_nav_focus(start_id, false);
                         }
                     }
                 }
@@ -610,7 +619,7 @@ impl<'a> Manager<'a> {
                                     .map(|w| w.key_nav())
                                     .unwrap_or(false)
                             {
-                                self.set_nav_focus(start_id);
+                                self.set_nav_focus(start_id, false);
                             }
                         }
                     }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -578,10 +578,11 @@ impl<'a> Manager<'a> {
                         };
                         self.send_popup_first(widget, start_id, event);
 
-                        if widget
-                            .find_leaf(start_id)
-                            .map(|w| w.key_nav())
-                            .unwrap_or(false)
+                        if self.state.config.borrow().mouse_nav_focus()
+                            && widget
+                                .find_leaf(start_id)
+                                .map(|w| w.key_nav())
+                                .unwrap_or(false)
                         {
                             self.set_nav_focus(start_id);
                         }
@@ -602,6 +603,15 @@ impl<'a> Manager<'a> {
                                 coord,
                             };
                             self.send_popup_first(widget, start_id, event);
+
+                            if self.state.config.borrow().touch_nav_focus()
+                                && widget
+                                    .find_leaf(start_id)
+                                    .map(|w| w.key_nav())
+                                    .unwrap_or(false)
+                            {
+                                self.set_nav_focus(start_id);
+                            }
                         }
                     }
                     TouchPhase::Moved => {

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -440,8 +440,8 @@ impl<'a> Manager<'a> {
             HoveredFileCancelled => ,
             */
             ReceivedCharacter(c) => {
-                if let Some(id) = self.state.sel_focus {
-                    if self.state.char_focus {
+                if self.state.char_focus {
+                    if let Some(id) = self.state.sel_focus {
                         // Filter out control codes (Unicode 5.11). These may be
                         // generated from combinations such as Ctrl+C by some other
                         // layer. We use our own shortcut system instead.

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -453,7 +453,7 @@ impl<'a> Manager<'a> {
                     // Filter out control codes (Unicode 5.11). These may be
                     // generated from combinations such as Ctrl+C by some other
                     // layer. We use our own shortcut system instead.
-                    if c >= '\u{20}' && !('\u{7f}'..='\u{9f}').contains(&c) {
+                    if c >= '\x20' && !('\x7f'..='\u{9f}').contains(&c) {
                         let event = Event::ReceivedCharacter(c);
                         self.send_event(widget, id, event);
                     }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -440,15 +440,13 @@ impl<'a> Manager<'a> {
             HoveredFileCancelled => ,
             */
             ReceivedCharacter(c) => {
-                if self.state.char_focus {
-                    if let Some(id) = self.state.sel_focus {
-                        // Filter out control codes (Unicode 5.11). These may be
-                        // generated from combinations such as Ctrl+C by some other
-                        // layer. We use our own shortcut system instead.
-                        if c >= '\u{20}' && !('\u{7f}'..='\u{9f}').contains(&c) {
-                            let event = Event::ReceivedCharacter(c);
-                            self.send_event(widget, id, event);
-                        }
+                if let Some(id) = self.state.char_focus() {
+                    // Filter out control codes (Unicode 5.11). These may be
+                    // generated from combinations such as Ctrl+C by some other
+                    // layer. We use our own shortcut system instead.
+                    if c >= '\u{20}' && !('\u{7f}'..='\u{9f}').contains(&c) {
+                        let event = Event::ReceivedCharacter(c);
+                        self.send_event(widget, id, event);
                     }
                 }
             }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -286,7 +286,6 @@ impl ManagerState {
         F: FnOnce(&mut Manager),
     {
         let mut mgr = Manager {
-            read_only: false,
             state: self,
             shell,
             action: TkAction::empty(),
@@ -303,7 +302,6 @@ impl ManagerState {
         W: Widget<Msg = VoidMsg> + ?Sized,
     {
         let mut mgr = Manager {
-            read_only: false,
             state: self,
             shell,
             action: TkAction::empty(),
@@ -367,12 +365,10 @@ impl ManagerState {
             }
         }
 
-        // To avoid infinite loops, we consider mgr read-only from here on.
-        // Since we don't wish to duplicate Handler::handle, we don't actually
-        // make mgr const, but merely pretend it is in the public API.
-        mgr.read_only = true;
-
+        // Warning: infinite loops are possible here if widgets always queue a
+        // new pending event when evaluating one of these:
         while let Some(item) = mgr.state.pending.pop() {
+            trace!("Handling Pending::{:?}", item);
             let (id, event) = match item {
                 Pending::LostCharFocus(id) => (id, Event::LostCharFocus),
                 Pending::LostSelFocus(id) => (id, Event::LostSelFocus),

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -577,6 +577,14 @@ impl<'a> Manager<'a> {
                             coord,
                         };
                         self.send_popup_first(widget, start_id, event);
+
+                        if widget
+                            .find_leaf(start_id)
+                            .map(|w| w.key_nav())
+                            .unwrap_or(false)
+                        {
+                            self.set_nav_focus(start_id);
+                        }
                     }
                 }
             }

--- a/crates/kas-core/src/event/shortcuts.rs
+++ b/crates/kas-core/src/event/shortcuts.rs
@@ -137,9 +137,10 @@ impl Shortcuts {
         }
         #[cfg(not(target_os = "macos"))]
         {
+            let shortcuts = [(VK::Q, Command::Exit), (VK::R, Command::FindReplace)];
+            map.extend(shortcuts.iter().cloned());
+
             let shortcuts = [
-                (VK::Q, Command::Exit),
-                (VK::R, Command::FindReplace),
                 (VK::Up, Command::ViewUp),
                 (VK::Down, Command::ViewDown),
                 (VK::Left, Command::WordLeft),
@@ -151,6 +152,11 @@ impl Shortcuts {
                 (VK::PageUp, Command::TabPrev),
                 (VK::PageDown, Command::TabNext),
             ];
+            map.extend(shortcuts.iter().cloned());
+
+            // Shift + Ctrl
+            let modifiers = ModifiersState::SHIFT | CMD;
+            let map = self.map.entry(modifiers).or_insert_with(Default::default);
             map.extend(shortcuts.iter().cloned());
         }
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -399,6 +399,11 @@ impl<M: 'static> event::SendEvent for ComboBox<M> {
         }
 
         if id <= self.popup.id() {
+            if event == Event::NavFocus && self.popup_id.is_none() {
+                // Steal focus since child is invisible
+                mgr.set_nav_focus(self.id(), false);
+            }
+
             let r = self.popup.send(mgr, id, event.clone());
             self.map_response(mgr, id, event, r)
         } else {

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -251,7 +251,7 @@ impl<M: 'static> ComboBox<M> {
                         if clr {
                             mgr.clear_nav_focus();
                         }
-                        mgr.next_nav_focus(s, rev);
+                        mgr.next_nav_focus(s, rev, true);
                         Response::None
                     };
                     match cmd {
@@ -304,14 +304,14 @@ impl<M: 'static> event::Handler for ComboBox<M> {
     type Msg = M;
 
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<M> {
-        let open_popup = |s: &mut Self, mgr: &mut Manager| {
+        let open_popup = |s: &mut Self, mgr: &mut Manager, notify: bool| {
             s.popup_id = mgr.add_popup(kas::Popup {
                 id: s.popup.id(),
                 parent: s.id(),
                 direction: Direction::Down,
             });
             if let Some(id) = s.popup.inner.get_child(s.active).map(|w| w.id()) {
-                mgr.set_nav_focus(id);
+                mgr.set_nav_focus(id, notify);
             }
         };
         match event {
@@ -319,7 +319,7 @@ impl<M: 'static> event::Handler for ComboBox<M> {
                 if let Some(id) = self.popup_id {
                     mgr.close_window(id);
                 } else {
-                    open_popup(self, mgr);
+                    open_popup(self, mgr, true);
                 }
             }
             Event::PressStart {
@@ -347,13 +347,13 @@ impl<M: 'static> event::Handler for ComboBox<M> {
                 ..
             } => {
                 if self.popup_id.is_none() {
-                    open_popup(self, mgr);
+                    open_popup(self, mgr, false);
                 }
                 let cond = self.popup.inner.rect().contains(coord);
                 let target = if cond { cur_id } else { None };
                 mgr.set_grab_depress(source, target);
                 if let Some(id) = target {
-                    mgr.set_nav_focus(id);
+                    mgr.set_nav_focus(id, false);
                 }
             }
             Event::PressEnd { end_id, .. } => {
@@ -361,7 +361,7 @@ impl<M: 'static> event::Handler for ComboBox<M> {
                     if id == self.id() {
                         if self.opening {
                             if self.popup_id.is_none() {
-                                open_popup(self, mgr);
+                                open_popup(self, mgr, false);
                             }
                             return Response::None;
                         }

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -1071,9 +1071,7 @@ impl<G: EditGuard + 'static> event::Handler for EditField<G> {
         ) -> Response<G::Msg> {
             if !s.has_key_focus && mgr.request_char_focus(s.id()) {
                 s.has_key_focus = true;
-                G::focus_gained(s, mgr)
-                    .map(|msg| msg.into())
-                    .unwrap_or(Response::None)
+                Response::none_or_msg(G::focus_gained(s, mgr))
             } else {
                 Response::None
             }

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -1122,15 +1122,17 @@ impl<G: EditGuard + 'static> event::Handler for EditField<G> {
                 TextInputAction::Cursor(coord, anchor, clear, repeats) => {
                     let mut response = Response::None;
                     self.set_edit_pos_from_coord(mgr, coord);
-                    if anchor {
-                        self.selection.set_anchor();
-                        response = request_focus(self, mgr);
-                    }
-                    if clear {
-                        self.selection.set_empty();
-                    }
-                    if repeats > 1 {
-                        self.selection.expand(&self.text, repeats);
+                    if self.has_key_focus || mgr.request_sel_focus(self.id()) {
+                        if anchor {
+                            self.selection.set_anchor();
+                            response = request_focus(self, mgr);
+                        }
+                        if clear {
+                            self.selection.set_empty();
+                        }
+                        if repeats > 1 {
+                            self.selection.expand(&self.text, repeats);
+                        }
                     }
                     response
                 }

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -1079,7 +1079,7 @@ impl<G: EditGuard + 'static> event::Handler for EditField<G> {
             }
         }
         match event {
-            Event::Activate => request_focus(self, mgr),
+            Event::Activate | Event::NavFocus => request_focus(self, mgr),
             Event::LostCharFocus => {
                 self.has_key_focus = false;
                 mgr.redraw(self.id());

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -1045,6 +1045,11 @@ impl<G: EditGuard> HasStr for EditField<G> {
 
 impl<G: EditGuard> HasString for EditField<G> {
     fn set_string(&mut self, string: String) -> TkAction {
+        // TODO: make text.set_string report bool for is changed?
+        if *self.text.text() == string {
+            return TkAction::empty();
+        }
+
         self.text.set_string(string);
         if kas::text::fonts::fonts().num_faces() > 0 {
             if let Some(req) = self.text.prepare() {

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -712,14 +712,10 @@ impl<G: EditGuard> EditField<G> {
         }
 
         let action = match key {
-            Command::Escape => {
-                if !self.selection.is_empty() {
-                    self.selection.set_empty();
-                    mgr.redraw(self.id());
-                    Action::None
-                } else {
-                    Action::Unhandled
-                }
+            Command::Escape | Command::Deselect if !selection.is_empty() => {
+                self.selection.set_empty();
+                mgr.redraw(self.id());
+                Action::None
             }
             Command::Return if shift || !self.multi_line => Action::Activate,
             Command::Return if self.multi_line => {
@@ -872,11 +868,6 @@ impl<G: EditGuard> EditField<G> {
                     .map(|(index, _)| index)
                     .unwrap_or(0);
                 Action::Delete(prev..pos)
-            }
-            Command::Deselect => {
-                self.selection.set_sel_pos(pos);
-                mgr.redraw(self.id());
-                Action::None
             }
             Command::SelectAll => {
                 self.selection.set_sel_pos(0);

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -97,7 +97,7 @@ impl<W: Menu<Msg = M>, D: Directional, M> event::Handler for MenuBar<W, D> {
                     {
                         mgr.set_grab_depress(source, Some(start_id));
                         self.find_leaf(start_id)
-                            .map(|w| mgr.next_nav_focus(w, false));
+                            .map(|w| mgr.next_nav_focus(w, false, false));
                         self.opening = false;
                         let delay = mgr.config().menu_delay();
                         if self.rect().contains(coord) {
@@ -128,7 +128,7 @@ impl<W: Menu<Msg = M>, D: Directional, M> event::Handler for MenuBar<W, D> {
                     cur_id.filter(|id| self.find_leaf(*id).map(|w| w.key_nav()).unwrap_or(false));
                 mgr.set_grab_depress(source, target_id);
                 if let Some(id) = target_id {
-                    mgr.set_nav_focus(id);
+                    mgr.set_nav_focus(id, false);
                     // We instantly open a sub-menu on motion over the bar,
                     // but delay when over a sub-menu (most intuitive?)
                     if self.rect().contains(coord) {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -77,7 +77,7 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
                 parent: self.id(),
                 direction: self.direction.as_direction(),
             });
-            mgr.next_nav_focus(self, false);
+            mgr.next_nav_focus(self, false, true);
         }
     }
     fn close_menu(&mut self, mgr: &mut Manager) {
@@ -208,7 +208,7 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
                                 if clr {
                                     mgr.clear_nav_focus();
                                 }
-                                mgr.next_nav_focus(s, rev);
+                                mgr.next_nav_focus(s, rev, true);
                             };
                             let rev = self.list.direction().is_reversed();
                             use Direction::*;

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -144,7 +144,7 @@ impl<T: FormattableText + 'static> event::Handler for ScrollLabel<T> {
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         match event {
             Event::Command(cmd, _) => match cmd {
-                Command::Escape | Command::Deselect => {
+                Command::Escape | Command::Deselect if !self.selection.is_empty() => {
                     self.selection.set_empty();
                     mgr.redraw(self.id());
                     Response::None

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -171,14 +171,16 @@ impl<T: FormattableText + 'static> event::Handler for ScrollLabel<T> {
                 },
                 TextInputAction::Cursor(coord, anchor, clear, repeats) => {
                     self.set_edit_pos_from_coord(mgr, coord);
-                    if anchor {
-                        self.selection.set_anchor();
-                    }
-                    if clear {
-                        self.selection.set_empty();
-                    }
-                    if repeats > 1 {
-                        self.selection.expand(&self.text, repeats);
+                    if mgr.request_sel_focus(self.id()) {
+                        if anchor {
+                            self.selection.set_anchor();
+                        }
+                        if clear {
+                            self.selection.set_empty();
+                        }
+                        if repeats > 1 {
+                            self.selection.expand(&self.text, repeats);
+                        }
                     }
                     Response::None
                 }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -8,7 +8,7 @@
 use super::Scrollable;
 use kas::draw::TextClass;
 use kas::event::components::{TextInput, TextInputAction};
-use kas::event::{self, ScrollDelta};
+use kas::event::{self, Command, ScrollDelta};
 use kas::geom::Vec2;
 use kas::prelude::*;
 use kas::text::format::{EditableText, FormattableText};
@@ -143,6 +143,26 @@ impl<T: FormattableText + 'static> event::Handler for ScrollLabel<T> {
 
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         match event {
+            Event::Command(cmd, _) => match cmd {
+                Command::Escape | Command::Deselect => {
+                    self.selection.set_empty();
+                    mgr.redraw(self.id());
+                    Response::None
+                }
+                Command::SelectAll => {
+                    self.selection.set_sel_pos(0);
+                    self.selection.set_edit_pos(self.text.str_len());
+                    mgr.redraw(self.id());
+                    Response::None
+                }
+                Command::Cut | Command::Copy => {
+                    let range = self.selection.range();
+                    mgr.set_clipboard((self.text.as_str()[range]).to_string());
+                    Response::None
+                }
+                // TODO: scroll by command
+                _ => Response::Unhandled,
+            },
             Event::LostSelFocus => {
                 self.selection.set_empty();
                 mgr.redraw(self.id());

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -715,20 +715,12 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
                 (Command::PageDown, Some(cur)) if cur < last => Some((cur + len / 2).min(last)),
                 _ => None,
             };
-            let action = if let Some(index) = data {
+            if let Some(index) = data {
                 // Set nav focus to index and update scroll position
                 // Note: we update nav focus before updating widgets; this is fine
-                mgr.set_nav_focus(self.widgets[index % len].widget.id());
-
-                let mut skip_off = Offset::ZERO;
-                skip_off.set_component(self.direction, skip);
-                let pos = self.core.rect.pos + self.frame_offset + skip_off * i32::conv(index);
-                let item_rect = Rect::new(pos, self.child_size);
-                self.scroll.focus_rect(item_rect, self.core.rect).1
-            } else {
-                TkAction::empty()
-            };
-            (action, Response::None)
+                mgr.set_nav_focus(self.widgets[index % len].widget.id(), true);
+            }
+            (TkAction::empty(), Response::None)
         } else {
             self.scroll
                 .scroll_by_event(event, self.core.rect.size, |source, _, coord| {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -676,21 +676,13 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> SendEvent
                 }
                 _ => None,
             };
-            let action = if let Some((ci, ri)) = data {
+            if let Some((ci, ri)) = data {
                 // Set nav focus to index and update scroll position
                 // Note: we update nav focus before updating widgets; this is fine
                 let index = (ci % cols) + (ri % rows) * cols;
-                mgr.set_nav_focus(self.widgets[index].widget.id());
-
-                let pos = self.core.rect.pos
-                    + self.frame_offset
-                    + skip.cwise_mul(Size(ci.cast(), ri.cast()));
-                let item_rect = Rect::new(pos, self.child_size);
-                self.scroll.focus_rect(item_rect, self.core.rect).1
-            } else {
-                TkAction::empty()
-            };
-            (action, Response::None)
+                mgr.set_nav_focus(self.widgets[index].widget.id(), true);
+            }
+            (TkAction::empty(), Response::None)
         } else {
             self.scroll
                 .scroll_by_event(event, self.core.rect.size, |source, _, coord| {


### PR DESCRIPTION
Fixes most of #231 plus a few more things:

- Escape does not clear nav focus
- (Shift+)Tab navigates from widgets with char focus (i.e. edit box)
- Key event sending now tries multiple paths until one does *not* return `Response::Unhandled`: (1) the widget with char focus or nav focus
- Allows limited commands (deselect, copy) to be sent to a `ScrollLabel` with selection focus
- Set (keyboard) navigation focus on mouse click or touch (configurable)
- Allow widgets like `EditBox` to request char focus on nav focus
- Make `next_nav_focus` wrap after first/last available widget
- Fix closing pop-ups with <kbd>Esc</kbd>
- `EditGuard::focus_gained` can no longer send a message (breaking change)
- Remove `read_only` state of `Manager`, used while sending pending events (this potentially allows widgets to cause infinite loops, but was causing issues; probably it's okay to rely on correct widget code here)