### PR TITLE
More event-handling fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,8 @@ jobs:
           cargo build --release --manifest-path examples/mandlebrot/Cargo.toml
       - name: Prepare
         run: |
-          strip target/release/examples/layout target/release/examples/gallery target/release/mandlebrot
-          mv target/release/mandlebrot target/release/examples/
+          strip target/release/examples/layout.exe target/release/examples/gallery.exe target/release/mandlebrot.exe
+          mv target/release/mandlebrot.exe target/release/examples/
           xcopy res target\release\examples\res /e/k/c/i/y
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -585,7 +585,9 @@ impl<'a> Manager<'a> {
 
                         if self.state.config.borrow().mouse_nav_focus() {
                             if let Some(w) = widget.find_leaf(start_id) {
-                                self.set_nav_focus(w.id(), false);
+                                if w.key_nav() {
+                                    self.set_nav_focus(w.id(), false);
+                                }
                             }
                         }
                     }
@@ -608,7 +610,9 @@ impl<'a> Manager<'a> {
 
                             if self.state.config.borrow().touch_nav_focus() {
                                 if let Some(w) = widget.find_leaf(start_id) {
-                                    self.set_nav_focus(w.id(), false);
+                                    if w.key_nav() {
+                                        self.set_nav_focus(w.id(), false);
+                                    }
                                 }
                             }
                         }

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -1122,11 +1122,11 @@ impl<G: EditGuard + 'static> event::Handler for EditField<G> {
                     Response::None
                 }
                 TextInputAction::Cursor(coord, anchor, clear, repeats) => {
-                    self.set_edit_pos_from_coord(mgr, coord);
-                    if self.has_key_focus || mgr.request_sel_focus(self.id()) {
+                    request_focus(self, mgr);
+                    if self.has_key_focus {
+                        self.set_edit_pos_from_coord(mgr, coord);
                         if anchor {
                             self.selection.set_anchor();
-                            request_focus(self, mgr);
                         }
                         if clear {
                             self.selection.set_empty();

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -106,8 +106,6 @@ impl<W: Menu<Msg = M>, D: Directional, M> event::Handler for MenuBar<W, D> {
                         && mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None)
                     {
                         mgr.set_grab_depress(source, Some(start_id));
-                        self.find_leaf(start_id)
-                            .map(|w| mgr.next_nav_focus(w, false, false));
                         self.opening = false;
                         let delay = mgr.config().menu_delay();
                         if self.rect().contains(coord) {
@@ -137,12 +135,12 @@ impl<W: Menu<Msg = M>, D: Directional, M> event::Handler for MenuBar<W, D> {
                 mgr.set_grab_depress(source, cur_id);
                 if let Some(id) = cur_id {
                     if id != self.id() && self.is_ancestor_of(id) {
-                        mgr.set_nav_focus(id, false);
                         // We instantly open a sub-menu on motion over the bar,
                         // but delay when over a sub-menu (most intuitive?)
                         if self.rect().contains(coord) {
                             self.set_menu_path(mgr, Some(id));
                         } else {
+                            mgr.set_nav_focus(id, false);
                             self.delayed_open = Some(id);
                             let delay = mgr.config().menu_delay();
                             mgr.update_on_timer(delay, self.id(), 0);

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -21,6 +21,7 @@ pub struct MenuBar<W: Menu, D: Directional = kas::dir::Right> {
     core: CoreData,
     #[widget]
     pub bar: List<D, SubMenu<D::Flipped, W>>,
+    ideal: Size,
     // Open mode. Used to close with click on root only when previously open.
     opening: bool,
     delayed_open: Option<WidgetId>,
@@ -46,6 +47,7 @@ impl<W: Menu, D: Directional> MenuBar<W, D> {
         MenuBar {
             core: Default::default(),
             bar: List::new_with_direction(direction, menus),
+            ideal: Size::ZERO,
             opening: false,
             delayed_open: None,
         }
@@ -55,11 +57,16 @@ impl<W: Menu, D: Directional> MenuBar<W, D> {
 // NOTE: we could use layout(single) except for alignment
 impl<W: Menu, D: Directional> Layout for MenuBar<W, D> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
-        self.bar.size_rules(size_handle, axis)
+        let rules = self.bar.size_rules(size_handle, axis);
+        self.ideal.set_component(axis, rules.ideal_size());
+        rules
     }
 
-    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, _: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
         self.core_data_mut().rect = rect;
+        let rect = align
+            .complete(Align::Default, Align::Default)
+            .aligned_rect(self.ideal, rect);
         let align = AlignHints::new(Some(Align::Default), Some(Align::Default));
         self.bar.set_rect(mgr, rect, align);
     }
@@ -129,7 +136,7 @@ impl<W: Menu<Msg = M>, D: Directional, M> event::Handler for MenuBar<W, D> {
             } => {
                 mgr.set_grab_depress(source, cur_id);
                 if let Some(id) = cur_id {
-                    if self.is_ancestor_of(id) {
+                    if id != self.id() && self.is_ancestor_of(id) {
                         mgr.set_nav_focus(id, false);
                         // We instantly open a sub-menu on motion over the bar,
                         // but delay when over a sub-menu (most intuitive?)

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -190,8 +190,8 @@ impl<T: FormattableText + 'static> event::Handler for ScrollLabel<T> {
                     delta => Response::Pan(delta),
                 },
                 TextInputAction::Cursor(coord, anchor, clear, repeats) => {
-                    self.set_edit_pos_from_coord(mgr, coord);
-                    if mgr.request_sel_focus(self.id()) {
+                    if (clear && repeats <= 1) || mgr.request_sel_focus(self.id()) {
+                        self.set_edit_pos_from_coord(mgr, coord);
                         if anchor {
                             self.selection.set_anchor();
                         }


### PR DESCRIPTION
Regarding #231:

- clicking on a non-nav widget does not clear or set nav focus
- mouse motion over the base menu bar does not do anything
- remove a couple of unwanted situations where `MenuBar` sets nav focus

Ultimately the menu code still feels fragile (menus rely on the root `MenuBar` to open/close sub-menus and set navigation focus on mouse motion) but this fixes obvious issues.