### PR TITLE
0.10.1: Fix button alignment/stretch, fix examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] — 2021-09-07
+
+This is a small patch:
+
+-   Fix button stretch and alignment, especially in the calculator example (#246)
+-   Fix loading the font DB before parsing Markdown (#246)
+-   Support `#[widget(align = stretch)]` (#246)
+
 ## [0.10.0] — 2021-09-05
 
 This release responds to three key criticisms of KAS: (1) slow compile times,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -90,7 +90,7 @@ unsize = ["kas-theme/unsize", "kas-wgpu/unsize"]
 winit = ["kas-core/winit"]
 
 [dependencies]
-kas-core = { version = "0.10.0", path = "crates/kas-core" }
+kas-core = { version = "0.10.1", path = "crates/kas-core" }
 kas-dylib = { version = "0.10.0", path = "crates/kas-dylib", optional = true }
 kas-widgets = { version = "0.10.0", path = "crates/kas-widgets" }
 kas-resvg = { version = "0.10.0", path = "crates/kas-resvg" }

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-core"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -73,7 +73,7 @@ dep_ron = { version = "0.6.4", package = "ron", optional = true }
 image = "0.23.14"
 
 [dependencies.kas-macros]
-version = "0.10.0"
+version = "0.10.1"
 path = "../kas-macros"
 
 [dependencies.kas-text]

--- a/crates/kas-core/src/layout/align.rs
+++ b/crates/kas-core/src/layout/align.rs
@@ -69,13 +69,10 @@ pub struct CompleteAlignment {
 
 impl CompleteAlignment {
     /// Construct a rect of size `ideal` within `rect` using the given alignment
-    ///
-    /// Note: this does not stretch, even with [`Align::Stretch`], since widget
-    /// stretching should be determined by the [`Stretch`] priority instead.
     pub fn aligned_rect(&self, ideal: Size, rect: Rect) -> Rect {
         let mut pos = rect.pos;
         let mut size = rect.size;
-        if ideal.0 < size.0 {
+        if ideal.0 < size.0 && self.halign != Align::Stretch {
             pos.0 += match self.halign {
                 Align::Centre => (size.0 - ideal.0) / 2,
                 Align::BR => size.0 - ideal.0,
@@ -83,7 +80,7 @@ impl CompleteAlignment {
             };
             size.0 = ideal.0;
         }
-        if ideal.1 < size.1 {
+        if ideal.1 < size.1 && self.valign != Align::Stretch {
             pos.1 += match self.valign {
                 Align::Centre => (size.1 - ideal.1) / 2,
                 Align::BR => size.1 - ideal.1,

--- a/crates/kas-macros/Cargo.toml
+++ b/crates/kas-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-macros"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/crates/kas-macros/src/args.rs
+++ b/crates/kas-macros/src/args.rs
@@ -418,7 +418,7 @@ impl Parse for WidgetAttrArgs {
                 let _: kw::align = content.parse()?;
                 let _: Eq = content.parse()?;
                 let ident: Ident = content.parse()?;
-                if ident == "centre" || ident == "center" {
+                if ident == "centre" || ident == "center" || ident == "stretch" {
                     args.halign = Some(ident.clone());
                     args.valign = Some(ident);
                 } else {

--- a/crates/kas-theme/Cargo.toml
+++ b/crates/kas-theme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-theme"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/crates/kas-theme/src/config.rs
+++ b/crates/kas-theme/src/config.rs
@@ -231,6 +231,7 @@ pub struct FontAliases {
 mod defaults {
     use super::*;
 
+    #[cfg(feature = "config")]
     pub fn add_mode() -> AddMode {
         AddMode::Prepend
     }

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-wgpu"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/crates/kas-wgpu/src/lib.rs
+++ b/crates/kas-wgpu/src/lib.rs
@@ -88,6 +88,12 @@ fn warn_about_error(msg: &str, mut error: &dyn std::error::Error) {
 
 /// A toolkit over winit and WebGPU
 ///
+/// Constructing the toolkit with [`Toolkit::new`] or [`Toolkit::new_custom`]
+/// reads configuration (depending on passed options or environment variables)
+/// and initialises the font database. Note that this database is a global
+/// singleton and some widgets and other library code may expect fonts to have
+/// been initialised first.
+///
 /// All KAS shells are expected to provide a similar `Toolkit` type and API.
 /// There is no trait abstraction over this API simply because there is very
 /// little reason to do so (and some reason not to: KISS).

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-widgets"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -13,6 +13,9 @@ use kas::event::{self, VirtualKeyCode, VirtualKeyCodes};
 use kas::prelude::*;
 
 /// A push-button with a generic label
+///
+/// Default alignment is centred. Content (label) alignment is derived from the
+/// button alignment.
 #[derive(Clone, Widget)]
 #[handler(noauto)]
 #[widget(config=noauto)]
@@ -204,6 +207,10 @@ impl<L: Widget<Msg = VoidMsg>, M: 'static> SendEvent for Button<L, M> {
 ///
 /// This is a specialised variant of [`Button`] supporting key shortcuts from an
 /// [`AccelString`] label and using a custom text class (and thus theme colour).
+///
+/// Default alignment of the button is to stretch horizontally and centre
+/// vertically. The text label is always centred (irrespective of alignment
+/// parameters).
 #[derive(Clone, Widget)]
 #[handler(handle=noauto)]
 #[widget(config=noauto)]
@@ -261,13 +268,13 @@ impl<M: 'static> Layout for TextButton<M> {
 
     fn set_rect(&mut self, _: &mut Manager, rect: Rect, align: AlignHints) {
         let rect = align
-            .complete(Align::Centre, Align::Centre)
+            .complete(Align::Stretch, Align::Centre)
             .aligned_rect(self.ideal_size, rect);
         self.core.rect = rect;
         let size = rect.size - self.frame_size;
         self.label.update_env(|env| {
             env.set_bounds(size.into());
-            env.set_align(align.unwrap_or(Align::Centre, Align::Centre));
+            env.set_align((Align::Centre, Align::Centre));
         });
     }
 

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), kas::shell::Error> {
             _ = TextButton::new_msg("&8", Key::Char('8')),
             #[widget(col = 2, row = 1)]
             _ = TextButton::new_msg("&9", Key::Char('9')),
-            #[widget(col = 3, row = 1, rspan = 2)]
+            #[widget(col = 3, row = 1, rspan = 2, align = stretch)]
             _ = TextButton::new_msg("&+", Key::Add),
             #[widget(col = 0, row = 2)]
             _ = TextButton::new_msg("&4", Key::Char('4')),
@@ -63,7 +63,7 @@ fn main() -> Result<(), kas::shell::Error> {
             _ = TextButton::new_msg("&2", Key::Char('2')),
             #[widget(col = 2, row = 3)]
             _ = TextButton::new_msg("&3", Key::Char('3')),
-            #[widget(col = 3, row = 3, rspan = 2)]
+            #[widget(col = 3, row = 3, rspan = 2, align = stretch)]
             _ = TextButton::new_msg("&=", Key::Equals).with_keys(&[VK::Return, VK::NumpadEnter]),
             #[widget(col = 0, row = 4, cspan = 2)]
             _ = TextButton::new_msg("&0", Key::Char('0')),

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -11,8 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build widgets.
     // Message is a Window with an "Ok" button and notification status.
     // Each Window::new method creates objects then solves constraints.
-    let text = kas::text::format::Markdown::new("Hello *world*!")?;
-    let window = MessageBox::new("Message", text);
+    let window = MessageBox::new("Message", "Hello world");
 
     let theme = kas::theme::FlatTheme::new();
     kas::shell::Toolkit::new(theme)?.with(window)?.run()

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -13,6 +13,8 @@ use kas::widgets::{EditBox, Label, ScrollBarRegion, TextButton, Window};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
+    let theme = kas::theme::FlatTheme::new();
+    let shell = kas::shell::Toolkit::new(theme)?;
 
     let doc = r"Markdown document
 ================
@@ -66,6 +68,5 @@ It also supports lists:
         },
     );
 
-    let theme = kas::theme::FlatTheme::new();
-    kas::shell::Toolkit::new(theme)?.with(window)?.run()
+    shell.with(window)?.run()
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -135,7 +135,7 @@
 //! is greater than the child's ideal size. These parameters are used to
 //! construct an [`AlignHints`] which is passed into [`Layout::set_rect`].
 //!
-//! -   `align = centre` (or `center`)
+//! -   `align = ...` — one of `centre`, `center`, `stretch`
 //! -   `halign = ...` — one of `default`, `left`, `centre`, `center`, `right`, `stretch`
 //! -   `valign = ...` — one of `default`, `top`, `centre`, `center`, `bottom`, `stretch`
 //!


### PR DESCRIPTION
Apparently the 0.10 release was too hasty, resulting in two issues:

- [x] Fix button alignment/stretch: e.g. calculator buttons should cover most of the available space
- [x] Fix markdown and hello examples: font resolving fails (probably due to the delayed font loading)