### PR TITLE
Fixes for menus and keyboard navigation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           strip target/release/examples/layout target/release/examples/gallery target/release/mandlebrot
           mv target/release/mandlebrot target/release/examples/
-          cp -a kas-wgpu/res target/release/examples/
+          cp -a res target/release/examples/
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
@@ -59,7 +59,7 @@ jobs:
         run: |
           strip target/release/examples/layout target/release/examples/gallery target/release/mandlebrot
           mv target/release/mandlebrot target/release/examples/
-          cp -a kas-wgpu/res target/release/examples/
+          cp -a res target/release/examples/
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
@@ -89,7 +89,7 @@ jobs:
         run: |
           strip target/release/examples/layout target/release/examples/gallery target/release/mandlebrot
           mv target/release/mandlebrot target/release/examples/
-          xcopy kas-wgpu\res target\release\examples\res /e/k/c/i/y
+          xcopy res target\release\examples\res /e/k/c/i/y
       - name: Upload
         uses: actions/upload-artifact@v2
         with:

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -396,7 +396,9 @@ impl<'a> Manager<'a> {
         }
 
         if let Some(id) = target {
-            self.set_nav_focus(id, true);
+            if widget.find_leaf(id).map(|w| w.key_nav()).unwrap_or(false) {
+                self.set_nav_focus(id, true);
+            }
             self.add_key_depress(scancode, id);
             self.send_event(widget, id, Event::Activate);
         }

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -246,7 +246,7 @@ impl<'a> Manager<'a> {
         let opt_id = self.shell.add_popup(popup.clone());
         if let Some(id) = opt_id {
             self.state.new_popups.push(popup.id);
-            self.state.popups.push((id, popup));
+            self.state.popups.push((id, popup, self.state.nav_focus));
             self.state.nav_focus = None;
             self.state.nav_stack.clear();
         }
@@ -280,13 +280,11 @@ impl<'a> Manager<'a> {
                 },
             )
         {
-            let (_, popup) = self.state.popups.remove(index);
+            let (_, popup, old_nav_focus) = self.state.popups.remove(index);
             self.state.popup_removed.push((popup.parent, id));
 
-            if self.state.nav_focus.is_some() {
-                // We guess that the parent supports key_nav:
-                self.state.nav_focus = Some(popup.parent);
-                self.state.nav_stack.clear();
+            if let Some(id) = old_nav_focus {
+                self.set_nav_focus(id, true);
             }
         }
 
@@ -687,7 +685,7 @@ impl<'a> Manager<'a> {
         type WidgetStack<'b> = SmallVec<[&'b dyn WidgetConfig; 16]>;
         let mut widget_stack = WidgetStack::new();
 
-        if let Some(id) = self.state.popups.last().map(|(_, p)| p.id) {
+        if let Some(id) = self.state.popups.last().map(|(_, p, _)| p.id) {
             if let Some(w) = widget.find_leaf(id) {
                 widget = w;
             } else {

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -649,6 +649,7 @@ impl<'a> Manager<'a> {
     pub fn set_nav_focus(&mut self, id: WidgetId, notify: bool) {
         if self.state.nav_focus != Some(id) {
             self.redraw(id);
+            self.state.char_focus = false;
             self.state.nav_focus = Some(id);
             self.state.nav_stack.clear();
             trace!("Manager: nav_focus = Some({})", id);
@@ -692,6 +693,11 @@ impl<'a> Manager<'a> {
                 return false;
             }
         }
+
+        // We redraw in all cases. Since this is not part of widget event
+        // processing, we can push directly to self.state.action.
+        self.state.send_action(TkAction::REDRAW);
+        self.state.char_focus = false;
 
         if self.state.nav_stack.is_empty() {
             if let Some(id) = self.state.nav_focus {
@@ -799,9 +805,6 @@ impl<'a> Manager<'a> {
             };
         }
 
-        // We redraw in all cases. Since this is not part of widget event
-        // processing, we can push directly to self.state.action.
-        self.state.send_action(TkAction::REDRAW);
         let nav_stack = &mut self.state.nav_stack;
         // Whether to restart from the beginning on failure
         let mut restart = self.state.nav_focus.is_some();

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -637,8 +637,10 @@ impl<'a> Manager<'a> {
 
     /// Set the keyboard navigation focus directly
     ///
-    /// [`WidgetConfig::key_nav`] *should* return true for the given widget,
-    /// otherwise navigation behaviour may not be correct.
+    /// Normally, [`WidgetConfig::key_nav`] will be true for the specified
+    /// widget, but this is not required, e.g. a `ScrollLabel` can receive focus
+    /// on text selection with the mouse. (Currently such widgets will receive
+    /// events like any other with nav focus, but this may change.)
     ///
     /// If `notify` is true, then [`Event::NavFocus`] will be sent to the new
     /// widget if focus is changed. This may cause UI adjustments such as
@@ -796,7 +798,7 @@ impl<'a> Manager<'a> {
                 if $widget.key_nav() && !$widget.is_disabled() {
                     let id = $widget.id();
                     $self.state.nav_focus = Some(id);
-                    trace!("Manager: nav_focus = {:?}", $self.state.nav_focus);
+                    trace!("Manager: nav_focus = Some({})", id);
                     if notify {
                         $self.state.pending.push(Pending::SetNavFocus(id));
                     }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -315,7 +315,7 @@ impl ManagerState {
                 .state
                 .popups
                 .iter()
-                .map(|(_, popup)| popup.parent)
+                .map(|(_, popup, _)| popup.parent)
                 .collect::<SmallVec<[WidgetId; 16]>>()
             {
                 mgr.send_event(widget, parent, Event::NewPopup(id));
@@ -499,7 +499,7 @@ impl<'a> Manager<'a> {
                     {
                         pan.coords[usize::conv(grab.pan_grab.1)].1 = coord;
                     }
-                } else if let Some(id) = self.state.popups.last().map(|(_, p)| p.parent) {
+                } else if let Some(id) = self.state.popups.last().map(|(_, p, _)| p.parent) {
                     let source = PressSource::Mouse(FAKE_MOUSE_BUTTON, 0);
                     let event = Event::PressMove {
                         source,

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -583,13 +583,10 @@ impl<'a> Manager<'a> {
                         };
                         self.send_popup_first(widget, start_id, event);
 
-                        if self.state.config.borrow().mouse_nav_focus()
-                            && widget
-                                .find_leaf(start_id)
-                                .map(|w| w.key_nav())
-                                .unwrap_or(false)
-                        {
-                            self.set_nav_focus(start_id, false);
+                        if self.state.config.borrow().mouse_nav_focus() {
+                            if let Some(w) = widget.find_leaf(start_id) {
+                                self.set_nav_focus(w.id(), false);
+                            }
                         }
                     }
                 }
@@ -609,13 +606,10 @@ impl<'a> Manager<'a> {
                             };
                             self.send_popup_first(widget, start_id, event);
 
-                            if self.state.config.borrow().touch_nav_focus()
-                                && widget
-                                    .find_leaf(start_id)
-                                    .map(|w| w.key_nav())
-                                    .unwrap_or(false)
-                            {
-                                self.set_nav_focus(start_id, false);
+                            if self.state.config.borrow().touch_nav_focus() {
+                                if let Some(w) = widget.find_leaf(start_id) {
+                                    self.set_nav_focus(w.id(), false);
+                                }
                             }
                         }
                     }

--- a/crates/kas-theme/src/colors.rs
+++ b/crates/kas-theme/src/colors.rs
@@ -211,8 +211,6 @@ impl ColorsLinear {
     pub fn menu_entry(&self, state: InputState) -> Option<Rgba> {
         if state.depress || state.nav_focus {
             Some(self.button.multiply(MULT_DEPRESS))
-        } else if state.hover {
-            Some(self.button.multiply(MULT_HIGHLIGHT).max(MIN_HIGHLIGHT))
         } else {
             None
         }

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -127,19 +127,19 @@ impl<W: Menu<Msg = M>, D: Directional, M> event::Handler for MenuBar<W, D> {
                 coord,
                 ..
             } => {
-                let target_id =
-                    cur_id.filter(|id| self.find_leaf(*id).map(|w| w.key_nav()).unwrap_or(false));
-                mgr.set_grab_depress(source, target_id);
-                if let Some(id) = target_id {
-                    mgr.set_nav_focus(id, false);
-                    // We instantly open a sub-menu on motion over the bar,
-                    // but delay when over a sub-menu (most intuitive?)
-                    if self.rect().contains(coord) {
-                        self.set_menu_path(mgr, Some(id));
-                    } else {
-                        self.delayed_open = Some(id);
-                        let delay = mgr.config().menu_delay();
-                        mgr.update_on_timer(delay, self.id(), 0);
+                mgr.set_grab_depress(source, cur_id);
+                if let Some(id) = cur_id {
+                    if self.is_ancestor_of(id) {
+                        mgr.set_nav_focus(id, false);
+                        // We instantly open a sub-menu on motion over the bar,
+                        // but delay when over a sub-menu (most intuitive?)
+                        if self.rect().contains(coord) {
+                            self.set_menu_path(mgr, Some(id));
+                        } else {
+                            self.delayed_open = Some(id);
+                            let delay = mgr.config().menu_delay();
+                            mgr.update_on_timer(delay, self.id(), 0);
+                        }
                     }
                 }
             }

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -39,7 +39,10 @@ impl<W: Menu, D: Directional + Default> MenuBar<W, D> {
 
 impl<W: Menu, D: Directional> MenuBar<W, D> {
     /// Construct a menubar with explicit direction
-    pub fn new_with_direction(direction: D, menus: Vec<SubMenu<D::Flipped, W>>) -> Self {
+    pub fn new_with_direction(direction: D, mut menus: Vec<SubMenu<D::Flipped, W>>) -> Self {
+        for menu in menus.iter_mut() {
+            menu.key_nav = false;
+        }
         MenuBar {
             core: Default::default(),
             bar: List::new_with_direction(direction, menus),

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -202,7 +202,7 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
                 Response::Pan(delta) => Response::Pan(delta),
                 Response::Focus(rect) => Response::Focus(rect),
                 Response::Unhandled => match event {
-                    Event::Command(key, _)  if self.popup_id.is_some()=> {
+                    Event::Command(key, _) if self.popup_id.is_some() => {
                         let dir = self.direction.as_direction();
                         let inner_vert = self.list.direction().is_vertical();
                         let next = |mgr: &mut Manager, s, clr, rev| {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -202,31 +202,29 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
                 Response::Pan(delta) => Response::Pan(delta),
                 Response::Focus(rect) => Response::Focus(rect),
                 Response::Unhandled => match event {
-                    Event::Command(key, _) if self.popup_id.is_some() => {
-                        if self.popup_id.is_some() {
-                            let dir = self.direction.as_direction();
-                            let inner_vert = self.list.direction().is_vertical();
-                            let next = |mgr: &mut Manager, s, clr, rev| {
-                                if clr {
-                                    mgr.clear_nav_focus();
-                                }
-                                mgr.next_nav_focus(s, rev, true);
-                            };
-                            let rev = self.list.direction().is_reversed();
-                            use Direction::*;
-                            match key {
-                                Command::Left if !inner_vert => next(mgr, self, false, !rev),
-                                Command::Right if !inner_vert => next(mgr, self, false, rev),
-                                Command::Up if inner_vert => next(mgr, self, false, !rev),
-                                Command::Down if inner_vert => next(mgr, self, false, rev),
-                                Command::Home => next(mgr, self, true, false),
-                                Command::End => next(mgr, self, true, true),
-                                Command::Left if dir == Right => self.close_menu(mgr),
-                                Command::Right if dir == Left => self.close_menu(mgr),
-                                Command::Up if dir == Down => self.close_menu(mgr),
-                                Command::Down if dir == Up => self.close_menu(mgr),
-                                _ => return Response::Unhandled,
+                    Event::Command(key, _)  if self.popup_id.is_some()=> {
+                        let dir = self.direction.as_direction();
+                        let inner_vert = self.list.direction().is_vertical();
+                        let next = |mgr: &mut Manager, s, clr, rev| {
+                            if clr {
+                                mgr.clear_nav_focus();
                             }
+                            mgr.next_nav_focus(s, rev, true);
+                        };
+                        let rev = self.list.direction().is_reversed();
+                        use Direction::*;
+                        match key {
+                            Command::Left if !inner_vert => next(mgr, self, false, !rev),
+                            Command::Right if !inner_vert => next(mgr, self, false, rev),
+                            Command::Up if inner_vert => next(mgr, self, false, !rev),
+                            Command::Down if inner_vert => next(mgr, self, false, rev),
+                            Command::Home => next(mgr, self, true, false),
+                            Command::End => next(mgr, self, true, true),
+                            Command::Left if dir == Right => self.close_menu(mgr),
+                            Command::Right if dir == Left => self.close_menu(mgr),
+                            Command::Up if dir == Down => self.close_menu(mgr),
+                            Command::Down if dir == Up => self.close_menu(mgr),
+                            _ => return Response::Unhandled,
                         }
                         Response::None
                     }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -20,6 +20,7 @@ pub struct SubMenu<D: Directional, W: Menu> {
     #[widget_core]
     core: CoreData,
     direction: D,
+    pub(crate) key_nav: bool,
     label: Text<AccelString>,
     label_off: Offset,
     frame_size: Size,
@@ -62,6 +63,7 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
         SubMenu {
             core: Default::default(),
             direction,
+            key_nav: true,
             label: Text::new_single(label.into()),
             label_off: Offset::ZERO,
             frame_size: Size::ZERO,
@@ -98,7 +100,7 @@ impl<D: Directional, W: Menu> WidgetConfig for SubMenu<D, W> {
     }
 
     fn key_nav(&self) -> bool {
-        true
+        self.key_nav
     }
     fn hover_highlight(&self) -> bool {
         true


### PR DESCRIPTION
Fixes the remainder of #231:

- Top-level menus are not reachable with the Tab key, only with mouse/touch or Alt+label
- Restore nav focus after closing menus
- Clear character focus (e.g. `EditBox`) when opening a popup menu