### PR TITLE
List vs IndexedList, row & column macros, doc fixes, misc

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -42,7 +42,7 @@ impl dyn WidgetCore {
 /// Users **must not** implement this `WidgetCore` trait manually or may face
 /// unexpected breaking changes.
 ///
-/// [`derive(Widget)`]: macros/index.html#the-derivewidget-macro
+/// [`derive(Widget)`]: https://docs.rs/kas/latest/kas/macros/index.html#the-derivewidget-macro
 pub trait WidgetCore: Any + fmt::Debug {
     /// Get self as type `Any`
     fn as_any(&self) -> &dyn Any;
@@ -167,7 +167,7 @@ pub trait WidgetCore: Any + fmt::Debug {
 /// (TODO: this is slow. Find an option for partial reconfigures. This requires
 /// better widget identifiers; see #91.)
 ///
-/// [`derive(Widget)`]: macros/index.html#the-derivewidget-macro
+/// [`derive(Widget)`]: https://docs.rs/kas/latest/kas/macros/index.html#the-derivewidget-macro
 pub trait WidgetChildren: WidgetCore {
     /// Get the first identifier of self or any children
     ///
@@ -321,7 +321,7 @@ pub trait WidgetChildren: WidgetCore {
 /// default implementations. Most frequently, this trait is used to implement
 /// some custom action during configure: [`WidgetConfig::configure`].
 ///
-/// [`derive(Widget)`]: macros/index.html#the-derivewidget-macro
+/// [`derive(Widget)`]: https://docs.rs/kas/latest/kas/macros/index.html#the-derivewidget-macro
 //
 // TODO(specialization): provide a blanket implementation, so that users only
 // need implement manually when they have something to configure.
@@ -401,7 +401,7 @@ pub trait WidgetConfig: Layout {
 ///
 /// For a description of the widget size model, see [`SizeRules`].
 ///
-/// [`derive(Widget)`]: macros/index.html#the-derivewidget-macro
+/// [`derive(Widget)`]: https://docs.rs/kas/latest/kas/macros/index.html#the-derivewidget-macro
 pub trait Layout: WidgetChildren {
     /// Get size rules for the given axis
     ///
@@ -561,5 +561,5 @@ pub trait Layout: WidgetChildren {
 /// To refer to a widget in generic functions, use `<W: Widget>` or
 /// `<M, W: Widget<Msg = M>>`.
 ///
-/// [`derive(Widget)`]: macros/index.html#the-derivewidget-macro
+/// [`derive(Widget)`]: https://docs.rs/kas/latest/kas/macros/index.html#the-derivewidget-macro
 pub trait Widget: event::SendEvent {}

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -35,7 +35,7 @@ pub trait Handler: WidgetConfig {
     /// The [`VoidMsg`] type may be used where messages are never generated.
     /// This is distinct from `()`, which might be applicable when a widget only
     /// needs to "wake up" a parent.
-    type Msg;
+    type Msg: 'static;
 
     /// Generic handler: translate presses to activations
     ///

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -125,8 +125,6 @@ pub struct ManagerState {
     popups: SmallVec<[(WindowId, crate::Popup, Option<WidgetId>); 16]>,
     new_popups: SmallVec<[WidgetId; 16]>,
     popup_removed: SmallVec<[(WidgetId, WindowId); 16]>,
-
-    time_start: Instant,
     time_updates: Vec<(Instant, WidgetId, u64)>,
     // TODO(opt): consider other containers, e.g. C++ multimap
     // or sorted Vec with binary search yielding a range

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -54,8 +54,6 @@ impl ManagerState {
             popups: Default::default(),
             new_popups: Default::default(),
             popup_removed: Default::default(),
-
-            time_start: Instant::now(),
             time_updates: vec![],
             handle_updates: HashMap::new(),
             pending: SmallVec::new(),

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -127,7 +127,7 @@ fn size_of_virtual_key_codes() {
 ///
 /// `From<VoidMsg>` is implemented for a number of language types;
 /// custom message types are required to implement this via the
-/// [`derive(VoidMsg)`](../macros/index.html#the-derivevoidmsg-macro) macro.
+/// [`derive(VoidMsg)`](https://docs.rs/kas/latest/kas/macros#the-derivevoidmsg-macro) macro.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum VoidMsg {}

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -47,7 +47,7 @@ mod storage;
 use crate::dir::{Direction, Directional};
 
 pub use align::{Align, AlignHints, CompleteAlignment};
-pub use grid_solver::{GridChildInfo, GridSetter, GridSolver};
+pub use grid_solver::{DefaultWithLen, GridChildInfo, GridSetter, GridSolver};
 pub use row_solver::{RowPositionSolver, RowSetter, RowSolver};
 pub use single_solver::{SingleSetter, SingleSolver};
 pub use size_rules::SizeRules;

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -79,7 +79,7 @@ impl<'a> ToTokens for SubstTyGenerics<'a> {
 
 /// Macro to derive widget traits
 ///
-/// See the [`kas::macros`](../../kas/macros/index.html) module documentation.
+/// See documentation [in the `kas::macros` module](https://docs.rs/kas/latest/kas/macros#the-derivewidget-macro).
 #[proc_macro_derive(
     Widget,
     attributes(handler, layout, layout_data, widget, widget_core, widget_derive)
@@ -584,7 +584,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 /// Macro to create a widget with anonymous type
 ///
-/// See the [`kas::macros`](../../kas/macros/index.html) module documentation.
+/// See documentation [in the `kas::macros` module](https://docs.rs/kas/latest/kas/macros#the-make_widget-macro).
 #[proc_macro]
 pub fn make_widget(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut find_handler_ty_buf: Vec<(Ident, Type)> = vec![];
@@ -840,7 +840,7 @@ pub fn make_widget(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 /// Macro to derive `From<VoidMsg>`
 ///
-/// See the [`kas::macros`](../../kas/macros/index.html) module documentation.
+/// See documentation [ in the `kas::macros` module](https://docs.rs/kas/latest/kas/macros#the-derivevoidmsg-macro).
 #[proc_macro_derive(VoidMsg)]
 pub fn derive_empty_msg(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = parse_macro_input!(input as syn::DeriveInput);

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -8,7 +8,7 @@
 use std::fmt::{self, Debug};
 use std::rc::Rc;
 
-use super::{Column, MenuEntry};
+use super::{IndexedColumn, MenuEntry};
 use kas::draw::TextClass;
 use kas::event::{self, Command, GrabMode};
 use kas::prelude::*;
@@ -117,7 +117,7 @@ impl ComboBox<VoidMsg> {
             frame_size: Default::default(),
             popup: ComboPopup {
                 core: Default::default(),
-                inner: Column::new(entries),
+                inner: IndexedColumn::new(entries),
             },
             active,
             opening: false,
@@ -429,5 +429,5 @@ struct ComboPopup {
     #[widget_core]
     core: CoreData,
     #[widget]
-    inner: Column<MenuEntry<()>>,
+    inner: IndexedColumn<MenuEntry<()>>,
 }

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -63,6 +63,8 @@ mod frame;
 mod grid;
 mod label;
 mod list;
+#[macro_use]
+mod macros;
 mod menu;
 mod nav_frame;
 mod progress;

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -5,11 +5,40 @@
 
 //! A row or column with run-time adjustable contents
 
-use std::ops::{Index, IndexMut};
-
 use kas::dir::{Down, Right};
 use kas::layout::{self, RulesSetter, RulesSolver};
 use kas::{event, prelude::*};
+use std::fmt::{self, Debug};
+use std::ops::{Index, IndexMut};
+
+/// Support for optionally-indexed messages
+pub trait FromIndexed<T> {
+    fn from_indexed(i: usize, t: T) -> Self;
+}
+impl<T> FromIndexed<T> for T {
+    #[inline]
+    fn from_indexed(_: usize, t: T) -> Self {
+        t
+    }
+}
+impl<T> FromIndexed<T> for (usize, T) {
+    #[inline]
+    fn from_indexed(i: usize, t: T) -> Self {
+        (i, t)
+    }
+}
+impl<T> FromIndexed<T> for (u32, T) {
+    #[inline]
+    fn from_indexed(i: usize, t: T) -> Self {
+        (i.cast(), t)
+    }
+}
+impl<T> FromIndexed<T> for (u64, T) {
+    #[inline]
+    fn from_indexed(i: usize, t: T) -> Self {
+        (i.cast(), t)
+    }
+}
 
 /// A generic row widget
 ///
@@ -20,6 +49,16 @@ pub type Row<W> = List<Right, W>;
 ///
 /// See documentation of [`List`] type.
 pub type Column<W> = List<Down, W>;
+
+/// A generic row widget
+///
+/// See documentation of [`IndexedList`] type.
+pub type IndexedRow<W> = IndexedList<Right, W>;
+
+/// A generic column widget
+///
+/// See documentation of [`IndexedList`] type.
+pub type IndexedColumn<W> = IndexedList<Down, W>;
 
 /// A row of boxed widgets
 ///
@@ -44,40 +83,146 @@ pub type BoxList<D, M> = List<D, Box<dyn Widget<Msg = M>>>;
 
 /// A generic row/column widget
 ///
-/// This type is generic over both directionality and the type of child widgets.
-/// Essentially, it is a [`Vec`] which also implements the [`Widget`] trait.
+/// This type is roughly [`Vec`] but for widgets. Generics:
 ///
-/// [`Row`] and [`Column`] are parameterisations with set directionality.
+/// -   `D:` [`Directional`] — fixed or run-time direction of layout
+/// -   `W:` [`Widget`] — type of widget
 ///
-/// [`BoxList`] (and its derivatives [`BoxRow`], [`BoxColumn`]) parameterise
-/// `W = Box<dyn Widget>`, thus supporting individually boxed child widgets.
-/// This allows use of multiple types of child widget at the cost of extra
-/// allocation, and requires dynamic dispatch of methods.
+/// The `List` widget forwards messages from children: `M = <W as Handler>::Msg`.
+///
+/// ## Alternatives
+///
+/// Some more specific type-defs are available:
+///
+/// -   [`Row`] fixes the direction to [`Right`]
+/// -   [`Column`] fixes the direction to [`Down`]
+/// -   [`BoxList`] is parameterised over the message type `M`, using boxed
+///     widgets: `Box<dyn Widget<Msg = M>>`
+/// -   [`BoxRow`] and [`BoxColumn`] are variants of [`BoxList`] with fixed direction
+///
+/// See also [`IndexedList`] and [`GenericList`] which allow other message types.
+///
+/// Where the entries are fixed, also consider custom [`Widget`] implementations.
+///
+/// ## Performance
 ///
 /// Configuring and resizing elements is O(n) in the number of children.
 /// Drawing and event handling is O(log n) in the number of children (assuming
 /// only a small number are visible at any one time).
+pub type List<D, W> = GenericList<D, W, <W as Handler>::Msg>;
+
+/// A generic row/column widget
 ///
-/// For fixed configurations of child widgets, [`make_widget`] can be used
-/// instead. [`make_widget`] has the advantage that it can support child widgets
-/// of multiple types without allocation and via static dispatch, but the
-/// disadvantage that drawing and event handling are O(n) in the number of
-/// children.
+/// This type is roughly [`Vec`] but for widgets. Generics:
 ///
-/// [`make_widget`]: ../macros/index.html#the-make_widget-macro
-#[derive(Clone, Default, Debug, Widget)]
-#[handler(send=noauto, msg=(usize, <W as event::Handler>::Msg))]
+/// -   `D:` [`Directional`] — fixed or run-time direction of layout
+/// -   `W:` [`Widget`] — type of widget
+///
+/// The `IndexedList` widget forwards messages from children together with the
+/// child's index in the list: `(usize, M)` where `M = <W as Handler>::Msg`.
+///
+/// ## Alternatives
+///
+/// Some more specific type-defs are available:
+///
+/// -   [`IndexedRow`] fixes the direction to [`Right`]
+/// -   [`IndexedColumn`] fixes the direction to [`Down`]
+///
+/// See also [`List`] and [`GenericList`] which allow other message types.
+///
+/// Where the entries are fixed, also consider custom [`Widget`] implementations.
+///
+/// ## Performance
+///
+/// Configuring and resizing elements is O(n) in the number of children.
+/// Drawing and event handling is O(log n) in the number of children (assuming
+/// only a small number are visible at any one time).
+pub type IndexedList<D, W> = GenericList<D, W, (usize, <W as Handler>::Msg)>;
+
+/// A generic row/column widget
+///
+/// This type is roughly [`Vec`] but for widgets. Generics:
+///
+/// -   `D:` [`Directional`] — fixed or run-time direction of layout
+/// -   `W:` [`Widget`] — type of widget
+/// -   `M` — the message type; restricted to `M:` [`FromIndexed`]`<M2>` where
+///     `M2` is the child's message type; this is usually either `M2` or `(usize, M2)`
+///
+/// ## Alternatives
+///
+/// Some more specific type-defs are available:
+///
+/// -   [`List`] fixes the message type to that of the child widget type `M`
+/// -   [`IndexedList`] fixes the message type to `(usize, M)`
+/// -   [`Row`], [`Column`], [`IndexedRow`], [`BoxList`], etc.
+///
+/// Where the entries are fixed, also consider custom [`Widget`] implementations.
+///
+/// ## Performance
+///
+/// Configuring and resizing elements is O(n) in the number of children.
+/// Drawing and event handling is O(log n) in the number of children (assuming
+/// only a small number are visible at any one time).
+#[derive(Widget)]
+#[handler(send=noauto, msg=M)]
 #[widget(children=noauto)]
-pub struct List<D: Directional, W: Widget> {
+pub struct GenericList<D: Directional, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> {
     first_id: WidgetId,
     #[widget_core]
     core: CoreData,
     widgets: Vec<W>,
     data: layout::DynRowStorage,
     direction: D,
+    _pd: std::marker::PhantomData<M>,
 }
 
-impl<D: Directional, W: Widget> WidgetChildren for List<D, W> {
+impl<D: Directional, W: Widget + Clone, M: FromIndexed<<W as Handler>::Msg> + 'static> Clone
+    for GenericList<D, W, M>
+{
+    fn clone(&self) -> Self {
+        GenericList {
+            first_id: self.first_id,
+            core: self.core.clone(),
+            widgets: self.widgets.clone(),
+            data: self.data.clone(),
+            direction: self.direction.clone(),
+            _pd: Default::default(),
+        }
+    }
+}
+
+impl<D: Directional + Default, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> Default
+    for GenericList<D, W, M>
+{
+    fn default() -> Self {
+        GenericList {
+            first_id: Default::default(),
+            core: Default::default(),
+            widgets: Default::default(),
+            data: Default::default(),
+            direction: Default::default(),
+            _pd: Default::default(),
+        }
+    }
+}
+
+impl<D: Directional, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> Debug
+    for GenericList<D, W, M>
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("GenericList")
+            .field("first_id", &self.first_id)
+            .field("core", &self.core)
+            .field("widgets", &self.widgets)
+            .field("data", &self.data)
+            .field("direction", &self.direction)
+            .finish()
+    }
+}
+
+impl<D: Directional, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> WidgetChildren
+    for GenericList<D, W, M>
+{
     #[inline]
     fn first_id(&self) -> WidgetId {
         self.first_id
@@ -99,7 +244,9 @@ impl<D: Directional, W: Widget> WidgetChildren for List<D, W> {
     }
 }
 
-impl<D: Directional, W: Widget> Layout for List<D, W> {
+impl<D: Directional, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> Layout
+    for GenericList<D, W, M>
+{
     fn size_rules(&mut self, size_handle: &mut dyn SizeHandle, axis: AxisInfo) -> SizeRules {
         let dim = (self.direction, self.widgets.len());
         let mut solver = layout::RowSolver::new(axis, dim, &mut self.data);
@@ -170,7 +317,9 @@ impl<D: Directional, W: Widget> Layout for List<D, W> {
     }
 }
 
-impl<D: Directional, W: Widget> event::SendEvent for List<D, W> {
+impl<D: Directional, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> event::SendEvent
+    for GenericList<D, W, M>
+{
     fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
         if !self.is_disabled() {
             for (i, child) in self.widgets.iter_mut().enumerate() {
@@ -185,7 +334,7 @@ impl<D: Directional, W: Widget> event::SendEvent for List<D, W> {
                                 id,
                                 kas::util::TryFormat(&msg)
                             );
-                            Response::Msg((i, msg))
+                            Response::Msg(FromIndexed::from_indexed(i, msg))
                         }
                     };
                 }
@@ -196,24 +345,27 @@ impl<D: Directional, W: Widget> event::SendEvent for List<D, W> {
     }
 }
 
-impl<D: Directional + Default, W: Widget> List<D, W> {
+impl<D: Directional + Default, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static>
+    GenericList<D, W, M>
+{
     /// Construct a new instance
     ///
     /// This constructor is available where the direction is determined by the
     /// type: for `D: Directional + Default`. In other cases, use
-    /// [`List::new_with_direction`].
+    /// [`Self::new_with_direction`].
     pub fn new(widgets: Vec<W>) -> Self {
-        List {
+        GenericList {
             first_id: Default::default(),
             core: Default::default(),
             widgets,
             data: Default::default(),
             direction: Default::default(),
+            _pd: Default::default(),
         }
     }
 }
 
-impl<W: Widget> List<Direction, W> {
+impl<W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> GenericList<Direction, W, M> {
     /// Set the direction of contents
     pub fn set_direction(&mut self, direction: Direction) -> TkAction {
         self.direction = direction;
@@ -222,15 +374,18 @@ impl<W: Widget> List<Direction, W> {
     }
 }
 
-impl<D: Directional, W: Widget> List<D, W> {
+impl<D: Directional, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static>
+    GenericList<D, W, M>
+{
     /// Construct a new instance with explicit direction
     pub fn new_with_direction(direction: D, widgets: Vec<W>) -> Self {
-        List {
+        GenericList {
             first_id: Default::default(),
             core: Default::default(),
             widgets,
             data: Default::default(),
             direction,
+            _pd: Default::default(),
         }
     }
 
@@ -402,7 +557,9 @@ impl<D: Directional, W: Widget> List<D, W> {
     }
 }
 
-impl<D: Directional, W: Widget> Index<usize> for List<D, W> {
+impl<D: Directional, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> Index<usize>
+    for GenericList<D, W, M>
+{
     type Output = W;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -410,7 +567,9 @@ impl<D: Directional, W: Widget> Index<usize> for List<D, W> {
     }
 }
 
-impl<D: Directional, W: Widget> IndexMut<usize> for List<D, W> {
+impl<D: Directional, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> IndexMut<usize>
+    for GenericList<D, W, M>
+{
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.widgets[index]
     }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -42,12 +42,12 @@ impl<T> FromIndexed<T> for (u64, T) {
 
 /// A generic row widget
 ///
-/// See documentation of [`List`] type.
+/// See documentation of [`List`] type. See also the [`row`](crate::row) macro.
 pub type Row<W> = List<Right, W>;
 
 /// A generic column widget
 ///
-/// See documentation of [`List`] type.
+/// See documentation of [`List`] type. See also the [`column`](crate::column) macro.
 pub type Column<W> = List<Down, W>;
 
 /// A generic row widget
@@ -96,6 +96,7 @@ pub type BoxList<D, M> = List<D, Box<dyn Widget<Msg = M>>>;
 ///
 /// -   [`Row`] fixes the direction to [`Right`]
 /// -   [`Column`] fixes the direction to [`Down`]
+/// -   [`row`](crate::row) and [`column`](crate::column) macros
 /// -   [`BoxList`] is parameterised over the message type `M`, using boxed
 ///     widgets: `Box<dyn Widget<Msg = M>>`
 /// -   [`BoxRow`] and [`BoxColumn`] are variants of [`BoxList`] with fixed direction

--- a/crates/kas-widgets/src/macros.rs
+++ b/crates/kas-widgets/src/macros.rs
@@ -1,0 +1,38 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Widget macros
+
+/// Sugar for `Row::new(vec![...])`
+///
+/// See [`vec`], [`Row`](crate::Row), [`List`](crate::List).
+#[macro_export]
+macro_rules! row {
+    () => {
+        $crate::Row::new(vec![])
+    };
+    ($item:expr; $n:expr) => {
+        $crate::Row::new(vec![$item; $n])
+    };
+    ($($item:expr),+ $(,)?) => {
+        $crate::Row::new(vec![$($item),*])
+    };
+}
+
+/// Sugar for `Column::new(vec![...])`
+///
+/// See also [`vec`], [`Column`](crate::Column), [`List`](crate::List).
+#[macro_export]
+macro_rules! column {
+    () => {
+        $crate::Column::new(vec![])
+    };
+    ($item:expr; $n:expr) => {
+        $crate::Column::new(vec![$item; $n])
+    };
+    ($($item:expr),+ $(,)?) => {
+        $crate::Column::new(vec![$($item),*])
+    };
+}

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -6,7 +6,7 @@
 //! Menubar
 
 use super::{Menu, SubMenu};
-use crate::List;
+use crate::IndexedList;
 use kas::event::{self, Command, GrabMode};
 use kas::prelude::*;
 
@@ -20,7 +20,7 @@ pub struct MenuBar<W: Menu, D: Directional = kas::dir::Right> {
     #[widget_core]
     core: CoreData,
     #[widget]
-    pub bar: List<D, SubMenu<D::Flipped, W>>,
+    pub bar: IndexedList<D, SubMenu<D::Flipped, W>>,
     ideal: Size,
     // Open mode. Used to close with click on root only when previously open.
     opening: bool,
@@ -46,7 +46,7 @@ impl<W: Menu, D: Directional> MenuBar<W, D> {
         }
         MenuBar {
             core: Default::default(),
-            bar: List::new_with_direction(direction, menus),
+            bar: IndexedList::new_with_direction(direction, menus),
             ideal: Size::ZERO,
             opening: false,
             delayed_open: None,

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -86,7 +86,7 @@ impl<W: Menu, D: Directional> Layout for MenuBar<W, D> {
         self.bar.draw(draw_handle, mgr, disabled);
     }
 }
-impl<W: Menu<Msg = M>, D: Directional, M> event::Handler for MenuBar<W, D> {
+impl<W: Menu<Msg = M>, D: Directional, M: 'static> event::Handler for MenuBar<W, D> {
     type Msg = M;
 
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -148,7 +148,7 @@ impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
     }
 }
 
-impl<D: Directional, M, W: Menu<Msg = M>> event::Handler for SubMenu<D, W> {
+impl<D: Directional, M: 'static, W: Menu<Msg = M>> event::Handler for SubMenu<D, W> {
     type Msg = M;
 
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<M> {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -237,7 +237,7 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
                     self.set_menu_path(mgr, Some(id));
                     Response::None
                 }
-                Response::Msg((_, msg)) => {
+                Response::Msg(msg) => {
                     self.close_menu(mgr);
                     Response::Msg(msg)
                 }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -5,43 +5,35 @@
 
 //! Counter example (simple button)
 
-use kas::macros::{make_widget, VoidMsg};
+use kas::macros::make_widget;
 use kas::prelude::*;
 use kas::widgets::{row, Label, TextButton, Window};
-
-#[derive(Clone, Debug, VoidMsg)]
-enum Message {
-    Decr,
-    Incr,
-}
 
 fn main() -> Result<(), kas::shell::Error> {
     env_logger::init();
 
-    let window = Window::new(
-        "Counter",
-        make_widget! {
-            #[layout(column)]
-            #[handler(msg = VoidMsg)]
-            struct {
-                #[widget(halign=centre)] display: Label<String> = Label::from("0"),
-                #[widget(use_msg = handle_button)] buttons -> Message = row![
-                    TextButton::new_msg("−", Message::Decr),
-                    TextButton::new_msg("+", Message::Incr),
-                ],
-                counter: usize = 0,
+    let counter = make_widget! {
+        #[layout(column)]
+        #[handler(msg = VoidMsg)]
+        struct {
+            #[widget(halign=centre)]
+            display: Label<String> = Label::from("0"),
+            #[widget(use_msg = handle_button)]
+            buttons = row![
+                TextButton::new_msg("−", -1),
+                TextButton::new_msg("+", 1),
+            ],
+            count: i32 = 0,
+        }
+        impl {
+            fn handle_button(&mut self, mgr: &mut Manager, incr: i32) {
+                self.count += incr;
+                *mgr |= self.display.set_string(self.count.to_string());
             }
-            impl {
-                fn handle_button(&mut self, mgr: &mut Manager, msg: Message) {
-                    match msg {
-                        Message::Decr => self.counter = self.counter.saturating_sub(1),
-                        Message::Incr => self.counter = self.counter.saturating_add(1),
-                    }
-                    *mgr |= self.display.set_string(self.counter.to_string());
-                }
-            }
-        },
-    );
+        }
+    };
+
+    let window = Window::new("Counter", counter);
 
     let theme = kas::theme::ShadedTheme::new().with_font_size(24.0);
     kas::shell::Toolkit::new(theme)?.with(window)?.run()

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -18,15 +18,6 @@ enum Message {
 fn main() -> Result<(), kas::shell::Error> {
     env_logger::init();
 
-    // Most examples use make_widget! for layout, but here we use the Row widget
-    // (compare with sync-counter.rs). Note that Row produces (index, child_msg)
-    // messages, thus we use map_msg to remove the unwanted index.
-    let buttons = Row::new(vec![
-        TextButton::new_msg("−", Message::Decr),
-        TextButton::new_msg("+", Message::Incr),
-    ])
-    .map_msg(|_, msg| msg.1);
-
     let window = Window::new(
         "Counter",
         make_widget! {
@@ -34,7 +25,10 @@ fn main() -> Result<(), kas::shell::Error> {
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget(halign=centre)] display: Label<String> = Label::from("0"),
-                #[widget(use_msg = handle_button)] buttons -> Message = buttons,
+                #[widget(use_msg = handle_button)] buttons -> Message = Row::new(vec![
+                    TextButton::new_msg("−", Message::Decr),
+                    TextButton::new_msg("+", Message::Incr),
+                ]),
                 counter: usize = 0,
             }
             impl {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -7,7 +7,7 @@
 
 use kas::macros::{make_widget, VoidMsg};
 use kas::prelude::*;
-use kas::widgets::{Label, Row, TextButton, Window};
+use kas::widgets::{row, Label, TextButton, Window};
 
 #[derive(Clone, Debug, VoidMsg)]
 enum Message {
@@ -25,10 +25,10 @@ fn main() -> Result<(), kas::shell::Error> {
             #[handler(msg = VoidMsg)]
             struct {
                 #[widget(halign=centre)] display: Label<String> = Label::from("0"),
-                #[widget(use_msg = handle_button)] buttons -> Message = Row::new(vec![
+                #[widget(use_msg = handle_button)] buttons -> Message = row![
                     TextButton::new_msg("−", Message::Decr),
                     TextButton::new_msg("+", Message::Incr),
-                ]),
+                ],
                 counter: usize = 0,
             }
             impl {

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -78,8 +78,7 @@ fn main() -> Result<(), kas::shell::Error> {
         cursor!(RowResize),
     ]);
 
-    let gallery = column.map_msg(|_, (_, msg)| msg);
-    let window = Window::new("Cursor gallery", gallery);
+    let window = Window::new("Cursor gallery", column);
     let theme = kas::theme::FlatTheme::new();
     kas::shell::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -134,7 +134,7 @@ fn main() -> Result<(), kas::shell::Error> {
         ListEntry::new(1, false),
         ListEntry::new(2, false),
     ];
-    let list = List::new_with_direction(Direction::Down, entries);
+    let list = IndexedList::new_with_direction(Direction::Down, entries);
 
     let window = Window::new(
         "Dynamic widget demo",
@@ -147,7 +147,7 @@ fn main() -> Result<(), kas::shell::Error> {
                 #[widget] _ = Label::new("Contents of selected entry:"),
                 #[widget] display: StringLabel = Label::from("Entry #0"),
                 #[widget] _ = Separator::new(),
-                #[widget(use_msg = set_radio)] list: ScrollBarRegion<List<Direction, ListEntry>> =
+                #[widget(use_msg = set_radio)] list: ScrollBarRegion<IndexedList<Direction, ListEntry>> =
                     ScrollBarRegion::new(list).with_bars(false, true),
                 #[widget] _ = Filler::maximize(),
                 active: usize = 0,

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -228,14 +228,14 @@ fn main() -> Result<(), kas::shell::Error> {
             #[widget(row=2, col=0)] _ = Label::new("TextButton"),
             #[widget(row=2, col=1)] _ = TextButton::new_msg("&Press me", Item::Button),
             #[widget(row=3, col=0)] _ = Label::new("Button<Image>"),
-            #[widget(row=3, col=1)] _ = Row::new(vec![
+            #[widget(row=3, col=1)] _ = row![
                 Button::new_msg(Image::new("res/sun_32.png"), Item::LightTheme)
                     .with_color(Rgb::rgb(0.3, 0.4, 0.5))
                     .with_keys(&[VK::L]),
                 Button::new_msg(Image::new("res/moon_32.png"), Item::DarkTheme)
                     .with_color(Rgb::grey(0.1))
                     .with_keys(&[VK::K]),
-            ]),
+            ],
             #[widget(row=4, col=0)] _ = Label::new("CheckBox"),
             #[widget(row=4, col=1)] _ = CheckBox::new("&Check me")
                 .with_state(true)

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -235,7 +235,7 @@ fn main() -> Result<(), kas::shell::Error> {
                 Button::new_msg(Image::new("res/moon_32.png"), Item::DarkTheme)
                     .with_color(Rgb::grey(0.1))
                     .with_keys(&[VK::K]),
-            ]).map_msg(|_, (_, m)| m),
+            ]),
             #[widget(row=4, col=0)] _ = Label::new("CheckBox"),
             #[widget(row=4, col=1)] _ = CheckBox::new("&Check me")
                 .with_state(true)

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -40,7 +40,6 @@ fn main() -> Result<(), kas::shell::Error> {
             struct {
                 #[widget(use_msg = handle_button)] buttons -> Message = buttons,
                 #[widget] panes: RowSplitter<EditField> = panes,
-                counter: usize = 0,
             }
             impl {
                 fn handle_button(&mut self, mgr: &mut Manager, msg: Message) {

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -9,20 +9,10 @@ use kas::event::{Manager, VoidMsg};
 use kas::macros::make_widget;
 use kas::updatable::SharedRc;
 use kas::widgets::view::SingleView;
-use kas::widgets::{TextButton, Window};
+use kas::widgets::{row, TextButton, Window};
 
 fn main() -> Result<(), kas::shell::Error> {
     env_logger::init();
-
-    let buttons = make_widget! {
-        #[layout(row)]
-        #[handler(msg = i32)]
-        #[derive(Clone)]
-        struct {
-            #[widget] _ = TextButton::new_msg("−", -1),
-            #[widget] _ = TextButton::new_msg("+", 1),
-        }
-    };
 
     let window = Window::new(
         "Counter",
@@ -33,7 +23,10 @@ fn main() -> Result<(), kas::shell::Error> {
             struct {
                 // SingleView embeds a shared value, here default-constructed to 0
                 #[widget(halign=centre)] counter: SingleView<SharedRc<i32>> = Default::default(),
-                #[widget(use_msg = update)] buttons -> i32 = buttons,
+                #[widget(use_msg = update)] buttons -> i32 = row![
+                    TextButton::new_msg("−", -1),
+                    TextButton::new_msg("+", 1),
+                ],
             }
             impl {
                 fn update(&mut self, mgr: &mut Manager, msg: i32) {


### PR DESCRIPTION
Various smaller changes aimed at improving app code.

The `Grid` widget is not used and possibly not useful in practice: although it can do the layout of `layout(grid)`, it cannot easily handle multiple widget types (this requires boxing and explicit mapping of messages), it cannot currently do custom alignment (could be fixed easily), it cannot have message handlers (any attempt to fix this would have significant limitations compared to custom widgets, e.g. no (named) field access), and cannot enable alt-bypass (used in the calculator).