### PR TITLE
Fix menu behaviour (#253)

### DIFF
--- a/crates/kas-core/src/core/data.rs
+++ b/crates/kas-core/src/core/data.rs
@@ -156,12 +156,6 @@ pub trait LayoutData {
 /// A pop-up widget's rect is not contained by its parent, therefore the parent
 /// must not call any [`Layout`] methods on the pop-up (whether or not it is
 /// visible). The window is responsible for calling these methods.
-///
-/// Other methods on the pop-up, including event handlers, should be called
-/// normally, with one exception: after calling an event handler on the pop-up,
-/// the parent should invoke [`Manager::pop_action`] and handle the action
-/// itself, where possible (using [`Manager::close_window`] to close it).
-/// Remaining actions should be added back to the [`Manager`].
 //
 // NOTE: it's tempting to include a pointer to the widget here. There are two
 // options: (a) an unsafe aliased pointer or (b) Rc<RefCell<dyn WidgetConfig>>.

--- a/crates/kas-core/src/data/shared_data.rs
+++ b/crates/kas-core/src/data/shared_data.rs
@@ -1,6 +1,0 @@
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License in the LICENSE-APACHE file or at:
-//     https://www.apache.org/licenses/LICENSE-2.0
-
-//! Traits for shared data objects

--- a/crates/kas-core/src/dir.rs
+++ b/crates/kas-core/src/dir.rs
@@ -5,6 +5,8 @@
 
 //! Direction types
 
+use std::fmt;
+
 /// Trait over directional types
 ///
 /// This trait has a variable implementation, [`Direction`], and several fixed
@@ -90,6 +92,21 @@ pub enum Direction {
     Down = 1,
     Left = 2,
     Up = 3,
+}
+
+impl fmt::Display for Direction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "{}",
+            match self {
+                Direction::Right => "Right",
+                Direction::Down => "Down",
+                Direction::Left => "Left",
+                Direction::Up => "Up",
+            }
+        )
+    }
 }
 
 impl Directional for Direction {

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -153,12 +153,6 @@ pub enum Event {
     /// A user-defined payload is passed. Interpretation of this payload is
     /// user-defined and unfortunately not type safe.
     HandleUpdate { handle: UpdateHandle, payload: u64 },
-    /// Notification that a new popup has been created
-    ///
-    /// This is sent to the parent of each open popup when a new popup is
-    /// created. This enables parents to close their popups when the new popup
-    /// is not a descendant of itself. The `WidgetId` is that of the popup.
-    NewPopup(WidgetId),
     /// Notification that a popup has been destroyed
     ///
     /// This is sent to the popup's parent after a popup has been removed.

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -13,7 +13,7 @@ use super::{GrabMode, Manager, Response, SendEvent}; // for doc-links
 use super::{MouseButton, UpdateHandle, VirtualKeyCode};
 
 use crate::geom::{Coord, DVec2, Offset};
-use crate::{WidgetId, WindowId};
+use crate::{dir::Direction, WidgetId, WindowId};
 
 /// Events addressed to a widget
 #[non_exhaustive]
@@ -381,6 +381,17 @@ impl Command {
     pub fn suitable_for_sel_focus(self) -> bool {
         use Command::*;
         matches!(self, Escape | Cut | Copy | Deselect)
+    }
+
+    /// Convert arrow keys to a direction
+    pub fn as_direction(self) -> Option<Direction> {
+        match self {
+            Command::Left => Some(Direction::Left),
+            Command::Right => Some(Direction::Right),
+            Command::Up => Some(Direction::Up),
+            Command::Down => Some(Direction::Down),
+            _ => None,
+        }
     }
 }
 

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -307,7 +307,7 @@ impl<'a> Manager<'a> {
             return;
         } else if vkey == VK::Escape {
             if let Some(id) = self.state.popups.last().map(|(id, _, _)| *id) {
-                self.close_window(id);
+                self.close_window(id, true);
                 return;
             }
         } else if !self.state.char_focus {
@@ -390,7 +390,7 @@ impl<'a> Manager<'a> {
             let last = self.state.popups.len() - 1;
             for i in 0..n {
                 let id = self.state.popups[last - i].0;
-                self.close_window(id);
+                self.close_window(id, false);
             }
         }
 
@@ -516,7 +516,7 @@ impl<'a> Manager<'a> {
                 Response::Unhandled => (),
                 _ => return,
             }
-            self.close_window(wid);
+            self.close_window(wid, false);
         }
         self.send_event(widget, id, event);
     }

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -618,6 +618,7 @@ impl<'a> Manager<'a> {
             self.redraw(id);
         }
         self.state.nav_focus = None;
+        self.clear_char_focus();
         trace!("Manager: nav_focus = None");
     }
 

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -258,8 +258,12 @@ impl<'a> Manager<'a> {
     ///
     /// In the case of a pop-up, all pop-ups created after this will also be
     /// removed (on the assumption they are a descendant of the first popup).
+    ///
+    /// If `restore_focus` then navigation focus will return to whichever widget
+    /// had focus before the popup was open. (Usually this is true excepting
+    /// where focus has already been changed.)
     #[inline]
-    pub fn close_window(&mut self, id: WindowId) {
+    pub fn close_window(&mut self, id: WindowId, restore_focus: bool) {
         if let Some(index) =
             self.state.popups.iter().enumerate().find_map(
                 |(i, p)| {
@@ -279,9 +283,14 @@ impl<'a> Manager<'a> {
                 old_nav_focus = onf;
             }
 
+            if !restore_focus {
+                old_nav_focus = None
+            }
             if let Some(id) = old_nav_focus {
                 self.set_nav_focus(id, true);
             }
+            // TODO: if popup.id is an ancestor of self.nav_focus then clear
+            // focus if not setting (currently we cannot test this)
         }
 
         self.shell.close_window(id);

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -216,17 +216,6 @@ impl<'a> Manager<'a> {
         self.action |= action;
     }
 
-    /// Get the current [`TkAction`], replacing with `None`
-    ///
-    /// The caller is responsible for ensuring the action is handled correctly;
-    /// generally this means matching only actions which can be handled locally
-    /// and downgrading the action, adding the result back to the [`Manager`].
-    pub fn pop_action(&mut self) -> TkAction {
-        let action = self.action;
-        self.action = TkAction::empty();
-        action
-    }
-
     /// Add an overlay (pop-up)
     ///
     /// A pop-up is a box used for things like tool-tips and menus which is

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -240,22 +240,6 @@ impl ManagerState {
         trace!("Manager::region_moved");
         // Note: redraw is already implied.
 
-        self.nav_focus = self
-            .nav_focus
-            .and_then(|id| widget.find_leaf(id).map(|w| w.id()));
-        if let Some(id) = self.sel_focus {
-            if let Some(new_id) = widget.find_leaf(id).map(|w| w.id()) {
-                self.sel_focus = Some(new_id);
-            } else {
-                if self.char_focus {
-                    self.pending.push(Pending::LostCharFocus(id));
-                    self.char_focus = false;
-                }
-                self.pending.push(Pending::LostSelFocus(id));
-                self.sel_focus = None;
-            }
-        }
-
         // Update hovered widget
         let hover = widget.find_id(self.last_mouse_coord);
         self.with(shell, |mgr| mgr.set_hover(widget, hover));

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -447,7 +447,7 @@ impl<'a> Manager<'a> {
             Focused(false) => {
                 // Window focus lost: close all popups
                 while let Some(id) = self.state.popups.last().map(|(id, _, _)| *id) {
-                    self.close_window(id);
+                    self.close_window(id, true);
                 }
             }
             KeyboardInput {

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -457,6 +457,12 @@ impl<'a> Manager<'a> {
                     }
                 }
             }
+            Focused(false) => {
+                // Window focus lost: close all popups
+                while let Some(id) = self.state.popups.last().map(|(id, _, _)| *id) {
+                    self.close_window(id);
+                }
+            }
             KeyboardInput {
                 input,
                 is_synthetic,

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -34,6 +34,11 @@ impl SelectionHelper {
         }
     }
 
+    /// Reset to the default state
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
     /// True if the edit pos equals the selection pos
     pub fn is_empty(&self) -> bool {
         self.edit_pos == self.sel_pos

--- a/crates/kas-core/src/toolkit.rs
+++ b/crates/kas-core/src/toolkit.rs
@@ -80,7 +80,7 @@ bitflags! {
         ///
         /// [`WidgetId`]: crate::WidgetId
         const RECONFIGURE = 1 << 16;
-        /// The current window or pop-up should be closed
+        /// The current window should be closed
         const CLOSE = 1 << 30;
         /// Close all windows and exit
         const EXIT = 1 << 31;

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -379,14 +379,6 @@ impl<M: 'static> event::Handler for ComboBox<M> {
                     mgr.close_window(id);
                 }
             }
-            Event::NewPopup(id) => {
-                // For a ComboBox, for any new Popup we should close self
-                if id != self.popup.id() {
-                    if let Some(id) = self.popup_id {
-                        mgr.close_window(id);
-                    }
-                }
-            }
             Event::PopupRemoved(id) => {
                 debug_assert_eq!(Some(id), self.popup_id);
                 self.popup_id = None;

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -299,9 +299,6 @@ impl<M: 'static> ComboBox<M> {
                 }
             }
         }
-        // NOTE: as part of the Popup API we are expected to trap
-        // TkAction::CLOSE here, but we know our widget doesn't generate
-        // this action.
     }
 }
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -273,7 +273,7 @@ impl<M: 'static> ComboBox<M> {
             Response::Focus(x) => Response::Focus(x),
             Response::Update | Response::Select => {
                 if let Some(id) = self.popup_id {
-                    mgr.close_window(id);
+                    mgr.close_window(id, true);
                 }
                 if let Some(index) = self.popup.inner.find_child_index(id) {
                     if index != self.active {
@@ -290,7 +290,7 @@ impl<M: 'static> ComboBox<M> {
             Response::Msg((index, ())) => {
                 *mgr |= self.set_active(index);
                 if let Some(id) = self.popup_id {
-                    mgr.close_window(id);
+                    mgr.close_window(id, true);
                 }
                 if let Some(ref f) = self.on_select {
                     Response::update_or_msg((f)(mgr, index))
@@ -319,7 +319,7 @@ impl<M: 'static> event::Handler for ComboBox<M> {
         match event {
             Event::Activate => {
                 if let Some(id) = self.popup_id {
-                    mgr.close_window(id);
+                    mgr.close_window(id, true);
                 } else {
                     open_popup(self, mgr, true);
                 }
@@ -337,7 +337,7 @@ impl<M: 'static> event::Handler for ComboBox<M> {
                     }
                 } else {
                     if let Some(id) = self.popup_id {
-                        mgr.close_window(id);
+                        mgr.close_window(id, false);
                     }
                     return Response::Unhandled;
                 }
@@ -373,7 +373,7 @@ impl<M: 'static> event::Handler for ComboBox<M> {
                     }
                 }
                 if let Some(id) = self.popup_id {
-                    mgr.close_window(id);
+                    mgr.close_window(id, true);
                 }
             }
             Event::PopupRemoved(id) => {

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -1044,6 +1044,7 @@ impl<G: EditGuard> HasString for EditField<G> {
         }
 
         self.text.set_string(string);
+        self.selection.clear();
         if kas::text::fonts::fonts().num_faces() > 0 {
             if let Some(req) = self.text.prepare() {
                 self.required = req.into();

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -33,7 +33,13 @@ pub trait Menu: Widget {
     /// are menus, these should open.
     ///
     /// `target == None` implies that all menus should close.
-    fn set_menu_path(&mut self, _mgr: &mut Manager, _target: Option<WidgetId>) {}
+    ///
+    /// When opening menus and `set_focus` is true, the first navigable child
+    /// of the newly opened menu will be given focus. This is used for keyboard
+    /// navigation only.
+    fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<WidgetId>, set_focus: bool) {
+        let _ = (mgr, target, set_focus);
+    }
 }
 
 impl<M: 'static> WidgetCore for Box<dyn Menu<Msg = M>> {
@@ -156,8 +162,8 @@ impl<M: 'static> Menu for Box<dyn Menu<Msg = M>> {
     fn menu_is_open(&self) -> bool {
         self.deref().menu_is_open()
     }
-    fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<WidgetId>) {
-        self.deref_mut().set_menu_path(mgr, target)
+    fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<WidgetId>, set_focus: bool) {
+        self.deref_mut().set_menu_path(mgr, target, set_focus)
     }
 }
 

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -33,9 +33,6 @@ impl<M: Clone + Debug + 'static> WidgetConfig for MenuEntry<M> {
     fn key_nav(&self) -> bool {
         true
     }
-    fn hover_highlight(&self) -> bool {
-        true
-    }
 }
 
 impl<M: Clone + Debug + 'static> Layout for MenuEntry<M> {

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -116,6 +116,8 @@ impl<W: Menu<Msg = M>, D: Directional, M: 'static> event::Handler for MenuBar<W,
                             {
                                 self.opening = true;
                                 self.set_menu_path(mgr, Some(start_id));
+                            } else {
+                                self.set_menu_path(mgr, None);
                             }
                         } else {
                             self.delayed_open = Some(start_id);

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -102,9 +102,6 @@ impl<D: Directional, W: Menu> WidgetConfig for SubMenu<D, W> {
     fn key_nav(&self) -> bool {
         self.key_nav
     }
-    fn hover_highlight(&self) -> bool {
-        true
-    }
 }
 
 impl<D: Directional, W: Menu> kas::Layout for SubMenu<D, W> {
@@ -156,11 +153,6 @@ impl<D: Directional, M: 'static, W: Menu<Msg = M>> event::Handler for SubMenu<D,
             Event::Activate => {
                 if self.popup_id.is_none() {
                     self.open_menu(mgr);
-                }
-            }
-            Event::NewPopup(id) => {
-                if self.popup_id.is_some() && !self.is_ancestor_of(id) {
-                    self.close_menu(mgr);
                 }
             }
             Event::PopupRemoved(id) => {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -214,13 +214,13 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
                     }
                     _ => Response::Unhandled,
                 },
-                Response::Update | Response::Select => {
+                Response::Select => {
                     self.set_menu_path(mgr, Some(id));
                     Response::None
                 }
-                Response::Msg(msg) => {
+                r @ (Response::Update | Response::Msg(_)) => {
                     self.close_menu(mgr);
-                    Response::Msg(msg)
+                    r
                 }
             }
         } else {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -84,9 +84,9 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
             }
         }
     }
-    fn close_menu(&mut self, mgr: &mut Manager) {
+    fn close_menu(&mut self, mgr: &mut Manager, restore_focus: bool) {
         if let Some(id) = self.popup_id {
-            mgr.close_window(id);
+            mgr.close_window(id, restore_focus);
         }
     }
 
@@ -98,7 +98,7 @@ impl<D: Directional, W: Menu> SubMenu<D, W> {
                     mgr.next_nav_focus(self, rev, true);
                     Response::None
                 } else if dir == self.direction.as_direction().reversed() {
-                    self.close_menu(mgr);
+                    self.close_menu(mgr, true);
                     Response::None
                 } else {
                     Response::Unhandled
@@ -221,7 +221,7 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
                     Response::None
                 }
                 r @ (Response::Update | Response::Msg(_)) => {
-                    self.close_menu(mgr);
+                    self.close_menu(mgr, true);
                     r
                 }
             }
@@ -266,7 +266,7 @@ impl<D: Directional, W: Menu> Menu for SubMenu<D, W> {
                     for i in 0..self.list.len() {
                         self.list[i].set_menu_path(mgr, None, set_focus);
                     }
-                    self.close_menu(mgr);
+                    self.close_menu(mgr, set_focus);
                 }
             }
         }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -181,17 +181,6 @@ impl<D: Directional, W: Menu> event::SendEvent for SubMenu<D, W> {
         if id <= self.list.id() {
             let r = self.list.send(mgr, id, event.clone());
 
-            // The pop-up API expects us to check actions here
-            // But NOTE: we don't actually use this. Should we remove from API?
-            match mgr.pop_action() {
-                TkAction::CLOSE => {
-                    if let Some(id) = self.popup_id {
-                        mgr.close_window(id);
-                    }
-                }
-                other => mgr.send_action(other),
-            }
-
             match r {
                 Response::None => Response::None,
                 Response::Pan(delta) => Response::Pan(delta),


### PR DESCRIPTION
Fixes #253, and in general menu behaviour:

- close open menu when clicking menubar and when window loses focus
- tighter event handling: `TkAction::CLOSE` is no longer an acceptable way of closing a popup (was unused); remove `Event::NewPopup`; close all descendants of a popup before the popup itself
- restrict setting navigation focus on popup open/close to (mostly) keyboard input since with the mouse this is redundant or wrong
- clear character-input focus when clearing navigation focus
- rewrite handling of arrow-key input