### PR TITLE
Edition 2021, Clippy, README, fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         toolchain: [stable]
         include:
           - os: ubuntu-latest
-            toolchain: "1.53.0"
+            toolchain: "1.56.0"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-          components: rustfmt
+          components: rustfmt, clippy
       - name: Install dependencies
         run: sudo apt-get install -y libxkbcommon-dev libxcb-shape0-dev libxcb-xfixes0-dev
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,8 @@ jobs:
         run: cargo test --all-features
       - name: Test examples/mandlebrot
         run: cargo test --manifest-path examples/mandlebrot/Cargo.toml --all-features
+      - name: Clippy
+        run: cargo +nightly clippy --all --features nightly -- -D warnings
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["gui"]
 categories = ["gui"]
 repository = "https://github.com/kas-gui/kas"
 exclude = ["/examples"]
-resolver = "2"
 
 [package.metadata.docs.rs]
 features = ["nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kas"
 version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "KAS GUI Toolkit"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@ Precompiled example apps can be downloaded as follows:
 -   download one of the `examples-*` artifacts
 
 
+Design
+------
+
+### Data or widget first?
+
+KAS uses a widget-first design: widgets are persistent and retain state; data
+must be pushed into widgets. *Many* modern UIs are data-first: widgets are
+built per-frame over a single persistent data object. There are significant
+trade-offs of a widget-first design:
+
+-   (for) widgets have embedded state; data-first designs may require explicitly
+    connecting widgets to state, for those that need it
+-   (against) dynamic layout is harder
+-   (for) updates are fast since only affected widgets need be touched; using
+    10,000+ widgets in a UI is not a problem
+-   (against) rebuilding the UI is much slower
+-   (for) pre-built "view widgets" with built-in support for scrolling
+    over large external databases (only retrieving visible entries)
+-   (against) "view widgets" are an emulation of data-first design over a
+    widget-first model, and less flexible
+
+
 Getting started
 ---------------
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Getting started
 
 ### Dependencies
 
-KAS requires a recent [Rust] compiler. Currently, version 1.53 or greater is
+KAS requires a recent [Rust] compiler. Currently, version 1.56 or greater is
 required. Using the **nightly** channel does have a few advantages:
 
 -   Proceedural macros emit better diagnostics. In some cases, diagnostics are

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kas-core"
 version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "KAS GUI / core"
 readme = "README.md"

--- a/crates/kas-core/src/draw/color.rs
+++ b/crates/kas-core/src/draw/color.rs
@@ -5,6 +5,8 @@
 
 //! Colour types
 
+#![allow(clippy::self_named_constructors)]
+
 use crate::cast::{Conv, ConvFloat};
 use thiserror::Error;
 

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -384,18 +384,15 @@ impl<'a> Manager<'a> {
         } else if vkey == VK::Tab {
             self.clear_char_focus();
             self.next_nav_focus(widget.as_widget_mut(), shift, true);
-            return;
         } else if vkey == VK::Escape {
             if let Some(id) = self.state.popups.last().map(|(id, _, _)| *id) {
                 self.close_window(id, true);
-                return;
             }
         } else if !self.state.char_focus {
             if let Some(id) = self.state.nav_focus {
                 if vkey == VK::Space || vkey == VK::Return || vkey == VK::NumpadEnter {
                     self.add_key_depress(scancode, id);
                     self.send_event(widget, id, Event::Activate);
-                    return;
                 }
             }
         }

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -301,25 +301,6 @@ impl<'a> Manager<'a> {
         use VirtualKeyCode as VK;
         let shift = self.state.modifiers.shift();
 
-        if vkey == VK::Tab {
-            self.clear_char_focus();
-            self.next_nav_focus(widget.as_widget_mut(), shift, true);
-            return;
-        } else if vkey == VK::Escape {
-            if let Some(id) = self.state.popups.last().map(|(id, _, _)| *id) {
-                self.close_window(id, true);
-                return;
-            }
-        } else if !self.state.char_focus {
-            if let Some(id) = self.state.nav_focus {
-                if vkey == VK::Space || vkey == VK::Return || vkey == VK::NumpadEnter {
-                    self.add_key_depress(scancode, id);
-                    self.send_event(widget, id, Event::Activate);
-                    return;
-                }
-            }
-        }
-
         let opt_command = self
             .state
             .config
@@ -400,6 +381,23 @@ impl<'a> Manager<'a> {
             }
             self.add_key_depress(scancode, id);
             self.send_event(widget, id, Event::Activate);
+        } else if vkey == VK::Tab {
+            self.clear_char_focus();
+            self.next_nav_focus(widget.as_widget_mut(), shift, true);
+            return;
+        } else if vkey == VK::Escape {
+            if let Some(id) = self.state.popups.last().map(|(id, _, _)| *id) {
+                self.close_window(id, true);
+                return;
+            }
+        } else if !self.state.char_focus {
+            if let Some(id) = self.state.nav_focus {
+                if vkey == VK::Space || vkey == VK::Return || vkey == VK::NumpadEnter {
+                    self.add_key_depress(scancode, id);
+                    self.send_event(widget, id, Event::Activate);
+                    return;
+                }
+            }
         }
     }
 

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -686,7 +686,7 @@ impl<'a> Manager<'a> {
         // processing, we can push directly to self.state.action.
         self.state.send_action(TkAction::REDRAW);
 
-        fn nav<'a>(
+        fn nav(
             mgr: &mut Manager,
             widget: &mut dyn WidgetConfig,
             focus: Option<WidgetId>,

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -99,12 +99,12 @@ impl ManagerState {
 
         // Enumerate and configure all widgets:
         let coord = self.last_mouse_coord;
-        self.with(shell, |mut mgr| {
+        self.with(shell, |mgr| {
             mgr.push_accel_layer(false);
             widget.configure_recurse(ConfigureManager {
                 id: &mut id,
                 map: &mut renames,
-                mgr: &mut mgr,
+                mgr,
             });
             mgr.pop_accel_layer(widget.id());
             debug_assert!(mgr.state.accel_stack.is_empty());

--- a/crates/kas-dylib/Cargo.toml
+++ b/crates/kas-dylib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kas-dylib"
 version = "0.10.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "KAS GUI / dylib"
 readme = "README.md"

--- a/crates/kas-dylib/src/lib.rs
+++ b/crates/kas-dylib/src/lib.rs
@@ -9,6 +9,7 @@
 //! faster. It may be preferable only to use this in debug builds.
 
 #![allow(unused_imports)]
+#![allow(clippy::single_component_path_imports)]
 
 use kas_core;
 #[cfg(feature = "kas-resvg")]

--- a/crates/kas-macros/Cargo.toml
+++ b/crates/kas-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kas-macros"
 version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "KAS GUI / macros"
 keywords = ["gui", "proc-macro"]

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -396,7 +396,9 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     let ident = &child.ident;
                     let update = if let Some(f) = child.args.update.as_ref() {
                         quote! {
-                            self.#f(mgr);
+                            if matches!(r, Response::Update) {
+                                self.#f(mgr);
+                            }
                         }
                     } else {
                         quote! {}

--- a/crates/kas-resvg/Cargo.toml
+++ b/crates/kas-resvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kas-resvg"
 version = "0.10.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "KAS GUI / widgets"
 readme = "README.md"

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -111,7 +111,7 @@ impl WidgetConfig for Svg {
             let fontdb = fonts_db.db();
             let font_family = fonts_db
                 .font_family_from_alias("SERIF")
-                .unwrap_or(String::new());
+                .unwrap_or_else(String::new);
             let font_size = mgr.size_handle(|sh| sh.pixels_from_em(1.0)) as f64;
 
             // TODO: some options here should be configurable

--- a/crates/kas-theme/Cargo.toml
+++ b/crates/kas-theme/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kas-theme"
 version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "KAS GUI / theme support"
 keywords = ["gui"]

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kas-wgpu"
 version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "KAS GUI / wgpu front-end"
 keywords = ["gui", "wgpu"]

--- a/crates/kas-wgpu/src/shared.rs
+++ b/crates/kas-wgpu/src/shared.rs
@@ -58,7 +58,7 @@ where
         info!("Using graphics adapter: {}", adapter.get_info().name);
 
         let desc = CB::device_descriptor();
-        let trace_path = options.wgpu_trace_path.as_ref().map(|p| p.as_path());
+        let trace_path = options.wgpu_trace_path.as_deref();
         let req = adapter.request_device(&desc, trace_path);
         let device_and_queue = futures::executor::block_on(req)?;
 

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -191,8 +191,8 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
     pub fn handle_closure(mut self, shared: &mut SharedState<C, T>) -> TkAction {
         let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
         let widget = &mut *self.widget;
-        self.mgr.with(&mut tkw, |mut mgr| {
-            widget.handle_closure(&mut mgr);
+        self.mgr.with(&mut tkw, |mgr| {
+            widget.handle_closure(mgr);
         });
         self.mgr.update(&mut tkw, &mut *self.widget)
     }
@@ -222,8 +222,8 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
     pub fn add_popup(&mut self, shared: &mut SharedState<C, T>, id: WindowId, popup: kas::Popup) {
         let window = &mut *self.widget;
         let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
-        self.mgr.with(&mut tkw, |mut mgr| {
-            kas::Window::add_popup(window, &mut mgr, id, popup);
+        self.mgr.with(&mut tkw, |mgr| {
+            kas::Window::add_popup(window, mgr, id, popup);
         });
     }
 
@@ -237,8 +237,8 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         } else {
             let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
             let widget = &mut *self.widget;
-            self.mgr.with(&mut tkw, |mut mgr| {
-                widget.remove_popup(&mut mgr, id);
+            self.mgr.with(&mut tkw, |mgr| {
+                widget.remove_popup(mgr, id);
             });
         }
     }

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kas-widgets"
 version = "0.10.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "KAS GUI / widgets"
 readme = "README.md"

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -391,12 +391,12 @@ impl<'a, W: Widget> GridBuilder<'a, W> {
 
     /// Iterate over childern
     pub fn iter(&self) -> impl Iterator<Item = &(GridChildInfo, W)> {
-        ListIter { list: &self.0 }
+        ListIter { list: self.0 }
     }
 
     /// Mutably iterate over childern
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut (GridChildInfo, W)> {
-        ListIterMut { list: &mut self.0 }
+        ListIterMut { list: self.0 }
     }
 }
 
@@ -444,7 +444,7 @@ struct ListIterMut<'a, W: Widget> {
 impl<'a, W: Widget> Iterator for ListIterMut<'a, W> {
     type Item = &'a mut (GridChildInfo, W);
     fn next(&mut self) -> Option<Self::Item> {
-        let list = std::mem::replace(&mut self.list, &mut []);
+        let list = std::mem::take(&mut self.list);
         if let Some((first, rest)) = list.split_first_mut() {
             self.list = rest;
             Some(first)

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -186,7 +186,7 @@ impl<D: Directional, W: Widget + Clone, M: FromIndexed<<W as Handler>::Msg> + 's
             core: self.core.clone(),
             widgets: self.widgets.clone(),
             data: self.data.clone(),
-            direction: self.direction.clone(),
+            direction: self.direction,
             _pd: Default::default(),
         }
     }
@@ -606,7 +606,7 @@ struct ListIterMut<'a, W: Widget> {
 impl<'a, W: Widget> Iterator for ListIterMut<'a, W> {
     type Item = &'a mut W;
     fn next(&mut self) -> Option<Self::Item> {
-        let list = std::mem::replace(&mut self.list, &mut []);
+        let list = std::mem::take(&mut self.list);
         if let Some((first, rest)) = list.split_first_mut() {
             self.list = rest;
             Some(first)

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -435,7 +435,7 @@ impl<
         match event {
             Event::HandleUpdate { .. } => {
                 self.update_view(mgr);
-                return Response::Update;
+                Response::Update
             }
             _ => Response::None,
         }

--- a/examples/custom-theme.rs
+++ b/examples/custom-theme.rs
@@ -19,17 +19,9 @@ use kas::theme::FlatTheme;
 /// A demo theme
 ///
 /// We set a custom background colour and use `FlatTheme` for everything else.
+#[derive(Default)]
 pub struct CustomTheme {
     inner: FlatTheme,
-}
-
-impl CustomTheme {
-    /// Construct
-    pub fn new() -> Self {
-        CustomTheme {
-            inner: FlatTheme::new(),
-        }
-    }
 }
 
 // manual impl because derive macro applies incorrect bounds
@@ -137,7 +129,7 @@ fn main() -> Result<(), kas::shell::Error> {
         }
     };
 
-    let theme = CustomTheme::new();
+    let theme = CustomTheme::default();
 
     let window = Window::new(
         "Theme demo",

--- a/examples/mandlebrot/Cargo.toml
+++ b/examples/mandlebrot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kas-mandlebrot"
 version = "0.10.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "KAS GUI / Mandlebrot example"
 publish = false

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -368,7 +368,7 @@ impl event::Handler for Mandlebrot {
                             Command::Right => DVec2(d, 0.0),
                             _ => return Response::Unhandled,
                         };
-                        self.delta = self.delta + self.alpha.complex_mul(delta);
+                        self.delta += self.alpha.complex_mul(delta);
                     }
                 }
                 mgr.redraw(self.id());


### PR DESCRIPTION
- Bumps edition to 2021
- Bumps MSRV to 1.56 (required for edition)
- README: adds a section on data- vs widget-first design
- Fix: custom input bindings are prioritised over tab navigation
- Fix: `#[widget(update = f)]` now only calls `f` on `Response::Update` (this is unused, and may be removed later anyway)
- Apply or hide all Clippy suggestions
- Require Clippy pass in CI