### PR TITLE
FilterListView; discard_msg and update; data/driver improvements

### DIFF
--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -12,7 +12,6 @@ use std::u16;
 use super::*;
 use crate::draw::{DrawShared, SizeHandle, ThemeApi};
 use crate::geom::{Coord, Offset, Vec2};
-use crate::updatable::Updatable;
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
 use crate::{TkAction, WidgetId, WindowId};
@@ -190,20 +189,6 @@ impl<'a> Manager<'a> {
             .entry(handle)
             .or_insert_with(Default::default)
             .insert(w_id);
-    }
-
-    /// Subscribe shaded data to an update handle
-    ///
-    /// [`Updatable::update_self`] will be called when the update handle is
-    /// triggered, and if this method returns another update handle, then all
-    /// subscribers to that handle are updated in turn.
-    pub fn update_shared_data(&mut self, handle: UpdateHandle, data: Rc<dyn Updatable>) {
-        trace!(
-            "Manager::update_shared_data: update {:?} on handle {:?}",
-            data,
-            handle
-        );
-        self.shell.update_shared_data(handle, data);
     }
 
     /// Notify that a widget must be redrawn

--- a/crates/kas-core/src/toolkit.rs
+++ b/crates/kas-core/src/toolkit.rs
@@ -12,13 +12,10 @@
 //! constructing and using an event manager ([`crate::event::ManagerState`]).
 //! The shell also provides the entrypoint, a type named `Toolkit`.
 
-use std::num::NonZeroU32;
-use std::rc::Rc;
-
 use crate::draw::{DrawShared, SizeHandle, ThemeApi};
 use crate::event;
 use crate::event::UpdateHandle;
-use crate::updatable::Updatable;
+use std::num::NonZeroU32;
 
 /// Identifier for a window or pop-up
 ///
@@ -119,9 +116,6 @@ pub trait ShellWindow {
 
     /// Close a window
     fn close_window(&mut self, id: WindowId);
-
-    /// Register `data` to be updated when an update with the given `handle` is triggered
-    fn update_shared_data(&mut self, handle: UpdateHandle, data: Rc<dyn Updatable>);
 
     /// Updates all subscribed widgets
     ///

--- a/crates/kas-core/src/updatable.rs
+++ b/crates/kas-core/src/updatable.rs
@@ -63,14 +63,6 @@ pub trait UpdatableHandler<K, M>: Updatable {
     fn handle(&self, key: &K, msg: &M) -> Option<UpdateHandle>;
 }
 
-/// Bound over all other "updatable" traits
-///
-/// This is intended for usage as a bound where [`Updatable`] and
-/// [`UpdatableHandler`] implementations are all
-/// required. It is automatically implemented when all these traits are.
-pub trait UpdatableAll<K, M>: UpdatableHandler<K, M> {}
-impl<K, M, T: UpdatableHandler<K, M>> UpdatableAll<K, M> for T {}
-
 // TODO(spec): can we add this?
 // impl<K, T> UpdatableHandler<K, VoidMsg> for T {
 //     fn handle(&self, _: &K, msg: &VoidMsg) -> Option<UpdateHandle> {

--- a/crates/kas-core/src/updatable.rs
+++ b/crates/kas-core/src/updatable.rs
@@ -17,7 +17,7 @@
 
 mod data_impls;
 mod data_traits;
-mod filter;
+pub mod filter;
 mod shared_rc;
 
 use crate::event::UpdateHandle;
@@ -29,7 +29,6 @@ use std::ops::Deref;
 pub use data_traits::{
     ListData, ListDataMut, MatrixData, MatrixDataMut, SingleData, SingleDataMut,
 };
-pub use filter::{Filter, FilteredList, SimpleCaseInsensitiveFilter};
 pub use shared_rc::SharedRc;
 
 /// Shared (data) objects which may notify of updates

--- a/crates/kas-core/src/updatable/filter.rs
+++ b/crates/kas-core/src/updatable/filter.rs
@@ -13,7 +13,6 @@ use crate::event::UpdateHandle;
 use crate::updatable::*;
 use std::cell::RefCell;
 use std::fmt::Debug;
-use std::rc::Rc;
 
 /// Types usable as a filter
 pub trait Filter<T>: Debug + 'static {
@@ -158,16 +157,6 @@ impl<T: ListData, F: Filter<T::Item>> Updatable for FilteredList<T, F> {
     fn update_self(&self) -> Option<UpdateHandle> {
         self.cell.borrow_mut().refresh(&self.data);
         Some(self.update)
-    }
-}
-impl<T: ListData + RecursivelyUpdatable + 'static, F: Filter<T::Item>> RecursivelyUpdatable
-    for Rc<FilteredList<T, F>>
-{
-    fn enable_recursive_updates(&self, mgr: &mut Manager) {
-        self.data.enable_recursive_updates(mgr);
-        if let Some(handle) = self.data.update_handle() {
-            mgr.update_shared_data(handle, self.clone());
-        }
     }
 }
 impl<K, M, T: ListData + UpdatableHandler<K, M> + 'static, F: Filter<T::Item>>

--- a/crates/kas-core/src/updatable/filter.rs
+++ b/crates/kas-core/src/updatable/filter.rs
@@ -9,81 +9,136 @@ use super::ListData;
 use crate::cast::Cast;
 #[allow(unused)]
 use crate::event::Manager;
-use crate::event::UpdateHandle;
+use crate::event::{UpdateHandle, VoidMsg};
 use crate::updatable::*;
 use std::cell::RefCell;
 use std::fmt::Debug;
+use std::rc::Rc;
 
 /// Types usable as a filter
-pub trait Filter<T>: Debug + 'static {
+pub trait Filter<T>: Updatable + 'static {
     /// Returns true if the given item matches this filter
     // TODO: once Accessor::get returns a reference, this should take item: &T where T: ?Sized
     fn matches(&self, item: T) -> bool;
 }
-impl<'a, T: Clone, X> Filter<&'a T> for X
-where
-    X: Filter<T>,
-{
-    fn matches(&self, item: &T) -> bool {
-        self.matches(item.clone())
+
+/// Filter: target contains self (case-sensitive string match)
+#[derive(Debug, Default, Clone)]
+pub struct ContainsString(Rc<(UpdateHandle, RefCell<String>)>);
+
+impl ContainsString {
+    /// Construct with given string
+    pub fn new<S: ToString>(s: S) -> Self {
+        let handle = UpdateHandle::new();
+        let data = RefCell::new(s.to_string());
+        ContainsString(Rc::new((handle, data)))
+    }
+}
+impl Updatable for ContainsString {
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        Some((self.0).0)
+    }
+}
+impl UpdatableHandler<(), String> for ContainsString {
+    fn handle(&self, _: &(), msg: &String) -> Option<UpdateHandle> {
+        self.update(msg.clone())
+    }
+}
+impl UpdatableHandler<(), VoidMsg> for ContainsString {
+    fn handle(&self, _: &(), _: &VoidMsg) -> Option<UpdateHandle> {
+        None
+    }
+}
+impl SingleData for ContainsString {
+    type Item = String;
+    fn get_cloned(&self) -> Self::Item {
+        (self.0).1.borrow().to_owned()
+    }
+    fn update(&self, value: Self::Item) -> Option<UpdateHandle> {
+        *(self.0).1.borrow_mut() = value;
+        Some((self.0).0)
+    }
+}
+impl SingleDataMut for ContainsString {
+    fn set(&mut self, value: Self::Item) {
+        *(self.0).1.borrow_mut() = value;
     }
 }
 
-impl<'a> Filter<&'a str> for &'static str {
+impl<'a> Filter<&'a str> for ContainsString {
     fn matches(&self, item: &str) -> bool {
-        item.contains(self)
+        item.contains(&self.get_cloned())
     }
 }
-impl<'a> Filter<&'a str> for String {
-    fn matches(&self, item: &str) -> bool {
-        item.contains(self)
-    }
-}
-impl Filter<String> for String {
+impl Filter<String> for ContainsString {
     fn matches(&self, item: String) -> bool {
-        item.contains(self)
+        Filter::<&str>::matches(self, &item)
     }
 }
 
-/// Case-insensitive string matcher
+/// Filter: target contains self (case-insensitive string match)
 ///
-/// This type will likely be removed at some point since it is inefficient and
-/// not accurate for all Unicode input.
-#[derive(Clone, Debug)]
-pub struct SimpleCaseInsensitiveFilter(String);
-impl SimpleCaseInsensitiveFilter {
-    /// Construct
-    pub fn new<T: ToString>(filter: T) -> Self {
-        // Note: this method of caseless matching is not unicode compliant!
-        // https://stackoverflow.com/questions/47298336/case-insensitive-string-matching-in-rust
-        SimpleCaseInsensitiveFilter(filter.to_string().to_uppercase())
+// Note: the implemented method of caseless matching is not unicode compliant,
+// however works in most cases (by converting both the source and the target to
+// upper case). See [question on StackOverflow].
+//
+// [question on StackOverflow]: https://stackoverflow.com/questions/47298336/case-insensitive-string-matching-in-rust
+#[derive(Debug, Default, Clone)]
+pub struct ContainsCaseInsensitive(Rc<(UpdateHandle, RefCell<(String, String)>)>);
+
+impl ContainsCaseInsensitive {
+    /// Construct with given string
+    pub fn new<S: ToString>(s: S) -> Self {
+        let handle = UpdateHandle::new();
+        let s = s.to_string();
+        let u = s.to_uppercase();
+        let data = RefCell::new((s, u));
+        ContainsCaseInsensitive(Rc::new((handle, data)))
     }
 }
-impl<'a> Filter<&'a str> for SimpleCaseInsensitiveFilter {
+impl Updatable for ContainsCaseInsensitive {
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        Some((self.0).0)
+    }
+}
+impl UpdatableHandler<(), String> for ContainsCaseInsensitive {
+    fn handle(&self, _: &(), msg: &String) -> Option<UpdateHandle> {
+        self.update(msg.clone())
+    }
+}
+impl UpdatableHandler<(), VoidMsg> for ContainsCaseInsensitive {
+    fn handle(&self, _: &(), _: &VoidMsg) -> Option<UpdateHandle> {
+        None
+    }
+}
+impl SingleData for ContainsCaseInsensitive {
+    type Item = String;
+    fn get_cloned(&self) -> Self::Item {
+        (self.0).1.borrow().0.clone()
+    }
+    fn update(&self, value: Self::Item) -> Option<UpdateHandle> {
+        let mut cell = (self.0).1.borrow_mut();
+        cell.0 = value;
+        cell.1 = cell.0.to_uppercase();
+        Some((self.0).0)
+    }
+}
+impl SingleDataMut for ContainsCaseInsensitive {
+    fn set(&mut self, value: Self::Item) {
+        let mut cell = (self.0).1.borrow_mut();
+        cell.0 = value;
+        cell.1 = cell.0.to_uppercase();
+    }
+}
+
+impl<'a> Filter<&'a str> for ContainsCaseInsensitive {
     fn matches(&self, item: &str) -> bool {
-        item.to_owned().to_uppercase().contains(&self.0)
+        Filter::<String>::matches(self, item.to_string())
     }
 }
-impl Filter<String> for SimpleCaseInsensitiveFilter {
+impl Filter<String> for ContainsCaseInsensitive {
     fn matches(&self, item: String) -> bool {
-        item.to_uppercase().contains(&self.0)
-    }
-}
-
-#[derive(Clone, Debug)]
-struct FilterView<T: ListData, F: Filter<T::Item>> {
-    filter: F,
-    view: Vec<T::Key>,
-}
-
-impl<T: ListData, F: Filter<T::Item>> FilterView<T, F> {
-    fn refresh(&mut self, data: &T) {
-        self.view.clear();
-        for (key, item) in data.iter_vec(usize::MAX) {
-            if self.filter.matches(item) {
-                self.view.push(key);
-            }
-        }
+        item.to_uppercase().contains(&(self.0).1.borrow().1)
     }
 }
 
@@ -109,8 +164,11 @@ pub struct FilteredList<T: ListData, F: Filter<T::Item>> {
     ///
     /// If adjusting this, one should call [`FilteredList::refresh`] after.
     pub data: T,
-    cell: RefCell<FilterView<T, F>>,
-    update: UpdateHandle,
+    /// Direct access to the filter
+    ///
+    /// If adjusting this, one should call [`FilteredList::refresh`] after.
+    pub filter: F,
+    view: RefCell<Vec<T::Key>>, // TODO: does this need to be in a RefCell?
 }
 
 impl<T: ListData, F: Filter<T::Item>> FilteredList<T, F> {
@@ -118,10 +176,8 @@ impl<T: ListData, F: Filter<T::Item>> FilteredList<T, F> {
     #[inline]
     pub fn new(data: T, filter: F) -> Self {
         let len = data.len().cast();
-        let view = Vec::with_capacity(len);
-        let cell = RefCell::new(FilterView { filter, view });
-        let update = UpdateHandle::new();
-        let s = FilteredList { data, cell, update };
+        let view = RefCell::new(Vec::with_capacity(len));
+        let s = FilteredList { data, filter, view };
         let _ = s.refresh();
         s
     }
@@ -132,31 +188,25 @@ impl<T: ListData, F: Filter<T::Item>> FilteredList<T, F> {
     /// Calling this directly may be useful in case the data is modified.
     ///
     /// An update should be triggered using the returned handle.
-    pub fn refresh(&self) -> UpdateHandle {
-        self.cell.borrow_mut().refresh(&self.data);
-        self.update
-    }
-
-    /// Update and apply the filter
-    ///
-    /// An update should be triggered using the returned handle.
-    /// See [`FilteredList::refresh`].
-    pub fn set_filter(&self, filter: F) -> UpdateHandle {
-        let mut cell = self.cell.borrow_mut();
-        cell.filter = filter;
-        cell.refresh(&self.data);
-        self.update
+    pub fn refresh(&self) -> Option<UpdateHandle> {
+        let mut view = self.view.borrow_mut();
+        view.clear();
+        for (key, item) in self.data.iter_vec(usize::MAX) {
+            if self.filter.matches(item) {
+                view.push(key);
+            }
+        }
+        self.filter.update_handle()
     }
 }
 
 impl<T: ListData, F: Filter<T::Item>> Updatable for FilteredList<T, F> {
     fn update_handle(&self) -> Option<UpdateHandle> {
-        Some(self.update)
+        self.filter.update_handle()
     }
 
     fn update_self(&self) -> Option<UpdateHandle> {
-        self.cell.borrow_mut().refresh(&self.data);
-        Some(self.update)
+        self.refresh()
     }
 }
 impl<K, M, T: ListData + UpdatableHandler<K, M> + 'static, F: Filter<T::Item>>
@@ -172,7 +222,7 @@ impl<T: ListData + 'static, F: Filter<T::Item>> ListData for FilteredList<T, F> 
     type Item = T::Item;
 
     fn len(&self) -> usize {
-        self.cell.borrow().view.len()
+        self.view.borrow().len()
     }
 
     fn contains_key(&self, key: &Self::Key) -> bool {
@@ -182,42 +232,40 @@ impl<T: ListData + 'static, F: Filter<T::Item>> ListData for FilteredList<T, F> 
     fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
         // Check the item against our filter (probably O(1)) instead of using
         // our filtered list (O(n) where n=self.len()).
-        let cell = self.cell.borrow();
         self.data
             .get_cloned(key)
-            .filter(|item| cell.filter.matches(item.clone()))
+            .filter(|item| self.filter.matches(item.clone()))
     }
 
     fn update(&self, key: &Self::Key, value: Self::Item) -> Option<UpdateHandle> {
         // Filtering does not affect result, but does affect the view
-        let mut cell = self.cell.borrow_mut();
         if self
             .data
             .get_cloned(key)
-            .map(|item| !cell.filter.matches(item))
+            .map(|item| !self.filter.matches(item))
             .unwrap_or(true)
         {
             // Not previously visible: no update occurs
             return None;
         }
 
-        let new_visible = cell.filter.matches(value.clone());
+        let new_visible = self.filter.matches(value.clone());
         let result = self.data.update(key, value);
         if result.is_some() && !new_visible {
             // remove the updated item from our filtered list
-            cell.view.retain(|item| item != key);
+            self.view.borrow_mut().retain(|item| item != key);
         }
         result
     }
 
     fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
-        let cell = self.cell.borrow();
+        let view = self.view.borrow();
         let end = self.len().min(start + limit);
         if start >= end {
             return Vec::new();
         }
         let mut v = Vec::with_capacity(end - start);
-        for k in &cell.view[start..end] {
+        for k in &view[start..end] {
             v.push((k.clone(), self.data.get_cloned(k).unwrap()));
         }
         v

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -20,10 +20,9 @@ use std::rc::Rc;
 
 /// Wrapper for single-thread shared data
 ///
-/// This wrapper adds an [`UpdateHandle`] and implements the [`Updatable`],
-/// [`RecursivelyUpdatable`] and [`UpdatableHandler`] traits (the latter two
-/// with dummy implementations — if you need custom handlers you will need your
-/// own shared data type).
+/// This wrapper adds an [`UpdateHandle`] and implements the [`Updatable`] and
+/// [`UpdatableHandler`] traits (the latter with a dummy implementation —
+/// if you need custom handlers you will need your own shared data type).
 #[derive(Clone, Debug)]
 pub struct SharedRc<T: Debug>(Rc<(UpdateHandle, RefCell<T>)>);
 
@@ -48,7 +47,6 @@ impl<T: Debug> Updatable for SharedRc<T> {
         Some((self.0).0)
     }
 }
-impl<T: Debug> RecursivelyUpdatable for SharedRc<T> {}
 
 impl<T: Clone + Debug, K, M> UpdatableHandler<K, M> for SharedRc<T> {
     fn handle(&self, _: &K, _: &M) -> Option<UpdateHandle> {

--- a/crates/kas-macros/src/args.rs
+++ b/crates/kas-macros/src/args.rs
@@ -218,6 +218,7 @@ mod kw {
     custom_keyword!(flatmap_msg);
     custom_keyword!(map_msg);
     custom_keyword!(use_msg);
+    custom_keyword!(discard_msg);
     custom_keyword!(msg);
     custom_keyword!(generics);
     custom_keyword!(single);
@@ -316,6 +317,7 @@ pub enum Handler {
     Use(Ident),
     Map(Ident),
     FlatMap(Ident),
+    Discard,
 }
 impl Handler {
     pub fn is_none(&self) -> bool {
@@ -323,7 +325,7 @@ impl Handler {
     }
     pub fn any_ref(&self) -> Option<&Ident> {
         match self {
-            Handler::None => None,
+            Handler::None | Handler::Discard => None,
             Handler::Use(n) | Handler::Map(n) | Handler::FlatMap(n) => Some(n),
         }
     }
@@ -466,11 +468,14 @@ impl Parse for WidgetAttrArgs {
                 let _: kw::use_msg = content.parse()?;
                 let _: Eq = content.parse()?;
                 args.handler = Handler::Use(content.parse()?);
+            } else if args.handler.is_none() && lookahead.peek(kw::discard_msg) {
+                let _: kw::discard_msg = content.parse()?;
+                args.handler = Handler::Discard;
             } else if lookahead.peek(kw::handler) {
                 let tok: Ident = content.parse()?;
                 return Err(Error::new(
                     tok.span(),
-                    "handler is obsolete; replace with flatmap_msg, map_msg or use_msg",
+                    "handler is obsolete; replace with flatmap_msg, map_msg, use_msg or discard_msg",
                 ));
             } else {
                 return Err(lookahead.error());
@@ -539,6 +544,7 @@ impl ToTokens for WidgetAttrArgs {
                 Handler::Use(f) => args.append_all(quote! { use_msg = #f }),
                 Handler::Map(f) => args.append_all(quote! { map_msg = #f }),
                 Handler::FlatMap(f) => args.append_all(quote! { flatmap_msg = #f }),
+                Handler::Discard => args.append_all(quote! { discard_msg }),
             }
             tokens.append_all(quote! { ( #args ) });
         }

--- a/crates/kas-macros/src/args.rs
+++ b/crates/kas-macros/src/args.rs
@@ -219,6 +219,7 @@ mod kw {
     custom_keyword!(map_msg);
     custom_keyword!(use_msg);
     custom_keyword!(discard_msg);
+    custom_keyword!(update);
     custom_keyword!(msg);
     custom_keyword!(generics);
     custom_keyword!(single);
@@ -339,6 +340,7 @@ pub struct WidgetAttrArgs {
     pub rspan: Option<Lit>,
     pub halign: Option<Ident>,
     pub valign: Option<Ident>,
+    pub update: Option<Ident>,
     pub handler: Handler,
 }
 
@@ -407,6 +409,7 @@ impl Parse for WidgetAttrArgs {
             rspan: None,
             halign: None,
             valign: None,
+            update: None,
             handler: Handler::None,
         };
         if input.is_empty() {
@@ -456,6 +459,10 @@ impl Parse for WidgetAttrArgs {
                 let _: kw::valign = content.parse()?;
                 let _: Eq = content.parse()?;
                 args.valign = Some(content.parse()?);
+            } else if args.update.is_none() && lookahead.peek(kw::update) {
+                let _: kw::update = content.parse()?;
+                let _: Eq = content.parse()?;
+                args.update = Some(content.parse()?);
             } else if args.handler.is_none() && lookahead.peek(kw::flatmap_msg) {
                 let _: kw::flatmap_msg = content.parse()?;
                 let _: Eq = content.parse()?;
@@ -535,6 +542,12 @@ impl ToTokens for WidgetAttrArgs {
                     args.append(comma.clone());
                 }
                 args.append_all(quote! { valign = #ident });
+            }
+            if let Some(ref ident) = self.update {
+                if !args.is_empty() {
+                    args.append(comma.clone());
+                }
+                args.append_all(quote! { update = #ident });
             }
             if !self.handler.is_none() && !args.is_empty() {
                 args.append(comma);

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -394,6 +394,13 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     let log_msg = quote! {};
 
                     let ident = &child.ident;
+                    let update = if let Some(f) = child.args.update.as_ref() {
+                        quote! {
+                            self.#f(mgr);
+                        }
+                    } else {
+                        quote! {}
+                    };
                     let handler = match &child.args.handler {
                         Handler::Use(f) => quote! {
                             r.try_into().unwrap_or_else(|msg| {
@@ -427,6 +434,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     ev_to_num.append_all(quote! {
                         if id <= self.#ident.id() {
                             let r = self.#ident.send(mgr, id, event);
+                            #update
                             #handler
                         } else
                     });

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -6,7 +6,6 @@
 //! `Window` and `WindowList` types
 
 use log::{debug, error, info, trace};
-use std::rc::Rc;
 use std::time::Instant;
 
 use kas::cast::Cast;
@@ -14,7 +13,6 @@ use kas::draw::{DrawIface, DrawShared, PassId, SizeHandle, ThemeApi};
 use kas::event::{CursorIcon, ManagerState, UpdateHandle};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
-use kas::updatable::Updatable;
 use kas::{TkAction, WindowId};
 use kas_theme::{Theme, Window as _};
 use winit::dpi::PhysicalSize;
@@ -434,10 +432,6 @@ where
 
     fn close_window(&mut self, id: WindowId) {
         self.shared.pending.push(PendingAction::CloseWindow(id));
-    }
-
-    fn update_shared_data(&mut self, handle: UpdateHandle, data: Rc<dyn Updatable>) {
-        self.shared.update_shared_data(handle, data);
     }
 
     fn trigger_update(&mut self, handle: UpdateHandle, payload: u64) {

--- a/crates/kas-widgets/src/view/driver.rs
+++ b/crates/kas-widgets/src/view/driver.rs
@@ -41,6 +41,21 @@ pub trait Driver<T>: Debug + 'static {
     fn new(&self) -> Self::Widget;
     /// Set the viewed data
     fn set(&self, widget: &mut Self::Widget, data: T) -> TkAction;
+    /// Get data from the view
+    ///
+    /// This method optionally constructs and returns `data` from the widget.
+    /// It is only useful on interactive widgets (e.g. a slider or edit box).
+    ///
+    /// When the constructed widget emits [`Response::Update`] or
+    /// [`Response::Msg`], the "view" (e.g. `SingleView`) calls this method; if
+    /// a data item is returned, then then it is passed to the data model's
+    /// `update` method to update the model.
+    ///
+    /// Note that, additionally, when [`Response::Msg`] is returned,
+    /// [`kas::updatable::UpdatableHandler`] may be used to observe the message.
+    /// Often it will be sufficient to implement custom handling/update logic
+    /// in only one of these places.
+    fn get(&self, widget: &Self::Widget) -> Option<T>;
 }
 
 /// Default view widget constructor
@@ -74,6 +89,7 @@ macro_rules! impl_via_to_string {
             fn set(&self, widget: &mut Self::Widget, data: $t) -> TkAction {
                 widget.set_string(data.to_string())
             }
+            fn get(&self, _: &Self::Widget) -> Option<$t> { None }
         }
         impl Driver<$t> for DefaultNav {
             type Msg = VoidMsg;
@@ -84,6 +100,7 @@ macro_rules! impl_via_to_string {
             fn set(&self, widget: &mut Self::Widget, data: $t) -> TkAction {
                 widget.set_string(data.to_string())
             }
+            fn get(&self, _: &Self::Widget) -> Option<$t> { None }
         }
     };
     ($t:ty, $($tt:ty),+) => {
@@ -105,6 +122,9 @@ impl Driver<bool> for Default {
     fn set(&self, widget: &mut Self::Widget, data: bool) -> TkAction {
         widget.set_bool(data)
     }
+    fn get(&self, widget: &Self::Widget) -> Option<bool> {
+        Some(widget.get_bool())
+    }
 }
 
 impl Driver<bool> for DefaultNav {
@@ -115,6 +135,9 @@ impl Driver<bool> for DefaultNav {
     }
     fn set(&self, widget: &mut Self::Widget, data: bool) -> TkAction {
         widget.set_bool(data)
+    }
+    fn get(&self, widget: &Self::Widget) -> Option<bool> {
+        Some(widget.get_bool())
     }
 }
 
@@ -151,6 +174,9 @@ where
     fn set(&self, widget: &mut Self::Widget, data: T) -> TkAction {
         Default.set(widget, data)
     }
+    fn get(&self, widget: &Self::Widget) -> Option<T> {
+        Default.get(widget)
+    }
 }
 
 impl<G: EditGuard + std::default::Default> Driver<String> for Widget<EditField<G>> {
@@ -163,6 +189,9 @@ impl<G: EditGuard + std::default::Default> Driver<String> for Widget<EditField<G
     fn set(&self, widget: &mut Self::Widget, data: String) -> TkAction {
         widget.set_string(data)
     }
+    fn get(&self, widget: &Self::Widget) -> Option<String> {
+        Some(widget.get_string())
+    }
 }
 impl<G: EditGuard + std::default::Default> Driver<String> for Widget<EditBox<G>> {
     type Msg = G::Msg;
@@ -174,6 +203,9 @@ impl<G: EditGuard + std::default::Default> Driver<String> for Widget<EditBox<G>>
     fn set(&self, widget: &mut Self::Widget, data: String) -> TkAction {
         widget.set_string(data)
     }
+    fn get(&self, widget: &Self::Widget) -> Option<String> {
+        Some(widget.get_string())
+    }
 }
 
 impl<D: Directional + std::default::Default> Driver<f32> for Widget<ProgressBar<D>> {
@@ -184,6 +216,9 @@ impl<D: Directional + std::default::Default> Driver<f32> for Widget<ProgressBar<
     }
     fn set(&self, widget: &mut Self::Widget, data: f32) -> TkAction {
         widget.set_value(data)
+    }
+    fn get(&self, widget: &Self::Widget) -> Option<f32> {
+        Some(widget.value())
     }
 }
 
@@ -208,6 +243,9 @@ impl Driver<bool> for CheckBox {
     fn set(&self, widget: &mut Self::Widget, data: bool) -> TkAction {
         widget.set_bool(data)
     }
+    fn get(&self, widget: &Self::Widget) -> Option<bool> {
+        Some(widget.get_bool())
+    }
 }
 
 /// [`crate::RadioBoxBare`] view widget constructor
@@ -229,6 +267,9 @@ impl Driver<bool> for RadioBoxBare {
     }
     fn set(&self, widget: &mut Self::Widget, data: bool) -> TkAction {
         widget.set_bool(data)
+    }
+    fn get(&self, widget: &Self::Widget) -> Option<bool> {
+        Some(widget.get_bool())
     }
 }
 
@@ -253,6 +294,9 @@ impl Driver<bool> for RadioBox {
     }
     fn set(&self, widget: &mut Self::Widget, data: bool) -> TkAction {
         widget.set_bool(data)
+    }
+    fn get(&self, widget: &Self::Widget) -> Option<bool> {
+        Some(widget.get_bool())
     }
 }
 
@@ -294,5 +338,8 @@ impl<T: SliderType, D: Directional> Driver<T> for Slider<T, D> {
     }
     fn set(&self, widget: &mut Self::Widget, data: T) -> TkAction {
         widget.set_value(data)
+    }
+    fn get(&self, widget: &Self::Widget) -> Option<T> {
+        Some(widget.value())
     }
 }

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -398,7 +398,10 @@ impl<
         if let Some(handle) = self.list.data().data.update_handle() {
             mgr.update_on_handle(handle, self.id());
         }
-        // ... but we don't need to watch self.list.data().update_handle()
+        // As well as when the filter changes
+        if let Some(handle) = self.list.data().update_handle() {
+            mgr.update_on_handle(handle, self.id());
+        }
     }
 }
 

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -10,9 +10,10 @@ use crate::Scrollable;
 use kas::event::ChildMsg;
 use kas::prelude::*;
 use kas::updatable::filter::Filter;
-use kas::updatable::{ListData, Updatable, UpdatableAll, UpdatableHandler};
+use kas::updatable::{ListData, Updatable, UpdatableHandler};
 use std::cell::RefCell;
 use std::fmt::Debug;
+use UpdatableHandler as UpdHandler;
 
 /// Filter accessor over another accessor
 ///
@@ -164,7 +165,7 @@ impl<T: ListData + 'static, F: Filter<T::Item>> ListData for FilteredList<T, F> 
 #[widget(config=noauto)]
 pub struct FilterListView<
     D: Directional,
-    T: ListData + UpdatableAll<T::Key, V::Msg> + 'static,
+    T: ListData + UpdHandler<T::Key, V::Msg> + 'static,
     F: Filter<T::Item>,
     V: Driver<T::Item> = driver::Default,
 > {
@@ -176,7 +177,7 @@ pub struct FilterListView<
 
 impl<
         D: Directional + Default,
-        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        T: ListData + UpdHandler<T::Key, V::Msg>,
         F: Filter<T::Item>,
         V: Driver<T::Item> + Default,
     > FilterListView<D, T, F, V>
@@ -192,7 +193,7 @@ impl<
 }
 impl<
         D: Directional,
-        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        T: ListData + UpdHandler<T::Key, V::Msg>,
         F: Filter<T::Item>,
         V: Driver<T::Item> + Default,
     > FilterListView<D, T, F, V>
@@ -204,7 +205,7 @@ impl<
 }
 impl<
         D: Directional + Default,
-        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        T: ListData + UpdHandler<T::Key, V::Msg>,
         F: Filter<T::Item>,
         V: Driver<T::Item>,
     > FilterListView<D, T, F, V>
@@ -215,7 +216,7 @@ impl<
     }
 }
 impl<
-        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        T: ListData + UpdHandler<T::Key, V::Msg>,
         F: Filter<T::Item>,
         V: Driver<T::Item> + Default,
     > FilterListView<Direction, T, F, V>
@@ -227,7 +228,7 @@ impl<
 }
 impl<
         D: Directional,
-        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        T: ListData + UpdHandler<T::Key, V::Msg>,
         F: Filter<T::Item>,
         V: Driver<T::Item>,
     > FilterListView<D, T, F, V>
@@ -376,7 +377,7 @@ impl<
 // TODO: support derive(Scrollable)?
 impl<
         D: Directional,
-        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        T: ListData + UpdHandler<T::Key, V::Msg>,
         F: Filter<T::Item>,
         V: Driver<T::Item>,
     > Scrollable for FilterListView<D, T, F, V>
@@ -404,7 +405,7 @@ impl<
 
 impl<
         D: Directional,
-        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        T: ListData + UpdHandler<T::Key, V::Msg>,
         F: Filter<T::Item>,
         V: Driver<T::Item>,
     > WidgetConfig for FilterListView<D, T, F, V>
@@ -423,7 +424,7 @@ impl<
 
 impl<
         D: Directional,
-        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        T: ListData + UpdHandler<T::Key, V::Msg>,
         F: Filter<T::Item>,
         V: Driver<T::Item>,
     > Handler for FilterListView<D, T, F, V>

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -241,25 +241,41 @@ impl<
         }
     }
 
-    // TODO: should this access pre-filter data?
     /// Access the stored data (pre-filter)
-    pub fn data(&self) -> &T {
+    pub fn unfiltered_data(&self) -> &T {
         &self.list.data().data
     }
 
     /// Mutably access the stored data (pre-filter)
     ///
     /// It may be necessary to use [`FilterListView::update_view`] to update the view of this data.
+    pub fn unfiltered_data_mut(&mut self) -> &mut T {
+        &mut self.list.data_mut().data
+    }
+
+    /// Access the stored data (post-filter)
+    pub fn data(&self) -> &T {
+        &self.list.data().data
+    }
+
+    /// Mutably access the stored data (post-filter)
+    ///
+    /// It may be necessary to use [`FilterListView::update_view`] to update the view of this data.
     pub fn data_mut(&mut self) -> &mut T {
         &mut self.list.data_mut().data
     }
 
-    /// Get a copy of the shared value at `key` (pre-filter)
+    /// Check whether a key has data (post-filter)
+    pub fn contains_key(&self, key: &T::Key) -> bool {
+        self.data().contains_key(key)
+    }
+
+    /// Get a copy of the shared value at `key` (post-filter)
     pub fn get_value(&self, key: &T::Key) -> Option<T::Item> {
         self.data().get_cloned(key)
     }
 
-    /// Set shared data (pre-filter)
+    /// Set shared data (post-filter)
     ///
     /// This method updates the shared data, if supported (see
     /// [`ListData::update`]). Other widgets sharing this data are notified
@@ -270,7 +286,7 @@ impl<
         }
     }
 
-    /// Update shared data (pre-filter)
+    /// Update shared data (post-filter)
     ///
     /// This is purely a convenience method over [`FilterListView::set_value`].
     /// It does nothing if no value is found at `key`.

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -1,0 +1,292 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Filter-list view widget
+
+use super::{driver, Driver, ListView, SelectionError, SelectionMode};
+use crate::Scrollable;
+use kas::event::ChildMsg;
+use kas::prelude::*;
+use kas::updatable::*;
+use kas::updatable::{FilteredList, ListData, UpdatableAll};
+use std::fmt::Debug;
+
+/// Filter-list view widget
+///
+/// This widget is a wrapper around [`ListView`] which applies a filter to the
+/// data list.
+///
+/// Why is a data-filter a widget and not a pure-data item, you ask? The answer
+/// is that a filter-list must be updated when the filter or the data changes,
+/// and, since filtering a list is not especially cheap, the filtering must be
+/// cached and updated when required, not every time the list view asks for more
+/// data. Although it is possible to do this with a data-view, that requires
+/// machinery for recursive-updates on data-structures and/or a mechanism to
+/// test whether the underlying list-data changed. Implementing as a widget
+/// avoids this.
+// TODO: impl Clone
+#[derive(Debug, Widget)]
+#[handler(handle=noauto, generics = <>)]
+#[layout(single)]
+#[widget(config=noauto)]
+pub struct FilterListView<
+    D: Directional,
+    T: ListData + UpdatableAll<T::Key, V::Msg> + 'static,
+    F: Filter<T::Item>,
+    V: Driver<T::Item> = driver::Default,
+> {
+    #[widget_core]
+    core: CoreData,
+    #[widget]
+    list: ListView<D, FilteredList<T, F>, V>,
+}
+
+impl<
+        D: Directional + Default,
+        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        F: Filter<T::Item>,
+        V: Driver<T::Item> + Default,
+    > FilterListView<D, T, F, V>
+{
+    /// Construct a new instance
+    ///
+    /// This constructor is available where the direction is determined by the
+    /// type: for `D: Directional + Default`. In other cases, use
+    /// [`FilterListView::new_with_direction`].
+    pub fn new(data: T, filter: F) -> Self {
+        Self::new_with_dir_driver(D::default(), <V as Default>::default(), data, filter)
+    }
+}
+impl<
+        D: Directional,
+        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        F: Filter<T::Item>,
+        V: Driver<T::Item> + Default,
+    > FilterListView<D, T, F, V>
+{
+    /// Construct a new instance with explicit direction
+    pub fn new_with_direction(direction: D, data: T, filter: F) -> Self {
+        Self::new_with_dir_driver(direction, <V as Default>::default(), data, filter)
+    }
+}
+impl<
+        D: Directional + Default,
+        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        F: Filter<T::Item>,
+        V: Driver<T::Item>,
+    > FilterListView<D, T, F, V>
+{
+    /// Construct a new instance with explicit view
+    pub fn new_with_driver(view: V, data: T, filter: F) -> Self {
+        Self::new_with_dir_driver(D::default(), view, data, filter)
+    }
+}
+impl<
+        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        F: Filter<T::Item>,
+        V: Driver<T::Item> + Default,
+    > FilterListView<Direction, T, F, V>
+{
+    /// Set the direction of contents
+    pub fn set_direction(&mut self, direction: Direction) -> TkAction {
+        self.list.set_direction(direction)
+    }
+}
+impl<
+        D: Directional,
+        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        F: Filter<T::Item>,
+        V: Driver<T::Item>,
+    > FilterListView<D, T, F, V>
+{
+    /// Construct a new instance with explicit direction and view
+    pub fn new_with_dir_driver(direction: D, view: V, data: T, filter: F) -> Self {
+        let data = FilteredList::new(data, filter);
+        FilterListView {
+            core: Default::default(),
+            list: ListView::new_with_dir_driver(direction, view, data),
+        }
+    }
+
+    // TODO: should this access pre-filter data?
+    /// Access the stored data (pre-filter)
+    pub fn data(&self) -> &T {
+        &self.list.data().data
+    }
+
+    /// Mutably access the stored data (pre-filter)
+    ///
+    /// It may be necessary to use [`FilterListView::update_view`] to update the view of this data.
+    pub fn data_mut(&mut self) -> &mut T {
+        &mut self.list.data_mut().data
+    }
+
+    /// Get a copy of the shared value at `key` (pre-filter)
+    pub fn get_value(&self, key: &T::Key) -> Option<T::Item> {
+        self.data().get_cloned(key)
+    }
+
+    /// Set shared data (pre-filter)
+    ///
+    /// This method updates the shared data, if supported (see
+    /// [`ListData::update`]). Other widgets sharing this data are notified
+    /// of the update, if data is changed.
+    pub fn set_value(&self, mgr: &mut Manager, key: &T::Key, data: T::Item) {
+        if let Some(handle) = self.data().update(key, data) {
+            mgr.trigger_update(handle, 0);
+        }
+    }
+
+    /// Update shared data (pre-filter)
+    ///
+    /// This is purely a convenience method over [`FilterListView::set_value`].
+    /// It does nothing if no value is found at `key`.
+    /// It notifies other widgets of updates to the shared data.
+    pub fn update_value<G: Fn(T::Item) -> T::Item>(&self, mgr: &mut Manager, key: &T::Key, f: G) {
+        if let Some(item) = self.get_value(key) {
+            self.set_value(mgr, key, f(item));
+        }
+    }
+
+    /// Get the current selection mode
+    pub fn selection_mode(&self) -> SelectionMode {
+        self.list.selection_mode()
+    }
+    /// Set the current selection mode
+    pub fn set_selection_mode(&mut self, mode: SelectionMode) -> TkAction {
+        self.list.set_selection_mode(mode)
+    }
+    /// Set the selection mode (inline)
+    pub fn with_selection_mode(mut self, mode: SelectionMode) -> Self {
+        let _ = self.set_selection_mode(mode);
+        self
+    }
+
+    /// Read the list of selected entries
+    ///
+    /// With mode [`SelectionMode::Single`] this may contain zero or one entry;
+    /// use `selected_iter().next()` to extract only the first (optional) entry.
+    pub fn selected_iter(&'_ self) -> impl Iterator<Item = &'_ T::Key> + '_ {
+        self.list.selected_iter()
+    }
+
+    /// Check whether an entry is selected
+    pub fn is_selected(&self, key: &T::Key) -> bool {
+        self.list.is_selected(key)
+    }
+
+    /// Clear all selected items
+    ///
+    /// Does not send [`ChildMsg`] responses.
+    pub fn clear_selected(&mut self) {
+        self.list.clear_selected()
+    }
+
+    /// Directly select an item
+    ///
+    /// Returns `true` if selected, `false` if already selected.
+    /// Fails if selection mode does not permit selection or if the key is
+    /// invalid or filtered out.
+    ///
+    /// Does not send [`ChildMsg`] responses.
+    pub fn select(&mut self, key: T::Key) -> Result<bool, SelectionError> {
+        self.list.select(key)
+    }
+
+    /// Directly deselect an item
+    ///
+    /// Returns `true` if deselected, `false` if not previously selected.
+    /// Also returns `false` on invalid and filtered-out keys.
+    ///
+    /// Does not send [`ChildMsg`] responses.
+    pub fn deselect(&mut self, key: &T::Key) -> bool {
+        self.list.deselect(key)
+    }
+
+    /// Manually trigger an update to handle changed data or filter
+    pub fn update_view(&mut self, mgr: &mut Manager) {
+        // TODO: update filter
+        self.list.update_view(mgr)
+    }
+
+    /// Get the direction of contents
+    pub fn direction(&self) -> Direction {
+        self.list.direction()
+    }
+
+    /// Set the preferred number of items visible (inline)
+    ///
+    /// This affects the (ideal) size request and whether children are sized
+    /// according to their ideal or minimum size but not the minimum size.
+    pub fn with_num_visible(mut self, number: i32) -> Self {
+        self.list = self.list.with_num_visible(number);
+        self
+    }
+}
+
+// TODO: support derive(Scrollable)?
+impl<
+        D: Directional,
+        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        F: Filter<T::Item>,
+        V: Driver<T::Item>,
+    > Scrollable for FilterListView<D, T, F, V>
+{
+    #[inline]
+    fn scroll_axes(&self, size: Size) -> (bool, bool) {
+        self.list.scroll_axes(size)
+    }
+
+    #[inline]
+    fn max_scroll_offset(&self) -> Offset {
+        self.list.max_scroll_offset()
+    }
+
+    #[inline]
+    fn scroll_offset(&self) -> Offset {
+        self.list.scroll_offset()
+    }
+
+    #[inline]
+    fn set_scroll_offset(&mut self, mgr: &mut Manager, offset: Offset) -> Offset {
+        self.list.set_scroll_offset(mgr, offset)
+    }
+}
+
+impl<
+        D: Directional,
+        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        F: Filter<T::Item>,
+        V: Driver<T::Item>,
+    > WidgetConfig for FilterListView<D, T, F, V>
+{
+    fn configure(&mut self, mgr: &mut Manager) {
+        // We must refresh the filtered list when the underlying list changes
+        if let Some(handle) = self.list.data().data.update_handle() {
+            mgr.update_on_handle(handle, self.id());
+        }
+        // ... but we don't need to watch self.list.data().update_handle()
+    }
+}
+
+impl<
+        D: Directional,
+        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        F: Filter<T::Item>,
+        V: Driver<T::Item>,
+    > Handler for FilterListView<D, T, F, V>
+{
+    type Msg = ChildMsg<T::Key, <V::Widget as Handler>::Msg>;
+
+    fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
+        match event {
+            Event::HandleUpdate { .. } => {
+                self.update_view(mgr);
+                return Response::Update;
+            }
+            _ => Response::None,
+        }
+    }
+}

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -9,8 +9,8 @@ use super::{driver, Driver, ListView, SelectionError, SelectionMode};
 use crate::Scrollable;
 use kas::event::ChildMsg;
 use kas::prelude::*;
-use kas::updatable::*;
-use kas::updatable::{FilteredList, ListData, UpdatableAll};
+use kas::updatable::filter::{Filter, FilteredList};
+use kas::updatable::{ListData, UpdatableAll};
 use std::fmt::Debug;
 
 /// Filter-list view widget

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -445,7 +445,6 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
     for ListView<D, T, V>
 {
     fn configure(&mut self, mgr: &mut Manager) {
-        self.data.enable_recursive_updates(mgr);
         if let Some(handle) = self.data.update_handle() {
             mgr.update_on_handle(handle, self.id());
         }

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -12,10 +12,11 @@ use crate::{ScrollComponent, Scrollable};
 use kas::event::{ChildMsg, Command, CursorIcon, GrabMode, PressSource};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
-use kas::updatable::{ListData, UpdatableAll};
+use kas::updatable::{ListData, UpdatableHandler};
 use linear_map::set::LinearSet;
 use log::{debug, trace};
 use std::time::Instant;
+use UpdatableHandler as UpdHandler;
 
 #[derive(Clone, Debug, Default)]
 struct WidgetData<K, W> {
@@ -28,7 +29,7 @@ struct WidgetData<K, W> {
 /// This widget supports a view over a list of shared data items.
 ///
 /// The shared data type `T` must support [`ListData`] and
-/// [`UpdatableAll`], the latter with key type `T::Key` and message type
+/// [`UpdatableHandler`], the latter with key type `T::Key` and message type
 /// matching the widget's message. One may use [`kas::updatable::SharedRc`]
 /// or a custom shared data type.
 ///
@@ -43,7 +44,7 @@ struct WidgetData<K, W> {
 #[widget(children=noauto, config=noauto)]
 pub struct ListView<
     D: Directional,
-    T: ListData + UpdatableAll<T::Key, V::Msg> + 'static,
+    T: ListData + UpdHandler<T::Key, V::Msg> + 'static,
     V: Driver<T::Item> = driver::Default,
 > {
     first_id: WidgetId,
@@ -75,7 +76,7 @@ pub struct ListView<
 
 impl<
         D: Directional + Default,
-        T: ListData + UpdatableAll<T::Key, V::Msg>,
+        T: ListData + UpdHandler<T::Key, V::Msg>,
         V: Driver<T::Item> + Default,
     > ListView<D, T, V>
 {
@@ -88,7 +89,7 @@ impl<
         Self::new_with_dir_driver(D::default(), <V as Default>::default(), data)
     }
 }
-impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item> + Default>
+impl<D: Directional, T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item> + Default>
     ListView<D, T, V>
 {
     /// Construct a new instance with explicit direction
@@ -96,7 +97,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
         Self::new_with_dir_driver(direction, <V as Default>::default(), data)
     }
 }
-impl<D: Directional + Default, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>>
+impl<D: Directional + Default, T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>>
     ListView<D, T, V>
 {
     /// Construct a new instance with explicit view
@@ -104,14 +105,14 @@ impl<D: Directional + Default, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Dr
         Self::new_with_dir_driver(D::default(), view, data)
     }
 }
-impl<T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> ListView<Direction, T, V> {
+impl<T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> ListView<Direction, T, V> {
     /// Set the direction of contents
     pub fn set_direction(&mut self, direction: Direction) -> TkAction {
         self.direction = direction;
         TkAction::SET_SIZE
     }
 }
-impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>>
+impl<D: Directional, T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>>
     ListView<D, T, V>
 {
     /// Construct a new instance with explicit direction and view
@@ -309,7 +310,7 @@ impl PositionSolver {
     }
 }
 
-impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>>
+impl<D: Directional, T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>>
     ListView<D, T, V>
 {
     /// Construct a position solver. Note: this does more work and updates to
@@ -382,7 +383,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
     }
 }
 
-impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Scrollable
+impl<D: Directional, T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> Scrollable
     for ListView<D, T, V>
 {
     fn scroll_axes(&self, size: Size) -> (bool, bool) {
@@ -415,7 +416,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
     }
 }
 
-impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> WidgetChildren
+impl<D: Directional, T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> WidgetChildren
     for ListView<D, T, V>
 {
     #[inline]
@@ -441,7 +442,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
     }
 }
 
-impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> WidgetConfig
+impl<D: Directional, T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> WidgetConfig
     for ListView<D, T, V>
 {
     fn configure(&mut self, mgr: &mut Manager) {
@@ -452,7 +453,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
     }
 }
 
-impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Layout
+impl<D: Directional, T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> Layout
     for ListView<D, T, V>
 {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
@@ -594,7 +595,7 @@ impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::It
     }
 }
 
-impl<D: Directional, T: ListData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> SendEvent
+impl<D: Directional, T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> SendEvent
     for ListView<D, T, V>
 {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -351,7 +351,6 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> WidgetCon
     for MatrixView<T, V>
 {
     fn configure(&mut self, mgr: &mut Manager) {
-        self.data.enable_recursive_updates(mgr);
         if let Some(handle) = self.data.update_handle() {
             mgr.update_on_handle(handle, self.id());
         }

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -12,10 +12,11 @@ use crate::{ScrollComponent, Scrollable};
 use kas::event::{ChildMsg, Command, CursorIcon, GrabMode, PressSource};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
-use kas::updatable::{MatrixData, UpdatableAll};
+use kas::updatable::{MatrixData, UpdatableHandler};
 use linear_map::set::LinearSet;
 use log::{debug, trace};
 use std::time::Instant;
+use UpdatableHandler as UpdHandler;
 
 #[derive(Clone, Debug, Default)]
 struct WidgetData<K, W> {
@@ -28,7 +29,7 @@ struct WidgetData<K, W> {
 /// This widget supports a view over a matrix of shared data items.
 ///
 /// The shared data type `T` must support [`MatrixData`] and
-/// [`UpdatableAll`], the latter with key type `T::Key` and message type
+/// [`UpdatableHandler`], the latter with key type `T::Key` and message type
 /// matching the widget's message. One may use [`kas::updatable::SharedRc`]
 /// or a custom shared data type.
 ///
@@ -42,7 +43,7 @@ struct WidgetData<K, W> {
 #[handler(send=noauto, msg=ChildMsg<T::Key, <V::Widget as Handler>::Msg>)]
 #[widget(children=noauto, config=noauto)]
 pub struct MatrixView<
-    T: MatrixData + UpdatableAll<T::Key, V::Msg> + 'static,
+    T: MatrixData + UpdHandler<T::Key, V::Msg> + 'static,
     V: Driver<T::Item> = driver::Default,
 > {
     first_id: WidgetId,
@@ -71,13 +72,13 @@ pub struct MatrixView<
     press_target: Option<T::Key>,
 }
 
-impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item> + Default> MatrixView<T, V> {
+impl<T: MatrixData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item> + Default> MatrixView<T, V> {
     /// Construct a new instance
     pub fn new(data: T) -> Self {
         Self::new_with_driver(<V as Default>::default(), data)
     }
 }
-impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> MatrixView<T, V> {
+impl<T: MatrixData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> MatrixView<T, V> {
     /// Construct a new instance with explicit view
     pub fn new_with_driver(view: V, data: T) -> Self {
         MatrixView {
@@ -293,7 +294,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> MatrixVie
     }
 }
 
-impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Scrollable
+impl<T: MatrixData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> Scrollable
     for MatrixView<T, V>
 {
     fn scroll_axes(&self, size: Size) -> (bool, bool) {
@@ -321,7 +322,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Scrollabl
     }
 }
 
-impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> WidgetChildren
+impl<T: MatrixData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> WidgetChildren
     for MatrixView<T, V>
 {
     #[inline]
@@ -347,7 +348,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> WidgetChi
     }
 }
 
-impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> WidgetConfig
+impl<T: MatrixData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> WidgetConfig
     for MatrixView<T, V>
 {
     fn configure(&mut self, mgr: &mut Manager) {
@@ -358,7 +359,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> WidgetCon
     }
 }
 
-impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Layout for MatrixView<T, V> {
+impl<T: MatrixData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> Layout for MatrixView<T, V> {
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         // We use an invisible frame for highlighting selections, drawing into the margin
         let inner_margin = size_handle.inner_margin().extract(axis);
@@ -508,7 +509,7 @@ impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> Layout fo
     }
 }
 
-impl<T: MatrixData + UpdatableAll<T::Key, V::Msg>, V: Driver<T::Item>> SendEvent
+impl<T: MatrixData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> SendEvent
     for MatrixView<T, V>
 {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {

--- a/crates/kas-widgets/src/view/mod.rs
+++ b/crates/kas-widgets/src/view/mod.rs
@@ -21,10 +21,6 @@
 //! `&'static [&'static str]` implements [`ListData`]. The [`SharedRc`] type
 //! provides the [`UpdateHandle`] required to synchronise views.
 //!
-//! ## Adapters
-//!
-//! -   [`FilteredList`] presents a filtered list over a [`ListData`]
-//!
 //! # View widgets and drivers
 //!
 //! Standard widgets may be used to view data items, but to construct these a
@@ -72,7 +68,7 @@
 use kas::event::UpdateHandle;
 use kas::macros::VoidMsg;
 #[allow(unused)]
-use kas::updatable::{filter::FilteredList, ListData, MatrixData, SharedRc, SingleData};
+use kas::updatable::{ListData, MatrixData, SharedRc, SingleData};
 use thiserror::Error;
 
 mod filter_list;

--- a/crates/kas-widgets/src/view/mod.rs
+++ b/crates/kas-widgets/src/view/mod.rs
@@ -75,6 +75,7 @@ use kas::macros::VoidMsg;
 use kas::updatable::{FilteredList, ListData, MatrixData, SharedRc, SingleData};
 use thiserror::Error;
 
+mod filter_list;
 mod list_view;
 mod matrix_view;
 mod single_view;
@@ -82,6 +83,7 @@ mod single_view;
 pub mod driver;
 
 pub use driver::Driver;
+pub use filter_list::FilterListView;
 pub use list_view::ListView;
 pub use matrix_view::MatrixView;
 pub use single_view::SingleView;

--- a/crates/kas-widgets/src/view/mod.rs
+++ b/crates/kas-widgets/src/view/mod.rs
@@ -19,7 +19,8 @@
 //! For simpler cases it is not always necessary to implement your own shared
 //! data type, for example `SharedRc<i32>` implements [`SingleData`] and
 //! `&'static [&'static str]` implements [`ListData`]. The [`SharedRc`] type
-//! provides the [`UpdateHandle`] required to synchronise views.
+//! provides an `update` method and the [`UpdateHandle`] required to synchronise
+//! views; `&[T]` does not (data is constant).
 //!
 //! # View widgets and drivers
 //!

--- a/crates/kas-widgets/src/view/mod.rs
+++ b/crates/kas-widgets/src/view/mod.rs
@@ -72,7 +72,7 @@
 use kas::event::UpdateHandle;
 use kas::macros::VoidMsg;
 #[allow(unused)]
-use kas::updatable::{FilteredList, ListData, MatrixData, SharedRc, SingleData};
+use kas::updatable::{filter::FilteredList, ListData, MatrixData, SharedRc, SingleData};
 use thiserror::Error;
 
 mod filter_list;

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -107,7 +107,6 @@ impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> Wid
     for SingleView<T, V>
 {
     fn configure(&mut self, mgr: &mut Manager) {
-        self.data.enable_recursive_updates(mgr);
         if let Some(handle) = self.data.update_handle() {
             mgr.update_on_handle(handle, self.id());
         }

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -139,7 +139,14 @@ impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> Sen
 
         if id < self.id() {
             let r = self.child.send(mgr, id, event);
-            if let Response::Msg(ref msg) = r {
+            if matches!(&r, Response::Update | Response::Msg(_)) {
+                if let Some(value) = self.view.get(&self.child) {
+                    if let Some(handle) = self.data.update(value) {
+                        mgr.trigger_update(handle, 0);
+                    }
+                }
+            }
+            if let Response::Msg(ref msg) = &r {
                 log::trace!(
                     "Received by {} from {}: {:?}",
                     self.id(),

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -7,15 +7,16 @@
 
 use super::{driver, Driver};
 use kas::prelude::*;
-use kas::updatable::{SingleData, UpdatableAll};
+use kas::updatable::{SingleData, UpdatableHandler};
 use std::fmt::{self};
+use UpdatableHandler as UpdHandler;
 
 /// Single view widget
 ///
 /// This widget supports a view over a shared data item.
 ///
 /// The shared data type `T` must support [`SingleData`] and
-/// [`UpdatableAll`], the latter with key type `()` and message type
+/// [`UpdatableHandler`], the latter with key type `()` and message type
 /// matching the widget's message. One may use [`kas::updatable::SharedRc`]
 /// or a custom shared data type.
 ///
@@ -27,7 +28,7 @@ use std::fmt::{self};
 #[layout(single)]
 #[handler(handle=noauto, send=noauto)]
 pub struct SingleView<
-    T: SingleData + UpdatableAll<(), V::Msg> + 'static,
+    T: SingleData + UpdHandler<(), V::Msg> + 'static,
     V: Driver<T::Item> = driver::Default,
 > {
     #[widget_core]
@@ -38,16 +39,14 @@ pub struct SingleView<
     child: V::Widget,
 }
 
-impl<
-        T: SingleData + UpdatableAll<(), V::Msg> + 'static + Default,
-        V: Driver<T::Item> + Default,
-    > Default for SingleView<T, V>
+impl<T: SingleData + UpdHandler<(), V::Msg> + 'static + Default, V: Driver<T::Item> + Default>
+    Default for SingleView<T, V>
 {
     fn default() -> Self {
         Self::new(T::default())
     }
 }
-impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item> + Default>
+impl<T: SingleData + UpdHandler<(), V::Msg> + 'static, V: Driver<T::Item> + Default>
     SingleView<T, V>
 {
     /// Construct a new instance
@@ -55,7 +54,7 @@ impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item> + De
         Self::new_with_driver(<V as Default>::default(), data)
     }
 }
-impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> SingleView<T, V> {
+impl<T: SingleData + UpdHandler<(), V::Msg> + 'static, V: Driver<T::Item>> SingleView<T, V> {
     /// Construct a new instance with explicit view
     pub fn new_with_driver(view: V, data: T) -> Self {
         let mut child = view.new();
@@ -103,7 +102,7 @@ impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> Sin
     }
 }
 
-impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> WidgetConfig
+impl<T: SingleData + UpdHandler<(), V::Msg> + 'static, V: Driver<T::Item>> WidgetConfig
     for SingleView<T, V>
 {
     fn configure(&mut self, mgr: &mut Manager) {
@@ -113,7 +112,7 @@ impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> Wid
     }
 }
 
-impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> Handler
+impl<T: SingleData + UpdHandler<(), V::Msg> + 'static, V: Driver<T::Item>> Handler
     for SingleView<T, V>
 {
     type Msg = <V::Widget as Handler>::Msg;
@@ -129,7 +128,7 @@ impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> Han
     }
 }
 
-impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> SendEvent
+impl<T: SingleData + UpdHandler<(), V::Msg> + 'static, V: Driver<T::Item>> SendEvent
     for SingleView<T, V>
 {
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
@@ -165,7 +164,7 @@ impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> Sen
     }
 }
 
-impl<T: SingleData + UpdatableAll<(), V::Msg> + 'static, V: Driver<T::Item>> fmt::Debug
+impl<T: SingleData + UpdHandler<(), V::Msg> + 'static, V: Driver<T::Item>> fmt::Debug
     for SingleView<T, V>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -191,6 +191,9 @@ impl Driver<(usize, bool, String)> for MyDriver {
             | widget.radio.set_bool(data.1)
             | widget.entry.set_string(data.2)
     }
+    fn get(&self, _widget: &Self::Widget) -> Option<(usize, bool, String)> {
+        None // unused
+    }
 }
 
 fn main() -> Result<(), kas::shell::Error> {

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -86,7 +86,6 @@ impl Updatable for MyData {
         Some(self.handle)
     }
 }
-impl RecursivelyUpdatable for MyData {}
 impl UpdatableHandler<usize, EntryMsg> for MyData {
     fn handle(&self, key: &usize, msg: &EntryMsg) -> Option<UpdateHandle> {
         match msg {

--- a/examples/filter-list.rs
+++ b/examples/filter-list.rs
@@ -8,37 +8,24 @@
 use kas::dir::Down;
 use kas::event::ChildMsg;
 use kas::prelude::*;
-use kas::updatable::ListData;
-use kas::widgets::view::{driver, ListView, SelectionMode, SingleView};
+use kas::updatable::filter::ContainsCaseInsensitive;
+use kas::widgets::view::{driver, FilterListView, SelectionMode, SingleView};
 use kas::widgets::{EditBox, Label, RadioBox, ScrollBars, Window};
 
-mod data {
-    use kas::updatable::filter::{ContainsCaseInsensitive, FilteredList};
-    use std::rc::Rc;
-
-    type SC = &'static [&'static str];
-    pub type Shared = Rc<FilteredList<SC, ContainsCaseInsensitive>>;
-
-    const MONTHS: &[&str] = &[
-        "January",
-        "February",
-        "March",
-        "April",
-        "May",
-        "June",
-        "July",
-        "August",
-        "September",
-        "October",
-        "November",
-        "December",
-    ];
-
-    pub fn get() -> Shared {
-        let filter = ContainsCaseInsensitive::new("");
-        Rc::new(FilteredList::new(MONTHS.into(), filter))
-    }
-}
+const MONTHS: &[&str] = &[
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
 
 fn main() -> Result<(), kas::shell::Error> {
     env_logger::init();
@@ -55,9 +42,9 @@ fn main() -> Result<(), kas::shell::Error> {
         }
     };
 
-    let data = data::get();
+    let data = MONTHS;
     println!("filter-list: {} entries", data.len());
-    let filter = data.filter.clone();
+    let filter = ContainsCaseInsensitive::new("");
     let filter_driver = driver::Widget::<EditBox>::default();
 
     let window = Window::new(
@@ -67,10 +54,15 @@ fn main() -> Result<(), kas::shell::Error> {
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget(use_msg = set_selection_mode)] _ = selection_mode,
-                #[widget] filter = SingleView::new_with_driver(filter_driver, filter),
+                #[widget] filter = SingleView::new_with_driver(filter_driver, filter.clone()),
                 #[widget(use_msg = select)] list:
-                    ScrollBars<ListView<Down, data::Shared, driver::DefaultNav>> =
-                    ScrollBars::new(ListView::new(data)),
+                    ScrollBars<FilterListView<
+                        Down,
+                        &'static [&'static str],
+                        ContainsCaseInsensitive,
+                        driver::DefaultNav,
+                    >> =
+                    ScrollBars::new(FilterListView::new(data, filter)),
             }
             impl {
                 fn set_selection_mode(&mut self, mgr: &mut Manager, mode: SelectionMode) {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,7 +50,7 @@
 //! These attributes may be used on fields: `widget`, `widget_core`,
 //! `widget_derive`,  `layout_data`.
 //! The `widget` attribute supports multiple parameters,
-//! discussed below (e.g. `#[widget(row=1, handler=f)]`).
+//! discussed below (e.g. `#[widget(row=1, use_msg=f)]`).
 //! Fields without attributes (plain data fields) are fine too.
 //!
 //! A simple example:
@@ -239,12 +239,17 @@
 //! ```
 //!
 //! A handler is a method on the parent struct with signature
-//! `fn f(&mut self, mgr: &mut Manager, item: Item) -> Response<Out>`
-//! (where `Item` is the child's message type and `Out` is the parent's message
-//! type).
+//! `fn f(&mut self, mgr: &mut Manager, msg: M) -> T`
+//! (where `M` is the child's message type). The return type `T` depends on
+//! the keyword used:
 //!
-//! A handler is bound to a child via the `widget` attribute, for example
-//! `#[widget(handler = f)] child: ChildType`.
+//! -   `#[widget(use_msg = f)]` — `T = ()` (no return value)
+//! -   `#[widget(map_msg = f)]` — `T = P` where `P` is the parent
+//!     widget's message type)
+//! -   `#[widget(flatmap_msg = f)]` — `T = Response<P>` where `P` is the parent
+//!     widget's message type)
+//! -   `#[widget(discard_msg)]` — message is discarded (no handler)
+//! -   `#[widget()]` — message is converted via `Into` (no handler)
 //!
 //! ### widget_derive
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -459,7 +459,7 @@
 // Imported for doc-links
 #[allow(unused)]
 use crate::{
-    event::{Handler, SendEvent},
+    event::{Handler, Response, SendEvent},
     layout::AlignHints,
     CoreData, Layout, LayoutData, Widget, WidgetChildren, WidgetConfig, WidgetCore, WidgetId,
 };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -251,6 +251,13 @@
 //! -   `#[widget(discard_msg)]` — message is discarded (no handler)
 //! -   `#[widget()]` — message is converted via `Into` (no handler)
 //!
+//! **Observing `Response::Update`**
+//!
+//! Widgets may return [`Response::Update`] on some interactions instead of
+//! [`Response::Msg`]. It is possible to observe such a response:
+//!
+//! -   `#[widget(update = f)]` where `f` has signature `fn f(&mut self, mgr: &mut Manager)`
+//!
 //! ### widget_derive
 //!
 //! The `#[widget_derive]` attribute may optionally appear on a field, and may


### PR DESCRIPTION
- Replace `FilteredList` "data-view" with `FilterListView` widget
- Make filters simpler to use by making a shared data object
- Remove complex recursive-data-update machinery that was required by `FilteredList`
- Restore `Driver::get` data-model-update mechanism (thus making a simple interactive widget over shared data update that data by default)
- Add `#[widget(discard_msg)]` and `#[widget(update = f)]`