### PR TITLE
Cleaner code; use_msg/map_msg/flatmap_msg

### DIFF
--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -31,7 +31,7 @@ pub struct MessageBox<T: FormattableText + 'static> {
     title: String,
     #[widget]
     label: Label<T>,
-    #[widget(handler = handle_button)]
+    #[widget(use_msg = handle_button)]
     button: TextButton<DialogButton>,
 }
 
@@ -50,11 +50,10 @@ impl<T: FormattableText + 'static> MessageBox<T> {
         }
     }
 
-    fn handle_button(&mut self, mgr: &mut Manager, msg: DialogButton) -> Response<VoidMsg> {
+    fn handle_button(&mut self, mgr: &mut Manager, msg: DialogButton) {
         match msg {
             DialogButton::Close => mgr.send_action(TkAction::CLOSE),
         };
-        Response::None
     }
 }
 

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -14,11 +14,6 @@ use kas::prelude::*;
 use kas::text::format::FormattableText;
 use kas::WindowId;
 
-#[derive(Clone, Debug, VoidMsg)]
-enum DialogButton {
-    Close,
-}
-
 /// A simple message box.
 #[derive(Clone, Debug, Widget)]
 #[layout(column)]
@@ -32,7 +27,7 @@ pub struct MessageBox<T: FormattableText + 'static> {
     #[widget]
     label: Label<T>,
     #[widget(use_msg = handle_button)]
-    button: TextButton<DialogButton>,
+    button: TextButton<()>,
 }
 
 impl<T: FormattableText + 'static> MessageBox<T> {
@@ -42,7 +37,7 @@ impl<T: FormattableText + 'static> MessageBox<T> {
             layout_data: Default::default(),
             title: title.to_string(),
             label: Label::new(message),
-            button: TextButton::new_msg("Ok", DialogButton::Close).with_keys(&[
+            button: TextButton::new_msg("Ok", ()).with_keys(&[
                 VirtualKeyCode::Return,
                 VirtualKeyCode::Space,
                 VirtualKeyCode::NumpadEnter,
@@ -50,10 +45,8 @@ impl<T: FormattableText + 'static> MessageBox<T> {
         }
     }
 
-    fn handle_button(&mut self, mgr: &mut Manager, msg: DialogButton) {
-        match msg {
-            DialogButton::Close => mgr.send_action(TkAction::CLOSE),
-        };
+    fn handle_button(&mut self, mgr: &mut Manager, _: ()) {
+        mgr.send_action(TkAction::CLOSE);
     }
 }
 

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 
 use kas::class::HasString;
 use kas::event::VirtualKeyCode as VK;
-use kas::event::{Manager, Response, VoidMsg};
+use kas::event::{Manager, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widgets::{EditBox, TextButton, Window};
 
@@ -82,15 +82,14 @@ fn main() -> Result<(), kas::shell::Error> {
         #[handler(msg = VoidMsg)]
         struct {
             #[widget] display: impl HasString = EditBox::new("0").editable(false).multi_line(true),
-            #[widget(handler = handle_button)] buttons -> Key = buttons,
+            #[widget(use_msg = handle_button)] buttons -> Key = buttons,
             calc: Calculator = Calculator::new(),
         }
         impl {
-            fn handle_button(&mut self, mgr: &mut Manager, msg: Key) -> Response<VoidMsg> {
+            fn handle_button(&mut self, mgr: &mut Manager, msg: Key) {
                 if self.calc.handle(msg) {
                     *mgr |= self.display.set_string(self.calc.display());
                 }
-                Response::None
             }
         }
     };

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -34,13 +34,11 @@ fn main() -> Result<(), kas::shell::Error> {
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget(halign=centre)] display: Label<String> = Label::from("0"),
-                #[widget(handler = handle_button)] buttons -> Message = buttons,
+                #[widget(use_msg = handle_button)] buttons -> Message = buttons,
                 counter: usize = 0,
             }
             impl {
-                fn handle_button(&mut self, mgr: &mut Manager, msg: Message)
-                    -> Response<VoidMsg>
-                {
+                fn handle_button(&mut self, mgr: &mut Manager, msg: Message) {
                     match msg {
                         Message::Decr => {
                             self.counter = self.counter.saturating_sub(1);
@@ -51,7 +49,6 @@ fn main() -> Result<(), kas::shell::Error> {
                             *mgr |= self.display.set_string(self.counter.to_string());
                         }
                     };
-                    Response::None
                 }
             }
         },

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -40,15 +40,10 @@ fn main() -> Result<(), kas::shell::Error> {
             impl {
                 fn handle_button(&mut self, mgr: &mut Manager, msg: Message) {
                     match msg {
-                        Message::Decr => {
-                            self.counter = self.counter.saturating_sub(1);
-                            *mgr |= self.display.set_string(self.counter.to_string());
-                        }
-                        Message::Incr => {
-                            self.counter = self.counter.saturating_add(1);
-                            *mgr |= self.display.set_string(self.counter.to_string());
-                        }
-                    };
+                        Message::Decr => self.counter = self.counter.saturating_sub(1),
+                        Message::Incr => self.counter = self.counter.saturating_add(1),
+                    }
+                    *mgr |= self.display.set_string(self.counter.to_string());
                 }
             }
         },

--- a/examples/custom-theme.rs
+++ b/examples/custom-theme.rs
@@ -145,19 +145,16 @@ fn main() -> Result<(), kas::shell::Error> {
             #[layout(single)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget(handler = handler)] _ = widgets,
+                #[widget(use_msg = handler)] _ = widgets,
             }
             impl {
-                fn handler(&mut self, _: &mut Manager, item: Item)
-                    -> Response<VoidMsg>
-                {
+                fn handler(&mut self, _: &mut Manager, item: Item) {
                     match item {
                         Item::White => BACKGROUND.with(|b| b.set(Rgba::WHITE)),
                         Item::Red => BACKGROUND.with(|b| b.set(Rgba::rgb(0.9, 0.2, 0.2))),
                         Item::Green => BACKGROUND.with(|b| b.set(Rgba::rgb(0.2, 0.9, 0.2))),
                         Item::Yellow => BACKGROUND.with(|b| b.set(Rgba::rgb(0.9, 0.9, 0.2))),
                     };
-                    Response::None
                 }
             }
         },

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -202,20 +202,20 @@ fn main() -> Result<(), kas::shell::Error> {
         #[handler(msg = Control)]
         struct {
             #[widget] _ = Label::new("Number of rows:"),
-            #[widget(handler = activate)] edit: impl HasString = EditBox::new("3")
+            #[widget(map_msg = activate)] edit: impl HasString = EditBox::new("3")
                 .on_afl(|text, _| text.parse::<usize>().ok()),
-            #[widget(handler = button)] _ = TextButton::new_msg("Set", Button::Set),
-            #[widget(handler = button)] _ = TextButton::new_msg("−", Button::Decr),
-            #[widget(handler = button)] _ = TextButton::new_msg("+", Button::Incr),
+            #[widget(map_msg = button)] _ = TextButton::new_msg("Set", Button::Set),
+            #[widget(map_msg = button)] _ = TextButton::new_msg("−", Button::Decr),
+            #[widget(map_msg = button)] _ = TextButton::new_msg("+", Button::Incr),
             #[widget] _ = TextButton::new_msg("↓↑", Control::Dir),
             n: usize = 3,
         }
         impl {
-            fn activate(&mut self, _: &mut Manager, n: usize) -> Response<Control> {
+            fn activate(&mut self, _: &mut Manager, n: usize) -> Control {
                 self.n = n;
-                Control::Set(n).into()
+                Control::Set(n)
             }
-            fn button(&mut self, mgr: &mut Manager, msg: Button) -> Response<Control> {
+            fn button(&mut self, mgr: &mut Manager, msg: Button) -> Control {
                 let n = match msg {
                     Button::Decr => self.n.saturating_sub(1),
                     Button::Incr => self.n.saturating_add(1),
@@ -223,7 +223,7 @@ fn main() -> Result<(), kas::shell::Error> {
                 };
                 *mgr |= self.edit.set_string(n.to_string());
                 self.n = n;
-                Control::Set(n).into()
+                Control::Set(n)
             }
         }
     };
@@ -242,15 +242,15 @@ fn main() -> Result<(), kas::shell::Error> {
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget] _ = Label::new("Demonstration of dynamic widget creation / deletion"),
-                #[widget(handler = control)] controls -> Control = controls,
+                #[widget(use_msg = control)] controls -> Control = controls,
                 #[widget] _ = Label::new("Contents of selected entry:"),
                 #[widget] display: StringLabel = Label::from("Entry #0"),
                 #[widget] _ = Separator::new(),
-                #[widget(handler = set_radio)] list: ScrollBars<MyList> =
+                #[widget(use_msg = set_radio)] list: ScrollBars<MyList> =
                     ScrollBars::new(list).with_bars(false, true),
             }
             impl {
-                fn control(&mut self, mgr: &mut Manager, control: Control) -> Response<VoidMsg> {
+                fn control(&mut self, mgr: &mut Manager, control: Control) {
                     match control {
                         Control::Set(len) => {
                             let (opt_text, handle) = self.list.data_mut().set_len(len);
@@ -264,9 +264,8 @@ fn main() -> Result<(), kas::shell::Error> {
                             *mgr |= self.list.set_direction(dir);
                         }
                     }
-                    Response::None
                 }
-                fn set_radio(&mut self, mgr: &mut Manager, msg: ChildMsg<usize, EntryMsg>) -> Response<VoidMsg> {
+                fn set_radio(&mut self, mgr: &mut Manager, msg: ChildMsg<usize, EntryMsg>) {
                     match msg {
                         ChildMsg::Select(_) | ChildMsg::Deselect(_) => (),
                         ChildMsg::Child(n, EntryMsg::Select) => {
@@ -279,7 +278,6 @@ fn main() -> Result<(), kas::shell::Error> {
                             }
                         }
                     }
-                    Response::None
                 }
             }
         },

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -103,20 +103,20 @@ fn main() -> Result<(), kas::shell::Error> {
         #[handler(msg = Control)]
         struct {
             #[widget] _ = Label::new("Number of rows:"),
-            #[widget(handler = activate)] edit: impl HasString = EditBox::new("3")
+            #[widget(map_msg = activate)] edit: impl HasString = EditBox::new("3")
                 .on_afl(|text, _| text.parse::<usize>().ok()),
-            #[widget(handler = button)] _ = TextButton::new_msg("Set", Button::Set),
-            #[widget(handler = button)] _ = TextButton::new_msg("−", Button::Decr),
-            #[widget(handler = button)] _ = TextButton::new_msg("+", Button::Incr),
+            #[widget(map_msg = button)] _ = TextButton::new_msg("Set", Button::Set),
+            #[widget(map_msg = button)] _ = TextButton::new_msg("−", Button::Decr),
+            #[widget(map_msg = button)] _ = TextButton::new_msg("+", Button::Incr),
             #[widget] _ = TextButton::new_msg("↓↑", Control::Dir),
             n: usize = 3,
         }
         impl {
-            fn activate(&mut self, _: &mut Manager, n: usize) -> Response<Control> {
+            fn activate(&mut self, _: &mut Manager, n: usize) -> Control {
                 self.n = n;
-                Control::Set(n).into()
+                Control::Set(n)
             }
-            fn button(&mut self, mgr: &mut Manager, msg: Button) -> Response<Control> {
+            fn button(&mut self, mgr: &mut Manager, msg: Button) -> Control {
                 let n = match msg {
                     Button::Set => self.n,
                     Button::Decr => self.n.saturating_sub(1),
@@ -124,7 +124,7 @@ fn main() -> Result<(), kas::shell::Error> {
                 };
                 *mgr |= self.edit.set_string(n.to_string());
                 self.n = n;
-                Control::Set(n).into()
+                Control::Set(n)
             }
         }
     };
@@ -143,17 +143,17 @@ fn main() -> Result<(), kas::shell::Error> {
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget] _ = Label::new("Demonstration of dynamic widget creation / deletion"),
-                #[widget(handler = control)] controls -> Control = controls,
+                #[widget(use_msg = control)] controls -> Control = controls,
                 #[widget] _ = Label::new("Contents of selected entry:"),
                 #[widget] display: StringLabel = Label::from("Entry #0"),
                 #[widget] _ = Separator::new(),
-                #[widget(handler = set_radio)] list: ScrollBarRegion<List<Direction, ListEntry>> =
+                #[widget(use_msg = set_radio)] list: ScrollBarRegion<List<Direction, ListEntry>> =
                     ScrollBarRegion::new(list).with_bars(false, true),
                 #[widget] _ = Filler::maximize(),
                 active: usize = 0,
             }
             impl {
-                fn control(&mut self, mgr: &mut Manager, control: Control) -> Response<VoidMsg> {
+                fn control(&mut self, mgr: &mut Manager, control: Control) {
                     match control {
                         Control::Set(len) => {
                             let active = self.active;
@@ -168,9 +168,8 @@ fn main() -> Result<(), kas::shell::Error> {
                             *mgr |= self.list.set_direction(dir);
                         }
                     }
-                    Response::None
                 }
-                fn set_radio(&mut self, mgr: &mut Manager, msg: (usize, EntryMsg)) -> Response<VoidMsg> {
+                fn set_radio(&mut self, mgr: &mut Manager, msg: (usize, EntryMsg)) {
                     let n = msg.0;
                     match msg.1 {
                         EntryMsg::Select => {
@@ -184,7 +183,6 @@ fn main() -> Result<(), kas::shell::Error> {
                             }
                         }
                     }
-                    Response::None
                 }
             }
         },

--- a/examples/filter-list.rs
+++ b/examples/filter-list.rs
@@ -64,33 +64,23 @@ fn main() -> Result<(), kas::shell::Error> {
             #[layout(down)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget(handler = set_selection_mode)] _ = selection_mode,
+                #[widget(use_msg = set_selection_mode)] _ = selection_mode,
                 #[widget] filter = EditBox::new("").on_edit(move |text, mgr| {
                     let update = data2
                         .set_filter(SimpleCaseInsensitiveFilter::new(text));
                     mgr.trigger_update(update, 0);
                     None
                 }),
-                #[widget(handler = select)] list:
+                #[widget(use_msg = select)] list:
                     ScrollBars<ListView<Down, data::Shared, driver::DefaultNav>> =
                     ScrollBars::new(ListView::new(data)),
             }
             impl {
-                fn set_selection_mode(
-                    &mut self,
-                    mgr: &mut Manager,
-                    mode: SelectionMode
-                ) -> Response<VoidMsg> {
+                fn set_selection_mode(&mut self, mgr: &mut Manager, mode: SelectionMode) {
                     *mgr |= self.list.set_selection_mode(mode);
-                    Response::None
                 }
-                fn select(
-                    &mut self,
-                    _: &mut Manager,
-                    msg: ChildMsg<usize, VoidMsg>,
-                ) -> Response<VoidMsg> {
+                fn select(&mut self, _: &mut Manager, msg: ChildMsg<usize, VoidMsg>) {
                     println!("Selection message: {:?}", msg);
-                    Response::None
                 }
             }
         },

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -58,9 +58,9 @@ struct TextEditPopup {
     edit: EditBox,
     #[widget(row = 1, col = 0)]
     fill: Filler,
-    #[widget(row=1, col=1, handler = close)]
+    #[widget(row=1, col=1, flatmap_msg = close)]
     cancel: TextButton<bool>,
-    #[widget(row=1, col=2, handler = close)]
+    #[widget(row=1, col=2, flatmap_msg = close)]
     save: TextButton<bool>,
     commit: bool,
 }
@@ -171,11 +171,11 @@ fn main() -> Result<(), kas::shell::Error> {
         #[handler(handle = noauto)]
         struct {
             #[widget] label: StringLabel = Label::from("Use button to edit →"),
-            #[widget(handler = edit)] edit = TextButton::new_msg("&Edit", ()),
+            #[widget(use_msg = edit)] edit = TextButton::new_msg("&Edit", ()),
             future: Option<Future<Option<String>>> = None,
         }
         impl {
-            fn edit(&mut self, mgr: &mut Manager, _: ()) -> VoidResponse {
+            fn edit(&mut self, mgr: &mut Manager, _: ()) {
                 if self.future.is_none() {
                     let text = self.label.get_string();
                     let mut window = Window::new("Edit text", TextEditPopup::new(text));
@@ -188,7 +188,6 @@ fn main() -> Result<(), kas::shell::Error> {
                     mgr.update_on_handle(update, self.id());
                     mgr.add_window(Box::new(window));
                 }
-                Response::None
             }
         }
         impl Handler {
@@ -253,10 +252,10 @@ fn main() -> Result<(), kas::shell::Error> {
                 ComboBox::new(&["&One", "T&wo", "Th&ree"], 0)
                 .on_select(|_, index| Some(Item::Combo((index + 1).cast()))),
             #[widget(row=8, col=0)] _ = Label::new("Slider"),
-            #[widget(row=8, col=1, handler = handle_slider)] s =
+            #[widget(row=8, col=1, map_msg = handle_slider)] s =
                 Slider::<i32, Right>::new(0, 10, 1).with_value(0),
             #[widget(row=9, col=0)] _ = Label::new("ScrollBar"),
-            #[widget(row=9, col=1, handler = handle_scroll)] sc: ScrollBar<Right> =
+            #[widget(row=9, col=1, map_msg = handle_scroll)] sc: ScrollBar<Right> =
                 ScrollBar::new().with_limits(100, 20),
             #[widget(row=10, col=1)] pg: ProgressBar<Right> = ProgressBar::new(),
             #[widget(row=10, col=0)] _ = Label::new("ProgressBar"),
@@ -267,13 +266,13 @@ fn main() -> Result<(), kas::shell::Error> {
             #[widget(row=12, col=1)] _ = popup_edit_box,
         }
         impl {
-            fn handle_slider(&mut self, _: &mut Manager, msg: i32) -> Response<Item> {
-                Response::Msg(Item::Slider(msg))
+            fn handle_slider(&mut self, _: &mut Manager, msg: i32) -> Item {
+                Item::Slider(msg)
             }
-            fn handle_scroll(&mut self, mgr: &mut Manager, msg: i32) -> Response<Item> {
+            fn handle_scroll(&mut self, mgr: &mut Manager, msg: i32) -> Item {
                 let ratio = msg as f32 / self.sc.max_value() as f32;
                 *mgr |= self.pg.set_value(ratio);
-                Response::Msg(Item::Scroll(msg))
+                Item::Scroll(msg)
             }
         }
     };
@@ -293,14 +292,14 @@ fn main() -> Result<(), kas::shell::Error> {
             #[layout(column)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget(handler = menu)] _ = menubar,
+                #[widget(use_msg = menu)] _ = menubar,
                 #[widget(halign = centre)] _ = Frame::new(head),
-                #[widget(handler = activations)] gallery:
+                #[widget(use_msg = activations)] gallery:
                     for<W: Widget<Msg = Item>> ScrollBarRegion<W> =
                         ScrollBarRegion::new(widgets),
             }
             impl {
-                fn menu(&mut self, mgr: &mut Manager, msg: Menu) -> VoidResponse {
+                fn menu(&mut self, mgr: &mut Manager, msg: Menu) {
                     match msg {
                         Menu::Theme(name) => {
                             println!("Theme: {:?}", name);
@@ -320,9 +319,8 @@ fn main() -> Result<(), kas::shell::Error> {
                             *mgr |= TkAction::EXIT;
                         }
                     }
-                    Response::None
                 }
-                fn activations(&mut self, mgr: &mut Manager, item: Item) -> VoidResponse {
+                fn activations(&mut self, mgr: &mut Manager, item: Item) {
                     match item {
                         Item::Button => println!("Clicked!"),
                         Item::LightTheme => mgr.adjust_theme(|theme| theme.set_scheme("light")),
@@ -334,7 +332,6 @@ fn main() -> Result<(), kas::shell::Error> {
                         Item::Slider(p) => println!("Slider: {}", p),
                         Item::Scroll(p) => println!("ScrollBar: {}", p),
                     };
-                    Response::None
                 }
             }
         },

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -428,10 +428,10 @@ struct MandlebrotWindow {
     label: Label<String>,
     #[widget(row=1, halign=centre)]
     iters: ReserveP<Label<String>>,
-    #[widget(row=2, handler = iter)]
+    #[widget(row=2, use_msg = iter)]
     slider: Slider<i32, kas::dir::Up>,
     // extra col span allows use of Label's margin
-    #[widget(col=1, cspan=2, row=1, rspan=2, handler = mbrot)]
+    #[widget(col=1, cspan=2, row=1, rspan=2, use_msg = mbrot)]
     mbrot: Mandlebrot,
 }
 impl MandlebrotWindow {
@@ -451,14 +451,12 @@ impl MandlebrotWindow {
         Window::new("Mandlebrot", w)
     }
 
-    fn iter(&mut self, mgr: &mut Manager, iter: i32) -> Response<VoidMsg> {
+    fn iter(&mut self, mgr: &mut Manager, iter: i32) {
         self.mbrot.iter = iter;
         *mgr |= self.iters.set_string(format!("{}", iter));
-        Response::None
     }
-    fn mbrot(&mut self, mgr: &mut Manager, _: ()) -> Response<VoidMsg> {
+    fn mbrot(&mut self, mgr: &mut Manager, _: ()) {
         *mgr |= self.label.set_string(self.mbrot.loc());
-        Response::None
     }
 }
 

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -6,7 +6,7 @@
 //! Markdown parsing demo
 
 use kas::class::HasStr;
-use kas::event::{Manager, Response, VoidMsg};
+use kas::event::{Manager, VoidMsg};
 use kas::macros::make_widget;
 use kas::text::format::Markdown;
 use kas::widgets::{EditBox, Label, ScrollBarRegion, TextButton, Window};
@@ -49,10 +49,10 @@ It also supports lists:
                     EditBox::new(doc).multi_line(true),
                 #[widget(row=0, col=1)] label: ScrollBarRegion<Label<Markdown>> =
                     ScrollBarRegion::new(Label::new(Markdown::new(doc)?)),
-                #[widget(row=1, col=1, handler=update)] _ = TextButton::new_msg("&Update", ()),
+                #[widget(row=1, col=1, use_msg=update)] _ = TextButton::new_msg("&Update", ()),
             }
             impl {
-                fn update(&mut self, mgr: &mut Manager, _: ()) -> Response<VoidMsg> {
+                fn update(&mut self, mgr: &mut Manager, _: ()) {
                     let text = match Markdown::new(self.editor.get_str()) {
                         Ok(text) => text,
                         Err(err) => {
@@ -62,7 +62,6 @@ It also supports lists:
                     };
                     // TODO: this should update the size requirements of the inner area
                     *mgr |= self.label.set_text(text);
-                    Response::None
                 }
             }
         },

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -5,7 +5,7 @@
 
 //! Counter example (simple button)
 
-use kas::event::{Manager, VoidMsg, VoidResponse};
+use kas::event::{Manager, VoidMsg};
 use kas::macros::{make_widget, VoidMsg};
 use kas::widgets::{EditField, RowSplitter, TextButton, Window};
 
@@ -38,14 +38,12 @@ fn main() -> Result<(), kas::shell::Error> {
             #[layout(column)]
             #[handler(msg = VoidMsg)]
             struct {
-                #[widget(handler = handle_button)] buttons -> Message = buttons,
+                #[widget(use_msg = handle_button)] buttons -> Message = buttons,
                 #[widget] panes: RowSplitter<EditField> = panes,
                 counter: usize = 0,
             }
             impl {
-                fn handle_button(&mut self, mgr: &mut Manager, msg: Message)
-                    -> VoidResponse
-                {
+                fn handle_button(&mut self, mgr: &mut Manager, msg: Message) {
                     match msg {
                         Message::Decr => {
                             *mgr |= self.panes.pop().1;
@@ -55,7 +53,6 @@ fn main() -> Result<(), kas::shell::Error> {
                             *mgr |= self.panes.push(EditField::new(format!("Pane {}", n)).multi_line(true));
                         }
                     };
-                    VoidResponse::None
                 }
             }
         },

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -22,19 +22,18 @@ fn make_window() -> Box<dyn kas::Window> {
         #[widget(config=noauto)]
         struct {
             #[widget] display: impl HasString = Frame::new(Label::new("0.000".to_string())),
-            #[widget(handler = reset)] _ = TextButton::new_msg("&reset", ()),
-            #[widget(handler = start)] _ = TextButton::new_msg("&start / &stop", ()),
+            #[widget(use_msg = reset)] _ = TextButton::new_msg("&reset", ()),
+            #[widget(use_msg = start)] _ = TextButton::new_msg("&start / &stop", ()),
             saved: Duration = Duration::default(),
             start: Option<Instant> = None,
         }
         impl {
-            fn reset(&mut self, mgr: &mut Manager, _: ()) -> Response<VoidMsg> {
+            fn reset(&mut self, mgr: &mut Manager, _: ()) {
                 self.saved = Duration::default();
                 self.start = None;
                 *mgr |= self.display.set_str("0.000");
-                Response::None
             }
-            fn start(&mut self, mgr: &mut Manager, _: ()) -> Response<VoidMsg> {
+            fn start(&mut self, mgr: &mut Manager, _: ()) {
                 if let Some(start) = self.start {
                     self.saved += Instant::now() - start;
                     self.start = None;
@@ -42,7 +41,6 @@ fn make_window() -> Box<dyn kas::Window> {
                     self.start = Some(Instant::now());
                     mgr.update_on_timer(Duration::new(0, 0), self.id(), 0);
                 }
-                Response::None
             }
         }
         impl kas::WidgetConfig {

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -6,27 +6,21 @@
 //! A counter synchronised between multiple windows
 
 use kas::event::{Manager, Response, VoidMsg};
-use kas::macros::{make_widget, VoidMsg};
+use kas::macros::make_widget;
 use kas::updatable::SharedRc;
 use kas::widgets::view::SingleView;
 use kas::widgets::{TextButton, Window};
-
-#[derive(Clone, Debug, VoidMsg)]
-enum Message {
-    Decr,
-    Incr,
-}
 
 fn main() -> Result<(), kas::shell::Error> {
     env_logger::init();
 
     let buttons = make_widget! {
         #[layout(row)]
-        #[handler(msg = Message)]
+        #[handler(msg = i32)]
         #[derive(Clone)]
         struct {
-            #[widget] _ = TextButton::new_msg("−", Message::Decr),
-            #[widget] _ = TextButton::new_msg("+", Message::Incr),
+            #[widget] _ = TextButton::new_msg("−", -1),
+            #[widget] _ = TextButton::new_msg("+", 1),
         }
     };
 
@@ -39,16 +33,13 @@ fn main() -> Result<(), kas::shell::Error> {
             struct {
                 // SingleView embeds a shared value, here default-constructed to 0
                 #[widget(halign=centre)] counter: SingleView<SharedRc<i32>> = Default::default(),
-                #[widget(handler = handle_button)] buttons -> Message = buttons,
+                #[widget(handler = handle_button)] buttons -> i32 = buttons,
             }
             impl {
-                fn handle_button(&mut self, mgr: &mut Manager, msg: Message)
+                fn handle_button(&mut self, mgr: &mut Manager, msg: i32)
                     -> Response<VoidMsg>
                 {
-                    self.counter.update_value(mgr, |v| v + match msg {
-                        Message::Decr => -1,
-                        Message::Incr => 1,
-                    });
+                    self.counter.update_value(mgr, |v| v + msg);
                     Response::None
                 }
             }

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -5,7 +5,7 @@
 
 //! A counter synchronised between multiple windows
 
-use kas::event::{Manager, Response, VoidMsg};
+use kas::event::{Manager, VoidMsg};
 use kas::macros::make_widget;
 use kas::updatable::SharedRc;
 use kas::widgets::view::SingleView;
@@ -33,14 +33,11 @@ fn main() -> Result<(), kas::shell::Error> {
             struct {
                 // SingleView embeds a shared value, here default-constructed to 0
                 #[widget(halign=centre)] counter: SingleView<SharedRc<i32>> = Default::default(),
-                #[widget(handler = handle_button)] buttons -> i32 = buttons,
+                #[widget(use_msg = update)] buttons -> i32 = buttons,
             }
             impl {
-                fn handle_button(&mut self, mgr: &mut Manager, msg: i32)
-                    -> Response<VoidMsg>
-                {
+                fn update(&mut self, mgr: &mut Manager, msg: i32) {
                     self.counter.update_value(mgr, |v| v + msg);
-                    Response::None
                 }
             }
         },

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -295,15 +295,14 @@
 //!     #[widget_core] core: CoreData,
 //!     #[layout_data] layout_data: <Self as LayoutData>::Data,
 //!     #[widget] label: StrLabel,
-//!     #[widget(handler = handler)] child: W,
+//!     #[widget(use_msg = handler)] child: W,
 //! }
 //!
 //! impl<W: Widget> MyWidget<W> {
-//!     fn handler(&mut self, mgr: &mut Manager, msg: ChildMessage) -> Response<VoidMsg> {
+//!     fn handler(&mut self, mgr: &mut Manager, msg: ChildMessage) {
 //!         match msg {
 //!             ChildMessage::A => { println!("handling ChildMessage::A"); }
 //!         }
-//!         Response::None
 //!     }
 //! }
 //! ```
@@ -367,11 +366,11 @@
 //!     #[handler(msg = VoidMsg)]
 //!     struct {
 //!         #[widget] _ = Label::new("Would you like to print a message?"),
-//!         #[widget(handler = buttons)] _ = button_box,
+//!         #[widget(use_msg = buttons)] _ = button_box,
 //!         message: String = message.into(),
 //!     }
 //!     impl {
-//!         fn buttons(&mut self, mgr: &mut Manager, msg: OkCancel) -> Response<VoidMsg> {
+//!         fn buttons(&mut self, mgr: &mut Manager, msg: OkCancel) {
 //!             match msg {
 //!                 OkCancel::Ok => {
 //!                     println!("Message: {}", self.message);
@@ -380,7 +379,6 @@
 //!             }
 //!             // Whichever button was pressed, we close the window:
 //!             *mgr |= TkAction::CLOSE;
-//!             Response::None
 //!         }
 //!     }
 //! });


### PR DESCRIPTION
Most significantly, the `#[widget(handler = f)]` argument `handler` is replaced with `use_msg`, `map_msg` and `flatmap_msg` arguments. This allows message handlers to return `()` or the new message type `M` or `Response<M>` respectively.

Also included: several small code simplifications/improvements.