### PR TITLE
Fix tab-navigation in ListView, partially

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -452,7 +452,13 @@ pub trait Layout: WidgetChildren {
     ///
     /// The default implementation often suffices: it will navigate through
     /// children in order.
-    fn spatial_nav(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
+    fn spatial_nav(
+        &mut self,
+        mgr: &mut Manager,
+        reverse: bool,
+        from: Option<usize>,
+    ) -> Option<usize> {
+        let _ = mgr;
         let last = self.num_children().wrapping_sub(1);
         if last == usize::MAX {
             return None;

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -108,7 +108,6 @@ pub struct ManagerState {
     sel_focus: Option<WidgetId>,
     nav_focus: Option<WidgetId>,
     nav_fallback: Option<WidgetId>,
-    nav_stack: SmallVec<[u32; 16]>,
     hover: Option<WidgetId>,
     hover_icon: CursorIcon,
     key_depress: LinearMap<u32, WidgetId>,
@@ -305,7 +304,7 @@ impl<'a> Manager<'a> {
 
         if vkey == VK::Tab {
             self.clear_char_focus();
-            self.next_nav_focus(widget.as_widget(), shift, true);
+            self.next_nav_focus(widget.as_widget_mut(), shift, true);
             return;
         } else if vkey == VK::Escape {
             if let Some(id) = self.state.popups.last().map(|(id, _, _)| *id) {

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -684,6 +684,7 @@ impl<'a> Manager<'a> {
         self.state.send_action(TkAction::REDRAW);
 
         fn nav<'a>(
+            mgr: &mut Manager,
             widget: &mut dyn WidgetConfig,
             focus: Option<WidgetId>,
             rev: bool,
@@ -724,7 +725,10 @@ impl<'a> Manager<'a> {
 
             if !rev {
                 if let Some(index) = child {
-                    if let Some(id) = widget.get_child_mut(index).and_then(|w| nav(w, focus, rev)) {
+                    if let Some(id) = widget
+                        .get_child_mut(index)
+                        .and_then(|w| nav(mgr, w, focus, rev))
+                    {
                         return Some(id);
                     }
                 } else if focus != Some(widget.id()) && widget.key_nav() {
@@ -732,9 +736,10 @@ impl<'a> Manager<'a> {
                 }
 
                 loop {
-                    if let Some(index) = widget.spatial_nav(rev, child) {
-                        if let Some(id) =
-                            widget.get_child_mut(index).and_then(|w| nav(w, focus, rev))
+                    if let Some(index) = widget.spatial_nav(mgr, rev, child) {
+                        if let Some(id) = widget
+                            .get_child_mut(index)
+                            .and_then(|w| nav(mgr, w, focus, rev))
                         {
                             return Some(id);
                         }
@@ -745,15 +750,19 @@ impl<'a> Manager<'a> {
                 }
             } else {
                 if let Some(index) = child {
-                    if let Some(id) = widget.get_child_mut(index).and_then(|w| nav(w, focus, rev)) {
+                    if let Some(id) = widget
+                        .get_child_mut(index)
+                        .and_then(|w| nav(mgr, w, focus, rev))
+                    {
                         return Some(id);
                     }
                 }
 
                 loop {
-                    if let Some(index) = widget.spatial_nav(rev, child) {
-                        if let Some(id) =
-                            widget.get_child_mut(index).and_then(|w| nav(w, focus, rev))
+                    if let Some(index) = widget.spatial_nav(mgr, rev, child) {
+                        if let Some(id) = widget
+                            .get_child_mut(index)
+                            .and_then(|w| nav(mgr, w, focus, rev))
                         {
                             return Some(id);
                         }
@@ -772,9 +781,9 @@ impl<'a> Manager<'a> {
         // Whether to restart from the beginning on failure
         let restart = self.state.nav_focus.is_some();
 
-        let mut opt_id = nav(widget, self.state.nav_focus, reverse);
+        let mut opt_id = nav(self, widget, self.state.nav_focus, reverse);
         if restart && opt_id.is_none() {
-            opt_id = nav(widget, None, reverse);
+            opt_id = nav(self, widget, None, reverse);
         }
 
         trace!("Manager: nav_focus = {:?}", opt_id);

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -625,7 +625,6 @@ impl<'a> Manager<'a> {
             self.redraw(id);
         }
         self.state.nav_focus = None;
-        self.state.nav_stack.clear();
         trace!("Manager: nav_focus = None");
     }
 
@@ -647,7 +646,6 @@ impl<'a> Manager<'a> {
                 self.clear_char_focus();
             }
             self.state.nav_focus = Some(id);
-            self.state.nav_stack.clear();
             trace!("Manager: nav_focus = Some({})", id);
             self.state.pending.push(Pending::SetNavFocus(id, key_focus));
         }
@@ -668,15 +666,12 @@ impl<'a> Manager<'a> {
     /// keyboard input, false if reacting to mouse or touch input.
     pub fn next_nav_focus(
         &mut self,
-        mut widget: &dyn WidgetConfig,
+        mut widget: &mut dyn WidgetConfig,
         reverse: bool,
         key_focus: bool,
     ) -> bool {
-        type WidgetStack<'b> = SmallVec<[&'b dyn WidgetConfig; 16]>;
-        let mut widget_stack = WidgetStack::new();
-
         if let Some(id) = self.state.popups.last().map(|(_, p, _)| p.id) {
-            if let Some(w) = widget.find_leaf(id) {
+            if let Some(w) = widget.find_leaf_mut(id) {
                 widget = w;
             } else {
                 // This is a corner-case. Do nothing.
@@ -688,176 +683,113 @@ impl<'a> Manager<'a> {
         // processing, we can push directly to self.state.action.
         self.state.send_action(TkAction::REDRAW);
 
-        if let Some(id) = self.state.nav_focus {
-            let mut i = 0;
-            'l: while id != widget.id() {
-                // We use nav_stack as a cache, but verify
-                if let Some(index) = self.state.nav_stack.get(i) {
-                    let w = widget.get_child((*index).cast()).unwrap();
-                    if w.is_ancestor_of(id) {
-                        i += 1;
-                        widget_stack.push(widget);
-                        widget = w;
-                        continue 'l;
-                    } else {
-                        // wrong child!
-                        self.state.nav_stack.truncate(i);
-                    }
+        fn nav<'a>(
+            widget: &mut dyn WidgetConfig,
+            focus: Option<WidgetId>,
+            rev: bool,
+        ) -> Option<WidgetId> {
+            let last = widget.num_children().wrapping_sub(1);
+            if widget.is_disabled() {
+                return None;
+            } else if last == usize::MAX {
+                if focus != Some(widget.id()) && widget.key_nav() {
+                    return Some(widget.id());
                 }
-
-                // Otherwise, we just do a linear search.
-                // TODO(opt): add WidgetChildren::find_ancestor_of method to
-                // allow optimisations for widgets with many children?
-                for index in 0..widget.num_children() {
-                    let w = widget.get_child(index).unwrap();
-                    if w.is_ancestor_of(id) {
-                        self.state.nav_stack.push(index.cast());
-                        i += 1;
-                        widget_stack.push(widget);
-                        widget = w;
-                        continue 'l;
-                    }
-                }
-
-                // This should be impossible if widgets are correctly configured
-                error!("next_nav_focus: unable to find widget {}", id);
-                self.clear_char_focus();
-                self.state.nav_focus = None;
-                self.state.nav_stack.clear();
-                return false;
+                return None;
             }
-        } else {
-            self.state.nav_stack.clear();
-        }
 
-        // Progresses to the first child (or last if reverse).
-        // Returns true if a child is found.
-        // Breaks to given lifetime on error.
-        macro_rules! do_child {
-            ($lt:lifetime, $nav_stack:ident, $widget:ident, $widget_stack:ident) => {{
-                if $widget.is_disabled() {
-                    false
-                } else if let Some(index) = $widget.spatial_nav(reverse, None) {
-                    let new = match $widget.get_child(index) {
-                        None => break $lt,
-                        Some(w) => w,
-                    };
-                    $nav_stack.push(index.cast());
-                    $widget_stack.push($widget);
-                    $widget = new;
-                    true
-                } else {
-                    false
-                }
-            }};
-        }
-
-        enum Case {
-            Sibling,
-            Pop,
-            End,
-        }
-
-        // Progresses to the next (or previous) sibling, otherwise pops to the
-        // parent. Breaks to given lifetime on error.
-        macro_rules! do_sibling_or_pop {
-            ($lt:lifetime, $nav_stack:ident, $widget:ident, $widget_stack:ident) => {{
-                match ($nav_stack.pop(), $widget_stack.pop()) {
-                    (Some(i), Some(w)) => {
-                        let index = i.cast();
-                        $widget = w;
-
-                        match $widget.spatial_nav(reverse, Some(index)) {
-                            Some(index) if !$widget.is_disabled() => {
-                                let new = match $widget.get_child(index) {
-                                    None => break $lt,
-                                    Some(w) => w,
-                                };
-                                $nav_stack.push(index.cast());
-                                $widget_stack.push($widget);
-                                $widget = new;
-                                Case::Sibling
-                            }
-                            _ => Case::Pop,
+            let mut child = None;
+            if let Some(id) = focus {
+                // Checking is_ancestor_of is just an optimisation
+                if widget.is_ancestor_of(id) && id != widget.id() {
+                    // TODO(opt): add WidgetChildren::find_ancestor_of method to
+                    // allow optimisations for widgets with many children?
+                    for index in 0..=last {
+                        if widget
+                            .get_child(index)
+                            .map(|w| w.is_ancestor_of(id))
+                            .unwrap_or(false)
+                        {
+                            child = Some(index);
+                            break;
                         }
                     }
-                    _ => Case::End,
-                }
-            }};
-        }
 
-        macro_rules! try_set_focus {
-            ($self:ident, $widget:ident) => {
-                if $widget.key_nav() && !$widget.is_disabled() {
-                    let id = $widget.id();
-                    if $self.state.sel_focus != Some(id) {
-                        $self.clear_char_focus();
+                    if child.is_none() {
+                        error!("unable to find widget {}", id);
+                        return None;
                     }
-                    $self.state.nav_focus = Some(id);
-                    trace!("Manager: nav_focus = Some({})", id);
-                    $self
-                        .state
-                        .pending
-                        .push(Pending::SetNavFocus(id, key_focus));
-                    return true;
                 }
-            };
-        }
+            }
 
-        let nav_stack = &mut self.state.nav_stack;
-        // Whether to restart from the beginning on failure
-        let mut restart = self.state.nav_focus.is_some();
-
-        if !reverse {
-            // Depth-first search without function recursion. Our starting
-            // entry has already been used (if applicable); the next
-            // candidate is its first child.
-            'l1: loop {
-                if do_child!('l1, nav_stack, widget, widget_stack) {
-                    try_set_focus!(self, widget);
-                    continue;
+            if !rev {
+                if let Some(index) = child {
+                    if let Some(id) = widget.get_child_mut(index).and_then(|w| nav(w, focus, rev)) {
+                        return Some(id);
+                    }
+                } else if focus != Some(widget.id()) && widget.key_nav() {
+                    return Some(widget.id());
                 }
 
                 loop {
-                    match do_sibling_or_pop!('l1, nav_stack, widget, widget_stack) {
-                        Case::Sibling => {
-                            try_set_focus!(self, widget);
-                            break;
+                    if let Some(index) = widget.spatial_nav(rev, child) {
+                        if let Some(id) =
+                            widget.get_child_mut(index).and_then(|w| nav(w, focus, rev))
+                        {
+                            return Some(id);
                         }
-                        Case::Pop => (),
-                        Case::End if restart => {
-                            restart = false;
-                            continue 'l1;
-                        }
-                        Case::End => break 'l1,
+                        child = Some(index);
+                    } else {
+                        return None;
                     }
                 }
-            }
-        } else {
-            // Reverse depth-first search
-            let mut start = self.state.nav_focus.is_none();
-            'l2: loop {
-                let case = if start {
-                    start = false;
-                    Case::Sibling
-                } else {
-                    do_sibling_or_pop!('l2, nav_stack, widget, widget_stack)
-                };
-                match case {
-                    Case::Sibling => while do_child!('l2, nav_stack, widget, widget_stack) {},
-                    Case::Pop => (),
-                    Case::End if restart => {
-                        restart = false;
-                        start = true;
-                        continue 'l2;
+            } else {
+                if let Some(index) = child {
+                    if let Some(id) = widget.get_child_mut(index).and_then(|w| nav(w, focus, rev)) {
+                        return Some(id);
                     }
-                    Case::End => break 'l2,
                 }
 
-                try_set_focus!(self, widget);
+                loop {
+                    if let Some(index) = widget.spatial_nav(rev, child) {
+                        if let Some(id) =
+                            widget.get_child_mut(index).and_then(|w| nav(w, focus, rev))
+                        {
+                            return Some(id);
+                        }
+                        child = Some(index);
+                    } else {
+                        return if focus != Some(widget.id()) && widget.key_nav() {
+                            Some(widget.id())
+                        } else {
+                            None
+                        };
+                    }
+                }
             }
         }
 
-        false
+        // Whether to restart from the beginning on failure
+        let restart = self.state.nav_focus.is_some();
+
+        let mut opt_id = nav(widget, self.state.nav_focus, reverse);
+        if restart && opt_id.is_none() {
+            opt_id = nav(widget, None, reverse);
+        }
+
+        trace!("Manager: nav_focus = {:?}", opt_id);
+        self.state.nav_focus = opt_id;
+
+        if let Some(id) = opt_id {
+            if self.state.sel_focus != Some(id) {
+                self.clear_char_focus();
+            }
+            self.state.pending.push(Pending::SetNavFocus(id, key_focus));
+        } else {
+            // Most likely an error occurred
+            self.clear_char_focus();
+            self.state.nav_focus = None;
+        }
+        opt_id.is_some()
     }
 }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -38,7 +38,6 @@ impl ManagerState {
             sel_focus: None,
             nav_focus: None,
             nav_fallback: None,
-            nav_stack: SmallVec::new(),
             hover: None,
             hover_icon: CursorIcon::Default,
             key_depress: Default::default(),

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -229,27 +229,46 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     for #name #ty_generics #where_clause
             {
                 #[inline]
-                fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
+                fn size_rules(
+                    &mut self,
+                    size_handle: &mut dyn ::kas::draw::SizeHandle,
+                    axis: ::kas::layout::AxisInfo,
+                ) -> ::kas::layout::SizeRules {
                     self.#inner.size_rules(size_handle, axis)
                 }
                 #[inline]
-                fn set_rect(&mut self, mgr: &mut Manager, rect: Rect, align: AlignHints) {
+                fn set_rect(
+                    &mut self,
+                    mgr: &mut ::kas::event::Manager,
+                    rect: ::kas::geom::Rect,
+                    align: ::kas::layout::AlignHints,
+                ) {
                     self.#inner.set_rect(mgr, rect, align);
                 }
                 #[inline]
-                fn translation(&self, child_index: usize) -> Offset {
+                fn translation(&self, child_index: usize) -> ::kas::geom::Offset {
                     self.#inner.translation(child_index)
                 }
                 #[inline]
-                fn spatial_nav(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
-                    self.#inner.spatial_nav(reverse, from)
+                fn spatial_nav(
+                    &mut self,
+                    mgr: &mut ::kas::event::Manager,
+                    reverse: bool,
+                    from: Option<usize>,
+                ) -> Option<usize> {
+                    self.#inner.spatial_nav(mgr, reverse, from)
                 }
                 #[inline]
-                fn find_id(&self, coord: Coord) -> Option<WidgetId> {
+                fn find_id(&self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
                     self.#inner.find_id(coord)
                 }
                 #[inline]
-                fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
+                fn draw(
+                    &self,
+                    draw_handle: &mut dyn ::kas::draw::DrawHandle,
+                    mgr: &::kas::event::ManagerState,
+                    disabled: bool,
+                ) {
                     self.#inner.draw(draw_handle, mgr, disabled);
                 }
             }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -65,7 +65,7 @@ impl<M: 'static> kas::Layout for ComboBox<M> {
         });
     }
 
-    fn spatial_nav(&self, _: bool, _: Option<usize>) -> Option<usize> {
+    fn spatial_nav(&mut self, _: &mut Manager, _: bool, _: Option<usize>) -> Option<usize> {
         // We have no child within our rect
         None
     }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -121,7 +121,12 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
         }
     }
 
-    fn spatial_nav(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
+    fn spatial_nav(
+        &mut self,
+        _: &mut Manager,
+        reverse: bool,
+        from: Option<usize>,
+    ) -> Option<usize> {
         if self.num_children() == 0 {
             return None;
         }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -126,7 +126,7 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
         });
     }
 
-    fn spatial_nav(&self, _: bool, _: Option<usize>) -> Option<usize> {
+    fn spatial_nav(&mut self, _: &mut Manager, _: bool, _: Option<usize>) -> Option<usize> {
         // We have no child within our rect
         None
     }

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -225,7 +225,7 @@ impl<D: Directional> Layout for ScrollBar<D> {
         let _ = self.update_handle();
     }
 
-    fn spatial_nav(&self, _: bool, _: Option<usize>) -> Option<usize> {
+    fn spatial_nav(&mut self, _: &mut Manager, _: bool, _: Option<usize>) -> Option<usize> {
         None // handle is not navigable
     }
 

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -240,7 +240,7 @@ impl<T: SliderType, D: Directional> Layout for Slider<T, D> {
         let _ = self.handle.set_size_and_offset(size, self.offset());
     }
 
-    fn spatial_nav(&self, _: bool, _: Option<usize>) -> Option<usize> {
+    fn spatial_nav(&mut self, _: &mut Manager, _: bool, _: Option<usize>) -> Option<usize> {
         None // handle is not navigable
     }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -180,7 +180,7 @@ impl<D: Directional, W: Widget> Layout for Splitter<D, W> {
         }
     }
 
-    fn spatial_nav(&self, _: bool, _: Option<usize>) -> Option<usize> {
+    fn spatial_nav(&mut self, _: &mut Manager, _: bool, _: Option<usize>) -> Option<usize> {
         None // handles are not navigable
     }
 

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -484,7 +484,12 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
         self.update_widgets(mgr);
     }
 
-    fn spatial_nav(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
+    fn spatial_nav(
+        &mut self,
+        mgr: &mut Manager,
+        reverse: bool,
+        from: Option<usize>,
+    ) -> Option<usize> {
         if self.cur_len == 0 {
             return None;
         }

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -434,6 +434,8 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Layout fo
         reverse: bool,
         from: Option<usize>,
     ) -> Option<usize> {
+        let _ = mgr; // TODO: this needs a rewrite like ListView::spatial_nav
+
         let cur_len = usize::conv(self.cur_len.0) * usize::conv(self.cur_len.1);
         if cur_len == 0 {
             return None;

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -428,7 +428,12 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Layout fo
         self.update_widgets(mgr);
     }
 
-    fn spatial_nav(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
+    fn spatial_nav(
+        &mut self,
+        mgr: &mut Manager,
+        reverse: bool,
+        from: Option<usize>,
+    ) -> Option<usize> {
         let cur_len = usize::conv(self.cur_len.0) * usize::conv(self.cur_len.1);
         if cur_len == 0 {
             return None;


### PR DESCRIPTION
This re-writes `Manager::next_nav_focus` and makes `spatial_nav` take `&mut self` and `mgr` in order to allow Tab to navigate correctly through a `ListView`. The same fix should be applied to `MatrixView` too, but there's another issue to fix first:

- scrolling through a `ListView` where one item has Tab-focus will jump focus to another item when the first is out of view (since the widget gets reassigned to a different data entry, and the `WidgetId` used for focus tracks the widget, not the data entry)