### PR TITLE
WidgetId revision, part 1: u64, paths; misc fixes

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -59,6 +59,7 @@ macros_log = ["kas-macros/log"]
 
 [dependencies]
 easy-cast = "0.4.2"
+lazy_static = "1.4"
 log = "0.4"
 smallvec = "1.6.1"
 stack_dst = { version = "0.6", optional = true }

--- a/crates/kas-core/src/core/data.rs
+++ b/crates/kas-core/src/core/data.rs
@@ -5,12 +5,9 @@
 
 //! Widget data types
 
-use std::fmt;
-use std::num::NonZeroU64;
-
 #[allow(unused)]
 use super::Layout;
-use super::Widget;
+use super::{Widget, WidgetId};
 use crate::event::{self, Manager};
 use crate::geom::Rect;
 use crate::layout::StorageChain;
@@ -36,69 +33,6 @@ impl Icon {
         let _ = (rgba, width, height);
         Result::<Self, std::convert::Infallible>::Ok(Icon)
     }
-}
-
-/// Widget identifier
-///
-/// All widgets are assigned an identifier which is unique within the window.
-/// This type may be tested for equality and order.
-///
-/// This type is small and cheap to copy. Internally it is "NonZero", thus
-/// `Option<WidgetId>` is a free extension (requires no extra memory).
-///
-/// Identifiers are assigned when configured and when re-configured
-/// (via [`crate::TkAction::RECONFIGURE`]). Since user-code is not notified of a
-/// re-configure, user-code should not store a `WidgetId`.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct WidgetId(NonZeroU64);
-
-impl WidgetId {
-    pub(crate) const FIRST: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(1) });
-    const LAST: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(u64::MAX) });
-
-    pub(crate) fn next(self) -> Self {
-        WidgetId(NonZeroU64::new(self.0.get() + 1).unwrap())
-    }
-
-    /// Convert `Option<WidgetId>` to `u64`
-    pub fn opt_to_u64(id: Option<WidgetId>) -> u64 {
-        match id {
-            None => 0,
-            Some(id) => id.into(),
-        }
-    }
-
-    /// Convert `u64` to `Option<WidgetId>`
-    ///
-    /// This always "succeeds", though the result may not identify any widget.
-    pub fn opt_from_u64(n: u64) -> Option<WidgetId> {
-        NonZeroU64::new(n).map(|nz| WidgetId(nz))
-    }
-}
-
-impl From<WidgetId> for u64 {
-    #[inline]
-    fn from(id: WidgetId) -> u64 {
-        id.0.get().into()
-    }
-}
-
-impl Default for WidgetId {
-    fn default() -> Self {
-        WidgetId::LAST
-    }
-}
-
-impl fmt::Display for WidgetId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "#{}", self.0)
-    }
-}
-
-#[test]
-fn size_of_option_widget_id() {
-    use std::mem::size_of;
-    assert_eq!(size_of::<WidgetId>(), size_of::<Option<WidgetId>>());
 }
 
 /// Common widget data

--- a/crates/kas-core/src/core/data.rs
+++ b/crates/kas-core/src/core/data.rs
@@ -5,9 +5,8 @@
 
 //! Widget data types
 
-use std::convert::TryFrom;
 use std::fmt;
-use std::num::NonZeroU32;
+use std::num::NonZeroU64;
 
 #[allow(unused)]
 use super::Layout;
@@ -51,40 +50,29 @@ impl Icon {
 /// (via [`crate::TkAction::RECONFIGURE`]). Since user-code is not notified of a
 /// re-configure, user-code should not store a `WidgetId`.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct WidgetId(NonZeroU32);
+pub struct WidgetId(NonZeroU64);
 
 impl WidgetId {
-    pub(crate) const FIRST: WidgetId = WidgetId(unsafe { NonZeroU32::new_unchecked(1) });
-    const LAST: WidgetId = WidgetId(unsafe { NonZeroU32::new_unchecked(u32::MAX) });
+    pub(crate) const FIRST: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(1) });
+    const LAST: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(u64::MAX) });
 
     pub(crate) fn next(self) -> Self {
-        WidgetId(NonZeroU32::new(self.0.get() + 1).unwrap())
+        WidgetId(NonZeroU64::new(self.0.get() + 1).unwrap())
     }
-}
 
-impl TryFrom<u32> for WidgetId {
-    type Error = ();
-    fn try_from(x: u32) -> Result<WidgetId, ()> {
-        NonZeroU32::new(x).map(WidgetId).ok_or(())
-    }
-}
-
-impl TryFrom<u64> for WidgetId {
-    type Error = ();
-    fn try_from(x: u64) -> Result<WidgetId, ()> {
-        if let Ok(x) = u32::try_from(x) {
-            if let Some(nz) = NonZeroU32::new(x) {
-                return Ok(WidgetId(nz));
-            }
+    /// Convert `Option<WidgetId>` to `u64`
+    pub fn opt_to_u64(id: Option<WidgetId>) -> u64 {
+        match id {
+            None => 0,
+            Some(id) => id.into(),
         }
-        Err(())
     }
-}
 
-impl From<WidgetId> for u32 {
-    #[inline]
-    fn from(id: WidgetId) -> u32 {
-        id.0.get()
+    /// Convert `u64` to `Option<WidgetId>`
+    ///
+    /// This always "succeeds", though the result may not identify any widget.
+    pub fn opt_from_u64(n: u64) -> Option<WidgetId> {
+        NonZeroU64::new(n).map(|nz| WidgetId(nz))
     }
 }
 

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -42,12 +42,6 @@ impl<M: 'static> WidgetCore for Box<dyn Widget<Msg = M>> {
 }
 
 impl<M: 'static> WidgetChildren for Box<dyn Widget<Msg = M>> {
-    fn first_id(&self) -> WidgetId {
-        self.as_ref().first_id()
-    }
-    fn record_first_id(&mut self, id: WidgetId) {
-        self.as_mut().record_first_id(id)
-    }
     fn num_children(&self) -> usize {
         self.as_ref().num_children()
     }

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -58,8 +58,8 @@ impl<M: 'static> WidgetChildren for Box<dyn Widget<Msg = M>> {
         self.as_mut().get_child_mut(index)
     }
 
-    fn find_child(&self, id: WidgetId) -> Option<usize> {
-        self.as_ref().find_child(id)
+    fn find_child_index(&self, id: WidgetId) -> Option<usize> {
+        self.as_ref().find_child_index(id)
     }
     fn find_leaf(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
         self.as_ref().find_leaf(id)

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -54,11 +54,11 @@ impl<M: 'static> WidgetChildren for Box<dyn Widget<Msg = M>> {
     fn find_child_index(&self, id: WidgetId) -> Option<usize> {
         self.as_ref().find_child_index(id)
     }
-    fn find_leaf(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
-        self.as_ref().find_leaf(id)
+    fn find_widget(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+        self.as_ref().find_widget(id)
     }
-    fn find_leaf_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
-        self.as_mut().find_leaf_mut(id)
+    fn find_widget_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
+        self.as_mut().find_widget_mut(id)
     }
 }
 

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -5,14 +5,13 @@
 
 //! Trait impls
 
-use std::any::Any;
-
 use super::*;
 use crate::draw::{DrawHandle, SizeHandle};
 use crate::event::{self, Event, Manager, ManagerState, Response};
 use crate::geom::{Coord, Rect};
 use crate::layout::{AlignHints, AxisInfo, SizeRules};
 use crate::{CoreData, WidgetId};
+use std::any::Any;
 
 impl<M: 'static> WidgetCore for Box<dyn Widget<Msg = M>> {
     fn as_any(&self) -> &dyn Any {

--- a/crates/kas-core/src/core/mod.rs
+++ b/crates/kas-core/src/core/mod.rs
@@ -8,9 +8,11 @@
 mod data;
 mod impls;
 mod widget;
+mod widget_id;
 
 pub use data::*;
 pub use widget::*;
+pub use widget_id::WidgetId;
 
 /// Provides a convenient `.boxed()` method on implementors
 pub trait Boxed<T: ?Sized> {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -169,25 +169,6 @@ pub trait WidgetCore: Any + fmt::Debug {
 ///
 /// [`derive(Widget)`]: https://docs.rs/kas/latest/kas/macros/index.html#the-derivewidget-macro
 pub trait WidgetChildren: WidgetCore {
-    /// Get the first identifier of self or any children
-    ///
-    /// Widget identifiers are assigned sequentially by depth-first-search,
-    /// children before parents. Any widget thus has a range of identifiers,
-    /// from the first assigned to any descendent (or self) to its own
-    /// ([`WidgetCore::id`]). This method must return the first identifier.
-    fn first_id(&self) -> WidgetId;
-
-    /// Record first identifier
-    ///
-    /// This is called during [`WidgetConfig::configure_recurse`] with the first
-    /// identifier. This may be used to implement [`WidgetChildren::first_id`],
-    /// although in many cases the first identifier can be read directly from
-    /// the first child. This method has a default implementation doing nothing.
-    ///
-    /// This method should only be called from `configure_recurse`.
-    #[inline]
-    fn record_first_id(&mut self, _id: WidgetId) {}
-
     /// Get the number of child widgets
     fn num_children(&self) -> usize;
 

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -222,7 +222,7 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// This requires that the widget tree has already been configured by
     /// [`event::ManagerState::configure`].
-    fn find_child(&self, id: WidgetId) -> Option<usize> {
+    fn find_child_index(&self, id: WidgetId) -> Option<usize> {
         if id < self.first_id() || id >= self.id() {
             return None;
         }
@@ -244,7 +244,7 @@ pub trait WidgetChildren: WidgetCore {
     /// This requires that the widget tree has already been configured by
     /// [`event::ManagerState::configure`].
     fn find_leaf(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
-        if let Some(child) = self.find_child(id) {
+        if let Some(child) = self.find_child_index(id) {
             self.get_child(child).unwrap().find_leaf(id)
         } else if id == self.id() {
             return Some(self.as_widget());
@@ -258,7 +258,7 @@ pub trait WidgetChildren: WidgetCore {
     /// This requires that the widget tree has already been configured by
     /// [`ManagerState::configure`].
     fn find_leaf_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
-        if let Some(child) = self.find_child(id) {
+        if let Some(child) = self.find_child_index(id) {
             self.get_child_mut(child).unwrap().find_leaf_mut(id)
         } else if id == self.id() {
             return Some(self.as_widget_mut());

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -215,7 +215,7 @@ pub trait WidgetChildren: WidgetCore {
     fn find_leaf(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
         if let Some(child) = self.find_child_index(id) {
             self.get_child(child).unwrap().find_leaf(id)
-        } else if id == self.id() {
+        } else if self.eq_id(id) {
             return Some(self.as_widget());
         } else {
             None
@@ -229,7 +229,7 @@ pub trait WidgetChildren: WidgetCore {
     fn find_leaf_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
         if let Some(child) = self.find_child_index(id) {
             self.get_child_mut(child).unwrap().find_leaf_mut(id)
-        } else if id == self.id() {
+        } else if self.eq_id(id) {
             return Some(self.as_widget_mut());
         } else {
             None
@@ -511,3 +511,19 @@ pub trait Layout: WidgetChildren {
 ///
 /// [`derive(Widget)`]: https://docs.rs/kas/latest/kas/macros/index.html#the-derivewidget-macro
 pub trait Widget: event::SendEvent {}
+
+/// Extension trait over widgets
+pub trait WidgetExt: WidgetCore {
+    /// Test widget identifier for equality
+    ///
+    /// This method may be used to test against `WidgetId`, `Option<WidgetId>`
+    /// and `Option<&WidgetId>`.
+    #[inline]
+    fn eq_id<T>(&self, rhs: T) -> bool
+    where
+        WidgetId: PartialEq<T>,
+    {
+        self.core_data().id == rhs
+    }
+}
+impl<W: WidgetCore + ?Sized> WidgetExt for W {}

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -208,13 +208,13 @@ pub trait WidgetChildren: WidgetCore {
         self.id().index_of_child(id)
     }
 
-    /// Find the leaf (lowest descendant) with this `id`, if any
+    /// Find the descendant with this `id`, if any
     ///
     /// This requires that the widget tree has already been configured by
     /// [`event::ManagerState::configure`].
-    fn find_leaf(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+    fn find_widget(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
         if let Some(child) = self.find_child_index(id) {
-            self.get_child(child).unwrap().find_leaf(id)
+            self.get_child(child).unwrap().find_widget(id)
         } else if self.eq_id(id) {
             return Some(self.as_widget());
         } else {
@@ -222,13 +222,13 @@ pub trait WidgetChildren: WidgetCore {
         }
     }
 
-    /// Find the leaf (lowest descendant) with this `id`, if any
+    /// Find the descendant with this `id`, if any
     ///
     /// This requires that the widget tree has already been configured by
     /// [`ManagerState::configure`].
-    fn find_leaf_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
+    fn find_widget_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
         if let Some(child) = self.find_child_index(id) {
-            self.get_child_mut(child).unwrap().find_leaf_mut(id)
+            self.get_child_mut(child).unwrap().find_widget_mut(id)
         } else if self.eq_id(id) {
             return Some(self.as_widget_mut());
         } else {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -305,6 +305,10 @@ pub trait WidgetConfig: Layout {
 
     /// Which cursor icon should be used on hover?
     ///
+    /// The "hovered" widget is determined by [`Layout::find_id`], thus is the
+    /// same widget which would receive click events. Other widgets do not
+    /// affect the cursor icon used.
+    ///
     /// Defaults to [`event::CursorIcon::Default`].
     #[inline]
     fn cursor_icon(&self) -> event::CursorIcon {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -94,6 +94,7 @@ pub trait WidgetCore: Any + fmt::Debug {
     /// let entry = MenuEntry::new("Disabled Item", ()).with_disabled(true);
     /// ```
     #[inline]
+    #[must_use]
     fn with_disabled(mut self, disabled: bool) -> Self
     where
         Self: Sized,

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -5,7 +5,7 @@
 
 //! Widget identifiers
 
-use crate::cast::Conv;
+use crate::cast::{Cast, Conv};
 use std::fmt;
 use std::iter::once;
 use std::mem::size_of;
@@ -54,7 +54,7 @@ fn next_from_bits(mut x: u64) -> (usize, u8) {
         y = (y << 3) | ((x & TAKE) >> 60);
         c += 1;
     }
-    (y as usize, c)
+    (y.cast(), c)
 }
 
 struct BitsIter(u8, u64);

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -1,0 +1,72 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Widget identifiers
+
+use std::fmt;
+use std::num::NonZeroU64;
+
+/// Widget identifier
+///
+/// All widgets are assigned an identifier which is unique within the window.
+/// This type may be tested for equality and order.
+///
+/// This type is small and cheap to copy. Internally it is "NonZero", thus
+/// `Option<WidgetId>` is a free extension (requires no extra memory).
+///
+/// Identifiers are assigned when configured and when re-configured
+/// (via [`crate::TkAction::RECONFIGURE`]). Since user-code is not notified of a
+/// re-configure, user-code should not store a `WidgetId`.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct WidgetId(NonZeroU64);
+
+impl WidgetId {
+    pub(crate) const FIRST: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(1) });
+    const LAST: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(u64::MAX) });
+
+    pub(crate) fn next(self) -> Self {
+        WidgetId(NonZeroU64::new(self.0.get() + 1).unwrap())
+    }
+
+    /// Convert `Option<WidgetId>` to `u64`
+    pub fn opt_to_u64(id: Option<WidgetId>) -> u64 {
+        match id {
+            None => 0,
+            Some(id) => id.into(),
+        }
+    }
+
+    /// Convert `u64` to `Option<WidgetId>`
+    ///
+    /// This always "succeeds", though the result may not identify any widget.
+    pub fn opt_from_u64(n: u64) -> Option<WidgetId> {
+        NonZeroU64::new(n).map(|nz| WidgetId(nz))
+    }
+}
+
+impl From<WidgetId> for u64 {
+    #[inline]
+    fn from(id: WidgetId) -> u64 {
+        id.0.get().into()
+    }
+}
+
+impl Default for WidgetId {
+    fn default() -> Self {
+        WidgetId::LAST
+    }
+}
+
+impl fmt::Display for WidgetId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "#{}", self.0)
+    }
+}
+
+#[test]
+fn size_of_option_widget_id() {
+    use std::mem::size_of;
+    assert_eq!(size_of::<WidgetId>(), size_of::<Option<WidgetId>>());
+}

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -5,8 +5,11 @@
 
 //! Widget identifiers
 
+use crate::cast::Conv;
 use std::fmt;
+use std::iter::once;
 use std::num::NonZeroU64;
+use std::sync::Mutex;
 
 /// Widget identifier
 ///
@@ -19,15 +22,90 @@ use std::num::NonZeroU64;
 /// Identifiers are assigned when configured and when re-configured
 /// (via [`crate::TkAction::RECONFIGURE`]). Since user-code is not notified of a
 /// re-configure, user-code should not store a `WidgetId`.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Hash, Eq)]
 pub struct WidgetId(NonZeroU64);
 
-impl WidgetId {
-    pub(crate) const FIRST: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(1) });
-    const LAST: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(u64::MAX) });
+/// The first byte (head) controls interpretation of the rest
+const MASK_HEAD: u64 = 0xFF_00_0000_0000_0000;
+const MASK_REST: u64 = !MASK_HEAD;
 
-    pub(crate) fn next(self) -> Self {
-        WidgetId(NonZeroU64::new(self.0.get() + 1).unwrap())
+/// `(x & MASK_HEAD) == USE_DB`: rest is index in DB
+const USE_DB: u64 = 0x01_00_0000_0000_0000;
+
+impl WidgetId {
+    /// Identifier of the window
+    pub(crate) const ROOT: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(USE_DB) });
+
+    const INVALID: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(MASK_REST) });
+
+    /// Returns true if `self` equals `id` or if `id` is a descendant of `self`
+    pub fn is_ancestor_of(self, id: Self) -> bool {
+        let self_id = self.0.get();
+        let child_id = id.0.get();
+        match (self_id & MASK_HEAD, child_id & MASK_HEAD) {
+            (USE_DB, USE_DB) => {
+                let db = DB.lock().unwrap();
+
+                let self_i = usize::conv(self_id & MASK_REST);
+                let child_i = usize::conv(child_id & MASK_REST);
+
+                let result = db[child_i].starts_with(&db[self_i]);
+                result
+            }
+            _ => false,
+        }
+    }
+
+    /// Get index of `child` relative to `self`
+    ///
+    /// Returns `None` if `child` is not a descendant of `self`.
+    pub fn index_of_child(self, child: Self) -> Option<usize> {
+        let self_id = self.0.get();
+        let child_id = child.0.get();
+        match (self_id & MASK_HEAD, child_id & MASK_HEAD) {
+            (USE_DB, USE_DB) => {
+                let db = DB.lock().unwrap();
+
+                let self_i = usize::conv(self_id & MASK_REST);
+                let child_i = usize::conv(child_id & MASK_REST);
+
+                let result = if db[child_i].starts_with(&db[self_i]) {
+                    let self_len = db[self_i].len();
+                    db[child_i][self_len..].iter().next().cloned()
+                } else {
+                    None
+                };
+                result
+            }
+            _ => None,
+        }
+    }
+
+    /// Make an identifier for the child with the given `index`
+    ///
+    /// Note: this is not a getter method. Calling multiple times with the same
+    /// `index` may or may not return the same value!
+    pub fn make_child(self, index: usize) -> Self {
+        let self_id = self.0.get();
+        match self_id & MASK_HEAD {
+            USE_DB => {
+                // We can assume the child must also use the DB
+                let mut db = DB.lock().unwrap();
+
+                let i = usize::conv(self_id & MASK_REST);
+                let path = db[i].iter().cloned().chain(once(index)).collect();
+
+                let id = u64::conv(db.len());
+                // We can quite safely assume this:
+                debug_assert_eq!(id & MASK_HEAD, 0);
+                let id = id & MASK_REST;
+
+                db.push(path);
+
+                WidgetId(NonZeroU64::new(USE_DB | id).unwrap())
+            }
+            _ => panic!("WidgetId::make_child: cannot make child of {}", self),
+        }
     }
 
     /// Convert `Option<WidgetId>` to `u64`
@@ -46,6 +124,23 @@ impl WidgetId {
     }
 }
 
+impl std::cmp::PartialEq for WidgetId {
+    fn eq(&self, rhs: &Self) -> bool {
+        let self_id = self.0.get();
+        let rhs_id = rhs.0.get();
+        match (self_id & MASK_HEAD, rhs_id & MASK_HEAD) {
+            (USE_DB, USE_DB) => {
+                let db = DB.lock().unwrap();
+
+                let self_i = usize::conv(self_id & MASK_REST);
+                let child_i = usize::conv(rhs_id & MASK_REST);
+                db[self_i] == db[child_i]
+            }
+            _ => self_id == rhs_id,
+        }
+    }
+}
+
 impl From<WidgetId> for u64 {
     #[inline]
     fn from(id: WidgetId) -> u64 {
@@ -55,14 +150,22 @@ impl From<WidgetId> for u64 {
 
 impl Default for WidgetId {
     fn default() -> Self {
-        WidgetId::LAST
+        WidgetId::INVALID
     }
 }
 
 impl fmt::Display for WidgetId {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "#{}", self.0)
+        let self_id = self.0.get();
+        match self_id & MASK_HEAD {
+            USE_DB => write!(f, "DB#{}", self_id & MASK_REST),
+            _ => todo!(),
+        }
     }
+}
+
+lazy_static::lazy_static! {
+    static ref DB: Mutex<Vec<Vec<usize>>> = Mutex::new(vec![vec![]]);
 }
 
 #[test]

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -8,9 +8,9 @@
 use crate::cast::Conv;
 use std::fmt;
 use std::iter::once;
+use std::mem::size_of;
 use std::num::NonZeroU64;
 use std::sync::Mutex;
-use std::mem::size_of;
 
 /// Widget identifier
 ///
@@ -73,6 +73,7 @@ impl Iterator for BitsIter {
         }
         let (next, blocks) = next_from_bits(self.1);
         self.0 -= blocks;
+        self.1 <<= 4 * blocks;
         Some(next)
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -82,41 +83,13 @@ impl Iterator for BitsIter {
 
 impl WidgetId {
     /// Identifier of the window
-    pub(crate) const ROOT: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(USE_DB) });
+    pub(crate) const ROOT: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(USE_BITS) });
 
     const INVALID: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(MASK_REST) });
 
     /// Returns true if `self` equals `id` or if `id` is a descendant of `self`
     pub fn is_ancestor_of(self, id: Self) -> bool {
-        let self_id = self.0.get();
-        let child_id = id.0.get();
-        if (child_id & USE_BITS) != 0 {
-            let self_blocks = block_len(self_id);
-            let child_blocks = block_len(child_id);
-            if (self_id & USE_BITS) == 0 || self_blocks > child_blocks {
-                return false;
-            }
-
-            let shift = 4 * (BLOCKS - self_blocks);
-            return (self_id & MASK_REST) >> shift == (child_id & MASK_REST) >> shift;
-        }
-
-        if (child_id & USE_DB) == 0 {
-            return false;
-        }
-
-        let db = DB.lock().unwrap();
-        let child_i = usize::conv(child_id & MASK_REST);
-
-        if (self_id & USE_BITS) != 0 {
-            let iter = BitsIter::new(self_id);
-            iter.zip(db[child_i].iter()).all(|(a, b)| a == *b)
-        } else if (self_id & USE_DB) != 0 {
-            let self_i = usize::conv(self_id & MASK_REST);
-            db[child_i].starts_with(&db[self_i])
-        } else {
-            false
-        }
+        self.index_of_child(id).is_some()
     }
 
     /// Get index of `child` relative to `self`
@@ -172,35 +145,38 @@ impl WidgetId {
     ///
     /// Note: this is not a getter method. Calling multiple times with the same
     /// `index` may or may not return the same value!
-    pub fn make_child(self, mut index: usize) -> Self {
+    pub fn make_child(self, index: usize) -> Self {
         let self_id = self.0.get();
         let mut path = None;
         if (self_id & USE_BITS) != 0 {
             // TODO(opt): this bit-packing approach is designed for space-optimisation, but it may
             // be better to use a simpler, less-compressed approach, possibly with u128 type.
             let block_len = block_len(self_id);
-            let avail_bits = 3 * (BLOCKS - block_len);
+            let avail_blocks = BLOCKS - block_len;
             let req_bits = 8 * size_of::<usize>() as u8 - index.leading_zeros() as u8;
-            if req_bits <= avail_bits {
-                let mut y = (index as u64 & 7) as u64;
+            if req_bits <= 3 * avail_blocks {
+                let mut x = index as u64;
+                let mut y = x & 7;
+                x >>= 3;
                 let mut shift = 4;
-                while index != 0 {
-                    y |= 1 << (shift - 1);
-                    y |= (index as u64 & 7) << shift;
-                    index >>= 3;
+                while x != 0 {
+                    y |= (8 | (x & 7)) << shift;
+                    x >>= 3;
                     shift += 4;
                 }
-                let used_blocks = (req_bits + 2) / 3;
+                // Note: zero is encoded with 1 block to force bump to len
+                let used_blocks = shift / 4;
+                debug_assert_eq!(used_blocks, ((req_bits + 2) / 3).max(1));
                 let len = (block_len as u64 + used_blocks as u64) << SHIFT_LEN;
-                let rest = y << BLOCKS - used_blocks;
-                let id = USE_BITS | len | rest;
+                let rest = y << 4 * avail_blocks - shift;
+                let id = USE_BITS | len | (self_id & MASK_REST) | rest;
                 return WidgetId(NonZeroU64::new(id).unwrap());
             } else {
                 path = Some(BitsIter::new(self_id).chain(once(index)).collect());
             }
         }
 
-        if (self_id & USE_DB) == 0 {
+        if (self_id & (USE_BITS | USE_DB)) == 0 {
             panic!("WidgetId::make_child: cannot make child of {}", self);
         }
 
@@ -273,8 +249,12 @@ impl fmt::Display for WidgetId {
         match self_id & MASK_HEAD {
             USE_BITS => {
                 let len = block_len(self_id);
-                let bits = (self_id & MASK_REST) >> (4 * (BLOCKS - len));
-                write!(f, "BITS#{1:0>0$x}", len as usize, bits)
+                if len == 0 {
+                    write!(f, "ROOT")
+                } else {
+                    let bits = (self_id & MASK_REST) >> (4 * (BLOCKS - len));
+                    write!(f, "BITS#{1:0>0$x}", len as usize, bits)
+                }
             }
             // TODO: encode as above?
             USE_DB => write!(f, "DB#{}", self_id & MASK_REST),
@@ -304,7 +284,10 @@ mod test {
         assert_eq!(next_from_bits(REST), (0, 1));
         assert_eq!(next_from_bits((7 << 60) | REST), (7, 1));
         assert_eq!(next_from_bits((0xB << 60) | (3 << 56)), (27, 2));
-        assert_eq!(next_from_bits(0xC9A4_F300_0000_0000), ((4 << 9) + (1<< 6) + (2<<3) + 4, 4));
+        assert_eq!(
+            next_from_bits(0xC9A4_F300_0000_0000),
+            ((4 << 9) + (1 << 6) + (2 << 3) + 4, 4)
+        );
     }
 
     #[test]
@@ -313,21 +296,95 @@ mod test {
             BitsIter::new(x).collect()
         }
         assert_eq!(as_vec(USE_BITS), vec![]);
-        assert_eq!(as_vec(0x87_1A93_007F_0000), vec![1, 139, 0, 0, 7]);
+        assert_eq!(as_vec(0x81_31_0000_0000_0000), vec![3]);
+        assert_eq!(as_vec(0x87_1A_9300_7F00_0000), vec![1, 139, 0, 0, 7]);
     }
 
     #[test]
     fn test_make_child() {
-        fn from_seq(seq: &[usize]) -> u64 {
+        fn test(seq: &[usize], x: u64) {
             let mut id = WidgetId::ROOT;
             for x in seq {
                 id = id.make_child(*x);
             }
-            id.into()
+            let v = u64::from(id);
+            if v != x {
+                panic!("test({:?}, {:x}): found {:x}", seq, x, v);
+            }
         }
 
-        assert_eq!(from_seq(&[]), USE_DB);
-        assert_eq!(from_seq(&[0, 0, 0]), USE_DB | (3 << SHIFT_LEN));
-        assert_eq!(from_seq(&[0, 1, 0]), USE_DB | (3 << SHIFT_LEN));
+        test(&[], USE_BITS);
+        test(&[0, 0, 0], USE_BITS | (3 << 56));
+        test(&[0, 1, 0], USE_BITS | (3 << 56) | (1 << 48));
+        test(&[9, 0, 1, 300], 0x879101cd40000000);
+        test(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0], 0x8e12345679091920);
+    }
+
+    #[test]
+    fn test_display() {
+        fn from_seq(seq: &[usize]) -> String {
+            let mut id = WidgetId::ROOT;
+            for x in seq {
+                id = id.make_child(*x);
+            }
+            format!("{}", id)
+        }
+
+        assert_eq!(from_seq(&[]), "ROOT");
+        assert_eq!(from_seq(&[0]), "BITS#0");
+        assert_eq!(from_seq(&[1, 2, 3]), "BITS#123");
+        assert_eq!(from_seq(&[5, 9, 13]), "BITS#59195");
+        assert_eq!(from_seq(&[321]), "BITS#d81");
+        assert!(from_seq(&[313553, 13513, 13511631]).starts_with("DB#"));
+    }
+
+    #[test]
+    fn test_is_ancestor() {
+        fn test(seq: &[usize], seq2: &[usize]) {
+            let mut id = WidgetId::ROOT;
+            for x in seq {
+                id = id.make_child(*x);
+            }
+            println!("id={} val={:x} from {:?}", id, u64::from(id), seq);
+            let mut id2 = id;
+            for x in seq2 {
+                id2 = id2.make_child(*x);
+            }
+            println!("id2={} val={:x} from {:?}", id2, u64::from(id2), seq2);
+            let next = seq2.iter().next().cloned();
+            assert_eq!(id.index_of_child(id2), next);
+            assert_eq!(id.is_ancestor_of(id2), next.is_some());
+        }
+
+        test(&[], &[]);
+        test(&[], &[1]);
+        test(&[], &[51930, 2, 18]);
+        test(&[5, 6, 0, 1, 1], &[]);
+        test(&[5, 6, 0, 1, 1], &[1, 1]);
+        test(&[8, 26], &[0]);
+        test(&[9, 9, 9, 9, 9, 9, 9], &[]);
+        test(&[9, 9, 9, 9, 9, 9, 9], &[6]);
+        test(&[9, 9, 9, 9, 9, 9, 9, 9], &[3]);
+    }
+
+    #[test]
+    fn test_not_ancestor() {
+        fn test(seq: &[usize], seq2: &[usize]) {
+            let mut id = WidgetId::ROOT;
+            for x in seq {
+                id = id.make_child(*x);
+            }
+            println!("id={} val={:x} from {:?}", id, u64::from(id), seq);
+            let mut id2 = WidgetId::ROOT;
+            for x in seq2 {
+                id2 = id2.make_child(*x);
+            }
+            println!("id2={} val={:x} from {:?}", id2, u64::from(id2), seq2);
+            assert_eq!(id.index_of_child(id2), None);
+            assert_eq!(id.is_ancestor_of(id2), false);
+        }
+
+        test(&[0], &[]);
+        test(&[2, 10, 1], &[2, 10]);
     }
 }

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::iter::once;
 use std::num::NonZeroU64;
 use std::sync::Mutex;
+use std::mem::size_of;
 
 /// Widget identifier
 ///
@@ -26,11 +27,58 @@ use std::sync::Mutex;
 pub struct WidgetId(NonZeroU64);
 
 /// The first byte (head) controls interpretation of the rest
-const MASK_HEAD: u64 = 0xFF_00_0000_0000_0000;
-const MASK_REST: u64 = !MASK_HEAD;
+const MASK_HEAD: u64 = 0xC000_0000_0000_0000;
+const MASK_LEN: u64 = 0x0F00_0000_0000_0000;
+const SHIFT_LEN: u8 = 56;
+const BLOCKS: u8 = 14;
+const MASK_REST: u64 = 0x00FF_FFFF_FFFF_FFFF;
 
+/// `(x & MASK_HEAD) == USE_BITS`: rest is a sequence of 4-bit blocks; len is number of blocks used
+const USE_BITS: u64 = 0x8000_0000_0000_0000;
 /// `(x & MASK_HEAD) == USE_DB`: rest is index in DB
-const USE_DB: u64 = 0x01_00_0000_0000_0000;
+const USE_DB: u64 = 0x4000_0000_0000_0000;
+
+#[inline]
+fn block_len(x: u64) -> u8 {
+    ((x & MASK_LEN) >> SHIFT_LEN) as u8
+}
+
+// Returns usize read from x plus blocks used
+fn next_from_bits(mut x: u64) -> (usize, u8) {
+    const TAKE: u64 = 0x7000_0000_0000_0000;
+    const HIGH: u64 = 0x8000_0000_0000_0000;
+    let mut y = (x & TAKE) >> 60;
+    let mut c = 1;
+    while (x & HIGH) != 0 {
+        x <<= 4;
+        y = (y << 3) | ((x & TAKE) >> 60);
+        c += 1;
+    }
+    (y as usize, c)
+}
+
+struct BitsIter(u8, u64);
+impl BitsIter {
+    fn new(bits: u64) -> Self {
+        assert!((bits & USE_BITS) != 0);
+        let len = (bits & MASK_LEN) >> SHIFT_LEN;
+        BitsIter(len as u8, bits << (64 - SHIFT_LEN))
+    }
+}
+impl Iterator for BitsIter {
+    type Item = usize;
+    fn next(&mut self) -> Option<usize> {
+        if self.0 == 0 {
+            return None;
+        }
+        let (next, blocks) = next_from_bits(self.1);
+        self.0 -= blocks;
+        Some(next)
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        ((self.0 != 0) as usize, Some(self.0 as usize))
+    }
+}
 
 impl WidgetId {
     /// Identifier of the window
@@ -42,17 +90,32 @@ impl WidgetId {
     pub fn is_ancestor_of(self, id: Self) -> bool {
         let self_id = self.0.get();
         let child_id = id.0.get();
-        match (self_id & MASK_HEAD, child_id & MASK_HEAD) {
-            (USE_DB, USE_DB) => {
-                let db = DB.lock().unwrap();
-
-                let self_i = usize::conv(self_id & MASK_REST);
-                let child_i = usize::conv(child_id & MASK_REST);
-
-                let result = db[child_i].starts_with(&db[self_i]);
-                result
+        if (child_id & USE_BITS) != 0 {
+            let self_blocks = block_len(self_id);
+            let child_blocks = block_len(child_id);
+            if (self_id & USE_BITS) == 0 || self_blocks > child_blocks {
+                return false;
             }
-            _ => false,
+
+            let shift = 4 * (BLOCKS - self_blocks);
+            return (self_id & MASK_REST) >> shift == (child_id & MASK_REST) >> shift;
+        }
+
+        if (child_id & USE_DB) == 0 {
+            return false;
+        }
+
+        let db = DB.lock().unwrap();
+        let child_i = usize::conv(child_id & MASK_REST);
+
+        if (self_id & USE_BITS) != 0 {
+            let iter = BitsIter::new(self_id);
+            iter.zip(db[child_i].iter()).all(|(a, b)| a == *b)
+        } else if (self_id & USE_DB) != 0 {
+            let self_i = usize::conv(self_id & MASK_REST);
+            db[child_i].starts_with(&db[self_i])
+        } else {
+            false
         }
     }
 
@@ -62,22 +125,46 @@ impl WidgetId {
     pub fn index_of_child(self, child: Self) -> Option<usize> {
         let self_id = self.0.get();
         let child_id = child.0.get();
-        match (self_id & MASK_HEAD, child_id & MASK_HEAD) {
-            (USE_DB, USE_DB) => {
-                let db = DB.lock().unwrap();
-
-                let self_i = usize::conv(self_id & MASK_REST);
-                let child_i = usize::conv(child_id & MASK_REST);
-
-                let result = if db[child_i].starts_with(&db[self_i]) {
-                    let self_len = db[self_i].len();
-                    db[child_i][self_len..].iter().next().cloned()
-                } else {
-                    None
-                };
-                result
+        if (child_id & USE_BITS) != 0 {
+            let self_blocks = block_len(self_id);
+            let child_blocks = block_len(child_id);
+            if (self_id & USE_BITS) == 0 || self_blocks >= child_blocks {
+                return None;
             }
-            _ => None,
+
+            let shift = 4 * (BLOCKS - self_blocks);
+            let child_rest = child_id & MASK_REST;
+            if (self_id & MASK_REST) >> shift != child_rest >> shift {
+                return None;
+            }
+
+            return Some(next_from_bits(child_rest << 8 + 4 * self_blocks).0);
+        }
+
+        if (child_id & USE_DB) == 0 {
+            return None;
+        }
+
+        let db = DB.lock().unwrap();
+        let child_slice = &db[usize::conv(child_id & MASK_REST)];
+
+        if (self_id & USE_BITS) != 0 {
+            let iter = BitsIter::new(self_id);
+            let mut child_iter = child_slice.iter();
+            if iter.zip(&mut child_iter).all(|(a, b)| a == *b) {
+                child_iter.next().cloned()
+            } else {
+                None
+            }
+        } else if (self_id & USE_DB) != 0 {
+            let self_slice = &db[usize::conv(self_id & MASK_REST)];
+            if child_slice.starts_with(self_slice) {
+                child_slice[self_slice.len()..].iter().next().cloned()
+            } else {
+                None
+            }
+        } else {
+            None
         }
     }
 
@@ -85,27 +172,53 @@ impl WidgetId {
     ///
     /// Note: this is not a getter method. Calling multiple times with the same
     /// `index` may or may not return the same value!
-    pub fn make_child(self, index: usize) -> Self {
+    pub fn make_child(self, mut index: usize) -> Self {
         let self_id = self.0.get();
-        match self_id & MASK_HEAD {
-            USE_DB => {
-                // We can assume the child must also use the DB
-                let mut db = DB.lock().unwrap();
-
-                let i = usize::conv(self_id & MASK_REST);
-                let path = db[i].iter().cloned().chain(once(index)).collect();
-
-                let id = u64::conv(db.len());
-                // We can quite safely assume this:
-                debug_assert_eq!(id & MASK_HEAD, 0);
-                let id = id & MASK_REST;
-
-                db.push(path);
-
-                WidgetId(NonZeroU64::new(USE_DB | id).unwrap())
+        let mut path = None;
+        if (self_id & USE_BITS) != 0 {
+            // TODO(opt): this bit-packing approach is designed for space-optimisation, but it may
+            // be better to use a simpler, less-compressed approach, possibly with u128 type.
+            let block_len = block_len(self_id);
+            let avail_bits = 3 * (BLOCKS - block_len);
+            let req_bits = 8 * size_of::<usize>() as u8 - index.leading_zeros() as u8;
+            if req_bits <= avail_bits {
+                let mut y = (index as u64 & 7) as u64;
+                let mut shift = 4;
+                while index != 0 {
+                    y |= 1 << (shift - 1);
+                    y |= (index as u64 & 7) << shift;
+                    index >>= 3;
+                    shift += 4;
+                }
+                let used_blocks = (req_bits + 2) / 3;
+                let len = (block_len as u64 + used_blocks as u64) << SHIFT_LEN;
+                let rest = y << BLOCKS - used_blocks;
+                let id = USE_BITS | len | rest;
+                return WidgetId(NonZeroU64::new(id).unwrap());
+            } else {
+                path = Some(BitsIter::new(self_id).chain(once(index)).collect());
             }
-            _ => panic!("WidgetId::make_child: cannot make child of {}", self),
         }
+
+        if (self_id & USE_DB) == 0 {
+            panic!("WidgetId::make_child: cannot make child of {}", self);
+        }
+
+        let mut db = DB.lock().unwrap();
+
+        let path = path.unwrap_or_else(|| {
+            let i = usize::conv(self_id & MASK_REST);
+            db[i].iter().cloned().chain(once(index)).collect()
+        });
+
+        let id = u64::conv(db.len());
+        // We can quite safely assume this:
+        debug_assert_eq!(id & MASK_HEAD, 0);
+        let id = id & MASK_REST;
+
+        db.push(path);
+
+        WidgetId(NonZeroU64::new(USE_DB | id).unwrap())
     }
 
     /// Convert `Option<WidgetId>` to `u64`
@@ -158,8 +271,14 @@ impl fmt::Display for WidgetId {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let self_id = self.0.get();
         match self_id & MASK_HEAD {
+            USE_BITS => {
+                let len = block_len(self_id);
+                let bits = (self_id & MASK_REST) >> (4 * (BLOCKS - len));
+                write!(f, "BITS#{1:0>0$x}", len as usize, bits)
+            }
+            // TODO: encode as above?
             USE_DB => write!(f, "DB#{}", self_id & MASK_REST),
-            _ => todo!(),
+            _ => write!(f, "INVALID"),
         }
     }
 }
@@ -168,8 +287,47 @@ lazy_static::lazy_static! {
     static ref DB: Mutex<Vec<Vec<usize>>> = Mutex::new(vec![vec![]]);
 }
 
-#[test]
-fn size_of_option_widget_id() {
-    use std::mem::size_of;
-    assert_eq!(size_of::<WidgetId>(), size_of::<Option<WidgetId>>());
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn size_of_option_widget_id() {
+        use std::mem::size_of;
+        assert_eq!(size_of::<WidgetId>(), size_of::<Option<WidgetId>>());
+    }
+
+    #[test]
+    fn test_next_from_bits() {
+        const REST: u64 = 0x0FFF_FFFF_FFFF_FFFF;
+        assert_eq!(next_from_bits(0), (0, 1));
+        assert_eq!(next_from_bits(REST), (0, 1));
+        assert_eq!(next_from_bits((7 << 60) | REST), (7, 1));
+        assert_eq!(next_from_bits((0xB << 60) | (3 << 56)), (27, 2));
+        assert_eq!(next_from_bits(0xC9A4_F300_0000_0000), ((4 << 9) + (1<< 6) + (2<<3) + 4, 4));
+    }
+
+    #[test]
+    fn text_bits_iter() {
+        fn as_vec(x: u64) -> Vec<usize> {
+            BitsIter::new(x).collect()
+        }
+        assert_eq!(as_vec(USE_BITS), vec![]);
+        assert_eq!(as_vec(0x87_1A93_007F_0000), vec![1, 139, 0, 0, 7]);
+    }
+
+    #[test]
+    fn test_make_child() {
+        fn from_seq(seq: &[usize]) -> u64 {
+            let mut id = WidgetId::ROOT;
+            for x in seq {
+                id = id.make_child(*x);
+            }
+            id.into()
+        }
+
+        assert_eq!(from_seq(&[]), USE_DB);
+        assert_eq!(from_seq(&[0, 0, 0]), USE_DB | (3 << SHIFT_LEN));
+        assert_eq!(from_seq(&[0, 1, 0]), USE_DB | (3 << SHIFT_LEN));
+    }
 }

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -87,6 +87,15 @@ impl WidgetId {
 
     const INVALID: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(MASK_REST) });
 
+    /// Is the identifier valid?
+    ///
+    /// Default-constructed identifiers are invalid. Comparing invalid ids is
+    /// considered a logic error and thus will panic in debug builds.
+    /// This method may be used to check an identifier's validity.
+    pub fn is_valid(self) -> bool {
+        self.0.get() & MASK_HEAD != 0
+    }
+
     /// Returns true if `self` equals `id` or if `id` is a descendant of `self`
     pub fn is_ancestor_of(self, id: Self) -> bool {
         let self_id = self.0.get();

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -234,11 +234,26 @@ impl WidgetId {
         WidgetId(NonZeroU64::new(USE_DB | id).unwrap())
     }
 
+    /// Convert to a `u64`
+    ///
+    /// This value should not be interpreted, except as follows:
+    ///
+    /// -   it is guaranteed non-zero
+    /// -   it may be passed to [`Self::opt_from_u64`]
+    pub fn as_u64(&self) -> u64 {
+        self.0.get().into()
+    }
+
     /// Convert `Option<WidgetId>` to `u64`
-    pub fn opt_to_u64(id: Option<WidgetId>) -> u64 {
+    ///
+    /// This value should not be interpreted, except as follows:
+    ///
+    /// -   it is zero if and only if `id == None`
+    /// -   it may be passed to [`Self::opt_from_u64`]
+    pub fn opt_to_u64(id: Option<&WidgetId>) -> u64 {
         match id {
             None => 0,
-            Some(id) => id.into(),
+            Some(id) => id.as_u64(),
         }
     }
 
@@ -293,13 +308,6 @@ impl<'a> std::cmp::PartialEq<Option<&'a WidgetId>> for WidgetId {
     #[inline]
     fn eq(&self, rhs: &Option<&'a WidgetId>) -> bool {
         rhs.map(|id| id == self).unwrap_or(false)
-    }
-}
-
-impl From<WidgetId> for u64 {
-    #[inline]
-    fn from(id: WidgetId) -> u64 {
-        id.0.get().into()
     }
 }
 
@@ -420,7 +428,7 @@ mod test {
             for x in seq {
                 id = id.make_child(*x);
             }
-            let v = u64::from(id);
+            let v = id.as_u64();
             if v != x {
                 panic!("test({:?}, {:x}): found {:x}", seq, x, v);
             }
@@ -461,12 +469,12 @@ mod test {
             for x in seq {
                 id = id.make_child(*x);
             }
-            println!("id={} val={:x} from {:?}", id, u64::from(id), seq);
+            println!("id={} val={:x} from {:?}", id, id.as_u64(), seq);
             let mut id2 = id;
             for x in seq2 {
                 id2 = id2.make_child(*x);
             }
-            println!("id2={} val={:x} from {:?}", id2, u64::from(id2), seq2);
+            println!("id2={} val={:x} from {:?}", id2, id2.as_u64(), seq2);
             let next = seq2.iter().next().cloned();
             assert_eq!(id.index_of_child(id2), next);
             assert_eq!(id.is_ancestor_of(id2), next.is_some() || id == id2);
@@ -491,12 +499,12 @@ mod test {
             for x in seq {
                 id = id.make_child(*x);
             }
-            println!("id={} val={:x} from {:?}", id, u64::from(id), seq);
+            println!("id={} val={:x} from {:?}", id, id.as_u64(), seq);
             let mut id2 = WidgetId::ROOT;
             for x in seq2 {
                 id2 = id2.make_child(*x);
             }
-            println!("id2={} val={:x} from {:?}", id2, u64::from(id2), seq2);
+            println!("id2={} val={:x} from {:?}", id2, id2.as_u64(), seq2);
             assert_eq!(id.index_of_child(id2), None);
             assert_eq!(id.is_ancestor_of(id2), false);
         }

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -273,6 +273,20 @@ impl std::cmp::PartialEq for WidgetId {
     }
 }
 
+impl std::cmp::PartialEq<Option<WidgetId>> for WidgetId {
+    #[inline]
+    fn eq(&self, rhs: &Option<WidgetId>) -> bool {
+        rhs.map(|id| id == *self).unwrap_or(false)
+    }
+}
+
+impl<'a> std::cmp::PartialEq<Option<&'a WidgetId>> for WidgetId {
+    #[inline]
+    fn eq(&self, rhs: &Option<&'a WidgetId>) -> bool {
+        rhs.map(|id| id == self).unwrap_or(false)
+    }
+}
+
 impl From<WidgetId> for u64 {
     #[inline]
     fn from(id: WidgetId) -> u64 {
@@ -385,7 +399,7 @@ mod test {
         fn as_vec(x: u64) -> Vec<usize> {
             BitsIter::new(x).collect()
         }
-        assert_eq!(as_vec(USE_BITS), vec![]);
+        assert_eq!(as_vec(USE_BITS), Vec::<usize>::new());
         assert_eq!(as_vec(0x81_31_0000_0000_0000), vec![3]);
         assert_eq!(as_vec(0x87_1A_9300_7F00_0000), vec![1, 139, 0, 0, 7]);
     }

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -196,6 +196,7 @@ impl WidgetId {
     ///
     /// Note: this is not a getter method. Calling multiple times with the same
     /// `index` may or may not return the same value!
+    #[must_use]
     pub fn make_child(self, index: usize) -> Self {
         let self_id = self.0.get();
         let mut path = None;

--- a/crates/kas-core/src/draw/color.rs
+++ b/crates/kas-core/src/draw/color.rs
@@ -65,11 +65,13 @@ impl Rgba {
     }
 
     /// Average three colour components (desaturate)
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn average(self) -> Self {
         Self::ga(self.sum() * (1.0 / 3.0), self.a)
     }
 
     /// Multiply and clamp three colour components
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn multiply(self, x: f32) -> Self {
         debug_assert!(x >= 0.0);
         Self {
@@ -81,6 +83,7 @@ impl Rgba {
     }
 
     /// Clamp each colour component to at least `min`
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn max(self, min: f32) -> Self {
         debug_assert!(min <= 1.0);
         Self {
@@ -144,11 +147,13 @@ impl Rgb {
     }
 
     /// Average three colour components (desaturate)
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn average(self) -> Self {
         Self::grey(self.sum() * (1.0 / 3.0))
     }
 
     /// Multiply and clamp three colour components
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn multiply(self, x: f32) -> Self {
         debug_assert!(x >= 0.0);
         Self {
@@ -159,6 +164,7 @@ impl Rgb {
     }
 
     /// Clamp each colour component to at least `min`
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn max(self, min: f32) -> Self {
         debug_assert!(min <= 1.0);
         Self {

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -38,7 +38,7 @@ pub enum TextInputAction {
     /// No action (event consumed)
     None,
     /// Event not used
-    Unhandled,
+    Unused,
     /// Pan text using the given `delta`
     Pan(Offset),
     /// Keyboard focus should be requested (if not already active)
@@ -129,12 +129,12 @@ impl TextInput {
                         Action::Cursor(coord, false, !mgr.modifiers().shift(), 1)
                     }
                     // Note: if the TimerUpdate were from another requester it
-                    // should technically be Unhandled, but it doesn't matter
+                    // should technically be Unused, but it doesn't matter
                     // so long as other consumers match this first.
                     _ => Action::None,
                 }
             }
-            _ => Action::Unhandled,
+            _ => Action::Unused,
         }
     }
 }

--- a/crates/kas-core/src/event/enums.rs
+++ b/crates/kas-core/src/event/enums.rs
@@ -71,6 +71,12 @@ pub enum CursorIcon {
     RowResize,
 }
 
+impl Default for CursorIcon {
+    fn default() -> Self {
+        CursorIcon::Default
+    }
+}
+
 /// Describes a button of a mouse controller.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -32,7 +32,7 @@ pub enum Event {
     /// This represents a control or navigation action, usually from the
     /// keyboard. It is sent to whichever widget is "most appropriate", then
     /// potentially to the "next most appropriate" target if the first returns
-    /// [`Response::Unhandled`], until handled or no more appropriate targets
+    /// [`Response::Unused`], until handled or no more appropriate targets
     /// are available (the exact logic is encoded in `Manager::start_key_event`).
     ///
     /// In some cases keys are remapped, e.g. a widget with selection focus but
@@ -193,7 +193,7 @@ pub enum Command {
     ///
     /// Each press of this key should somehow relax control. It is expected that
     /// widgets receiving this key repeatedly eventually (soon) have no more
-    /// use for this themselves and return it via [`Response::Unhandled`].
+    /// use for this themselves and return it via [`Response::Unused`].
     ///
     /// This is in some cases remapped to [`Command::Deselect`].
     Escape,

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -95,26 +95,19 @@ pub trait SendEvent: Handler {
     /// if self.is_disabled() {
     ///     return Response::Unhandled;
     /// }
-    /// if id <= self.child1.id() {
-    ///     self.child1.event(mgr, id, event).into()
-    /// } else if id <= self.child2.id() {
-    ///     self.child2.event(mgr, id, event).into()
-    /// } ... {
-    /// } else {
-    ///     debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
-    ///     Manager::handle_generic(self, mgr, event)
+    /// match self.id().index_of_child(id) {
+    ///     Some(0) => self.child0.send(mgr, id, event).into(),
+    ///     Some(1) => self.child1.send(mgr, id, event).into(),
+    ///     // ...
+    ///     _ => {
+    ///         debug_assert_eq!(self.id(), id);
+    ///         Manager::handle_generic(self, mgr, event),
+    ///     }
     /// }
-    /// ```
-    /// Parents which don't handle any events themselves may simplify this:
-    /// ```no_test
-    /// if !self.is_disabled() && id <= self.w.id() {
-    ///     return self.w.send(mgr, id, event);
-    /// }
-    /// Response::Unhandled
     /// ```
     ///
-    /// When the child's [`Handler::Msg`] type is not [`VoidMsg`], its response
-    /// messages can be handled here (in place of `.into()` above).
+    /// When the child's [`Handler::Msg`] type is not something which converts
+    /// into the widget's own message type, it must be handled here (in place of `.into()`).
     ///
     /// The example above uses [`Manager::handle_generic`], which is an optional
     /// tool able to perform some simplifications on events. It is also valid to

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -60,11 +60,11 @@ pub trait Handler: WidgetConfig {
     /// Handle an event and return a user-defined message
     ///
     /// Widgets should handle any events applicable to themselves here, and
-    /// return all other events via [`Response::Unhandled`].
+    /// return all other events via [`Response::Unused`].
     #[inline]
     fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
         let _ = (mgr, event);
-        Response::Unhandled
+        Response::Unused
     }
 }
 
@@ -93,7 +93,7 @@ pub trait SendEvent: Handler {
     /// The following logic is recommended for routing events:
     /// ```no_test
     /// if self.is_disabled() {
-    ///     return Response::Unhandled;
+    ///     return Response::Unused;
     /// }
     /// match self.id().index_of_child(id) {
     ///     Some(0) => self.child0.send(mgr, id, event).into(),

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -8,7 +8,7 @@
 use super::*;
 #[allow(unused)]
 use crate::Widget; // for doc-links
-use crate::{WidgetConfig, WidgetId};
+use crate::{WidgetConfig, WidgetExt, WidgetId};
 
 /// Event handling for a [`Widget`]
 ///
@@ -136,12 +136,12 @@ impl<'a> Manager<'a> {
                     return Response::Used;
                 }
                 Event::PressMove { source, cur_id, .. } => {
-                    let cond = cur_id == Some(widget.id());
+                    let cond = widget.eq_id(cur_id);
                     let target = if cond { cur_id } else { None };
                     mgr.set_grab_depress(source, target);
                     return Response::Used;
                 }
-                Event::PressEnd { end_id, .. } if end_id == Some(widget.id()) => {
+                Event::PressEnd { end_id, .. } if widget.eq_id(end_id) => {
                     event = Event::Activate;
                 }
                 _ => (),

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -133,13 +133,13 @@ impl<'a> Manager<'a> {
             match event {
                 Event::PressStart { source, coord, .. } if source.is_primary() => {
                     mgr.request_grab(widget.id(), source, coord, GrabMode::Grab, None);
-                    return Response::None;
+                    return Response::Used;
                 }
                 Event::PressMove { source, cur_id, .. } => {
                     let cond = cur_id == Some(widget.id());
                     let target = if cond { cur_id } else { None };
                     mgr.set_grab_depress(source, target);
-                    return Response::None;
+                    return Response::Used;
                 }
                 Event::PressEnd { end_id, .. } if end_id == Some(widget.id()) => {
                     event = Event::Activate;

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -268,15 +268,10 @@ impl<'a> Manager<'a> {
             self.state.hover = w_id;
 
             if let Some(id) = w_id {
-                let mut icon = widget.cursor_icon();
-                let mut widget = widget.as_widget();
-                while let Some(child) = widget.find_child_index(id) {
-                    widget = widget.get_child(child).unwrap();
-                    let child_icon = widget.cursor_icon();
-                    if child_icon != CursorIcon::Default {
-                        icon = child_icon;
-                    }
-                }
+                let icon = widget
+                    .find_leaf(id)
+                    .map(|w| w.cursor_icon())
+                    .unwrap_or_default();
                 if icon != self.state.hover_icon {
                     self.state.hover_icon = icon;
                     if self.state.mouse_grab.is_none() {

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -270,7 +270,7 @@ impl<'a> Manager<'a> {
             if let Some(id) = w_id {
                 let mut icon = widget.cursor_icon();
                 let mut widget = widget.as_widget();
-                while let Some(child) = widget.find_child(id) {
+                while let Some(child) = widget.find_child_index(id) {
                     widget = widget.get_child(child).unwrap();
                     let child_icon = widget.cursor_icon();
                     if child_icon != CursorIcon::Default {

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -256,22 +256,16 @@ impl<'a> Manager<'a> {
                     self.redraw(id);
                 }
             }
-            if let Some(id) = w_id {
-                if widget
-                    .find_widget(id)
-                    .map(|w| w.hover_highlight())
-                    .unwrap_or(false)
-                {
-                    self.redraw(id);
-                }
-            }
             self.state.hover = w_id;
 
             if let Some(id) = w_id {
-                let icon = widget
-                    .find_widget(id)
-                    .map(|w| w.cursor_icon())
-                    .unwrap_or_default();
+                let mut icon = Default::default();
+                if let Some(w) = widget.find_widget(id) {
+                    if w.hover_highlight() {
+                        self.redraw(id);
+                    }
+                    icon = w.cursor_icon();
+                }
                 if icon != self.state.hover_icon {
                     self.state.hover_icon = icon;
                     if self.state.mouse_grab.is_none() {

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -249,7 +249,7 @@ impl<'a> Manager<'a> {
             trace!("Manager: hover = {:?}", w_id);
             if let Some(id) = self.state.hover {
                 if widget
-                    .find_leaf(id)
+                    .find_widget(id)
                     .map(|w| w.hover_highlight())
                     .unwrap_or(false)
                 {
@@ -258,7 +258,7 @@ impl<'a> Manager<'a> {
             }
             if let Some(id) = w_id {
                 if widget
-                    .find_leaf(id)
+                    .find_widget(id)
                     .map(|w| w.hover_highlight())
                     .unwrap_or(false)
                 {
@@ -269,7 +269,7 @@ impl<'a> Manager<'a> {
 
             if let Some(id) = w_id {
                 let icon = widget
-                    .find_leaf(id)
+                    .find_widget(id)
                     .map(|w| w.cursor_icon())
                     .unwrap_or_default();
                 if icon != self.state.hover_icon {
@@ -371,7 +371,7 @@ impl<'a> Manager<'a> {
         }
 
         if let Some(id) = target {
-            if widget.find_leaf(id).map(|w| w.key_nav()).unwrap_or(false) {
+            if widget.find_widget(id).map(|w| w.key_nav()).unwrap_or(false) {
                 self.set_nav_focus(id, true);
             }
             self.add_key_depress(scancode, id);

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -486,7 +486,7 @@ impl<'a> Manager<'a> {
         let _ = widget.send(self, id, event);
     }
 
-    // Similar to send_event, but return true only if response != Response::Unhandled
+    // Similar to send_event, but return true only if response != Response::Unused
     fn try_send_event<W: Widget + ?Sized>(
         &mut self,
         widget: &mut W,
@@ -495,7 +495,7 @@ impl<'a> Manager<'a> {
     ) -> bool {
         trace!("Send to {}: {:?}", id, event);
         let r = widget.send(self, id, event);
-        !matches!(r, Response::Unhandled)
+        !matches!(r, Response::Unused)
     }
 
     fn send_popup_first<W: Widget + ?Sized>(&mut self, widget: &mut W, id: WidgetId, event: Event) {
@@ -503,7 +503,7 @@ impl<'a> Manager<'a> {
         {
             trace!("Send to popup parent: {}: {:?}", parent, event);
             match widget.send(self, parent, event.clone()) {
-                Response::Unhandled => (),
+                Response::Unused => (),
                 _ => return,
             }
             self.close_window(wid, false);

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -551,7 +551,9 @@ impl<'a: 'b, 'b> ConfigureManager<'a, 'b> {
             "multiple use of ConfigureManager::get_id without construction of child"
         );
         self.used = true;
-        self.map.insert(old_id, self.id);
+        if old_id.is_valid() {
+            self.map.insert(old_id, self.id);
+        }
         self.id
     }
 

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -168,7 +168,7 @@ impl<'a> Manager<'a> {
             break;
         }
 
-        self.state.time_updates.sort_by(|a, b| b.cmp(a)); // reverse sort
+        self.state.time_updates.sort_by(|a, b| b.0.cmp(&a.0)); // reverse sort
     }
 
     /// Subscribe to an update handle

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -499,7 +499,7 @@ impl<'a> Manager<'a> {
     ///
     /// Since these events are *requested*, the widget should consume them even
     /// if not required, although in practice this
-    /// only affects parents intercepting [`Response::Unhandled`] events.
+    /// only affects parents intercepting [`Response::Unused`] events.
     ///
     /// This method normally succeeds, but fails when
     /// multiple widgets attempt a grab the same press source simultaneously

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -674,7 +674,7 @@ impl<'a> Manager<'a> {
         key_focus: bool,
     ) -> bool {
         if let Some(id) = self.state.popups.last().map(|(_, p, _)| p.id) {
-            if let Some(w) = widget.find_leaf_mut(id) {
+            if let Some(w) = widget.find_widget_mut(id) {
                 widget = w;
             } else {
                 // This is a corner-case. Do nothing.

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -14,7 +14,7 @@ use crate::draw::{DrawShared, SizeHandle, ThemeApi};
 use crate::geom::{Coord, Offset, Vec2};
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
-use crate::{TkAction, WidgetId, WindowId};
+use crate::{TkAction, WidgetExt, WidgetId, WindowId};
 
 impl<'a> std::ops::BitOrAssign<TkAction> for Manager<'a> {
     #[inline]
@@ -696,7 +696,7 @@ impl<'a> Manager<'a> {
             if widget.is_disabled() {
                 return None;
             } else if last == usize::MAX {
-                if focus != Some(widget.id()) && widget.key_nav() {
+                if !widget.eq_id(focus) && widget.key_nav() {
                     return Some(widget.id());
                 }
                 return None;
@@ -705,7 +705,7 @@ impl<'a> Manager<'a> {
             let mut child = None;
             if let Some(id) = focus {
                 // Checking is_ancestor_of is just an optimisation
-                if widget.is_ancestor_of(id) && id != widget.id() {
+                if widget.is_ancestor_of(id) && !widget.eq_id(id) {
                     // TODO(opt): add WidgetChildren::find_ancestor_of method to
                     // allow optimisations for widgets with many children?
                     for index in 0..=last {
@@ -734,7 +734,7 @@ impl<'a> Manager<'a> {
                     {
                         return Some(id);
                     }
-                } else if focus != Some(widget.id()) && widget.key_nav() {
+                } else if !widget.eq_id(focus) && widget.key_nav() {
                     return Some(widget.id());
                 }
 
@@ -771,7 +771,7 @@ impl<'a> Manager<'a> {
                         }
                         child = Some(index);
                     } else {
-                        return if focus != Some(widget.id()) && widget.key_nav() {
+                        return if !widget.eq_id(focus) && widget.key_nav() {
                             Some(widget.id())
                         } else {
                             None

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -302,7 +302,7 @@ impl ManagerState {
         while let Some(id) = mgr.state.new_popups.pop() {
             while let Some((_, popup, _)) = mgr.state.popups.last() {
                 if widget
-                    .find_leaf(popup.parent)
+                    .find_widget(popup.parent)
                     .map(|w| w.is_ancestor_of(id))
                     .unwrap_or(false)
                 {
@@ -574,7 +574,7 @@ impl<'a> Manager<'a> {
                     // No mouse grab but have a hover target
                     if state == ElementState::Pressed {
                         if self.state.config.borrow().mouse_nav_focus() {
-                            if let Some(w) = widget.find_leaf(start_id) {
+                            if let Some(w) = widget.find_widget(start_id) {
                                 if w.key_nav() {
                                     self.set_nav_focus(w.id(), false);
                                 }
@@ -600,7 +600,7 @@ impl<'a> Manager<'a> {
                     TouchPhase::Started => {
                         if let Some(start_id) = widget.find_id(coord) {
                             if self.state.config.borrow().touch_nav_focus() {
-                                if let Some(w) = widget.find_leaf(start_id) {
+                                if let Some(w) = widget.find_widget(start_id) {
                                     if w.key_nav() {
                                         self.set_nav_focus(w.id(), false);
                                     }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -426,8 +426,8 @@ impl<'a> Manager<'a> {
         use winit::event::{ElementState, MouseScrollDelta, TouchPhase, WindowEvent::*};
 
         // Note: since <W as Handler>::Msg = VoidMsg, only two values of
-        // Response are possible: None and Unhandled. We don't have any use for
-        // Unhandled events here, so we can freely ignore all responses.
+        // Response are possible: Used and Unused. We don't have any use for
+        // Unused events here, so we can freely ignore all responses.
 
         match event {
             CloseRequested => self.send_action(TkAction::CLOSE),

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -573,14 +573,6 @@ impl<'a> Manager<'a> {
                 } else if let Some(start_id) = self.state.hover {
                     // No mouse grab but have a hover target
                     if state == ElementState::Pressed {
-                        let source = PressSource::Mouse(button, self.state.last_click_repetitions);
-                        let event = Event::PressStart {
-                            source,
-                            start_id,
-                            coord,
-                        };
-                        self.send_popup_first(widget, start_id, event);
-
                         if self.state.config.borrow().mouse_nav_focus() {
                             if let Some(w) = widget.find_leaf(start_id) {
                                 if w.key_nav() {
@@ -588,6 +580,14 @@ impl<'a> Manager<'a> {
                                 }
                             }
                         }
+
+                        let source = PressSource::Mouse(button, self.state.last_click_repetitions);
+                        let event = Event::PressStart {
+                            source,
+                            start_id,
+                            coord,
+                        };
+                        self.send_popup_first(widget, start_id, event);
                     }
                 }
             }
@@ -599,13 +599,6 @@ impl<'a> Manager<'a> {
                 match touch.phase {
                     TouchPhase::Started => {
                         if let Some(start_id) = widget.find_id(coord) {
-                            let event = Event::PressStart {
-                                source,
-                                start_id,
-                                coord,
-                            };
-                            self.send_popup_first(widget, start_id, event);
-
                             if self.state.config.borrow().touch_nav_focus() {
                                 if let Some(w) = widget.find_leaf(start_id) {
                                     if w.key_nav() {
@@ -613,6 +606,13 @@ impl<'a> Manager<'a> {
                                     }
                                 }
                             }
+
+                            let event = Event::PressStart {
+                                source,
+                                start_id,
+                                coord,
+                            };
+                            self.send_popup_first(widget, start_id, event);
                         }
                     }
                     TouchPhase::Moved => {

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -173,13 +173,17 @@ impl<K, M> From<VoidMsg> for ChildMsg<K, M> {
     }
 }
 
+/// Convert Response<ChildMsg<_, M>> to Response<M>
+///
+/// `ChildMsg::Child(_, msg)`  translates to `Response::Msg(msg)`; other
+/// variants translate to `Response::Used`.
 impl<K, M> From<Response<ChildMsg<K, M>>> for Response<M> {
     fn from(r: Response<ChildMsg<K, M>>) -> Self {
         match Response::try_from(r) {
             Ok(r) => r,
             Err(msg) => match msg {
                 ChildMsg::Child(_, msg) => Response::Msg(msg),
-                _ => Response::None,
+                _ => Response::Used,
             },
         }
     }

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -28,7 +28,7 @@
 //!
 //! The [`Response`] enum has a few variants; most important is `Msg(msg)`
 //! which passes a user-defined payload up to a parent widget. The
-//! `Unhandled(event)` and `Focus(rect)` variants may be trapped by any parent
+//! `Unused` and `Focus(rect)` variants may be trapped by any parent
 //! for secondary purposes, e.g. to adjust a `ScrollRegion`.
 //!
 //! ## Mouse and touch events
@@ -51,7 +51,7 @@
 //!
 //! When a pop-up widget is created, this forces keyboard focus to that widget
 //! and receives a "weak" grab on press actions, meaning that the widget
-//! receives this input first, but if returned via `Response::Unhandled` the
+//! receives this input first, but if returned via `Response::Unused` the
 //! input passes immediately to the next target. This allows pop-up menus to
 //! get first chance of handling input and to dismiss themselves when input is
 //! for other widgets without blocking other widgets from accepting that input.

--- a/crates/kas-core/src/event/response.rs
+++ b/crates/kas-core/src/event/response.rs
@@ -18,23 +18,24 @@ use crate::geom::{Offset, Rect};
 #[derive(Clone, Debug)]
 #[must_use]
 pub enum Response<M> {
-    /// Unhandled event
+    /// Event was unused
     ///
-    /// Indicates that the event was not consumed. An ancestor or the event
-    /// manager is thus able to make use of this event.
-    Unhandled,
-    /// Event is consumed; no active response
+    /// Unused events may be used by a parent/ancestor widget or passed to
+    /// another handler until used.
+    Unused,
+    /// Event is used, no other result
     ///
-    /// This implies that the event was consumed, but does not affect parents.
-    /// Note that we consider "view changes" (i.e. scrolling) to not be of
-    /// external interest.
+    /// All variants besides `Unused` indicate that the event was used. This
+    /// variant is used when no further action happens.
     Used,
     /// Pan scrollable regions by the given delta
     ///
     /// With the usual scroll offset conventions, this delta must be subtracted
     /// from the scroll offset.
     Pan(Offset),
-    /// (Keyboard) focus has changed. This region should be made visible.
+    /// (Keyboard) focus has changed
+    ///
+    /// This region (in the child's coordinate space) should be made visible.
     Focus(Rect),
     /// Widget wishes to be selected (or have selection status toggled)
     Select,
@@ -78,10 +79,10 @@ impl<M> Response<M> {
         matches!(self, Response::Used)
     }
 
-    /// True if variant is `Unhandled`
+    /// True if variant is `Unused`
     #[inline]
-    pub fn is_unhandled(&self) -> bool {
-        matches!(self, Response::Unhandled)
+    pub fn is_unused(&self) -> bool {
+        matches!(self, Response::Unused)
     }
 
     /// True if variant is `Msg`
@@ -119,7 +120,7 @@ impl<M> Response<M> {
     pub fn try_from<N>(r: Response<N>) -> Result<Self, N> {
         use Response::*;
         match r {
-            Unhandled => Ok(Unhandled),
+            Unused => Ok(Unused),
             Used => Ok(Used),
             Pan(delta) => Ok(Pan(delta)),
             Focus(rect) => Ok(Focus(rect)),

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -51,12 +51,14 @@ macro_rules! impl_common {
 
             /// Return the minimum, componentwise
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn min(self, other: Self) -> Self {
                 Self(self.0.min(other.0), self.1.min(other.1))
             }
 
             /// Return the maximum, componentwise
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn max(self, other: Self) -> Self {
                 Self(self.0.max(other.0), self.1.max(other.1))
             }
@@ -65,24 +67,28 @@ macro_rules! impl_common {
             ///
             /// In the case that `min > max`, the `min` value is returned.
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn clamp(self, min: Self, max: Self) -> Self {
                 self.min(max).max(min)
             }
 
             /// Return the transpose (swap x and y values)
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn transpose(self) -> Self {
                 Self(self.1, self.0)
             }
 
             /// Return the result of component-wise multiplication
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn cwise_mul(self, rhs: Self) -> Self {
                 Self(self.0 * rhs.0, self.1 * rhs.1)
             }
 
             /// Return the result of component-wise division
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn cwise_div(self, rhs: Self) -> Self {
                 Self(self.0 / rhs.0, self.1 / rhs.1)
             }
@@ -297,6 +303,7 @@ impl Size {
 
     /// Subtraction, clamping the result to 0 or greater
     #[inline]
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn clamped_sub(self, rhs: Self) -> Self {
         // This impl should aid vectorisation. We avoid Sub impl because of its check.
         Size(self.0 - rhs.0, self.1 - rhs.1).max(Size::ZERO)
@@ -624,6 +631,7 @@ impl Rect {
 
     /// Shrink self in all directions by the given `n`
     #[inline]
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn shrink(&self, n: i32) -> Rect {
         let pos = self.pos + Offset::splat(n);
         let size = self.size.clamped_sub(Size::splat(n + n));
@@ -632,6 +640,7 @@ impl Rect {
 
     /// Expand self in all directions by the given `n`
     #[inline]
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn expand(&self, n: i32) -> Rect {
         debug_assert!(n >= 0);
         let pos = self.pos - Offset::splat(n);

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -60,6 +60,7 @@ impl Quad {
     ///
     /// In debug mode, this asserts `a.le(b)` after shrinking.
     #[inline]
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn shrink(&self, value: f32) -> Quad {
         let a = self.a + value;
         let b = self.b - value;
@@ -71,6 +72,7 @@ impl Quad {
     ///
     /// In debug mode, this asserts `a.le(b)` after shrinking.
     #[inline]
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn grow(&self, value: f32) -> Quad {
         let a = self.a - value;
         let b = self.b + value;
@@ -82,6 +84,7 @@ impl Quad {
     ///
     /// In debug mode, this asserts `a.le(b)` after shrinking.
     #[inline]
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn shrink_vec(&self, value: Vec2) -> Quad {
         let a = self.a + value;
         let b = self.b - value;
@@ -174,42 +177,49 @@ macro_rules! impl_vec2 {
 
             /// Return the minimum, componentwise
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn min(self, other: Self) -> Self {
                 $T(self.0.min(other.0), self.1.min(other.1))
             }
 
             /// Return the maximum, componentwise
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn max(self, other: Self) -> Self {
                 $T(self.0.max(other.0), self.1.max(other.1))
             }
 
             /// Take the absolute value of each component
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn abs(self) -> Self {
                 $T(self.0.abs(), self.1.abs())
             }
 
             /// Take the floor of each component
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn floor(self) -> Self {
                 $T(self.0.floor(), self.1.floor())
             }
 
             /// Take the ceiling of each component
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn ceil(self) -> Self {
                 $T(self.0.ceil(), self.1.ceil())
             }
 
             /// Round each component to the nearest integer
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn round(self) -> Self {
                 $T(self.0.round(), self.1.round())
             }
 
             /// For each component, return `±1` with the same sign as `self`.
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn sign(self) -> Self {
                 let one: $f = 1.0;
                 $T(one.copysign(self.0), one.copysign(self.1))
@@ -241,6 +251,7 @@ macro_rules! impl_vec2 {
 
             /// Multiply two vectors as if they are complex numbers
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn complex_mul(self, rhs: Self) -> Self {
                 $T(
                     self.0 * rhs.0 - self.1 * rhs.1,
@@ -250,12 +261,14 @@ macro_rules! impl_vec2 {
 
             /// Divide by a second vector as if they are complex numbers
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn complex_div(self, rhs: Self) -> Self {
                 self.complex_mul(rhs.complex_inv())
             }
 
             /// Take the complex reciprocal
             #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
             pub fn complex_inv(self) -> Self {
                 let ssi = 1.0 / self.sum_square();
                 $T(self.0 * ssi, -self.1 * ssi)

--- a/crates/kas-core/src/layout/align.rs
+++ b/crates/kas-core/src/layout/align.rs
@@ -51,6 +51,7 @@ impl AlignHints {
     }
 
     /// Combine two hints (first takes priority)
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn combine(self, rhs: AlignHints) -> Self {
         Self {
             horiz: self.horiz.or(rhs.horiz),

--- a/crates/kas-core/src/layout/size_rules.rs
+++ b/crates/kas-core/src/layout/size_rules.rs
@@ -248,6 +248,7 @@ impl SizeRules {
 
     /// Use the maximum size of `self` and `rhs`.
     #[inline]
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn max(self, rhs: Self) -> SizeRules {
         SizeRules {
             a: self.a.max(rhs.a),
@@ -302,6 +303,7 @@ impl SizeRules {
     /// Note also that appending [`SizeRules::EMPTY`] does include interior
     /// margins (those between `EMPTY` and the other rules) within the result.
     #[inline]
+    #[must_use = "method does not modify self but returns a new value"]
     pub fn appended(self, rhs: SizeRules) -> Self {
         let c: i32 = self.m.1.max(rhs.m.0).into();
         SizeRules {

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -39,4 +39,4 @@ pub use crate::WidgetId;
 #[doc(no_inline)]
 pub use crate::{Boxed, TkAction};
 #[doc(no_inline)]
-pub use crate::{Layout, Widget, WidgetChildren, WidgetConfig, WidgetCore};
+pub use crate::{Layout, Widget, WidgetChildren, WidgetConfig, WidgetCore, WidgetExt};

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -148,12 +148,6 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
             impl #impl_generics ::kas::WidgetChildren
                 for #name #ty_generics #where_clause
             {
-                fn first_id(&self) -> ::kas::WidgetId {
-                    self.#inner.first_id()
-                }
-                fn record_first_id(&mut self, id: WidgetId) {
-                    self.#inner.record_first_id(id);
-                }
                 fn num_children(&self) -> usize {
                     self.#inner.num_children()
                 }
@@ -166,13 +160,6 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
             }
         });
     } else if impl_widget_children {
-        let first_id = if args.children.is_empty() {
-            quote! { self.id() }
-        } else {
-            let ident = &args.children[0].ident;
-            quote! { self.#ident.first_id() }
-        };
-
         let count = args.children.len();
 
         let mut get_rules = quote! {};
@@ -187,9 +174,6 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
             impl #impl_generics ::kas::WidgetChildren
                 for #name #ty_generics #where_clause
             {
-                fn first_id(&self) -> ::kas::WidgetId {
-                    #first_id
-                }
                 fn num_children(&self) -> usize {
                     #count
                 }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -413,7 +413,7 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
             quote! {
                 use ::kas::{WidgetCore, event::Response};
                 if self.is_disabled() {
-                    return Response::Unhandled;
+                    return Response::Unused;
                 }
 
                 let self_id = self.id();
@@ -422,7 +422,7 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
                     _ if id == self_id => ::kas::event::Manager::handle_generic(self, mgr, event),
                     _ => {
                         debug_assert!(false, "SendEvent::send: bad WidgetId");
-                        Response::Unhandled
+                        Response::Unused
                     }
                 }
             }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -376,7 +376,7 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
                         r.try_into().unwrap_or_else(|msg| {
                             #log_msg
                             let _: () = self.#f(mgr, msg);
-                            Response::None
+                            Response::Used
                         })
                     },
                     Handler::Map(f) => quote! {
@@ -395,7 +395,7 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
                         r.try_into().unwrap_or_else(|msg| {
                             #log_msg
                             let _ = msg;
-                            Response::None
+                            Response::Used
                         })
                     },
                     Handler::None => quote! { r.into() },
@@ -422,7 +422,7 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
                     _ if id == self_id => ::kas::event::Manager::handle_generic(self, mgr, event),
                     _ => {
                         debug_assert!(false, "SendEvent::send: bad WidgetId");
-                        Response::None
+                        Response::Unhandled
                     }
                 }
             }

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -70,6 +70,7 @@ widget! {
 
         /// Adjust scaling
         #[inline]
+        #[must_use]
         pub fn with_scaling(mut self, f: impl FnOnce(SpriteDisplay) -> SpriteDisplay) -> Self {
             self.sprite = f(self.sprite);
             self

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -61,12 +61,14 @@ widget! {
         }
 
         /// Set margins
+        #[must_use]
         pub fn with_margins(mut self, margins: MarginSelector) -> Self {
             self.margins = margins;
             self
         }
 
         /// Set stretch policy
+        #[must_use]
         pub fn with_stretch(mut self, stretch: Stretch) -> Self {
             self.stretch = stretch;
             self

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -66,6 +66,7 @@ impl FlatTheme {
     ///
     /// Units: Points per Em (standard unit of font size)
     #[inline]
+    #[must_use]
     pub fn with_font_size(mut self, pt_size: f32) -> Self {
         self.config.set_font_size(pt_size);
         self
@@ -75,6 +76,7 @@ impl FlatTheme {
     ///
     /// If no scheme by this name is found the scheme is left unchanged.
     #[inline]
+    #[must_use]
     pub fn with_colours(mut self, name: &str) -> Self {
         if let Some(scheme) = self.config.get_color_scheme(name) {
             self.config.set_active_scheme(name);

--- a/crates/kas-theme/src/multi.rs
+++ b/crates/kas-theme/src/multi.rs
@@ -51,6 +51,7 @@ impl<DS> MultiThemeBuilder<DS> {
     /// Note: the constraints of this method vary depending on the `unsize`
     /// feature.
     #[cfg(feature = "unsize")]
+    #[must_use]
     pub fn add<S: ToString, U>(mut self, name: S, theme: U) -> Self
     where
         U: Unsize<dyn ThemeDst<DS>>,
@@ -67,6 +68,7 @@ impl<DS> MultiThemeBuilder<DS> {
     /// Note: the constraints of this method vary depending on the `unsize`
     /// feature.
     #[cfg(not(feature = "unsize"))]
+    #[must_use]
     pub fn add<S: ToString, T>(mut self, name: S, theme: T) -> Self
     where
         DS: DrawSharedImpl,

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -38,6 +38,7 @@ impl ShadedTheme {
     /// Set font size
     ///
     /// Units: Points per Em (standard unit of font size)
+    #[must_use]
     pub fn with_font_size(mut self, pt_size: f32) -> Self {
         self.flat.config.set_font_size(pt_size);
         self
@@ -46,6 +47,7 @@ impl ShadedTheme {
     /// Set the colour scheme
     ///
     /// If no scheme by this name is found the scheme is left unchanged.
+    #[must_use]
     pub fn with_colours(mut self, scheme: &str) -> Self {
         self.flat.config.set_active_scheme(scheme);
         if let Some(scheme) = self.flat.config.get_color_scheme(scheme) {

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -54,7 +54,9 @@ widget! {
                 return Response::Unhandled;
             }
 
-            if id < self.id() {
+            if id == self.id() {
+                self.handle(mgr, event)
+            } else {
                 let r = self.inner.send(mgr, id, event);
                 r.try_into().unwrap_or_else(|msg| {
                     log::trace!(
@@ -65,9 +67,6 @@ widget! {
                     );
                     (self.map)(mgr, msg)
                 })
-            } else {
-                debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
-                self.handle(mgr, event)
             }
         }
     }

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -54,7 +54,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if id == self.id() {
+            if self.eq_id(id) {
                 self.handle(mgr, event)
             } else {
                 let r = self.inner.send(mgr, id, event);

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -51,7 +51,7 @@ widget! {
     impl SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             if id == self.id() {

--- a/crates/kas-widgets/src/adapter/widget_ext.rs
+++ b/crates/kas-widgets/src/adapter/widget_ext.rs
@@ -31,12 +31,12 @@ pub trait WidgetExt: Widget {
     /// Construct a wrapper widget which discards messages from this widget
     ///
     /// Responses from this widget with a message payload are mapped to
-    /// [`Response::None`].
+    /// [`Response::Used`].
     fn map_msg_discard<M>(self) -> MapResponse<Self, M>
     where
         Self: Sized,
     {
-        MapResponse::new(self, |_, _| Response::None)
+        MapResponse::new(self, |_, _| Response::Used)
     }
 
     /// Construct a wrapper widget which maps message responses from this widget

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -149,11 +149,14 @@ widget! {
 
     impl SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<M> {
-            if id < self.id() {
-                self.inner.send(mgr, id, event).void_into()
-            } else {
-                debug_assert_eq!(id, self.id());
+            if self.is_disabled() {
+                return Response::Unhandled;
+            }
+            if id == self.id() {
                 Manager::handle_generic(self, mgr, event)
+            } else {
+                debug_assert!(self.inner.id().is_ancestor_of(id));
+                self.inner.send(mgr, id, event).void_into()
             }
         }
     }

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -142,7 +142,7 @@ widget! {
         fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<M> {
             match event {
                 Event::Activate => Response::used_or_msg(self.on_push.as_ref().and_then(|f| f(mgr))),
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }
@@ -150,7 +150,7 @@ widget! {
     impl SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<M> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
             if id == self.id() {
                 Manager::handle_generic(self, mgr, event)
@@ -320,7 +320,7 @@ widget! {
         fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<M> {
             match event {
                 Event::Activate => Response::used_or_msg(self.on_push.as_ref().and_then(|f| f(mgr))),
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -68,7 +68,7 @@ widget! {
         ///
         /// On activation (through user input events or [`Event::Activate`]) the
         /// closure `f` is called. The result of `f` is converted to
-        /// [`Response::Msg`] or [`Response::None`] and returned to the parent.
+        /// [`Response::Msg`] or [`Response::Used`] and returned to the parent.
         #[inline]
         pub fn on_push<M, F>(self, f: F) -> Button<W, M>
         where
@@ -90,7 +90,7 @@ widget! {
         ///
         /// On activation (through user input events or [`Event::Activate`]) the
         /// closure `f` is called. The result of `f` is converted to
-        /// [`Response::Msg`] or [`Response::None`] and returned to the parent.
+        /// [`Response::Msg`] or [`Response::Used`] and returned to the parent.
         #[inline]
         pub fn new_on<F>(inner: W, f: F) -> Self
         where
@@ -141,7 +141,7 @@ widget! {
 
         fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<M> {
             match event {
-                Event::Activate => Response::none_or_msg(self.on_push.as_ref().and_then(|f| f(mgr))),
+                Event::Activate => Response::used_or_msg(self.on_push.as_ref().and_then(|f| f(mgr))),
                 _ => Response::Unhandled,
             }
         }
@@ -226,7 +226,7 @@ widget! {
         ///
         /// On activation (through user input events or [`Event::Activate`]) the
         /// closure `f` is called. The result of `f` is converted to
-        /// [`Response::Msg`] or [`Response::None`] and returned to the parent.
+        /// [`Response::Msg`] or [`Response::Used`] and returned to the parent.
         #[inline]
         pub fn on_push<M, F>(self, f: F) -> TextButton<M>
         where
@@ -249,7 +249,7 @@ widget! {
         ///
         /// On activation (through user input events or [`Event::Activate`]) the
         /// closure `f` is called. The result of `f` is converted to
-        /// [`Response::Msg`] or [`Response::None`] and returned to the parent.
+        /// [`Response::Msg`] or [`Response::Used`] and returned to the parent.
         #[inline]
         pub fn new_on<S: Into<AccelString>, F>(label: S, f: F) -> Self
         where
@@ -319,7 +319,7 @@ widget! {
 
         fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<M> {
             match event {
-                Event::Activate => Response::none_or_msg(self.on_push.as_ref().and_then(|f| f(mgr))),
+                Event::Activate => Response::used_or_msg(self.on_push.as_ref().and_then(|f| f(mgr))),
                 _ => Response::Unhandled,
             }
         }

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -152,7 +152,7 @@ widget! {
             if self.is_disabled() {
                 return Response::Unused;
             }
-            if id == self.id() {
+            if self.eq_id(id) {
                 Manager::handle_generic(self, mgr, event)
             } else {
                 debug_assert!(self.inner.id().is_ancestor_of(id));

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -113,6 +113,7 @@ widget! {
         }
 
         /// Add accelerator keys (chain style)
+        #[must_use]
         pub fn with_keys(mut self, keys: &[VirtualKeyCode]) -> Self {
             self.keys1.clear();
             self.keys1.extend_from_slice(keys);
@@ -125,6 +126,7 @@ widget! {
         }
 
         /// Set button color (chain style)
+        #[must_use]
         pub fn with_color(mut self, color: Rgb) -> Self {
             self.color = Some(color);
             self
@@ -274,6 +276,7 @@ widget! {
         /// Add accelerator keys (chain style)
         ///
         /// These keys are added to those inferred from the label via `&` marks.
+        #[must_use]
         pub fn with_keys(mut self, keys: &[VirtualKeyCode]) -> Self {
             self.keys1.clear();
             self.keys1.extend_from_slice(keys);
@@ -286,6 +289,7 @@ widget! {
         }
 
         /// Set button color (chain style)
+        #[must_use]
         pub fn with_color(mut self, color: Rgb) -> Self {
             self.color = Some(color);
             self

--- a/crates/kas-widgets/src/checkbox.rs
+++ b/crates/kas-widgets/src/checkbox.rs
@@ -91,6 +91,7 @@ widget! {
     impl Self {
         /// Set the initial state of the checkbox.
         #[inline]
+        #[must_use]
         pub fn with_state(mut self, state: bool) -> Self {
             self.state = state;
             self
@@ -208,6 +209,7 @@ widget! {
 
         /// Set the initial state of the checkbox.
         #[inline]
+        #[must_use]
         pub fn with_state(mut self, state: bool) -> Self {
             self.checkbox = self.checkbox.with_state(state);
             self

--- a/crates/kas-widgets/src/checkbox.rs
+++ b/crates/kas-widgets/src/checkbox.rs
@@ -123,7 +123,7 @@ widget! {
                     mgr.redraw(self.id());
                     Response::update_or_msg(self.on_toggle.as_ref().and_then(|f| f(mgr, self.state)))
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -147,7 +147,11 @@ widget! {
                 return Response::Unhandled;
             }
 
-            if id <= self.popup.id() {
+            if id == self.id() {
+                Manager::handle_generic(self, mgr, event)
+            } else {
+                debug_assert!(self.popup.id().is_ancestor_of(id));
+
                 if let Event::NavFocus(key_focus) = event {
                     if self.popup_id.is_none() {
                         // Steal focus since child is invisible
@@ -160,8 +164,6 @@ widget! {
 
                 let r = self.popup.send(mgr, id, event.clone());
                 self.map_response(mgr, id, event, r)
-            } else {
-                Manager::handle_generic(self, mgr, event)
             }
         }
     }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -118,7 +118,7 @@ widget! {
                 }
                 Event::PressEnd { end_id, .. } => {
                     if let Some(id) = end_id {
-                        if id == self.id() {
+                        if self.eq_id(id) {
                             if self.opening {
                                 if self.popup_id.is_none() {
                                     open_popup(self, mgr, false);
@@ -151,7 +151,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if id == self.id() {
+            if self.eq_id(id) {
                 Manager::handle_generic(self, mgr, event)
             } else {
                 debug_assert!(self.popup.id().is_ancestor_of(id));

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -78,6 +78,7 @@ widget! {
                     } else {
                         open_popup(self, mgr, true);
                     }
+                    Response::Used
                 }
                 Event::PressStart {
                     source,
@@ -90,11 +91,12 @@ widget! {
                             mgr.set_grab_depress(source, Some(start_id));
                             self.opening = self.popup_id.is_none();
                         }
+                        Response::Used
                     } else {
                         if let Some(id) = self.popup_id {
                             mgr.close_window(id, false);
                         }
-                        return Response::Unhandled;
+                        Response::Unhandled
                     }
                 }
                 Event::PressMove {
@@ -112,6 +114,7 @@ widget! {
                     if let Some(id) = target {
                         mgr.set_nav_focus(id, false);
                     }
+                    Response::Used
                 }
                 Event::PressEnd { end_id, .. } => {
                     if let Some(id) = end_id {
@@ -120,7 +123,7 @@ widget! {
                                 if self.popup_id.is_none() {
                                     open_popup(self, mgr, false);
                                 }
-                                return Response::None;
+                                return Response::Used;
                             }
                         } else if self.popup_id.is_some() && self.popup.is_ancestor_of(id) {
                             let r = self.popup.send(mgr, id, Event::Activate);
@@ -130,14 +133,15 @@ widget! {
                     if let Some(id) = self.popup_id {
                         mgr.close_window(id, true);
                     }
+                    Response::Used
                 }
                 Event::PopupRemoved(id) => {
                     debug_assert_eq!(Some(id), self.popup_id);
                     self.popup_id = None;
+                    Response::Used
                 }
-                _ => return Response::Unhandled,
+                _ => Response::Unhandled,
             }
-            Response::None
         }
     }
 
@@ -159,7 +163,7 @@ widget! {
                     }
                     // Don't bother sending Response::Focus here since NavFocus will
                     // be sent to this widget, and handle_generic will respond.
-                    return Response::None;
+                    return Response::Used;
                 }
 
                 let r = self.popup.send(mgr, id, event.clone());
@@ -335,7 +339,6 @@ impl<M: 'static> ComboBox<M> {
         r: Response<(usize, ())>,
     ) -> Response<M> {
         match r {
-            Response::None => Response::None,
             Response::Unhandled => match event {
                 Event::Command(cmd, _) => {
                     let next = |mgr: &mut Manager, s, clr, rev| {
@@ -343,7 +346,7 @@ impl<M: 'static> ComboBox<M> {
                             mgr.clear_nav_focus();
                         }
                         mgr.next_nav_focus(s, rev, true);
-                        Response::None
+                        Response::Used
                     };
                     match cmd {
                         Command::Up => next(mgr, self, false, true),
@@ -355,6 +358,7 @@ impl<M: 'static> ComboBox<M> {
                 }
                 _ => Response::Unhandled,
             },
+            Response::Used => Response::Used,
             Response::Pan(delta) => Response::Pan(delta),
             Response::Focus(x) => Response::Focus(x),
             Response::Update | Response::Select => {
@@ -371,7 +375,7 @@ impl<M: 'static> ComboBox<M> {
                         };
                     }
                 }
-                Response::None
+                Response::Used
             }
             Response::Msg((index, ())) => {
                 *mgr |= self.set_active(index);

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -96,7 +96,7 @@ widget! {
                         if let Some(id) = self.popup_id {
                             mgr.close_window(id, false);
                         }
-                        Response::Unhandled
+                        Response::Unused
                     }
                 }
                 Event::PressMove {
@@ -140,7 +140,7 @@ widget! {
                     self.popup_id = None;
                     Response::Used
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }
@@ -148,7 +148,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             if id == self.id() {
@@ -339,7 +339,7 @@ impl<M: 'static> ComboBox<M> {
         r: Response<(usize, ())>,
     ) -> Response<M> {
         match r {
-            Response::Unhandled => match event {
+            Response::Unused => match event {
                 Event::Command(cmd, _) => {
                     let next = |mgr: &mut Manager, s, clr, rev| {
                         if clr {
@@ -353,10 +353,10 @@ impl<M: 'static> ComboBox<M> {
                         Command::Down => next(mgr, self, false, false),
                         Command::Home => next(mgr, self, true, false),
                         Command::End => next(mgr, self, true, true),
-                        _ => Response::Unhandled,
+                        _ => Response::Unused,
                     }
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             },
             Response::Used => Response::Used,
             Response::Pan(delta) => Response::Pan(delta),

--- a/crates/kas-widgets/src/drag.rs
+++ b/crates/kas-widgets/src/drag.rs
@@ -67,18 +67,18 @@ widget! {
             match event {
                 Event::PressStart { source, coord, .. } => {
                     if !self.grab_press(mgr, source, coord) {
-                        return Response::None;
+                        return Response::Used;
                     }
 
                     // Event delivery implies coord is over the handle.
                     self.press_coord = coord - self.offset();
-                    Response::None
+                    Response::Used
                 }
                 Event::PressMove { source, coord, .. } if Some(source) == self.press_source => {
                     let offset = coord - self.press_coord;
                     let (offset, action) = self.set_offset(offset);
                     if action.is_empty() {
-                        Response::None
+                        Response::Used
                     } else {
                         mgr.send_action(action);
                         Response::Msg(offset)
@@ -86,7 +86,7 @@ widget! {
                 }
                 Event::PressEnd { source, .. } if Some(source) == self.press_source => {
                     self.press_source = None;
-                    Response::None
+                    Response::Used
                 }
                 _ => Response::Unhandled,
             }

--- a/crates/kas-widgets/src/drag.rs
+++ b/crates/kas-widgets/src/drag.rs
@@ -88,7 +88,7 @@ widget! {
                     self.press_source = None;
                     Response::Used
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -33,7 +33,7 @@ impl Default for LastEdit {
 
 enum EditAction {
     None,
-    Unhandled,
+    Unused,
     Activate,
     Edit,
 }
@@ -509,16 +509,16 @@ widget! {
                     if self.has_key_focus {
                         match self.control_key(mgr, cmd, shift) {
                             EditAction::None => Response::Used,
-                            EditAction::Unhandled => Response::Unhandled,
+                            EditAction::Unused => Response::Unused,
                             EditAction::Activate => Response::used_or_msg(G::activate(self, mgr)),
                             EditAction::Edit => Response::update_or_msg(G::edit(self, mgr)),
                         }
                     } else {
-                        Response::Unhandled
+                        Response::Unused
                     }
                 }
                 Event::ReceivedCharacter(c) => match self.received_char(mgr, c) {
-                    false => Response::Unhandled,
+                    false => Response::Unused,
                     true => Response::update_or_msg(G::edit(self, mgr)),
                 },
                 Event::Scroll(delta) => {
@@ -537,7 +537,7 @@ widget! {
                 }
                 event => match self.input_handler.handle(mgr, self.id(), event) {
                     TextInputAction::None => Response::Used,
-                    TextInputAction::Unhandled => Response::Unhandled,
+                    TextInputAction::Unused => Response::Unused,
                     TextInputAction::Pan(delta) => match self.pan_delta(mgr, delta) {
                         delta if delta == Offset::ZERO => Response::Used,
                         delta => Response::Pan(delta),
@@ -782,7 +782,7 @@ impl<G: EditGuard> EditField<G> {
 
     fn control_key(&mut self, mgr: &mut Manager, key: Command, mut shift: bool) -> EditAction {
         if !self.editable {
-            return EditAction::Unhandled;
+            return EditAction::Unused;
         }
 
         let mut buf = [0u8; 4];
@@ -793,7 +793,7 @@ impl<G: EditGuard> EditField<G> {
 
         enum Action<'a> {
             None,
-            Unhandled,
+            Unused,
             Activate,
             Edit,
             Insert(&'a str, LastEdit),
@@ -1009,12 +1009,12 @@ impl<G: EditGuard> EditField<G> {
                 }
                 Action::Edit
             }
-            _ => Action::Unhandled,
+            _ => Action::Unused,
         };
 
         let result = match action {
             Action::None => EditAction::None,
-            Action::Unhandled => EditAction::Unhandled,
+            Action::Unused => EditAction::Unused,
             Action::Activate => EditAction::Activate,
             Action::Edit => EditAction::Edit,
             Action::Insert(s, edit) => {

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -286,6 +286,7 @@ impl EditBox<()> {
 impl<G: EditGuard> EditBox<G> {
     /// Set whether this `EditBox` is editable (inline)
     #[inline]
+    #[must_use]
     pub fn editable(mut self, editable: bool) -> Self {
         self.inner = self.inner.editable(editable);
         self
@@ -305,6 +306,7 @@ impl<G: EditGuard> EditBox<G> {
 
     /// Set whether this `EditBox` shows multiple text lines
     #[inline]
+    #[must_use]
     pub fn multi_line(mut self, multi_line: bool) -> Self {
         self.inner = self.inner.multi_line(multi_line);
         self
@@ -707,6 +709,7 @@ impl EditField<()> {
 impl<G: EditGuard> EditField<G> {
     /// Set whether this `EditField` is editable (inline)
     #[inline]
+    #[must_use]
     pub fn editable(mut self, editable: bool) -> Self {
         self.editable = editable;
         self
@@ -724,6 +727,7 @@ impl<G: EditGuard> EditField<G> {
 
     /// Set whether this `EditField` shows multiple text lines
     #[inline]
+    #[must_use]
     pub fn multi_line(mut self, multi_line: bool) -> Self {
         self.multi_line = multi_line;
         self

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -83,9 +83,9 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() {
-                for child in self.widgets.iter_mut() {
-                    if id <= child.1.id() {
-                        let r = child.1.send(mgr, id, event);
+                if let Some(index) = self.id().index_of_child(id) {
+                    if let Some((_, child)) = self.widgets.get_mut(index) {
+                        let r = child.send(mgr, id, event);
                         return match Response::try_from(r) {
                             Ok(r) => r,
                             Err(msg) => {

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -48,7 +48,6 @@ widget! {
     #[derive(Clone, Debug)]
     #[handler(msg=<W as Handler>::Msg)]
     pub struct Grid<W: Widget> {
-        first_id: WidgetId,
         #[widget_core]
         core: CoreData,
         widgets: Vec<(GridChildInfo, W)>,
@@ -57,13 +56,6 @@ widget! {
     }
 
     impl WidgetChildren for Self {
-        #[inline]
-        fn first_id(&self) -> WidgetId {
-            self.first_id
-        }
-        fn record_first_id(&mut self, id: WidgetId) {
-            self.first_id = id;
-        }
         #[inline]
         fn num_children(&self) -> usize {
             self.widgets.len()

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -102,7 +102,7 @@ widget! {
                 }
             }
 
-            Response::Unhandled
+            Response::Unused
         }
     }
 }

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -49,6 +49,7 @@
 
 // Use ``never_loop`` until: https://github.com/rust-lang/rust-clippy/issues/7397 is fixed
 #![allow(clippy::or_fun_call, clippy::never_loop, clippy::comparison_chain)]
+#![allow(clippy::needless_late_init)]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(feature = "min_spec", feature(min_specialization))]
 

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -424,18 +424,6 @@ widget! {
                 list: &mut self.widgets,
             }
         }
-
-        /// Get the index of the child which is an ancestor of `id`, if any
-        pub fn find_child_index(&self, id: WidgetId) -> Option<usize> {
-            if id >= self.first_id {
-                for (i, child) in self.widgets.iter().enumerate() {
-                    if id <= child.id() {
-                        return Some(i);
-                    }
-                }
-            }
-            None
-        }
     }
 
     impl Index<usize> for Self {

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -204,8 +204,8 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() {
-                for (i, child) in self.widgets.iter_mut().enumerate() {
-                    if id <= child.id() {
+                if let Some(index) = self.id().index_of_child(id) {
+                    if let Some(child) = self.widgets.get_mut(index) {
                         let r = child.send(mgr, id, event);
                         return match Response::try_from(r) {
                             Ok(r) => r,
@@ -216,7 +216,7 @@ widget! {
                                     id,
                                     kas::util::TryFormat(&msg)
                                 );
-                                Response::Msg(FromIndexed::from_indexed(i, msg))
+                                Response::Msg(FromIndexed::from_indexed(index, msg))
                             }
                         };
                     }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -172,7 +172,6 @@ widget! {
         W: Widget,
         M: FromIndexed<<W as Handler>::Msg> + 'static,
     > {
-        first_id: WidgetId,
         #[widget_core]
         core: CoreData,
         widgets: Vec<W>,
@@ -182,13 +181,6 @@ widget! {
     }
 
     impl WidgetChildren for Self {
-        #[inline]
-        fn first_id(&self) -> WidgetId {
-            self.first_id
-        }
-        fn record_first_id(&mut self, id: WidgetId) {
-            self.first_id = id;
-        }
         #[inline]
         fn num_children(&self) -> usize {
             self.widgets.len()
@@ -261,7 +253,6 @@ widget! {
         #[inline]
         pub fn new_with_direction(direction: D, widgets: Vec<W>) -> Self {
             GenericList {
-                first_id: Default::default(),
                 core: Default::default(),
                 widgets,
                 data: Default::default(),

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -223,7 +223,7 @@ widget! {
                 }
             }
 
-            Response::Unhandled
+            Response::Unused
         }
     }
 

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -70,12 +70,6 @@ impl<M: 'static> WidgetCore for Box<dyn Menu<Msg = M>> {
 }
 
 impl<M: 'static> WidgetChildren for Box<dyn Menu<Msg = M>> {
-    fn first_id(&self) -> WidgetId {
-        self.as_ref().first_id()
-    }
-    fn record_first_id(&mut self, id: WidgetId) {
-        self.as_mut().record_first_id(id)
-    }
     fn num_children(&self) -> usize {
         self.as_ref().num_children()
     }

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -86,8 +86,8 @@ impl<M: 'static> WidgetChildren for Box<dyn Menu<Msg = M>> {
         self.as_mut().get_child_mut(index)
     }
 
-    fn find_child(&self, id: WidgetId) -> Option<usize> {
-        self.as_ref().find_child(id)
+    fn find_child_index(&self, id: WidgetId) -> Option<usize> {
+        self.as_ref().find_child_index(id)
     }
     fn find_leaf(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
         self.as_ref().find_leaf(id)

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -83,11 +83,11 @@ impl<M: 'static> WidgetChildren for Box<dyn Menu<Msg = M>> {
     fn find_child_index(&self, id: WidgetId) -> Option<usize> {
         self.as_ref().find_child_index(id)
     }
-    fn find_leaf(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
-        self.as_ref().find_leaf(id)
+    fn find_widget(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+        self.as_ref().find_widget(id)
     }
-    fn find_leaf_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
-        self.as_mut().find_leaf_mut(id)
+    fn find_widget_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
+        self.as_mut().find_widget_mut(id)
     }
 }
 

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -130,6 +130,13 @@ widget! {
             make_layout!(self.core; row: [self.checkbox, self.label])
         }
 
+        fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
+            if !self.rect().contains(coord) {
+                return None;
+            }
+            Some(self.checkbox.id())
+        }
+
         fn draw(&mut self, draw: &mut dyn DrawHandle, mgr: &ManagerState, disabled: bool) {
             let state = self.checkbox.input_state(mgr, disabled);
             draw.menu_entry(self.core.rect, state);

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -196,6 +196,7 @@ widget! {
 
         /// Set the initial state of the checkbox.
         #[inline]
+        #[must_use]
         pub fn with_state(mut self, state: bool) -> Self {
             self.checkbox = self.checkbox.with_state(state);
             self

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -96,7 +96,7 @@ widget! {
         fn handle(&mut self, _: &mut Manager, event: Event) -> Response<M> {
             match event {
                 Event::Activate => self.msg.clone().into(),
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -183,8 +183,10 @@ widget! {
                 return Response::Unhandled;
             }
 
-            if id <= self.bar.id() {
-                return match self.bar.send(mgr, id, event.clone()) {
+            if id == self.id() {
+                self.handle(mgr, event)
+            } else {
+                match self.bar.send(mgr, id, event.clone()) {
                     Response::Unhandled => self.handle(mgr, event),
                     r => r.try_into().unwrap_or_else(|(_, msg)| {
                         log::trace!(
@@ -195,10 +197,8 @@ widget! {
                         );
                         Response::Msg(msg)
                     }),
-                };
+                }
             }
-
-            self.handle(mgr, event)
         }
     }
 

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -82,7 +82,7 @@ widget! {
                                 if self
                                     .bar
                                     .iter()
-                                    .any(|w| w.id() == start_id && !w.menu_is_open())
+                                    .any(|w| w.eq_id(start_id) && !w.menu_is_open())
                                 {
                                     self.opening = true;
                                     self.set_menu_path(mgr, Some(start_id), false);
@@ -108,7 +108,7 @@ widget! {
                 } => {
                     mgr.set_grab_depress(source, cur_id);
                     if let Some(id) = cur_id {
-                        if id != self.id() && self.is_ancestor_of(id) {
+                        if !self.eq_id(id) && self.is_ancestor_of(id) {
                             // We instantly open a sub-menu on motion over the bar,
                             // but delay when over a sub-menu (most intuitive?)
                             if self.rect().contains(coord) {
@@ -133,7 +133,7 @@ widget! {
                             if !self.opening {
                                 self.delayed_open = None;
                                 for i in 0..self.bar.len() {
-                                    if self.bar[i].id() == id {
+                                    if self.bar[i].eq_id(id) {
                                         self.bar[i].set_menu_path(mgr, None, false);
                                     }
                                 }
@@ -188,7 +188,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if id == self.id() {
+            if self.eq_id(id) {
                 self.handle(mgr, event)
             } else {
                 match self.bar.send(mgr, id, event.clone()) {

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -97,7 +97,7 @@ widget! {
                         Response::Used
                     } else {
                         self.delayed_open = None;
-                        Response::Unhandled
+                        Response::Unused
                     }
                 }
                 Event::PressMove {
@@ -174,10 +174,10 @@ widget! {
                             mgr.next_nav_focus(self, reverse, true);
                             Response::Used
                         }
-                        None => Response::Unhandled,
+                        None => Response::Unused,
                     }
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }
@@ -185,14 +185,14 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             if id == self.id() {
                 self.handle(mgr, event)
             } else {
                 match self.bar.send(mgr, id, event.clone()) {
-                    Response::Unhandled => self.handle(mgr, event),
+                    Response::Unused => self.handle(mgr, event),
                     r => r.try_into().unwrap_or_else(|(_, msg)| {
                         log::trace!(
                             "Received by {} from {}: {:?}",

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -64,6 +64,7 @@ widget! {
                     if let Some(id) = self.delayed_open {
                         self.set_menu_path(mgr, Some(id), false);
                     }
+                    Response::Used
                 }
                 Event::PressStart {
                     source,
@@ -93,9 +94,10 @@ widget! {
                                 mgr.update_on_timer(delay, self.id(), 0);
                             }
                         }
+                        Response::Used
                     } else {
                         self.delayed_open = None;
-                        return Response::Unhandled;
+                        Response::Unhandled
                     }
                 }
                 Event::PressMove {
@@ -119,6 +121,7 @@ widget! {
                             }
                         }
                     }
+                    Response::Used
                 }
                 Event::PressEnd { coord, end_id, .. } => {
                     if end_id.map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
@@ -144,6 +147,7 @@ widget! {
                         // not on the menu
                         self.set_menu_path(mgr, None, false);
                     }
+                    Response::Used
                 }
                 Event::Command(cmd, _) => {
                     // Arrow keys can switch to the next / previous menu
@@ -164,16 +168,17 @@ widget! {
                                     break;
                                 }
                             }
+                            Response::Used
                         }
                         Some(_) => {
                             mgr.next_nav_focus(self, reverse, true);
+                            Response::Used
                         }
-                        None => return Response::Unhandled,
+                        None => Response::Unhandled,
                     }
                 }
-                _ => return Response::Unhandled,
+                _ => Response::Unhandled,
             }
-            Response::None
         }
     }
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -121,9 +121,9 @@ widget! {
 
     impl WidgetConfig for Self {
         fn configure_recurse(&mut self, mut cmgr: ConfigureManager) {
+            self.core_data_mut().id = cmgr.get_id(self.id());
             cmgr.mgr().push_accel_layer(true);
-            self.list.configure_recurse(cmgr.child());
-            self.core_data_mut().id = cmgr.next_id(self.id());
+            self.list.configure_recurse(cmgr.child(0));
             let mgr = cmgr.mgr();
             mgr.pop_accel_layer(self.id());
             mgr.add_accel_keys(self.id(), self.label.text().keys());
@@ -188,7 +188,9 @@ widget! {
                 return Response::Unhandled;
             }
 
-            if id <= self.list.id() {
+            if id == self.id() {
+                Manager::handle_generic(self, mgr, event)
+            } else {
                 let r = self.list.send(mgr, id, event.clone());
 
                 match r {
@@ -210,8 +212,6 @@ widget! {
                         r
                     }
                 }
-            } else {
-                Manager::handle_generic(self, mgr, event)
             }
         }
     }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -100,7 +100,7 @@ widget! {
                         self.close_menu(mgr, true);
                         Response::Used
                     } else {
-                        Response::Unhandled
+                        Response::Unused
                     }
                 } else if matches!(cmd, Command::Home | Command::End) {
                     mgr.clear_nav_focus();
@@ -108,13 +108,13 @@ widget! {
                     mgr.next_nav_focus(self, rev, true);
                     Response::Used
                 } else {
-                    Response::Unhandled
+                    Response::Unused
                 }
             } else if Some(self.direction.as_direction()) == cmd.as_direction() {
                 self.open_menu(mgr, true);
                 Response::Used
             } else {
-                Response::Unhandled
+                Response::Unused
             }
         }
     }
@@ -178,7 +178,7 @@ widget! {
                     Response::Used
                 }
                 Event::Command(cmd, _) => self.handle_dir_key(mgr, cmd),
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }
@@ -186,7 +186,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             if id == self.id() {
@@ -195,11 +195,11 @@ widget! {
                 let r = self.list.send(mgr, id, event.clone());
 
                 match r {
-                    Response::Unhandled => match event {
+                    Response::Unused => match event {
                         Event::Command(cmd, _) if self.popup_id.is_some() => {
                             self.handle_dir_key(mgr, cmd)
                         }
-                        _ => Response::Unhandled,
+                        _ => Response::Unused,
                     },
                     Response::Used => Response::Used,
                     Response::Pan(delta) => Response::Pan(delta),

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -189,7 +189,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if id == self.id() {
+            if self.eq_id(id) {
                 Manager::handle_generic(self, mgr, event)
             } else {
                 let r = self.list.send(mgr, id, event.clone());
@@ -240,7 +240,7 @@ widget! {
                         }
                     } else {
                         self.open_menu(mgr, set_focus);
-                        if id != self.id() {
+                        if !self.eq_id(id) {
                             for i in 0..self.list.len() {
                                 self.list[i].set_menu_path(mgr, target, set_focus);
                             }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -95,10 +95,10 @@ widget! {
                     if dir.is_vertical() == self.list.direction().is_vertical() {
                         let rev = dir.is_reversed() ^ self.list.direction().is_reversed();
                         mgr.next_nav_focus(self, rev, true);
-                        Response::None
+                        Response::Used
                     } else if dir == self.direction.as_direction().reversed() {
                         self.close_menu(mgr, true);
-                        Response::None
+                        Response::Used
                     } else {
                         Response::Unhandled
                     }
@@ -106,13 +106,13 @@ widget! {
                     mgr.clear_nav_focus();
                     let rev = cmd == Command::End;
                     mgr.next_nav_focus(self, rev, true);
-                    Response::None
+                    Response::Used
                 } else {
                     Response::Unhandled
                 }
             } else if Some(self.direction.as_direction()) == cmd.as_direction() {
                 self.open_menu(mgr, true);
-                Response::None
+                Response::Used
             } else {
                 Response::Unhandled
             }
@@ -170,15 +170,16 @@ widget! {
                     if self.popup_id.is_none() {
                         self.open_menu(mgr, true);
                     }
+                    Response::Used
                 }
                 Event::PopupRemoved(id) => {
                     debug_assert_eq!(Some(id), self.popup_id);
                     self.popup_id = None;
+                    Response::Used
                 }
-                Event::Command(cmd, _) => return self.handle_dir_key(mgr, cmd),
-                _ => return Response::Unhandled,
+                Event::Command(cmd, _) => self.handle_dir_key(mgr, cmd),
+                _ => Response::Unhandled,
             }
-            Response::None
         }
     }
 
@@ -194,18 +195,18 @@ widget! {
                 let r = self.list.send(mgr, id, event.clone());
 
                 match r {
-                    Response::None => Response::None,
-                    Response::Pan(delta) => Response::Pan(delta),
-                    Response::Focus(rect) => Response::Focus(rect),
                     Response::Unhandled => match event {
                         Event::Command(cmd, _) if self.popup_id.is_some() => {
                             self.handle_dir_key(mgr, cmd)
                         }
                         _ => Response::Unhandled,
                     },
+                    Response::Used => Response::Used,
+                    Response::Pan(delta) => Response::Pan(delta),
+                    Response::Focus(rect) => Response::Focus(rect),
                     Response::Select => {
                         self.set_menu_path(mgr, Some(id), true);
-                        Response::None
+                        Response::Used
                     }
                     r @ (Response::Update | Response::Msg(_)) => {
                         self.close_menu(mgr, true);

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -43,7 +43,7 @@ widget! {
         fn handle(&mut self, _mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
             match event {
                 Event::Activate => Response::Select,
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/crates/kas-widgets/src/progress.rs
+++ b/crates/kas-widgets/src/progress.rs
@@ -48,6 +48,7 @@ widget! {
 
         /// Set the initial value
         #[inline]
+        #[must_use]
         pub fn with_value(mut self, value: f32) -> Self {
             self.value = value.max(0.0).min(1.0);
             self

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -8,7 +8,6 @@
 use super::AccelLabel;
 use kas::prelude::*;
 use log::trace;
-use std::convert::TryFrom;
 use std::rc::Rc;
 
 widget! {
@@ -58,8 +57,8 @@ widget! {
                     }
                 }
                 Event::HandleUpdate { payload, .. } => {
-                    let id = WidgetId::try_from(payload).unwrap();
-                    if self.state && id != self.id() {
+                    let opt_id = WidgetId::opt_from_u64(payload);
+                    if self.state && opt_id != Some(self.id()) {
                         trace!("RadioBoxBare: unset {}", self.id());
                         self.state = false;
                         mgr.redraw(self.id());

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -53,7 +53,7 @@ widget! {
                         mgr.trigger_update(self.handle, self.id().into());
                         Response::update_or_msg(self.on_select.as_ref().and_then(|f| f(mgr)))
                     } else {
-                        Response::None
+                        Response::Used
                     }
                 }
                 Event::HandleUpdate { payload, .. } => {
@@ -64,7 +64,7 @@ widget! {
                         mgr.redraw(self.id());
                         Response::Update
                     } else {
-                        Response::None
+                        Response::Used
                     }
                 }
                 _ => Response::Unhandled,

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -50,7 +50,7 @@ widget! {
                         trace!("RadioBoxBare: set {}", self.id());
                         self.state = true;
                         mgr.redraw(self.id());
-                        mgr.trigger_update(self.handle, self.id().into());
+                        mgr.trigger_update(self.handle, self.id().as_u64());
                         Response::update_or_msg(self.on_select.as_ref().and_then(|f| f(mgr)))
                     } else {
                         Response::Used

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -58,7 +58,7 @@ widget! {
                 }
                 Event::HandleUpdate { payload, .. } => {
                     let opt_id = WidgetId::opt_from_u64(payload);
-                    if self.state && opt_id != Some(self.id()) {
+                    if self.state && !self.eq_id(opt_id) {
                         trace!("RadioBoxBare: unset {}", self.id());
                         self.state = false;
                         mgr.redraw(self.id());

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -149,6 +149,7 @@ widget! {
 
         /// Set the initial state of the radiobox.
         #[inline]
+        #[must_use]
         pub fn with_state(mut self, state: bool) -> Self {
             self.state = state;
             self
@@ -276,6 +277,7 @@ widget! {
 
         /// Set the initial state of the radiobox.
         #[inline]
+        #[must_use]
         pub fn with_state(mut self, state: bool) -> Self {
             self.radiobox = self.radiobox.with_state(state);
             self

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -67,7 +67,7 @@ widget! {
                         Response::Used
                     }
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -367,7 +367,7 @@ widget! {
                 return Response::Unhandled;
             }
 
-            if id <= self.inner.id() {
+            if self.inner.id().is_ancestor_of(id) {
                 let child_event = self.scroll.offset_event(event.clone());
                 match self.inner.send(mgr, id, child_event) {
                     Response::Unhandled => (),

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -385,7 +385,7 @@ widget! {
                     r => return r,
                 }
             } else {
-                debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
+                debug_assert!(self.eq_id(id), "SendEvent::send: bad WidgetId");
             };
 
             let id = self.id();

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -159,9 +159,9 @@ impl ScrollComponent {
     /// ```
     ///
     /// If the returned [`TkAction`] is `None`, the scroll offset has not changed and
-    /// the returned [`Response`] is either `None` or `Unhandled(..)`.
+    /// the returned [`Response`] is either `Used` or `Unhandled`.
     /// If the returned [`TkAction`] is not `None`, the scroll offset has been
-    /// updated and the second return value is `Response::None`.
+    /// updated and the second return value is `Response::Used`.
     #[inline]
     pub fn scroll_by_event<PS: FnMut(PressSource, WidgetId, Coord)>(
         &mut self,
@@ -170,7 +170,7 @@ impl ScrollComponent {
         mut on_press_start: PS,
     ) -> (TkAction, Response<VoidMsg>) {
         let mut action = TkAction::empty();
-        let mut response = Response::None;
+        let mut response = Response::Used;
 
         match event {
             Event::Command(Command::Home, _) => {
@@ -373,7 +373,7 @@ widget! {
                     Response::Unhandled => (),
                     Response::Pan(delta) => {
                         return match self.scroll_by_delta(mgr, delta) {
-                            delta if delta == Offset::ZERO => Response::None,
+                            delta if delta == Offset::ZERO => Response::Used,
                             delta => Response::Pan(delta),
                         };
                     }

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -159,7 +159,7 @@ impl ScrollComponent {
     /// ```
     ///
     /// If the returned [`TkAction`] is `None`, the scroll offset has not changed and
-    /// the returned [`Response`] is either `Used` or `Unhandled`.
+    /// the returned [`Response`] is either `Used` or `Unused`.
     /// If the returned [`TkAction`] is not `None`, the scroll offset has been
     /// updated and the second return value is `Response::Used`.
     #[inline]
@@ -187,7 +187,7 @@ impl ScrollComponent {
                     Command::Down => LineDelta(0.0, -1.0),
                     Command::PageUp => PixelDelta(Offset(0, window_size.1 / 2)),
                     Command::PageDown => PixelDelta(Offset(0, -(window_size.1 / 2))),
-                    _ => return (action, Response::Unhandled),
+                    _ => return (action, Response::Unused),
                 };
 
                 let d = match delta {
@@ -228,7 +228,7 @@ impl ScrollComponent {
                 }
             }
             Event::PressEnd { .. } => (), // consume due to request
-            _ => response = Response::Unhandled,
+            _ => response = Response::Unused,
         }
         (action, response)
     }
@@ -364,13 +364,13 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             if self.inner.id().is_ancestor_of(id) {
                 let child_event = self.scroll.offset_event(event.clone());
                 match self.inner.send(mgr, id, child_event) {
-                    Response::Unhandled => (),
+                    Response::Unused => (),
                     Response::Pan(delta) => {
                         return match self.scroll_by_delta(mgr, delta) {
                             delta if delta == Offset::ZERO => Response::Used,

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -170,7 +170,7 @@ widget! {
                         Response::Used
                     }
                     // TODO: scroll by command
-                    _ => Response::Unhandled,
+                    _ => Response::Unused,
                 },
                 Event::LostSelFocus => {
                     self.selection.set_empty();
@@ -193,7 +193,7 @@ widget! {
                 }
                 event => match self.input_handler.handle(mgr, self.id(), event) {
                     TextInputAction::None | TextInputAction::Focus => Response::Used,
-                    TextInputAction::Unhandled => Response::Unhandled,
+                    TextInputAction::Unused => Response::Unused,
                     TextInputAction::Pan(delta) => match self.pan_delta(mgr, delta) {
                         delta if delta == Offset::ZERO => Response::Used,
                         delta => Response::Pan(delta),

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -156,18 +156,18 @@ widget! {
                     Command::Escape | Command::Deselect if !self.selection.is_empty() => {
                         self.selection.set_empty();
                         mgr.redraw(self.id());
-                        Response::None
+                        Response::Used
                     }
                     Command::SelectAll => {
                         self.selection.set_sel_pos(0);
                         self.selection.set_edit_pos(self.text.str_len());
                         mgr.redraw(self.id());
-                        Response::None
+                        Response::Used
                     }
                     Command::Cut | Command::Copy => {
                         let range = self.selection.range();
                         mgr.set_clipboard((self.text.as_str()[range]).to_string());
-                        Response::None
+                        Response::Used
                     }
                     // TODO: scroll by command
                     _ => Response::Unhandled,
@@ -175,7 +175,7 @@ widget! {
                 Event::LostSelFocus => {
                     self.selection.set_empty();
                     mgr.redraw(self.id());
-                    Response::None
+                    Response::Used
                 }
                 Event::Scroll(delta) => {
                     let delta2 = match delta {
@@ -187,15 +187,15 @@ widget! {
                         ScrollDelta::PixelDelta(coord) => coord,
                     };
                     match self.pan_delta(mgr, delta2) {
-                        delta if delta == Offset::ZERO => Response::None,
+                        delta if delta == Offset::ZERO => Response::Used,
                         delta => Response::Pan(delta),
                     }
                 }
                 event => match self.input_handler.handle(mgr, self.id(), event) {
-                    TextInputAction::None | TextInputAction::Focus => Response::None,
+                    TextInputAction::None | TextInputAction::Focus => Response::Used,
                     TextInputAction::Unhandled => Response::Unhandled,
                     TextInputAction::Pan(delta) => match self.pan_delta(mgr, delta) {
-                        delta if delta == Offset::ZERO => Response::None,
+                        delta if delta == Offset::ZERO => Response::Used,
                         delta => Response::Pan(delta),
                     },
                     TextInputAction::Cursor(coord, anchor, clear, repeats) => {
@@ -211,7 +211,7 @@ widget! {
                                 self.selection.expand(&self.text, repeats);
                             }
                         }
-                        Response::None
+                        Response::Used
                     }
                 },
             }

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -247,7 +247,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             let offset = if id == self.id() {
@@ -255,7 +255,7 @@ widget! {
                     Event::PressStart { source, coord, .. } => {
                         self.handle.handle_press_on_track(mgr, source, coord)
                     }
-                    _ => return Response::Unhandled,
+                    _ => return Response::Unused,
                 }
             } else {
                 debug_assert!(self.handle.id().is_ancestor_of(id));
@@ -641,7 +641,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             match self.id().index_of_child(id) {
@@ -674,7 +674,7 @@ widget! {
                 _ if id == self.id() => self.handle(mgr, event),
                 _ => {
                     debug_assert!(false, "SendEvent::send: bad WidgetId");
-                    Response::Unhandled
+                    Response::Unused
                 }
             }
         }

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -250,7 +250,7 @@ widget! {
                 return Response::Unused;
             }
 
-            let offset = if id == self.id() {
+            let offset = if self.eq_id(id) {
                 match event {
                     Event::PressStart { source, coord, .. } => {
                         self.handle.handle_press_on_track(mgr, source, coord)
@@ -671,7 +671,7 @@ widget! {
                     }
                     r => r,
                 }
-                _ if id == self.id() => self.handle(mgr, event),
+                _ if self.eq_id(id) => self.handle(mgr, event),
                 _ => {
                     debug_assert!(false, "SendEvent::send: bad WidgetId");
                     Response::Unused

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -64,6 +64,7 @@ widget! {
         ///
         /// See [`ScrollBar::set_limits`].
         #[inline]
+        #[must_use]
         pub fn with_limits(mut self, max_value: i32, handle_value: i32) -> Self {
             let _ = self.set_limits(max_value, handle_value);
             self
@@ -71,6 +72,7 @@ widget! {
 
         /// Set the initial value
         #[inline]
+        #[must_use]
         pub fn with_value(mut self, value: i32) -> Self {
             self.value = value.clamp(0, self.max_value);
             self
@@ -353,6 +355,7 @@ widget! {
         /// This has the side-effect of reserving enough space for scroll bars even
         /// when not required.
         #[inline]
+        #[must_use]
         pub fn with_auto_bars(self, enable: bool) -> Self {
             ScrollBarRegion(self.0.with_auto_bars(enable))
         }
@@ -361,6 +364,7 @@ widget! {
         ///
         /// Calling this method also disables automatic scroll bars.
         #[inline]
+        #[must_use]
         pub fn with_bars(self, horiz: bool, vert: bool) -> Self {
             ScrollBarRegion(self.0.with_bars(horiz, vert))
         }
@@ -467,6 +471,7 @@ widget! {
         /// This has the side-effect of reserving enough space for scroll bars even
         /// when not required.
         #[inline]
+        #[must_use]
         pub fn with_auto_bars(mut self, enable: bool) -> Self {
             self.auto_bars = enable;
             self
@@ -476,6 +481,7 @@ widget! {
         ///
         /// Calling this method also disables automatic scroll bars.
         #[inline]
+        #[must_use]
         pub fn with_bars(mut self, horiz: bool, vert: bool) -> Self {
             self.auto_bars = false;
             self.show_bars = (horiz, vert);

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -269,7 +269,7 @@ widget! {
                 mgr.redraw(self.handle.id());
                 Response::Msg(self.value)
             } else {
-                Response::None
+                Response::Used
             }
         }
     }
@@ -651,7 +651,7 @@ widget! {
                     .unwrap_or_else(|msg| {
                         let offset = Offset(msg, self.inner.scroll_offset().1);
                         self.inner.set_scroll_offset(mgr, offset);
-                        Response::None
+                        Response::Used
                     }),
                 Some(1) => self.vert_bar
                     .send(mgr, id, event)
@@ -659,7 +659,7 @@ widget! {
                     .unwrap_or_else(|msg| {
                         let offset = Offset(self.inner.scroll_offset().0, msg);
                         self.inner.set_scroll_offset(mgr, offset);
-                        Response::None
+                        Response::Used
                     }),
                 Some(2) => match self.inner.send(mgr, id, event) {
                     Response::Focus(rect) => {
@@ -674,7 +674,7 @@ widget! {
                 _ if id == self.id() => self.handle(mgr, event),
                 _ => {
                     debug_assert!(false, "SendEvent::send: bad WidgetId");
-                    Response::None
+                    Response::Unhandled
                 }
             }
         }

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -268,7 +268,7 @@ widget! {
                 return Response::Unhandled;
             }
 
-            let offset = if id <= self.handle.id() {
+            let offset = if self.handle.id().is_ancestor_of(id) {
                 match event {
                     Event::NavFocus(key_focus) => {
                         mgr.set_nav_focus(self.id(), key_focus);
@@ -280,6 +280,7 @@ widget! {
                     },
                 }
             } else {
+                debug_assert_eq!(id, self.id());
                 match event {
                     Event::NavFocus(true) => {
                         return Response::Focus(self.rect());

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -272,7 +272,7 @@ widget! {
                 match event {
                     Event::NavFocus(key_focus) => {
                         mgr.set_nav_focus(self.id(), key_focus);
-                        return Response::None; // NavFocus event will be sent to self
+                        return Response::Used; // NavFocus event will be sent to self
                     }
                     event => match self.handle.send(mgr, id, event).try_into() {
                         Ok(res) => return res,
@@ -286,7 +286,7 @@ widget! {
                         return Response::Focus(self.rect());
                     }
                     Event::NavFocus(false) => {
-                        return Response::None;
+                        return Response::Used;
                     }
                     Event::Command(cmd, _) => {
                         let rev = self.direction.is_reversed();
@@ -316,7 +316,7 @@ widget! {
                         };
                         let action = self.set_value(v);
                         return if action.is_empty() {
-                            Response::None
+                            Response::Used
                         } else {
                             mgr.send_action(action);
                             Response::Msg(self.value)
@@ -332,7 +332,7 @@ widget! {
             let r = if self.set_offset(offset) {
                 Response::Msg(self.value)
             } else {
-                Response::None
+                Response::Used
             };
             *mgr |= self.handle.set_offset(self.offset()).1;
             r

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -30,6 +30,7 @@ pub trait SliderType:
     ///
     /// Also note that this method is not required to preserve precision
     /// (e.g. `u128::mul_64` may drop some low-order bits with large numbers).
+    #[must_use]
     fn mul_f64(self, scalar: f64) -> Self;
 }
 
@@ -143,6 +144,7 @@ widget! {
 
         /// Set the initial value
         #[inline]
+        #[must_use]
         pub fn with_value(mut self, mut value: T) -> Self {
             if value < self.range.0 {
                 value = self.range.0;

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -265,7 +265,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             let offset = if self.handle.id().is_ancestor_of(id) {
@@ -312,7 +312,7 @@ widget! {
                             }
                             Command::Home => self.range.0,
                             Command::End => self.range.1,
-                            _ => return Response::Unhandled,
+                            _ => return Response::Unused,
                         };
                         let action = self.set_value(v);
                         return if action.is_empty() {
@@ -325,7 +325,7 @@ widget! {
                     Event::PressStart { source, coord, .. } => {
                         self.handle.handle_press_on_track(mgr, source, coord)
                     }
-                    _ => return Response::Unhandled,
+                    _ => return Response::Unused,
                 }
             };
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -74,7 +74,6 @@ widget! {
     #[derive(Clone, Default, Debug)]
     #[handler(msg=<W as event::Handler>::Msg)]
     pub struct Splitter<D: Directional, W: Widget> {
-        first_id: WidgetId,
         #[widget_core]
         core: CoreData,
         widgets: Vec<W>,
@@ -84,13 +83,6 @@ widget! {
     }
 
     impl WidgetChildren for Self {
-        #[inline]
-        fn first_id(&self) -> WidgetId {
-            self.first_id
-        }
-        fn record_first_id(&mut self, id: WidgetId) {
-            self.first_id = id;
-        }
         #[inline]
         fn num_children(&self) -> usize {
             self.widgets.len() + self.handles.len()
@@ -288,7 +280,6 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         let mut handles = Vec::new();
         handles.resize_with(widgets.len().saturating_sub(1), DragHandle::new);
         Splitter {
-            first_id: Default::default(),
             core: Default::default(),
             widgets,
             handles,

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -230,7 +230,7 @@ widget! {
                                 // Message is the new offset relative to the track;
                                 // the handle has already adjusted its position
                                 self.adjust_size(mgr, n);
-                                Response::None
+                                Response::Used
                             });
                         }
                     }

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -237,7 +237,7 @@ widget! {
                 }
             }
 
-            Response::Unhandled
+            Response::Unused
         }
     }
 

--- a/crates/kas-widgets/src/sprite.rs
+++ b/crates/kas-widgets/src/sprite.rs
@@ -70,6 +70,7 @@ impl Image {
 
     /// Adjust scaling
     #[inline]
+    #[must_use]
     pub fn with_scaling(mut self, f: impl FnOnce(SpriteDisplay) -> SpriteDisplay) -> Self {
         self.sprite = f(self.sprite);
         self

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -89,8 +89,8 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() {
-                for (index, child) in self.widgets.iter_mut().enumerate() {
-                    if id <= child.id() {
+                if let Some(index) = self.id().index_of_child(id) {
+                    if let Some(child) = self.widgets.get_mut(index) {
                         return match child.send(mgr, id, event) {
                             Response::Focus(rect) => {
                                 *mgr |= self.set_active(index);

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -34,7 +34,6 @@ widget! {
     #[derive(Clone, Default, Debug)]
     #[handler(msg=<W as event::Handler>::Msg)]
     pub struct Stack<W: Widget> {
-        first_id: WidgetId,
         #[widget_core]
         core: CoreData,
         widgets: Vec<W>,
@@ -42,13 +41,6 @@ widget! {
     }
 
     impl WidgetChildren for Self {
-        #[inline]
-        fn first_id(&self) -> WidgetId {
-            self.first_id
-        }
-        fn record_first_id(&mut self, id: WidgetId) {
-            self.first_id = id;
-        }
         #[inline]
         fn num_children(&self) -> usize {
             self.widgets.len()
@@ -136,7 +128,6 @@ impl<W: Widget> Stack<W> {
     /// visible; otherwise, no widget will be visible.
     pub fn new(widgets: Vec<W>, active: usize) -> Self {
         Stack {
-            first_id: Default::default(),
             core: Default::default(),
             widgets,
             active,

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -102,7 +102,7 @@ widget! {
                 }
             }
 
-            Response::Unhandled
+            Response::Unused
         }
     }
 

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -396,7 +396,7 @@ widget! {
                     self.update_view(mgr);
                     Response::Update
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -284,6 +284,7 @@ widget! {
             self.list.set_selection_mode(mode)
         }
         /// Set the selection mode (inline)
+        #[must_use]
         pub fn with_selection_mode(mut self, mode: SelectionMode) -> Self {
             let _ = self.set_selection_mode(mode);
             self
@@ -345,6 +346,7 @@ widget! {
         ///
         /// This affects the (ideal) size request and whether children are sized
         /// according to their ideal or minimum size but not the minimum size.
+        #[must_use]
         pub fn with_num_visible(mut self, number: i32) -> Self {
             self.list = self.list.with_num_visible(number);
             self

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -396,7 +396,7 @@ widget! {
                     self.update_view(mgr);
                     Response::Update
                 }
-                _ => Response::None,
+                _ => Response::Unhandled,
             }
         }
     }

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -549,20 +549,13 @@ widget! {
                 return Response::Unhandled;
             }
 
-            if id < self.id() {
+            if let Some(index) = self.id().index_of_child(id) {
                 let child_event = self.scroll.offset_event(event.clone());
-                let index;
-                let response = 'outer: loop {
-                    // We forward events to all children, even if not visible
-                    // (e.g. these may be subscribed to an UpdateHandle).
-                    for (i, child) in self.widgets.iter_mut().enumerate() {
-                        if id <= child.widget.id() {
-                            index = i;
-                            let r = child.widget.send(mgr, id, child_event);
-                            break 'outer (child.key.clone(), r);
-                        }
-                    }
-                    debug_assert!(false, "SendEvent::send: bad WidgetId");
+                let response;
+                if let Some(child) = self.widgets.get_mut(index) {
+                    let r = child.widget.send(mgr, id, child_event);
+                    response = (child.key.clone(), r);
+                } else {
                     return Response::Unhandled;
                 };
                 if matches!(&response.1, Response::Update | Response::Msg(_)) {

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -47,7 +47,6 @@ widget! {
         T: ListData + UpdHandler<T::Key, V::Msg> + 'static,
         V: Driver<T::Item> = driver::Default,
     > {
-        first_id: WidgetId,
         #[widget_core]
         core: CoreData,
         frame_offset: Offset,
@@ -107,7 +106,6 @@ widget! {
         /// Construct a new instance with explicit direction and view
         pub fn new_with_dir_driver(direction: D, view: V, data: T) -> Self {
             ListView {
-                first_id: Default::default(),
                 core: Default::default(),
                 frame_offset: Default::default(),
                 frame_size: Default::default(),
@@ -375,13 +373,6 @@ widget! {
     }
 
     impl WidgetChildren for Self {
-        #[inline]
-        fn first_id(&self) -> WidgetId {
-            self.first_id
-        }
-        fn record_first_id(&mut self, id: WidgetId) {
-            self.first_id = id;
-        }
         #[inline]
         fn num_children(&self) -> usize {
             self.widgets.len()

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -711,7 +711,7 @@ widget! {
                 let solver = self.position_solver(mgr);
                 let cur = mgr
                     .nav_focus()
-                    .and_then(|id| self.find_child(id))
+                    .and_then(|id| self.find_child_index(id))
                     .map(|index| solver.child_to_data(index));
                 let last = self.data.len().wrapping_sub(1);
                 let is_vert = self.direction.is_vertical();

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -635,7 +635,7 @@ widget! {
                     }
                 }
             } else {
-                debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
+                debug_assert!(self.eq_id(id), "SendEvent::send: bad WidgetId");
                 match event {
                     Event::HandleUpdate { .. } => {
                         // TODO(opt): use the update payload to indicate which widgets need updating?

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -546,7 +546,7 @@ widget! {
     impl SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             if let Some(index) = self.id().index_of_child(id) {
@@ -556,7 +556,7 @@ widget! {
                     let r = child.widget.send(mgr, id, child_event);
                     response = (child.key.clone(), r);
                 } else {
-                    return Response::Unhandled;
+                    return Response::Unused;
                 };
                 if matches!(&response.1, Response::Update | Response::Msg(_)) {
                     let wd = &self.widgets[index];
@@ -569,7 +569,7 @@ widget! {
                     }
                 }
                 match response {
-                    (key, Response::Unhandled) => {
+                    (key, Response::Unused) => {
                         if let Event::PressStart { source, coord, .. } = event {
                             if source.is_primary() {
                                 // We request a grab with our ID, hence the

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -189,6 +189,7 @@ widget! {
             }
         }
         /// Set the selection mode (inline)
+        #[must_use]
         pub fn with_selection_mode(mut self, mode: SelectionMode) -> Self {
             let _ = self.set_selection_mode(mode);
             self
@@ -265,6 +266,7 @@ widget! {
         ///
         /// This affects the (ideal) size request and whether children are sized
         /// according to their ideal or minimum size but not the minimum size.
+        #[must_use]
         pub fn with_num_visible(mut self, number: i32) -> Self {
             self.ideal_visible = number;
             self

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -41,7 +41,6 @@ widget! {
     /// This widget is [`Scrollable`], supporting keyboard, wheel and drag
     /// scrolling. You may wish to wrap this widget with [`ScrollBars`].
     #[derive(Clone, Debug)]
-    #[handler(msg=ChildMsg<T::Key, <V::Widget as Handler>::Msg>)]
     pub struct ListView<
         D: Directional,
         T: ListData + UpdHandler<T::Key, V::Msg> + 'static,
@@ -543,6 +542,117 @@ widget! {
         }
     }
 
+    impl Handler for Self {
+        type Msg = ChildMsg<T::Key, <V::Widget as Handler>::Msg>;
+
+        fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
+            let self_id = self.id();
+            match event {
+                Event::HandleUpdate { .. } => {
+                    // TODO(opt): use the update payload to indicate which widgets need updating?
+                    self.update_view(mgr);
+                    return Response::Update;
+                }
+                Event::PressMove { source, coord, .. } if self.press_event == Some(source) => {
+                    if let PressPhase::Start(start_coord) = self.press_phase {
+                        if mgr.config_test_pan_thresh(coord - start_coord) {
+                            self.press_phase = PressPhase::Pan;
+                        }
+                    }
+                    match self.press_phase {
+                        PressPhase::Pan => {
+                            mgr.update_grab_cursor(self_id, CursorIcon::Grabbing);
+                            // fall through to scroll handler
+                        }
+                        _ => return Response::Used,
+                    }
+                }
+                Event::PressEnd { source, .. } if self.press_event == Some(source) => {
+                    self.press_event = None;
+                    if self.press_phase == PressPhase::Pan {
+                        return Response::Used;
+                    }
+                    return match self.sel_mode {
+                        SelectionMode::None => Response::Used,
+                        SelectionMode::Single => {
+                            self.selection.clear();
+                            if let Some(ref key) = self.press_target {
+                                self.selection.insert(key.clone());
+                                ChildMsg::Select(key.clone()).into()
+                            } else {
+                                Response::Used
+                            }
+                        }
+                        SelectionMode::Multiple => {
+                            if let Some(ref key) = self.press_target {
+                                if self.selection.remove(key) {
+                                    ChildMsg::Deselect(key.clone()).into()
+                                } else {
+                                    self.selection.insert(key.clone());
+                                    ChildMsg::Select(key.clone()).into()
+                                }
+                            } else {
+                                Response::Used
+                            }
+                        }
+                    };
+                }
+                Event::Command(cmd, _) => {
+                    let solver = self.position_solver(mgr);
+                    let cur = mgr
+                        .nav_focus()
+                        .and_then(|id| self.find_child_index(id))
+                        .map(|index| solver.child_to_data(index));
+                    let last = self.data.len().wrapping_sub(1);
+                    let is_vert = self.direction.is_vertical();
+                    let len = solver.cur_len;
+
+                    let data = match (cmd, cur) {
+                        _ if last == usize::MAX => None,
+                        _ if !self.widgets[0].widget.key_nav() => None,
+                        (Command::Home, _) => Some(0),
+                        (Command::End, _) => Some(last),
+                        (Command::Left, Some(cur)) if !is_vert && cur > 0 => Some(cur - 1),
+                        (Command::Up, Some(cur)) if is_vert && cur > 0 => Some(cur - 1),
+                        (Command::Right, Some(cur)) if !is_vert && cur < last => Some(cur + 1),
+                        (Command::Down, Some(cur)) if is_vert && cur < last => Some(cur + 1),
+                        (Command::PageUp, Some(cur)) if cur > 0 => Some(cur.saturating_sub(len / 2)),
+                        (Command::PageDown, Some(cur)) if cur < last => Some((cur + len / 2).min(last)),
+                        _ => None,
+                    };
+                    return if let Some(index) = data {
+                        // Set nav focus to index and update scroll position
+                        let (rect, action) = self.scroll.focus_rect(solver.rect(index), self.core.rect);
+                        if !action.is_empty() {
+                            *mgr |= action;
+                            self.update_widgets(mgr);
+                        }
+                        let len = usize::conv(self.cur_len);
+                        mgr.set_nav_focus(self.widgets[index % len].widget.id(), true);
+                        Response::Focus(rect)
+                    } else {
+                        Response::Used
+                    };
+                }
+                _ => (), // fall through to scroll handler
+            }
+
+            let (action, response) =
+                self.scroll
+                    .scroll_by_event(event, self.core.rect.size, |source, _, coord| {
+                        if source.is_primary() && mgr.config_enable_mouse_pan() {
+                            let icon = Some(CursorIcon::Grabbing);
+                            mgr.request_grab(self_id, source, coord, GrabMode::Grab, icon);
+                        }
+                    });
+            if !action.is_empty() {
+                *mgr |= action;
+                self.update_widgets(mgr);
+            }
+            response.void_into()
+        }
+    }
+
     impl SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
@@ -558,6 +668,7 @@ widget! {
                 } else {
                     return Response::Unused;
                 };
+
                 if matches!(&response.1, Response::Update | Response::Msg(_)) {
                     let wd = &self.widgets[index];
                     if let Some(key) = wd.key.as_ref() {
@@ -568,36 +679,41 @@ widget! {
                         }
                     }
                 }
+
                 match response {
                     (key, Response::Unused) => {
                         if let Event::PressStart { source, coord, .. } = event {
                             if source.is_primary() {
                                 // We request a grab with our ID, hence the
-                                // PressMove/PressEnd events are matched below.
+                                // PressMove/PressEnd events are matched in handle().
                                 if mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None) {
                                     self.press_event = Some(source);
                                     self.press_phase = PressPhase::Start(coord);
                                     self.press_target = key;
                                 }
-                                return Response::Used;
+                                Response::Used
+                            } else {
+                                Response::Unused
                             }
+                        } else {
+                            self.handle(mgr, event)
                         }
                     }
-                    (_, Response::Used) => return Response::Used,
+                    (_, Response::Used) => Response::Used,
                     (_, Response::Pan(delta)) => {
-                        return match self.scroll_by_delta(mgr, delta) {
+                        match self.scroll_by_delta(mgr, delta) {
                             delta if delta == Offset::ZERO => Response::Used,
                             delta => Response::Pan(delta),
-                        };
+                        }
                     }
                     (_, Response::Focus(rect)) => {
                         let (rect, action) = self.scroll.focus_rect(rect, self.core.rect);
                         *mgr |= action;
                         self.update_widgets(mgr);
-                        return Response::Focus(rect);
+                        Response::Focus(rect)
                     }
                     (Some(key), Response::Select) => {
-                        return match self.sel_mode {
+                        match self.sel_mode {
                             SelectionMode::None => Response::Used,
                             SelectionMode::Single => {
                                 self.selection.clear();
@@ -612,10 +728,10 @@ widget! {
                                     Response::Msg(ChildMsg::Select(key))
                                 }
                             }
-                        };
+                        }
                     }
-                    (None, Response::Select) => return Response::Used,
-                    (_, Response::Update) => return Response::Used,
+                    (None, Response::Select) => Response::Used,
+                    (_, Response::Update) => Response::Used,
                     (key, Response::Msg(msg)) => {
                         trace!(
                             "Received by {} from {:?}: {:?}",
@@ -627,120 +743,16 @@ widget! {
                             if let Some(handle) = self.data.handle(&key, &msg) {
                                 mgr.trigger_update(handle, 0);
                             }
-                            return Response::Msg(ChildMsg::Child(key, msg));
+                            Response::Msg(ChildMsg::Child(key, msg))
                         } else {
                             log::warn!("ListView: response from widget with no key");
-                            return Response::Used;
+                            Response::Used
                         }
                     }
                 }
             } else {
                 debug_assert!(self.eq_id(id), "SendEvent::send: bad WidgetId");
-                match event {
-                    Event::HandleUpdate { .. } => {
-                        // TODO(opt): use the update payload to indicate which widgets need updating?
-                        self.update_view(mgr);
-                        return Response::Update;
-                    }
-                    Event::PressMove { source, coord, .. } if self.press_event == Some(source) => {
-                        if let PressPhase::Start(start_coord) = self.press_phase {
-                            if mgr.config_test_pan_thresh(coord - start_coord) {
-                                self.press_phase = PressPhase::Pan;
-                            }
-                        }
-                        match self.press_phase {
-                            PressPhase::Pan => {
-                                mgr.update_grab_cursor(self.id(), CursorIcon::Grabbing);
-                                // fall through to scroll handler
-                            }
-                            _ => return Response::Used,
-                        }
-                    }
-                    Event::PressEnd { source, .. } if self.press_event == Some(source) => {
-                        self.press_event = None;
-                        if self.press_phase == PressPhase::Pan {
-                            return Response::Used;
-                        }
-                        return match self.sel_mode {
-                            SelectionMode::None => Response::Used,
-                            SelectionMode::Single => {
-                                self.selection.clear();
-                                if let Some(ref key) = self.press_target {
-                                    self.selection.insert(key.clone());
-                                    ChildMsg::Select(key.clone()).into()
-                                } else {
-                                    Response::Used
-                                }
-                            }
-                            SelectionMode::Multiple => {
-                                if let Some(ref key) = self.press_target {
-                                    if self.selection.remove(key) {
-                                        ChildMsg::Deselect(key.clone()).into()
-                                    } else {
-                                        self.selection.insert(key.clone());
-                                        ChildMsg::Select(key.clone()).into()
-                                    }
-                                } else {
-                                    Response::Used
-                                }
-                            }
-                        };
-                    }
-                    _ => (), // fall through to scroll handler
-                }
-            };
-
-            let id = self.id();
-            if let Event::Command(cmd, _) = event {
-                let solver = self.position_solver(mgr);
-                let cur = mgr
-                    .nav_focus()
-                    .and_then(|id| self.find_child_index(id))
-                    .map(|index| solver.child_to_data(index));
-                let last = self.data.len().wrapping_sub(1);
-                let is_vert = self.direction.is_vertical();
-                let len = solver.cur_len;
-
-                let data = match (cmd, cur) {
-                    _ if last == usize::MAX => None,
-                    _ if !self.widgets[0].widget.key_nav() => None,
-                    (Command::Home, _) => Some(0),
-                    (Command::End, _) => Some(last),
-                    (Command::Left, Some(cur)) if !is_vert && cur > 0 => Some(cur - 1),
-                    (Command::Up, Some(cur)) if is_vert && cur > 0 => Some(cur - 1),
-                    (Command::Right, Some(cur)) if !is_vert && cur < last => Some(cur + 1),
-                    (Command::Down, Some(cur)) if is_vert && cur < last => Some(cur + 1),
-                    (Command::PageUp, Some(cur)) if cur > 0 => Some(cur.saturating_sub(len / 2)),
-                    (Command::PageDown, Some(cur)) if cur < last => Some((cur + len / 2).min(last)),
-                    _ => None,
-                };
-                if let Some(index) = data {
-                    // Set nav focus to index and update scroll position
-                    let (rect, action) = self.scroll.focus_rect(solver.rect(index), self.core.rect);
-                    if !action.is_empty() {
-                        *mgr |= action;
-                        self.update_widgets(mgr);
-                    }
-                    let len = usize::conv(self.cur_len);
-                    mgr.set_nav_focus(self.widgets[index % len].widget.id(), true);
-                    Response::Focus(rect)
-                } else {
-                    Response::Used
-                }
-            } else {
-                let (action, response) =
-                    self.scroll
-                        .scroll_by_event(event, self.core.rect.size, |source, _, coord| {
-                            if source.is_primary() && mgr.config_enable_mouse_pan() {
-                                let icon = Some(CursorIcon::Grabbing);
-                                mgr.request_grab(id, source, coord, GrabMode::Grab, icon);
-                            }
-                        });
-                if !action.is_empty() {
-                    *mgr |= action;
-                    self.update_widgets(mgr);
-                }
-                response.void_into()
+                self.handle(mgr, event)
             }
         }
     }

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -690,7 +690,7 @@ widget! {
 
                 let cur = mgr
                     .nav_focus()
-                    .and_then(|id| self.find_child(id))
+                    .and_then(|id| self.find_child_index(id))
                     .map(|index| {
                         let mut col_index = col_start + index % cols;
                         let mut row_index = row_start + index / cols;

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -52,7 +52,6 @@ widget! {
         T: MatrixData + UpdHandler<T::Key, V::Msg> + 'static,
         V: Driver<T::Item> = driver::Default,
     > {
-        first_id: WidgetId,
         #[widget_core]
         core: CoreData,
         frame_offset: Offset,
@@ -87,7 +86,6 @@ widget! {
         /// Construct a new instance with explicit view
         pub fn new_with_driver(view: V, data: T) -> Self {
             MatrixView {
-                first_id: Default::default(),
                 core: Default::default(),
                 frame_offset: Default::default(),
                 frame_size: Default::default(),
@@ -329,13 +327,6 @@ widget! {
     }
 
     impl WidgetChildren for Self {
-        #[inline]
-        fn first_id(&self) -> WidgetId {
-            self.first_id
-        }
-        fn record_first_id(&mut self, id: WidgetId) {
-            self.first_id = id;
-        }
         #[inline]
         fn num_children(&self) -> usize {
             self.widgets.len()

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -520,20 +520,13 @@ widget! {
                 return Response::Unhandled;
             }
 
-            if id < self.id() {
+            if let Some(index) = self.id().index_of_child(id) {
                 let child_event = self.scroll.offset_event(event.clone());
-                let index;
-                let response = 'outer: loop {
-                    // We forward events to all children, even if not visible
-                    // (e.g. these may be subscribed to an UpdateHandle).
-                    for (i, child) in self.widgets.iter_mut().enumerate() {
-                        if id <= child.widget.id() {
-                            index = i;
-                            let r = child.widget.send(mgr, id, child_event);
-                            break 'outer (child.key.clone(), r);
-                        }
-                    }
-                    debug_assert!(false, "SendEvent::send: bad WidgetId");
+                let response;
+                if let Some(child) = self.widgets.get_mut(index) {
+                    let r = child.widget.send(mgr, id, child_event);
+                    response = (child.key.clone(), r);
+                } else {
                     return Response::Unhandled;
                 };
                 if matches!(&response.1, Response::Update | Response::Msg(_)) {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -169,6 +169,7 @@ widget! {
             }
         }
         /// Set the selection mode (inline)
+        #[must_use]
         pub fn with_selection_mode(mut self, mode: SelectionMode) -> Self {
             let _ = self.set_selection_mode(mode);
             self
@@ -240,6 +241,7 @@ widget! {
         ///
         /// This affects the (ideal) size request and whether children are sized
         /// according to their ideal or minimum size but not the minimum size.
+        #[must_use]
         pub fn with_num_visible(mut self, rows: i32, cols: i32) -> Self {
             self.ideal_len = Dim { rows, cols };
             self

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -517,7 +517,7 @@ widget! {
     impl SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             if let Some(index) = self.id().index_of_child(id) {
@@ -527,7 +527,7 @@ widget! {
                     let r = child.widget.send(mgr, id, child_event);
                     response = (child.key.clone(), r);
                 } else {
-                    return Response::Unhandled;
+                    return Response::Unused;
                 };
                 if matches!(&response.1, Response::Update | Response::Msg(_)) {
                     let wd = &self.widgets[index];
@@ -540,7 +540,7 @@ widget! {
                     }
                 }
                 match response {
-                    (key, Response::Unhandled) => {
+                    (key, Response::Unused) => {
                         if let Event::PressStart { source, coord, .. } = event {
                             if source.is_primary() {
                                 // We request a grab with our ID, hence the

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -540,7 +540,6 @@ widget! {
                     }
                 }
                 match response {
-                    (_, Response::None) => return Response::None,
                     (key, Response::Unhandled) => {
                         if let Event::PressStart { source, coord, .. } = event {
                             if source.is_primary() {
@@ -551,13 +550,14 @@ widget! {
                                     self.press_phase = PressPhase::Start(coord);
                                     self.press_target = key;
                                 }
-                                return Response::None;
+                                return Response::Used;
                             }
                         }
                     }
+                    (_, Response::Used) => return Response::Used,
                     (_, Response::Pan(delta)) => {
                         return match self.scroll_by_delta(mgr, delta) {
-                            delta if delta == Offset::ZERO => Response::None,
+                            delta if delta == Offset::ZERO => Response::Used,
                             delta => Response::Pan(delta),
                         };
                     }
@@ -569,7 +569,7 @@ widget! {
                     }
                     (Some(key), Response::Select) => {
                         return match self.sel_mode {
-                            SelectionMode::None => Response::None,
+                            SelectionMode::None => Response::Used,
                             SelectionMode::Single => {
                                 self.selection.clear();
                                 self.selection.insert(key.clone());
@@ -585,8 +585,8 @@ widget! {
                             }
                         };
                     }
-                    (None, Response::Select) => return Response::None,
-                    (_, Response::Update) => return Response::None,
+                    (None, Response::Select) => return Response::Used,
+                    (_, Response::Update) => return Response::Used,
                     (key, Response::Msg(msg)) => {
                         trace!(
                             "Received by {} from {:?}: {:?}",
@@ -601,7 +601,7 @@ widget! {
                             return Response::Msg(ChildMsg::Child(key, msg));
                         } else {
                             log::warn!("MatrixView: response from widget with no key");
-                            return Response::None;
+                            return Response::Used;
                         }
                     }
                 }
@@ -623,23 +623,23 @@ widget! {
                                 mgr.update_grab_cursor(self.id(), CursorIcon::Grabbing);
                                 // fall through to scroll handler
                             }
-                            _ => return Response::None,
+                            _ => return Response::Used,
                         }
                     }
                     Event::PressEnd { source, .. } if self.press_event == Some(source) => {
                         self.press_event = None;
                         if self.press_phase == PressPhase::Pan {
-                            return Response::None;
+                            return Response::Used;
                         }
                         return match self.sel_mode {
-                            SelectionMode::None => Response::None,
+                            SelectionMode::None => Response::Used,
                             SelectionMode::Single => {
                                 self.selection.clear();
                                 if let Some(ref key) = self.press_target {
                                     self.selection.insert(key.clone());
                                     ChildMsg::Select(key.clone()).into()
                                 } else {
-                                    Response::None
+                                    Response::Used
                                 }
                             }
                             SelectionMode::Multiple => {
@@ -651,7 +651,7 @@ widget! {
                                         ChildMsg::Select(key.clone()).into()
                                     }
                                 } else {
-                                    Response::None
+                                    Response::Used
                                 }
                             }
                         };
@@ -712,7 +712,7 @@ widget! {
                     let index = (ci % cols) + (ri % rows) * cols;
                     mgr.set_nav_focus(self.widgets[index].widget.id(), true);
                 }
-                (TkAction::empty(), Response::None)
+                (TkAction::empty(), Response::Used)
             } else {
                 self.scroll
                     .scroll_by_event(event, self.core.rect.size, |source, _, coord| {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -606,7 +606,7 @@ widget! {
                     }
                 }
             } else {
-                debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
+                debug_assert!(self.eq_id(id), "SendEvent::send: bad WidgetId");
                 match event {
                     Event::HandleUpdate { .. } => {
                         self.update_view(mgr);

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -131,7 +131,9 @@ widget! {
                 return Response::Unhandled;
             }
 
-            if id < self.id() {
+            if id == self.id() {
+                self.handle(mgr, event)
+            } else {
                 let r = self.child.send(mgr, id, event);
                 if matches!(&r, Response::Update | Response::Msg(_)) {
                     if let Some(value) = self.view.get(&self.child) {
@@ -152,9 +154,6 @@ widget! {
                     }
                 }
                 r
-            } else {
-                debug_assert!(id == self.id(), "SendEvent::send: bad WidgetId");
-                self.handle(mgr, event)
             }
         }
     }

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -120,7 +120,7 @@ widget! {
                     *mgr |= self.view.set(&mut self.child, value);
                     Response::Update
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }
@@ -128,7 +128,7 @@ widget! {
     impl SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() {
-                return Response::Unhandled;
+                return Response::Unused;
             }
 
             if id == self.id() {

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -131,7 +131,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if id == self.id() {
+            if self.eq_id(id) {
                 self.handle(mgr, event)
             } else {
                 let r = self.child.send(mgr, id, event);

--- a/crates/kas-widgets/src/window.rs
+++ b/crates/kas-widgets/src/window.rs
@@ -67,7 +67,7 @@ widget! {
             if self.is_disabled() || self.eq_id(id) {
                 Response::Unused
             } else {
-                return self.w.send(mgr, id, event).into();
+                self.w.send(mgr, id, event).into()
             }
         }
     }

--- a/crates/kas-widgets/src/window.rs
+++ b/crates/kas-widgets/src/window.rs
@@ -41,7 +41,7 @@ widget! {
                 return None;
             }
             for popup in self.popups.iter_mut().rev() {
-                if let Some(id) = self.w.find_leaf_mut(popup.1.id).and_then(|w| w.find_id(coord)) {
+                if let Some(id) = self.w.find_widget_mut(popup.1.id).and_then(|w| w.find_id(coord)) {
                     return Some(id);
                 }
             }
@@ -53,7 +53,7 @@ widget! {
             let disabled = disabled || self.is_disabled();
             self.w.draw(draw, mgr, disabled);
             for (_, popup) in &self.popups {
-                if let Some(widget) = self.w.find_leaf_mut(popup.id) {
+                if let Some(widget) = self.w.find_widget_mut(popup.id) {
                     draw.with_overlay(widget.rect(), &mut |draw| {
                         widget.draw(draw, mgr, disabled);
                     });
@@ -222,7 +222,7 @@ impl<W: Widget> Window<W> {
         let popup = &mut self.popups[index].1;
 
         let c = find_rect(self.w.as_widget(), popup.parent).unwrap();
-        let widget = self.w.find_leaf_mut(popup.id).unwrap();
+        let widget = self.w.find_widget_mut(popup.id).unwrap();
         let mut cache = mgr.size_handle(|sh| layout::SolveCache::find_constraints(widget, sh));
         let ideal = cache.ideal(false);
         let m = cache.margins();

--- a/crates/kas-widgets/src/window.rs
+++ b/crates/kas-widgets/src/window.rs
@@ -64,7 +64,7 @@ widget! {
 
     impl SendEvent for Self where W::Msg: Into<VoidMsg> {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
-            if self.is_disabled() || id == self.id() {
+            if self.is_disabled() || self.eq_id(id) {
                 Response::Unused
             } else {
                 return self.w.send(mgr, id, event).into();

--- a/crates/kas-widgets/src/window.rs
+++ b/crates/kas-widgets/src/window.rs
@@ -65,7 +65,7 @@ widget! {
     impl SendEvent for Self where W::Msg: Into<VoidMsg> {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.is_disabled() || id == self.id() {
-                Response::Unhandled
+                Response::Unused
             } else {
                 return self.w.send(mgr, id, event).into();
             }

--- a/examples/async-event.rs
+++ b/examples/async-event.rs
@@ -77,7 +77,7 @@ widget! {
                     // Note: event has `handle` and `payload` params.
                     // We only need to request a redraw.
                     mgr.redraw(self.id());
-                    Response::None
+                    Response::Used
                 }
                 _ => Response::Unhandled,
             }

--- a/examples/async-event.rs
+++ b/examples/async-event.rs
@@ -79,7 +79,7 @@ widget! {
                     mgr.redraw(self.id());
                     Response::Used
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -139,7 +139,7 @@ widget! {
                     mgr.update_on_timer(Duration::new(0, ns), self.id(), 0);
                     Response::Used
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -137,7 +137,7 @@ widget! {
                     let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
                     info!("Requesting update in {}ns", ns);
                     mgr.update_on_timer(Duration::new(0, ns), self.id(), 0);
-                    Response::None
+                    Response::Used
                 }
                 _ => Response::Unhandled,
             }

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -13,6 +13,7 @@ widget! {
     #[derive(Clone, Debug)]
     #[widget{
         layout = single;
+        find_id = Some(self.id());
     }]
     struct CursorWidget {
         #[widget_core]

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -91,7 +91,7 @@ widget! {
             match event {
                 Event::Command(Command::Escape, _) => self.close(mgr, false),
                 Event::Command(Command::Return, _) => self.close(mgr, true),
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }
@@ -204,7 +204,7 @@ fn main() -> Result<(), kas::shell::Error> {
                         }
                         Response::Used
                     }
-                    _ => Response::Unhandled,
+                    _ => Response::Unused,
                 }
             }
         }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -77,7 +77,7 @@ widget! {
         fn close(&mut self, mgr: &mut Manager, commit: bool) -> VoidResponse {
             self.commit = commit;
             mgr.send_action(TkAction::CLOSE);
-            Response::None
+            Response::Used
         }
     }
     impl WidgetConfig for TextEditPopup {
@@ -202,7 +202,7 @@ fn main() -> Result<(), kas::shell::Error> {
                                 *mgr |= self.label.set_string(text);
                             }
                         }
-                        Response::None
+                        Response::Used
                     }
                     _ => Response::Unhandled,
                 }

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -365,7 +365,7 @@ widget! {
                                 Command::Down => DVec2(0.0, d),
                                 Command::Left => DVec2(-d, 0.0),
                                 Command::Right => DVec2(d, 0.0),
-                                _ => return Response::Unhandled,
+                                _ => return Response::Unused,
                             };
                             self.delta += self.alpha.complex_mul(delta);
                         }
@@ -410,7 +410,7 @@ widget! {
                     );
                     Response::Used
                 }
-                _ => Response::Unhandled,
+                _ => Response::Unused,
             }
         }
     }

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -408,9 +408,9 @@ widget! {
                         event::GrabMode::PanFull,
                         Some(event::CursorIcon::Grabbing),
                     );
-                    Response::None
+                    Response::Used
                 }
-                _ => Response::None,
+                _ => Response::Unhandled,
             }
         }
     }

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -62,7 +62,7 @@ fn make_window() -> Box<dyn kas::Window> {
                         }
                         Response::Used
                     }
-                    _ => Response::Unhandled,
+                    _ => Response::Unused,
                 }
             }
         }

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -60,7 +60,7 @@ fn make_window() -> Box<dyn kas::Window> {
                             *mgr |= self.display.set_string(text);
                             mgr.update_on_timer(Duration::new(0, 1), self.id(), 0);
                         }
-                        Response::None
+                        Response::Used
                     }
                     _ => Response::Unhandled,
                 }


### PR DESCRIPTION
Widget identifier revision, part 1.

- New `widget_id` module
- `WidgetId` is now 64-bit (previously 32-bit), and stores a compressed path (sequence of child indices) where possible.
- `WidgetId` fallback for long paths: allocate on the heap and reference via a global array. This is a temporary solution until part 2 lands.
- Print-outs of `WidgetId` are now an encoded path, with one hex char per level except that `9-F` indicate chaining (continued to next char). This is somewhat readable and more informative than the old numeric print-out.

Issues left to part 2:

- `PartialEq for WidgetId` panics on invalid id.
- Paths are never deallocated; effectively this is a memory leak (which could be an issue in a UI frequently assigning new IDs, currently not the case but planned).
- Using `WidgetId::opt_from_u64` with a bad value could cause a panic (this is the main reason for a global lookup array, instead of storing a pointer directly).

Changes to `Widget` traits:

- Rename `WidgetChildren::find_child` → `find_child_index`
- Rename `WidgetChildren::find_leaf` → `find_widget`
- Removal of `first_id` (no longer required)
- Add `WidgetExt` trait with `eq_id` method

Misc changes/fixes:

- Simpler mouse-hover icon policy
- Fix click on `MenuToggle` label
- Rename `Response::None` → `Used` and `Unhandled` → `Unused`
- Fix missing `Default` impl for `CursorIcon` without winit
- Prettier event-manager code (manager, list/matrix view)
- Add `#[must_use]` on various methods returning `Self`, as is considered sensible