### PR TITLE
Text in SVGs, pan-dist-threshold for view widgets, several fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ features = ["raster"]
 
 [dev-dependencies]
 chrono = "0.4"
-env_logger = "0.8"
+env_logger = "0.9"
 log = "0.4"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,9 @@ clipboard = ["kas-wgpu/clipboard"]
 markdown = ["kas-core/markdown"]
 
 # Enable text shaping
-shaping = ["kas-wgpu/shaping"]
+shaping = ["kas-core/shaping"]
+# Alternative: use Harfbuzz library for shaping
+harfbuzz = ["kas-core/harfbuzz"]
 
 # Enable config read/write
 #TODO(cargo): once weak-dep-features (cargo#8832) is stable, add "winit?/serde"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -77,7 +77,7 @@ version = "0.9.1"
 path = "../kas-macros"
 
 [dependencies.kas-text]
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -34,6 +34,11 @@ internal_doc = []
 # Enable Markdown parsing
 markdown = ["kas-text/markdown"]
 
+# Enable text shaping
+shaping = ["kas-text/shaping"]
+# Alternative: use Harfbuzz library for shaping
+harfbuzz = ["kas-text/harfbuzz"]
+
 # Enable config read/write
 #TODO(cargo): once weak-dep-features (cargo#8832) is stable, add "winit?/serde"
 # and remove the serde feature requirement under dependencies.winit.

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -57,7 +57,7 @@ easy-cast = "0.4.2"
 log = "0.4"
 smallvec = "1.6.1"
 stack_dst = { version = "0.6", optional = true }
-bitflags = "1.2.1" # only used without winit
+bitflags = "1.3.1" # only used without winit
 unicode-segmentation = "1.7"
 linear-map = "1.2.0"
 thiserror = "1.0.23"

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -352,6 +352,7 @@ pub trait WidgetConfig: Layout {
     /// Is this widget navigable via Tab key?
     ///
     /// Defaults to `false`.
+    #[inline]
     fn key_nav(&self) -> bool {
         false
     }
@@ -360,6 +361,7 @@ pub trait WidgetConfig: Layout {
     ///
     /// If true, a redraw will be requested whenever this widget gains or loses
     /// mouse-hover status.
+    #[inline]
     fn hover_highlight(&self) -> bool {
         false
     }
@@ -367,6 +369,7 @@ pub trait WidgetConfig: Layout {
     /// Which cursor icon should be used on hover?
     ///
     /// Defaults to [`event::CursorIcon::Default`].
+    #[inline]
     fn cursor_icon(&self) -> event::CursorIcon {
         event::CursorIcon::Default
     }

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -131,15 +131,26 @@ pub trait WidgetCore: Any + fmt::Debug {
     fn input_state(&self, mgr: &ManagerState, disabled: bool) -> InputState {
         let id = self.core_data().id;
         let (char_focus, sel_focus) = mgr.has_char_focus(id);
-        InputState {
-            disabled: self.core_data().disabled || disabled,
-            error: false,
-            hover: mgr.is_hovered(id),
-            depress: mgr.is_depressed(id),
-            nav_focus: mgr.nav_focus(id),
-            char_focus,
-            sel_focus,
+        let mut state = InputState::empty();
+        if self.core_data().disabled || disabled {
+            state |= InputState::DISABLED;
         }
+        if mgr.is_hovered(id) {
+            state |= InputState::HOVER;
+        }
+        if mgr.is_depressed(id) {
+            state |= InputState::DEPRESS;
+        }
+        if mgr.nav_focus(id) {
+            state |= InputState::NAV_FOCUS;
+        }
+        if char_focus {
+            state |= InputState::CHAR_FOCUS;
+        }
+        if sel_focus {
+            state |= InputState::SEL_FOCUS;
+        }
+        state
     }
 }
 

--- a/crates/kas-core/src/draw/handle.rs
+++ b/crates/kas-core/src/draw/handle.rs
@@ -758,6 +758,7 @@ mod test {
 
         let text = crate::text::Text::new_single("sample");
         let class = TextClass::Label;
-        draw_handle.text_selected(Coord::ZERO, &text, .., class)
+        let state = InputState::empty();
+        draw_handle.text_selected(Coord::ZERO, &text, .., class, state)
     }
 }

--- a/crates/kas-core/src/draw/handle.rs
+++ b/crates/kas-core/src/draw/handle.rs
@@ -302,21 +302,28 @@ pub trait DrawHandle {
     /// Draw some text using the standard font
     ///
     /// The dimensions required for this text may be queried with [`SizeHandle::text_bound`].
-    fn text(&mut self, pos: Coord, text: &TextDisplay, class: TextClass);
+    fn text(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, state: InputState);
 
     /// Draw text with effects
     ///
     /// [`DrawHandle::text`] already supports *font* effects: bold,
     /// emphasis, text size. In addition, this method supports underline and
     /// strikethrough effects.
-    fn text_effects(&mut self, pos: Coord, text: &dyn TextApi, class: TextClass);
+    fn text_effects(&mut self, pos: Coord, text: &dyn TextApi, class: TextClass, state: InputState);
 
     /// Draw an `AccelString` text
     ///
     /// The `text` is drawn within the rect from `pos` to `text.env().bounds`.
     ///
     /// The dimensions required for this text may be queried with [`SizeHandle::text_bound`].
-    fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass);
+    fn text_accel(
+        &mut self,
+        pos: Coord,
+        text: &Text<AccelString>,
+        accel: bool,
+        class: TextClass,
+        state: InputState,
+    );
 
     /// Method used to implement [`DrawHandleExt::text_selected`]
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
@@ -327,6 +334,7 @@ pub trait DrawHandle {
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
+        state: InputState,
     );
 
     /// Draw an edit marker at the given `byte` index on this `text`
@@ -425,6 +433,7 @@ pub trait DrawHandleExt: DrawHandle {
         text: T,
         range: R,
         class: TextClass,
+        state: InputState,
     ) {
         let start = match range.start_bound() {
             Bound::Included(n) => *n,
@@ -437,7 +446,7 @@ pub trait DrawHandleExt: DrawHandle {
             Bound::Unbounded => usize::MAX,
         };
         let range = Range { start, end };
-        self.text_selected_range(pos, text.as_ref(), range, class);
+        self.text_selected_range(pos, text.as_ref(), range, class, state);
     }
 }
 
@@ -544,14 +553,27 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
     fn selection_box(&mut self, rect: Rect) {
         self.deref_mut().selection_box(rect);
     }
-    fn text(&mut self, pos: Coord, text: &TextDisplay, class: TextClass) {
-        self.deref_mut().text(pos, text, class)
+    fn text(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, state: InputState) {
+        self.deref_mut().text(pos, text, class, state)
     }
-    fn text_effects(&mut self, pos: Coord, text: &dyn TextApi, class: TextClass) {
-        self.deref_mut().text_effects(pos, text, class);
+    fn text_effects(
+        &mut self,
+        pos: Coord,
+        text: &dyn TextApi,
+        class: TextClass,
+        state: InputState,
+    ) {
+        self.deref_mut().text_effects(pos, text, class, state);
     }
-    fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
-        self.deref_mut().text_accel(pos, text, state, class);
+    fn text_accel(
+        &mut self,
+        pos: Coord,
+        text: &Text<AccelString>,
+        accel: bool,
+        class: TextClass,
+        state: InputState,
+    ) {
+        self.deref_mut().text_accel(pos, text, accel, class, state);
     }
     fn text_selected_range(
         &mut self,
@@ -559,9 +581,10 @@ impl<H: DrawHandle> DrawHandle for Box<H> {
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
+        state: InputState,
     ) {
         self.deref_mut()
-            .text_selected_range(pos, text, range, class);
+            .text_selected_range(pos, text, range, class, state);
     }
     fn edit_marker(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
         self.deref_mut().edit_marker(pos, text, class, byte)
@@ -630,14 +653,27 @@ where
     fn selection_box(&mut self, rect: Rect) {
         self.deref_mut().selection_box(rect);
     }
-    fn text(&mut self, pos: Coord, text: &TextDisplay, class: TextClass) {
-        self.deref_mut().text(pos, text, class)
+    fn text(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, state: InputState) {
+        self.deref_mut().text(pos, text, class, state)
     }
-    fn text_effects(&mut self, pos: Coord, text: &dyn TextApi, class: TextClass) {
-        self.deref_mut().text_effects(pos, text, class);
+    fn text_effects(
+        &mut self,
+        pos: Coord,
+        text: &dyn TextApi,
+        class: TextClass,
+        state: InputState,
+    ) {
+        self.deref_mut().text_effects(pos, text, class, state);
     }
-    fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
-        self.deref_mut().text_accel(pos, text, state, class);
+    fn text_accel(
+        &mut self,
+        pos: Coord,
+        text: &Text<AccelString>,
+        accel: bool,
+        class: TextClass,
+        state: InputState,
+    ) {
+        self.deref_mut().text_accel(pos, text, accel, class, state);
     }
     fn text_selected_range(
         &mut self,
@@ -645,9 +681,10 @@ where
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
+        state: InputState,
     ) {
         self.deref_mut()
-            .text_selected_range(pos, text, range, class);
+            .text_selected_range(pos, text, range, class, state);
     }
     fn edit_marker(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
         self.deref_mut().edit_marker(pos, text, class, byte)

--- a/crates/kas-core/src/draw/handle.rs
+++ b/crates/kas-core/src/draw/handle.rs
@@ -18,49 +18,77 @@ use crate::text::{AccelString, Text, TextApi, TextDisplay};
 #[allow(unused)]
 use crate::text::TextApiExt;
 
-/// Input and highlighting state of a widget
-///
-/// This struct is used to adjust the appearance of [`DrawHandle`]'s primitives.
-///
-/// Multiple instances can be combined via [`std::ops::BitOr`]: `lhs | rhs`.
-#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
-pub struct InputState {
-    /// Disabled widgets are not responsive to input and usually drawn in grey.
+bitflags! {
+    /// Input and highlighting state of a widget
     ///
-    /// All other states should be ignored when disabled.
-    pub disabled: bool,
-    /// Some widgets, such as `EditBox`, use a red background on error
-    pub error: bool,
-    /// "Hover" is true if the mouse is over this element
-    pub hover: bool,
-    /// Elements such as buttons, handles and menu entries may be depressed
-    /// (visually pushed) by a click or touch event or an accelerator key.
-    /// This is often visualised by a darker colour and/or by offsetting
-    /// graphics. The `hover` state should be ignored when depressed.
-    pub depress: bool,
-    /// Keyboard navigation of UIs moves a "focus" from widget to widget.
-    pub nav_focus: bool,
-    /// "Character focus" implies this widget is ready to receive text input
-    /// (e.g. typing into an input field).
-    pub char_focus: bool,
-    /// "Selection focus" allows things such as text to be selected. Selection
-    /// focus implies that the widget also has character focus.
-    pub sel_focus: bool,
+    /// This struct is used to adjust the appearance of [`DrawHandle`]'s primitives.
+    #[derive(Default)]
+    pub struct InputState: u8 {
+        /// Disabled widgets are not responsive to input and usually drawn in grey.
+        ///
+        /// All other states should be ignored when disabled.
+        const DISABLED = 1 << 0;
+        /// Some widgets, such as `EditBox`, use a red background on error
+        const ERROR = 1 << 1;
+        /// "Hover" is true if the mouse is over this element
+        const HOVER = 1 << 2;
+        /// Elements such as buttons, handles and menu entries may be depressed
+        /// (visually pushed) by a click or touch event or an accelerator key.
+        /// This is often visualised by a darker colour and/or by offsetting
+        /// graphics. The `hover` state should be ignored when depressed.
+        const DEPRESS = 1 << 3;
+        /// Keyboard navigation of UIs moves a "focus" from widget to widget.
+        const NAV_FOCUS = 1 << 4;
+        /// "Character focus" implies this widget is ready to receive text input
+        /// (e.g. typing into an input field).
+        const CHAR_FOCUS = 1 << 5;
+        /// "Selection focus" allows things such as text to be selected. Selection
+        /// focus implies that the widget also has character focus.
+        const SEL_FOCUS = 1 << 6;
+    }
 }
 
-impl std::ops::BitOr for InputState {
-    type Output = Self;
+impl InputState {
+    /// Extract `DISABLED` bit
+    #[inline]
+    pub fn disabled(self) -> bool {
+        self.contains(InputState::DISABLED)
+    }
 
-    fn bitor(self, rhs: Self) -> Self {
-        InputState {
-            disabled: self.disabled || rhs.disabled,
-            error: self.error || rhs.error,
-            hover: self.hover || rhs.hover,
-            depress: self.depress || rhs.depress,
-            nav_focus: self.nav_focus || rhs.nav_focus,
-            char_focus: self.char_focus || rhs.char_focus,
-            sel_focus: self.sel_focus || rhs.sel_focus,
-        }
+    /// Extract `ERROR` bit
+    #[inline]
+    pub fn error(self) -> bool {
+        self.contains(InputState::ERROR)
+    }
+
+    /// Extract `HOVER` bit
+    #[inline]
+    pub fn hover(self) -> bool {
+        self.contains(InputState::HOVER)
+    }
+
+    /// Extract `DEPRESS` bit
+    #[inline]
+    pub fn depress(self) -> bool {
+        self.contains(InputState::DEPRESS)
+    }
+
+    /// Extract `NAV_FOCUS` bit
+    #[inline]
+    pub fn nav_focus(self) -> bool {
+        self.contains(InputState::NAV_FOCUS)
+    }
+
+    /// Extract `CHAR_FOCUS` bit
+    #[inline]
+    pub fn char_focus(self) -> bool {
+        self.contains(InputState::CHAR_FOCUS)
+    }
+
+    /// Extract `SEL_FOCUS` bit
+    #[inline]
+    pub fn sel_focus(self) -> bool {
+        self.contains(InputState::SEL_FOCUS)
     }
 }
 

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -98,8 +98,7 @@ impl TextInput {
                         Action::Pan(delta)
                     }
                     TouchPhase::Start(id, start_coord) if id == touch_id => {
-                        let delta = coord - start_coord;
-                        if delta.distance_l_inf() > mgr.config().pan_dist_thresh() {
+                        if mgr.config_test_pan_thresh(coord - start_coord) {
                             self.touch_phase = TouchPhase::Pan(id);
                             Action::Pan(delta)
                         } else {

--- a/crates/kas-core/src/event/config.rs
+++ b/crates/kas-core/src/event/config.rs
@@ -24,9 +24,8 @@ pub struct Config {
     )]
     touch_text_sel_delay_ns: u32,
 
-    // TODO: multiply by scale factor on access?
     #[cfg_attr(feature = "config", serde(default = "defaults::pan_dist_thresh"))]
-    pan_dist_thresh: i32,
+    pan_dist_thresh: f32,
 
     #[cfg_attr(feature = "config", serde(default = "defaults::mouse_pan"))]
     mouse_pan: MousePan,
@@ -77,7 +76,7 @@ impl Config {
     /// start; otherwise the system should wait for the text-selection timer.
     /// We currently recommend the L-inf distance metric (max of abs of values).
     #[inline]
-    pub fn pan_dist_thresh(&self) -> i32 {
+    pub fn pan_dist_thresh(&self) -> f32 {
         self.pan_dist_thresh
     }
 
@@ -163,8 +162,8 @@ mod defaults {
     pub fn touch_text_sel_delay_ns() -> u32 {
         1_000_000_000
     }
-    pub fn pan_dist_thresh() -> i32 {
-        2
+    pub fn pan_dist_thresh() -> f32 {
+        2.1
     }
     pub fn mouse_pan() -> MousePan {
         MousePan::Always

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -47,6 +47,16 @@ pub trait Handler: WidgetConfig {
         false
     }
 
+    /// Generic handler: focus rect on key navigation
+    ///
+    /// If this widget receives [`Event::NavFocus`]`(true)` then return
+    /// [`Response::Focus`] with the widget's rect. By default this is true if
+    /// and only if [`WidgetConfig::key_nav`] is true.
+    #[inline]
+    fn focus_on_key_nav(&self) -> bool {
+        self.key_nav()
+    }
+
     /// Handle an event and return a user-defined message
     ///
     /// Widgets should handle any events applicable to themselves here, and
@@ -145,7 +155,7 @@ impl<'a> Manager<'a> {
             };
         }
 
-        if event == Event::NavFocus(true) {
+        if widget.focus_on_key_nav() && event == Event::NavFocus(true) {
             return Response::Focus(widget.rect());
         }
 

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -101,6 +101,7 @@ enum Pending {
 #[derive(Debug)]
 pub struct ManagerState {
     config: Rc<RefCell<Config>>,
+    scale_factor: f32,
     end_id: WidgetId,
     modifiers: ModifiersState,
     /// char focus is on same widget as sel_focus; otherwise its value is ignored

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -11,7 +11,7 @@ use std::u16;
 
 use super::*;
 use crate::draw::{DrawShared, SizeHandle, ThemeApi};
-use crate::geom::Coord;
+use crate::geom::{Coord, Offset, Vec2};
 use crate::updatable::Updatable;
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
@@ -110,6 +110,21 @@ impl<'a> Manager<'a> {
         self.config()
             .mouse_text_pan()
             .is_enabled_with(self.modifiers())
+    }
+
+    /// Test pan threshold against config, adjusted for scale factor
+    ///
+    /// Returns true when `dist` is large enough to switch to pan mode.
+    #[inline]
+    pub fn config_test_pan_thresh(&self, dist: Offset) -> bool {
+        let thresh = self.config().pan_dist_thresh() * self.scale_factor();
+        Vec2::from(dist).sum_square() >= thresh * thresh
+    }
+
+    /// Access the screen's scale factor
+    #[inline]
+    pub fn scale_factor(&self) -> f32 {
+        self.state.scale_factor
     }
 
     /// Schedule an update

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -29,9 +29,10 @@ const FAKE_MOUSE_BUTTON: MouseButton = MouseButton::Other(0);
 impl ManagerState {
     /// Construct an event manager per-window data struct
     #[inline]
-    pub fn new(config: Rc<RefCell<Config>>) -> Self {
+    pub fn new(config: Rc<RefCell<Config>>, scale_factor: f32) -> Self {
         ManagerState {
             config,
+            scale_factor,
             end_id: Default::default(),
             modifiers: ModifiersState::empty(),
             char_focus: false,
@@ -60,6 +61,10 @@ impl ManagerState {
             pending: SmallVec::new(),
             action: TkAction::empty(),
         }
+    }
+
+    pub fn set_scale_factor(&mut self, scale_factor: f32) {
+        self.scale_factor = scale_factor;
     }
 
     /// Configure event manager for a widget tree.

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -15,7 +15,9 @@ pub use crate::class::*;
 #[doc(no_inline)]
 pub use crate::dir::{Direction, Directional};
 #[doc(no_inline)]
-pub use crate::draw::{DrawHandle, DrawHandleExt, DrawShared, ImageId, SizeHandle, ThemeApi};
+pub use crate::draw::{
+    DrawHandle, DrawHandleExt, DrawShared, ImageId, InputState, SizeHandle, ThemeApi,
+};
 #[doc(no_inline)]
 pub use crate::event::{
     Event, Handler, Manager, ManagerState, Response, SendEvent, UpdateHandle, VoidMsg,

--- a/crates/kas-resvg/Cargo.toml
+++ b/crates/kas-resvg/Cargo.toml
@@ -26,9 +26,9 @@ canvas = []
 svg = ["resvg", "usvg"]
 
 [dependencies]
-tiny-skia = { version = "0.5.1" }
-resvg = { version = "0.15.0", optional = true }
-usvg = { version = "0.15.0", optional = true }
+tiny-skia = { version = "0.6.1" }
+resvg = { version = "0.16.0", optional = true }
+usvg = { version = "0.16.0", optional = true }
 
 # We must rename this package since macros expect kas to be in scope:
 kas = { version = "0.9.1", package = "kas-core", path = "../kas-core" }

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -110,7 +110,7 @@ impl WidgetConfig for Svg {
             if let Some(path) = self.path.parent() {
                 opts.resources_dir = Some(path.to_path_buf());
             }
-            let scale_factor = mgr.size_handle(|sh| sh.scale_factor());
+            let scale_factor = mgr.scale_factor();
             opts.dpi = 96.0 * f64::conv(scale_factor);
             // TODO: allow configuration for rendering options (speed vs quality)
             // TODO: set font family and database

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -115,7 +115,7 @@ impl WidgetConfig for Svg {
             // TODO: allow configuration for rendering options (speed vs quality)
             // TODO: set font family and database
 
-            let tree = usvg::Tree::from_data(&data, &opts).unwrap();
+            let tree = usvg::Tree::from_data(&data, &opts.to_ref()).unwrap();
             let size = tree.svg_node().size.to_screen_size().dimensions();
             self.tree = Some(tree);
             let size = Vec2(size.0.cast(), size.1.cast());

--- a/crates/kas-theme/src/colors.rs
+++ b/crates/kas-theme/src/colors.rs
@@ -177,11 +177,11 @@ impl ColorsSrgb {
 impl ColorsLinear {
     /// Adjust a colour depending on state
     pub fn adjust_for_state(col: Rgba, state: InputState) -> Rgba {
-        if state.disabled {
+        if state.disabled() {
             col.average()
-        } else if state.depress {
+        } else if state.depress() {
             col.multiply(MULT_DEPRESS)
-        } else if state.hover || state.char_focus {
+        } else if state.hover() || state.char_focus() {
             col.multiply(MULT_HIGHLIGHT).max(MIN_HIGHLIGHT)
         } else {
             col
@@ -190,9 +190,9 @@ impl ColorsLinear {
 
     /// Get colour of a text area, depending on state
     pub fn edit_bg(&self, state: InputState) -> Rgba {
-        if state.disabled {
+        if state.disabled() {
             self.edit_bg_disabled
-        } else if state.error {
+        } else if state.error() {
             self.edit_bg_error
         } else {
             self.edit_bg
@@ -201,7 +201,7 @@ impl ColorsLinear {
 
     /// Get colour for navigation highlight region, if any
     pub fn nav_region(&self, state: InputState) -> Option<Rgba> {
-        if state.nav_focus && !state.disabled {
+        if state.nav_focus() && !state.disabled() {
             Some(self.nav_focus)
         } else {
             None
@@ -224,7 +224,7 @@ impl ColorsLinear {
     pub fn check_mark_state(&self, state: InputState, checked: bool) -> Option<Rgba> {
         if checked {
             Some(Self::adjust_for_state(self.accent, state))
-        } else if state.depress {
+        } else if state.depress() {
             Some(self.accent.multiply(MULT_DEPRESS))
         } else {
             None
@@ -233,7 +233,7 @@ impl ColorsLinear {
 
     /// Get background highlight colour of a menu entry, if any
     pub fn menu_entry(&self, state: InputState) -> Option<Rgba> {
-        if state.depress || state.nav_focus {
+        if state.depress() || state.nav_focus() {
             Some(self.accent_soft.multiply(MULT_DEPRESS))
         } else {
             None

--- a/crates/kas-theme/src/colors.rs
+++ b/crates/kas-theme/src/colors.rs
@@ -25,6 +25,8 @@ pub struct Colors<C> {
     pub frame: C,
     /// Background colour of `EditBox`
     pub edit_bg: C,
+    /// Background colour of `EditBox` (disabled state)
+    pub edit_bg_disabled: C,
     /// Background colour of `EditBox` (error state)
     pub edit_bg_error: C,
     /// Theme accent
@@ -69,6 +71,7 @@ impl From<ColorsSrgb> for ColorsLinear {
             accent_soft: col.accent_soft.into(),
             nav_focus: col.nav_focus.into(),
             edit_bg: col.edit_bg.into(),
+            edit_bg_disabled: col.edit_bg_disabled.into(),
             edit_bg_error: col.edit_bg_error.into(),
             text: col.text.into(),
             text_invert: col.text_invert.into(),
@@ -88,6 +91,7 @@ impl From<ColorsLinear> for ColorsSrgb {
             accent_soft: col.accent_soft.into(),
             nav_focus: col.nav_focus.into(),
             edit_bg: col.edit_bg.into(),
+            edit_bg_disabled: col.edit_bg_disabled.into(),
             edit_bg_error: col.edit_bg_error.into(),
             text: col.text.into(),
             text_invert: col.text_invert.into(),
@@ -122,6 +126,7 @@ impl ColorsSrgb {
             accent_soft: Rgba8Srgb::from_str("#B38DF9").unwrap(),
             nav_focus: Rgba8Srgb::from_str("#7E3FF2").unwrap(),
             edit_bg: Rgba8Srgb::from_str("#FAFAFA").unwrap(),
+            edit_bg_disabled: Rgba8Srgb::from_str("#DCDCDC").unwrap(),
             edit_bg_error: Rgba8Srgb::from_str("#FFBCBC").unwrap(),
             text: Rgba8Srgb::from_str("#000000").unwrap(),
             text_invert: Rgba8Srgb::from_str("#FFFFFF").unwrap(),
@@ -139,7 +144,8 @@ impl ColorsSrgb {
             accent: Rgba8Srgb::from_str("#F74C00").unwrap(),
             accent_soft: Rgba8Srgb::from_str("#E77346").unwrap(),
             nav_focus: Rgba8Srgb::from_str("#A33100").unwrap(),
-            edit_bg: Rgba8Srgb::from_str("#595959").unwrap(),
+            edit_bg: Rgba8Srgb::from_str("#303030").unwrap(),
+            edit_bg_disabled: Rgba8Srgb::from_str("#606060").unwrap(),
             edit_bg_error: Rgba8Srgb::from_str("#FFBCBC").unwrap(),
             text: Rgba8Srgb::from_str("#FFFFFF").unwrap(),
             text_invert: Rgba8Srgb::from_str("#000000").unwrap(),
@@ -158,6 +164,7 @@ impl ColorsSrgb {
             accent_soft: Rgba8Srgb::from_str("#7CDAFF").unwrap(),
             nav_focus: Rgba8Srgb::from_str("#3B697A").unwrap(),
             edit_bg: Rgba8Srgb::from_str("#FFFFFF").unwrap(),
+            edit_bg_disabled: Rgba8Srgb::from_str("#DCDCDC").unwrap(),
             edit_bg_error: Rgba8Srgb::from_str("#FFBCBC").unwrap(),
             text: Rgba8Srgb::from_str("#000000").unwrap(),
             text_invert: Rgba8Srgb::from_str("#FFFFFF").unwrap(),
@@ -182,9 +189,9 @@ impl ColorsLinear {
     }
 
     /// Get colour of a text area, depending on state
-    pub fn bg_col(&self, state: InputState) -> Rgba {
+    pub fn edit_bg(&self, state: InputState) -> Rgba {
         if state.disabled {
-            self.edit_bg.average()
+            self.edit_bg_disabled
         } else if state.error {
             self.edit_bg_error
         } else {

--- a/crates/kas-theme/src/config.rs
+++ b/crates/kas-theme/src/config.rs
@@ -223,12 +223,17 @@ impl ThemeConfig for Config {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
 pub struct FontAliases {
+    #[cfg_attr(feature = "config", serde(default = "defaults::add_mode"))]
     mode: AddMode,
     list: Vec<String>,
 }
 
 mod defaults {
     use super::*;
+
+    pub fn add_mode() -> AddMode {
+        AddMode::Prepend
+    }
 
     pub fn font_size() -> f32 {
         10.0

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -473,12 +473,7 @@ where
         let outer = Quad::from(rect);
 
         state.depress = false;
-        let col_bg = match state.error {
-            true => self.cols.edit_bg_error,
-            false => self.cols.edit_bg,
-        };
-        let col_bg = ColorsLinear::adjust_for_state(col_bg, state);
-
+        let col_bg = self.cols.edit_bg(state);
         if col_bg != self.cols.background {
             let inner = outer.shrink(self.w.dims.button_frame as f32 * BG_SHRINK_FACTOR);
             self.draw.rect(inner, col_bg);
@@ -516,7 +511,7 @@ where
         let outer = Quad::from(rect);
 
         let col_frame = self.cols.nav_region(state).unwrap_or(self.cols.frame);
-        let inner = self.button_frame(outer, col_frame, self.cols.background, state);
+        let inner = self.button_frame(outer, col_frame, self.cols.edit_bg(state), state);
 
         if let Some(col) = self.cols.check_mark_state(state, checked) {
             let inner = inner.shrink((2 * self.w.dims.inner_margin) as f32);
@@ -543,8 +538,7 @@ where
             self.draw.circle_2col(shadow_outer, col1, col2);
         }
 
-        let col_bg = ColorsLinear::adjust_for_state(self.cols.background, state);
-        self.draw.circle(outer, 0.0, col_bg);
+        self.draw.circle(outer, 0.0, self.cols.edit_bg(state));
 
         const F: f32 = 2.0 * (1.0 - BG_SHRINK_FACTOR); // match checkbox frame
         let r = 1.0 - F * self.w.dims.button_frame as f32 / rect.size.0 as f32;

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -356,25 +356,41 @@ where
         self.draw.frame(outer, inner, col);
     }
 
-    fn text(&mut self, pos: Coord, text: &TextDisplay, _: TextClass) {
+    fn text(&mut self, pos: Coord, text: &TextDisplay, _: TextClass, state: InputState) {
         let pos = pos;
-        let col = self.cols.text;
+        let col = if state.disabled {
+            self.cols.text_disabled
+        } else {
+            self.cols.text
+        };
         self.draw.text(pos.into(), text, col);
     }
 
-    fn text_effects(&mut self, pos: Coord, text: &dyn TextApi, _: TextClass) {
-        self.draw.text_col_effects(
-            (pos).into(),
-            text.display(),
-            self.cols.text,
-            text.effect_tokens(),
-        );
+    fn text_effects(&mut self, pos: Coord, text: &dyn TextApi, _: TextClass, state: InputState) {
+        let col = if state.disabled {
+            self.cols.text_disabled
+        } else {
+            self.cols.text
+        };
+        self.draw
+            .text_col_effects((pos).into(), text.display(), col, text.effect_tokens());
     }
 
-    fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, _: TextClass) {
+    fn text_accel(
+        &mut self,
+        pos: Coord,
+        text: &Text<AccelString>,
+        accel: bool,
+        _: TextClass,
+        state: InputState,
+    ) {
         let pos = Vec2::from(pos);
-        let col = self.cols.text;
-        if state {
+        let col = if state.disabled {
+            self.cols.text_disabled
+        } else {
+            self.cols.text
+        };
+        if accel {
             let effects = text.text().effect_tokens();
             self.draw.text_col_effects(pos, text.as_ref(), col, effects);
         } else {
@@ -388,9 +404,14 @@ where
         text: &TextDisplay,
         range: Range<usize>,
         _: TextClass,
+        state: InputState,
     ) {
         let pos = Vec2::from(pos);
-        let col = self.cols.text;
+        let col = if state.disabled {
+            self.cols.text_disabled
+        } else {
+            self.cols.text
+        };
         let sel_col = self.cols.text_over(self.cols.text_sel_bg);
 
         // Draw background:

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -244,9 +244,9 @@ where
         let inner = outer.shrink(self.w.dims.button_frame as f32);
         let col_bg = ColorsLinear::adjust_for_state(col_bg, state);
 
-        if !(state.disabled || state.depress) {
+        if !(state.disabled() || state.depress()) {
             let (mut a, mut b) = (self.w.dims.shadow_a, self.w.dims.shadow_b);
-            if state.hover {
+            if state.hover() {
                 a = a * SHADOW_HOVER;
                 b = b * SHADOW_HOVER;
             }
@@ -358,7 +358,7 @@ where
 
     fn text(&mut self, pos: Coord, text: &TextDisplay, _: TextClass, state: InputState) {
         let pos = pos;
-        let col = if state.disabled {
+        let col = if state.disabled() {
             self.cols.text_disabled
         } else {
             self.cols.text
@@ -367,7 +367,7 @@ where
     }
 
     fn text_effects(&mut self, pos: Coord, text: &dyn TextApi, _: TextClass, state: InputState) {
-        let col = if state.disabled {
+        let col = if state.disabled() {
             self.cols.text_disabled
         } else {
             self.cols.text
@@ -385,7 +385,7 @@ where
         state: InputState,
     ) {
         let pos = Vec2::from(pos);
-        let col = if state.disabled {
+        let col = if state.disabled() {
             self.cols.text_disabled
         } else {
             self.cols.text
@@ -407,7 +407,7 @@ where
         state: InputState,
     ) {
         let pos = Vec2::from(pos);
-        let col = if state.disabled {
+        let col = if state.disabled() {
             self.cols.text_disabled
         } else {
             self.cols.text
@@ -481,7 +481,7 @@ where
     fn button(&mut self, rect: Rect, col: Option<color::Rgb>, state: InputState) {
         let outer = Quad::from(rect);
 
-        let col_bg = if state.nav_focus && !state.disabled {
+        let col_bg = if state.nav_focus() && !state.disabled() {
             self.cols.accent_soft
         } else {
             col.map(|c| c.into()).unwrap_or(self.cols.background)
@@ -493,7 +493,7 @@ where
     fn edit_box(&mut self, rect: Rect, mut state: InputState) {
         let outer = Quad::from(rect);
 
-        state.depress = false;
+        state.remove(InputState::DEPRESS);
         let col_bg = self.cols.edit_bg(state);
         if col_bg != self.cols.background {
             let inner = outer.shrink(self.w.dims.button_frame as f32 * BG_SHRINK_FACTOR);
@@ -504,12 +504,12 @@ where
         self.draw
             .rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
 
-        if state.nav_focus || state.hover {
+        if state.nav_focus() || state.hover() {
             let r = 0.5 * self.w.dims.button_frame as f32;
             let y = outer.b.1 - r;
             let a = Vec2(outer.a.0 + r, y);
             let b = Vec2(outer.b.0 - r, y);
-            let col = if state.nav_focus {
+            let col = if state.nav_focus() {
                 self.cols.nav_focus
             } else {
                 self.cols.text
@@ -544,10 +544,10 @@ where
         let outer = Quad::from(rect);
         let col = self.cols.nav_region(state).unwrap_or(self.cols.frame);
 
-        if !(state.disabled || state.depress) {
+        if !(state.disabled() || state.depress()) {
             let (mut a, mut b) = (self.w.dims.shadow_a, self.w.dims.shadow_b);
             let mut mult = 0.65;
-            if state.hover {
+            if state.hover() {
                 mult *= SHADOW_HOVER;
             }
             a = a * mult;
@@ -585,7 +585,7 @@ where
         let r = outer.size().min_comp() * 0.125;
         let outer = outer.shrink(r);
         let inner = outer.shrink(3.0 * r);
-        let col = if state.depress || state.nav_focus {
+        let col = if state.depress() || state.nav_focus() {
             self.cols.nav_focus
         } else {
             self.cols.accent_soft
@@ -624,17 +624,17 @@ where
         let offset = Offset::from((h_rect.size - size) / 2);
         let outer = Quad::from(Rect::new(h_rect.pos + offset, size));
 
-        let col = if state.nav_focus && !state.disabled {
+        let col = if state.nav_focus() && !state.disabled() {
             self.cols.accent_soft
         } else {
             self.cols.background
         };
         let col = ColorsLinear::adjust_for_state(col, state);
 
-        if !(state.disabled || state.depress) {
+        if !state.contains(InputState::DISABLED | InputState::DEPRESS) {
             let (mut a, mut b) = (self.w.dims.shadow_a, self.w.dims.shadow_b);
             let mut mult = 0.6;
-            if state.hover {
+            if state.hover() {
                 mult *= SHADOW_HOVER;
             }
             a = a * mult;

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -504,7 +504,7 @@ where
         self.draw
             .rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
 
-        if state.nav_focus() || state.hover() {
+        if !state.disabled() && (state.nav_focus() || state.hover()) {
             let r = 0.5 * self.w.dims.button_frame as f32;
             let y = outer.b.1 - r;
             let a = Vec2(outer.a.0 + r, y);

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -336,12 +336,12 @@ where
     }
 
     fn edit_box(&mut self, rect: Rect, state: InputState) {
-        let bg_col = self.cols.bg_col(state);
+        let bg_col = self.cols.edit_bg(state);
         self.draw_edit_box(rect, bg_col, self.cols.nav_region(state));
     }
 
     fn checkbox(&mut self, rect: Rect, checked: bool, state: InputState) {
-        let bg_col = self.cols.bg_col(state);
+        let bg_col = self.cols.edit_bg(state);
         let nav_col = self.cols.nav_region(state).or(Some(bg_col));
 
         let inner = self.draw_edit_box(rect, bg_col, nav_col);
@@ -352,7 +352,7 @@ where
     }
 
     fn radiobox(&mut self, rect: Rect, checked: bool, state: InputState) {
-        let bg_col = self.cols.bg_col(state);
+        let bg_col = self.cols.edit_bg(state);
         let nav_col = self.cols.nav_region(state).or(Some(bg_col));
 
         let inner = self.draw_edit_box(rect, bg_col, nav_col);

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -290,16 +290,29 @@ where
         self.as_flat().selection_box(rect);
     }
 
-    fn text(&mut self, pos: Coord, text: &TextDisplay, class: TextClass) {
-        self.as_flat().text(pos, text, class);
+    fn text(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, state: InputState) {
+        self.as_flat().text(pos, text, class, state);
     }
 
-    fn text_effects(&mut self, pos: Coord, text: &dyn TextApi, class: TextClass) {
-        self.as_flat().text_effects(pos, text, class);
+    fn text_effects(
+        &mut self,
+        pos: Coord,
+        text: &dyn TextApi,
+        class: TextClass,
+        state: InputState,
+    ) {
+        self.as_flat().text_effects(pos, text, class, state);
     }
 
-    fn text_accel(&mut self, pos: Coord, text: &Text<AccelString>, state: bool, class: TextClass) {
-        self.as_flat().text_accel(pos, text, state, class);
+    fn text_accel(
+        &mut self,
+        pos: Coord,
+        text: &Text<AccelString>,
+        accel: bool,
+        class: TextClass,
+        state: InputState,
+    ) {
+        self.as_flat().text_accel(pos, text, accel, class, state);
     }
 
     fn text_selected_range(
@@ -308,8 +321,10 @@ where
         text: &TextDisplay,
         range: Range<usize>,
         class: TextClass,
+        state: InputState,
     ) {
-        self.as_flat().text_selected_range(pos, text, range, class);
+        self.as_flat()
+            .text_selected_range(pos, text, range, class, state);
     }
 
     fn edit_marker(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -17,6 +17,7 @@ default = ["clipboard", "stack_dst", "shaping", "raster"]
 nightly = ["unsize", "kas-theme/nightly"]
 
 shaping = ["kas-text/shaping"]
+harfbuzz = ["kas-text/harfbuzz"]
 raster = ["kas-text/raster"]
 
 # Use Generic Associated Types (this is too unstable to include in nightly!)

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -33,7 +33,7 @@ stack_dst = ["kas-theme/stack_dst"]
 unsize = ["kas-theme/unsize"]
 
 [dependencies]
-kas-text = { version = "0.3.4" }
+kas-text = { version = "0.4.0" }
 bytemuck = "1.7.0"
 futures = "0.3"
 log = "0.4"

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -55,7 +55,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         let scale_factor = shared.scale_factor as f32;
         let mut theme_window = shared.theme.new_window(scale_factor);
 
-        let mut mgr = ManagerState::new(shared.config.clone());
+        let mut mgr = ManagerState::new(shared.config.clone(), scale_factor);
         let mut tkw = TkWindow::new(shared, None, &mut theme_window);
         mgr.configure(&mut tkw, &mut *widget);
 
@@ -126,9 +126,11 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
             } => {
                 // Note: API allows us to set new window size here.
                 shared.scale_factor = scale_factor;
+                let scale_factor = scale_factor as f32;
+                self.mgr.set_scale_factor(scale_factor);
                 shared
                     .theme
-                    .update_window(&mut self.theme_window, scale_factor as f32);
+                    .update_window(&mut self.theme_window, scale_factor);
                 self.solve_cache.invalidate_rule_cache();
                 self.do_resize(shared, *new_inner_size);
             }

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -35,9 +35,9 @@ unicode-segmentation = "1.7"
 linear-map = "1.2.0"
 thiserror = "1.0.23"
 image = "0.23.14"
-tiny-skia = { version = "0.5.1", optional = true }
-resvg = { version = "0.15.0", optional = true }
-usvg = { version = "0.15.0", optional = true }
+tiny-skia = { version = "0.6.1", optional = true }
+resvg = { version = "0.16.0", optional = true }
+usvg = { version = "0.16.0", optional = true }
 kas-macros = { version = "0.9.1", path = "../kas-macros" }
 
 # We must rename this package since macros expect kas to be in scope:

--- a/crates/kas-widgets/src/adapter/label.rs
+++ b/crates/kas-widgets/src/adapter/label.rs
@@ -102,8 +102,9 @@ impl<W: Widget, D: Directional> Layout for WithLabel<W, D> {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
         let disabled = disabled || self.is_disabled();
         self.inner.draw(draw_handle, mgr, disabled);
-        let state = mgr.show_accel_labels();
-        draw_handle.text_accel(self.label_pos, &self.label, state, TextClass::Label);
+        let accel = mgr.show_accel_labels();
+        let state = self.input_state(mgr, disabled);
+        draw_handle.text_accel(self.label_pos, &self.label, accel, TextClass::Label, state);
     }
 }
 

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -274,8 +274,9 @@ impl<M: 'static> Layout for TextButton<M> {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         draw_handle.button(self.core.rect, self.color, self.input_state(mgr, disabled));
         let pos = self.core.rect.pos + self.frame_offset;
-        let state = mgr.show_accel_labels();
-        draw_handle.text_accel(pos, &self.label, state, TextClass::Button);
+        let accel = mgr.show_accel_labels();
+        let state = self.input_state(mgr, disabled);
+        draw_handle.text_accel(pos, &self.label, accel, TextClass::Button, state);
     }
 }
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -73,7 +73,7 @@ impl<M: 'static> kas::Layout for ComboBox<M> {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         let mut state = self.input_state(mgr, disabled);
         if self.popup_id.is_some() {
-            state.depress = true;
+            state.insert(InputState::DEPRESS);
         }
         draw_handle.button(self.core.rect, None, state);
         draw_handle.text(

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -76,7 +76,12 @@ impl<M: 'static> kas::Layout for ComboBox<M> {
             state.depress = true;
         }
         draw_handle.button(self.core.rect, None, state);
-        draw_handle.text(self.core.rect.pos, self.label.as_ref(), TextClass::Button);
+        draw_handle.text(
+            self.core.rect.pos,
+            self.label.as_ref(),
+            TextClass::Button,
+            state,
+        );
     }
 }
 

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -360,7 +360,9 @@ impl<G: EditGuard> Layout for EditBox<G> {
         // We draw highlights for input state of inner:
         let disabled = disabled || self.is_disabled() || self.inner.is_disabled();
         let mut input_state = self.inner.input_state(mgr, disabled);
-        input_state.error = self.inner.has_error();
+        if self.inner.has_error() {
+            input_state.insert(InputState::ERROR);
+        }
         draw_handle.edit_box(self.core.rect, input_state);
         self.inner.draw(draw_handle, mgr, disabled);
     }

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -1053,6 +1053,11 @@ impl<G: EditGuard> HasString for EditField<G> {
 impl<G: EditGuard + 'static> event::Handler for EditField<G> {
     type Msg = G::Msg;
 
+    #[inline]
+    fn focus_on_key_nav(&self) -> bool {
+        false
+    }
+
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         fn request_focus<G: EditGuard + 'static>(s: &mut EditField<G>, mgr: &mut Manager) {
             if !s.has_key_focus && mgr.request_char_focus(s.id()) {

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -489,7 +489,7 @@ impl<G: EditGuard> Layout for EditField<G> {
                     class,
                 );
             }
-            if self.input_state(mgr, disabled).char_focus {
+            if mgr.has_char_focus(self.id()).0 {
                 draw_handle.edit_marker(
                     self.rect().pos,
                     self.text.as_ref(),

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -475,9 +475,10 @@ impl<G: EditGuard> Layout for EditField<G> {
         } else {
             TextClass::Edit
         };
+        let state = self.input_state(mgr, disabled);
         draw_handle.with_clip_region(self.rect(), self.view_offset, &mut |draw_handle| {
             if self.selection.is_empty() {
-                draw_handle.text(self.rect().pos, self.text.as_ref(), class);
+                draw_handle.text(self.rect().pos, self.text.as_ref(), class, state);
             } else {
                 // TODO(opt): we could cache the selection rectangles here to make
                 // drawing more efficient (self.text.highlight_lines(range) output).
@@ -487,6 +488,7 @@ impl<G: EditGuard> Layout for EditField<G> {
                     &self.text,
                     self.selection.range(),
                     class,
+                    state,
                 );
             }
             if mgr.has_char_focus(self.id()).0 {

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -35,34 +35,55 @@ impl<T: FormattableText + 'static> Layout for Label<T> {
     }
 
     #[cfg(feature = "min_spec")]
-    default fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        draw_handle.text_effects(self.core.rect.pos, &self.label, TextClass::Label);
+    default fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
+        let state = self.input_state(mgr, disabled);
+        draw_handle.text_effects(self.core.rect.pos, &self.label, TextClass::Label, state);
     }
     #[cfg(not(feature = "min_spec"))]
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        draw_handle.text_effects(self.core.rect.pos, &self.label, TextClass::Label);
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
+        let state = self.input_state(mgr, disabled);
+        draw_handle.text_effects(self.core.rect.pos, &self.label, TextClass::Label, state);
     }
 }
 
 #[cfg(feature = "min_spec")]
 impl Layout for AccelLabel {
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, _: bool) {
-        let state = mgr.show_accel_labels();
-        draw_handle.text_accel(self.core.rect.pos, &self.label, state, TextClass::Label);
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
+        let state = self.input_state(mgr, disabled);
+        let accel = mgr.show_accel_labels();
+        draw_handle.text_accel(
+            self.core.rect.pos,
+            &self.label,
+            accel,
+            TextClass::Label,
+            state,
+        );
     }
 }
 
 // Str/String representations have no effects, so use simpler draw call
 #[cfg(feature = "min_spec")]
 impl<'a> Layout for Label<&'a str> {
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        draw_handle.text(self.core.rect.pos, self.label.as_ref(), TextClass::Label);
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
+        let state = self.input_state(mgr, disabled);
+        draw_handle.text(
+            self.core.rect.pos,
+            self.label.as_ref(),
+            TextClass::Label,
+            state,
+        );
     }
 }
 #[cfg(feature = "min_spec")]
 impl Layout for StringLabel {
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
-        draw_handle.text(self.core.rect.pos, self.label.as_ref(), TextClass::Label);
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
+        let state = self.input_state(mgr, disabled);
+        draw_handle.text(
+            self.core.rect.pos,
+            self.label.as_ref(),
+            TextClass::Label,
+            state,
+        );
     }
 }
 

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -65,6 +65,7 @@ impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {
             &self.label,
             mgr.show_accel_labels(),
             TextClass::MenuLabel,
+            self.input_state(mgr, disabled),
         );
     }
 }

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -205,8 +205,8 @@ impl<M: 'static> MenuToggle<M> {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
         let state = self.checkbox.input_state(mgr, disabled);
         draw_handle.menu_entry(self.core.rect, state);
-        self.checkbox.draw(draw_handle, mgr, state.disabled);
-        self.label.draw(draw_handle, mgr, state.disabled);
+        self.checkbox.draw(draw_handle, mgr, state.disabled());
+        self.label.draw(draw_handle, mgr, state.disabled());
     }
 }
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -141,6 +141,7 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
             &self.label,
             mgr.show_accel_labels(),
             TextClass::MenuLabel,
+            state,
         );
     }
 }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -133,7 +133,9 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
 
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         let mut state = self.input_state(mgr, disabled);
-        state.depress = state.depress || self.popup_id.is_some();
+        if self.popup_id.is_some() {
+            state.insert(InputState::DEPRESS);
+        }
         draw_handle.menu_entry(self.core.rect, state);
         let pos = self.core.rect.pos + self.label_off;
         draw_handle.text_accel(

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -66,7 +66,7 @@ impl<W: Widget> Layout for NavFrame<W> {
     fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         let input_state = self.input_state(mgr, disabled);
         draw_handle.nav_frame(self.rect(), input_state);
-        self.inner.draw(draw_handle, mgr, input_state.disabled);
+        self.inner.draw(draw_handle, mgr, input_state.disabled());
     }
 }
 

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -49,11 +49,12 @@ impl<T: FormattableText + 'static> Layout for ScrollLabel<T> {
         self.set_view_offset_from_edit_pos();
     }
 
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &event::ManagerState, _: bool) {
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &event::ManagerState, disabled: bool) {
         let class = TextClass::LabelScroll;
+        let state = self.input_state(mgr, disabled);
         draw_handle.with_clip_region(self.rect(), self.view_offset, &mut |draw_handle| {
             if self.selection.is_empty() {
-                draw_handle.text(self.rect().pos, self.text.as_ref(), class);
+                draw_handle.text(self.rect().pos, self.text.as_ref(), class, state);
             } else {
                 // TODO(opt): we could cache the selection rectangles here to make
                 // drawing more efficient (self.text.highlight_lines(range) output).
@@ -63,6 +64,7 @@ impl<T: FormattableText + 'static> Layout for ScrollLabel<T> {
                     &self.text,
                     self.selection.range(),
                     class,
+                    state,
                 );
             }
         });

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -693,8 +693,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
                 }
                 Event::PressMove { source, coord, .. } if self.press_event == Some(source) => {
                     if let PressPhase::Start(start_coord) = self.press_phase {
-                        let delta = coord - start_coord;
-                        if delta.distance_l_inf() > mgr.config().pan_dist_thresh() {
+                        if mgr.config_test_pan_thresh(coord - start_coord) {
                             self.press_phase = PressPhase::Pan;
                         }
                     }

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -606,8 +606,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> SendEvent
                 }
                 Event::PressMove { source, coord, .. } if self.press_event == Some(source) => {
                     if let PressPhase::Start(start_coord) = self.press_phase {
-                        let delta = coord - start_coord;
-                        if delta.distance_l_inf() > mgr.config().pan_dist_thresh() {
+                        if mgr.config_test_pan_thresh(coord - start_coord) {
                             self.press_phase = PressPhase::Pan;
                         }
                     }

--- a/crates/kas-widgets/src/view/mod.rs
+++ b/crates/kas-widgets/src/view/mod.rs
@@ -86,6 +86,13 @@ pub use list_view::ListView;
 pub use matrix_view::MatrixView;
 pub use single_view::SingleView;
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum PressPhase {
+    None,
+    Start(kas::geom::Coord),
+    Pan,
+}
+
 /// Selection mode used by [`ListView`]
 #[derive(Clone, Copy, Debug, VoidMsg)]
 pub enum SelectionMode {

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -63,11 +63,12 @@ impl Layout for Clock {
         self.time_pos = pos;
     }
 
-    fn draw(&self, draw_handle: &mut dyn DrawHandle, _: &ManagerState, _: bool) {
+    fn draw(&self, draw_handle: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
         let col_face = color::Rgba::grey(0.4);
         let col_hands = color::Rgba8Srgb::rgb(124, 124, 170).into();
         let col_secs = color::Rgba8Srgb::rgb(203, 124, 124).into();
         let text_class = TextClass::Label;
+        let state = self.input_state(mgr, disabled);
 
         // We use the low-level draw device to draw our clock. This means it is
         // not themeable, but gives us much more flexible draw routines.
@@ -108,8 +109,8 @@ impl Layout for Clock {
         line_seg(a_min, 0.0, half * 0.8, half * 0.015, col_hands);
         line_seg(a_sec, 0.0, half * 0.9, half * 0.005, col_secs);
 
-        draw_handle.text(self.date_pos, self.date.as_ref(), text_class);
-        draw_handle.text(self.time_pos, self.time.as_ref(), text_class);
+        draw_handle.text(self.date_pos, self.date.as_ref(), text_class, state);
+        draw_handle.text(self.time_pos, self.time.as_ref(), text_class, state);
     }
 }
 

--- a/examples/mandlebrot/Cargo.toml
+++ b/examples/mandlebrot/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 kas = { version = "0.9.1", path = "../.." }
 chrono = "0.4"
-env_logger = "0.8"
+env_logger = "0.9"
 log = "0.4"
 wgpu = "0.10.0"
 bytemuck = "1.7.0"


### PR DESCRIPTION
- Fix nav focus on `EditField`
- Add `edit_bg_disabled` colour
- Pass `InputState` to theme when drawing text
- Use `bitflags` to compress `InputState`
- `ListView`, `MatrixView`: add drag-start-threshold via `pan_dist_thresh` config option
- Fix: apply scale factor to pan threshold; use L2 norm for distance
- Re-export harfbuzz feature flag
- Fix `FlatTheme::edit_box` to not show underline when disabled
- Bump versions of dependencies
- Enable text in SVGs