### PR TITLE
Force wgpu to use raw-window-handle 0.3.4 for winit compatibility

### DIFF
--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -38,6 +38,7 @@ futures = "0.3"
 log = "0.4"
 smallvec = "1.6.1"
 wgpu = { version = "0.11.0", features = ["spirv"] }
+raw-window-handle = "0.3.4"
 winit = "0.26"
 thiserror = "1.0.23"
 window_clipboard = { version = "0.2.0", optional = true }


### PR DESCRIPTION
kas-wgpu depends on winit 0.26 which exposes raw-window-handle 0.4 types in its public API. As a result, wgpu (which exposes raw-window-handle 0.3 types in its public API) must be forced to use raw-window-handle 0.3.4, which is compatible with 0.4.x. Otherwise in projects with a stale Cargo.lock containing raw-window-handle <= 0.3.3 but latest kas-wgpu, you'll get a trait mismatch build error.

See https://github.com/kas-gui/kas/discussions/261.