### PR TITLE
OnMessage trait

### DIFF
--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -97,7 +97,7 @@ pub use enums::{CursorIcon, ModifiersState, MouseButton, VirtualKeyCode};
 pub use events::*;
 pub use handler::{Handler, SendEvent};
 pub use manager::{ConfigureManager, GrabMode, Manager, ManagerState};
-pub use response::Response;
+pub use response::{OnMessage, Response};
 pub use update::UpdateHandle;
 
 /// A type supporting a small number of key bindings

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -20,7 +20,7 @@ pub use crate::draw::{
 };
 #[doc(no_inline)]
 pub use crate::event::{
-    Event, Handler, Manager, ManagerState, Response, SendEvent, UpdateHandle, VoidMsg,
+    Event, Handler, Manager, ManagerState, OnMessage, Response, SendEvent, UpdateHandle, VoidMsg,
 };
 #[doc(no_inline)]
 pub use crate::geom::{Coord, Offset, Rect, Size};

--- a/crates/kas-macros/src/args.rs
+++ b/crates/kas-macros/src/args.rs
@@ -219,7 +219,6 @@ mod kw {
     custom_keyword!(map_msg);
     custom_keyword!(use_msg);
     custom_keyword!(discard_msg);
-    custom_keyword!(update);
     custom_keyword!(msg);
     custom_keyword!(generics);
     custom_keyword!(single);
@@ -340,7 +339,6 @@ pub struct WidgetAttrArgs {
     pub rspan: Option<Lit>,
     pub halign: Option<Ident>,
     pub valign: Option<Ident>,
-    pub update: Option<Ident>,
     pub handler: Handler,
 }
 
@@ -409,7 +407,6 @@ impl Parse for WidgetAttrArgs {
             rspan: None,
             halign: None,
             valign: None,
-            update: None,
             handler: Handler::None,
         };
         if input.is_empty() {
@@ -459,10 +456,6 @@ impl Parse for WidgetAttrArgs {
                 let _: kw::valign = content.parse()?;
                 let _: Eq = content.parse()?;
                 args.valign = Some(content.parse()?);
-            } else if args.update.is_none() && lookahead.peek(kw::update) {
-                let _: kw::update = content.parse()?;
-                let _: Eq = content.parse()?;
-                args.update = Some(content.parse()?);
             } else if args.handler.is_none() && lookahead.peek(kw::flatmap_msg) {
                 let _: kw::flatmap_msg = content.parse()?;
                 let _: Eq = content.parse()?;
@@ -542,12 +535,6 @@ impl ToTokens for WidgetAttrArgs {
                     args.append(comma.clone());
                 }
                 args.append_all(quote! { valign = #ident });
-            }
-            if let Some(ref ident) = self.update {
-                if !args.is_empty() {
-                    args.append(comma.clone());
-                }
-                args.append_all(quote! { update = #ident });
             }
             if !self.handler.is_none() && !args.is_empty() {
                 args.append(comma);

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -394,15 +394,6 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     let log_msg = quote! {};
 
                     let ident = &child.ident;
-                    let update = if let Some(f) = child.args.update.as_ref() {
-                        quote! {
-                            if matches!(r, Response::Update) {
-                                self.#f(mgr);
-                            }
-                        }
-                    } else {
-                        quote! {}
-                    };
                     let handler = match &child.args.handler {
                         Handler::Use(f) => quote! {
                             r.try_into().unwrap_or_else(|msg| {
@@ -436,7 +427,6 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     ev_to_num.append_all(quote! {
                         if id <= self.#ident.id() {
                             let r = self.#ident.send(mgr, id, event);
-                            #update
                             #handler
                         } else
                     });

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -20,6 +20,7 @@ use kas::prelude::*;
 #[handler(noauto)]
 #[widget(config=noauto)]
 #[widget_derive(class_traits)]
+// TODO: less restriction on label
 pub struct Button<L: Widget<Msg = VoidMsg>, M: 'static> {
     #[widget_core]
     core: kas::CoreData,

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -26,7 +26,7 @@ pub struct MessageBox<T: FormattableText + 'static> {
     title: String,
     #[widget]
     label: Label<T>,
-    #[widget(use_msg = handle_button)]
+    #[widget]
     button: TextButton<()>,
 }
 
@@ -44,9 +44,12 @@ impl<T: FormattableText + 'static> MessageBox<T> {
             ]),
         }
     }
+}
 
-    fn handle_button(&mut self, mgr: &mut Manager, _: ()) {
+impl<T: FormattableText + 'static> OnMessage<()> for MessageBox<T> {
+    fn on_msg(&mut self, mgr: &mut Manager, _: usize, _: ()) -> Response<VoidMsg> {
         mgr.send_action(TkAction::CLOSE);
+        Response::None
     }
 }
 

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -48,6 +48,7 @@ pub type BoxGrid<M> = Grid<Box<dyn Widget<Msg = M>>>;
 #[derive(Clone, Debug, Widget)]
 #[handler(send=noauto, msg=<W as Handler>::Msg)]
 #[widget(children=noauto)]
+// TODO: support custom message type
 pub struct Grid<W: Widget> {
     first_id: WidgetId,
     #[widget_core]

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -167,6 +167,7 @@ pub type IndexedList<D, W> = GenericList<D, W, (usize, <W as Handler>::Msg)>;
 #[derive(Widget)]
 #[handler(send=noauto, msg=M)]
 #[widget(children=noauto)]
+// TODO: replace FromIndexed?
 pub struct GenericList<D: Directional, W: Widget, M: FromIndexed<<W as Handler>::Msg> + 'static> {
     first_id: WidgetId,
     #[widget_core]

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -245,6 +245,7 @@ impl ScrollComponent {
 #[widget(config=noauto)]
 #[handler(send=noauto, msg = <W as event::Handler>::Msg)]
 #[widget_derive(class_traits, Deref, DerefMut)]
+// TODO: support message handling?
 pub struct ScrollRegion<W: Widget> {
     #[widget_core]
     core: CoreData,

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -15,9 +15,6 @@ use kas::text::format::{EditableText, FormattableText};
 use kas::text::SelectionHelper;
 
 /// A text label supporting scrolling and selection
-///
-/// TODO: this should support copying to clipboard (like editbox), but it never
-/// has keyboard focus and we don't yet have another way of capturing Ctrl+C.
 #[derive(Clone, Default, Debug, Widget)]
 #[widget(config(cursor_icon = event::CursorIcon::Text))]
 #[handler(handle=noauto)]


### PR DESCRIPTION
There are a couple of challenges with the existing per-child-widget message handler system:

- binding the same handler to multiple children is tedious
- binding handlers to generic parent widgets such as `List` cannot work in the same way

Instead, this attempts to bind handlers based on the message type by requiring parent widgets implement a new `OnMessage` trait. But first we need a couple of auto-implementations:

- children with `VoidMsg` message type should be supported automatically
- children with the same message type as the parent should automatically forward the message

Problem: these generic implementations overlap. Except: we already worked around this via `derive(VoidMsg)`: each viable message type supports `From<VoidMsg>`, thus we can implement a rule for any `M: From<N>` where `M` and `N` are the parent's and child's message types respectively.

Problem: implementing a specific handler which is not covered by the above rule is now reported as a conflict: https://github.com/rust-lang/rust/issues/90587. This blocks further progress here.