### PR TITLE
WidgetId revision, part 2

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -59,7 +59,6 @@ macros_log = ["kas-macros/log"]
 
 [dependencies]
 easy-cast = "0.4.2"
-lazy_static = "1.4"
 log = "0.4"
 smallvec = "1.6.1"
 stack_dst = { version = "0.6", optional = true }

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -51,13 +51,13 @@ impl<M: 'static> WidgetChildren for Box<dyn Widget<Msg = M>> {
         self.as_mut().get_child_mut(index)
     }
 
-    fn find_child_index(&self, id: WidgetId) -> Option<usize> {
+    fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
         self.as_ref().find_child_index(id)
     }
-    fn find_widget(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+    fn find_widget(&self, id: &WidgetId) -> Option<&dyn WidgetConfig> {
         self.as_ref().find_widget(id)
     }
-    fn find_widget_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
+    fn find_widget_mut(&mut self, id: &WidgetId) -> Option<&mut dyn WidgetConfig> {
         self.as_mut().find_widget_mut(id)
     }
 }

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -142,13 +142,13 @@ pub trait WidgetCore: Any + fmt::Debug {
         if self.core_data().disabled || disabled {
             state |= InputState::DISABLED;
         }
-        if mgr.is_hovered(&id) {
+        if mgr.is_hovered(id) {
             state |= InputState::HOVER;
         }
-        if mgr.is_depressed(&id) {
+        if mgr.is_depressed(id) {
             state |= InputState::DEPRESS;
         }
-        if mgr.nav_focus(&id) {
+        if mgr.nav_focus(id) {
             state |= InputState::NAV_FOCUS;
         }
         if char_focus {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -205,8 +205,8 @@ pub trait WidgetChildren: WidgetCore {
 
     /// Find the child which is an ancestor of this `id`, if any
     ///
-    /// This child may then be accessed via [`Self::get_child`] or
-    /// [`Self::get_child_mut`].
+    /// Warning: the return value is not guaranteed to be a valid child, thus
+    /// calls to methods like [`Self::get_child`] must handle `None` return.
     ///
     /// This requires that the widget tree has already been configured by
     /// [`event::ManagerState::configure`].
@@ -220,8 +220,9 @@ pub trait WidgetChildren: WidgetCore {
     /// This requires that the widget tree has already been configured by
     /// [`event::ManagerState::configure`].
     fn find_widget(&self, id: &WidgetId) -> Option<&dyn WidgetConfig> {
-        if let Some(child) = self.find_child_index(id) {
-            self.get_child(child).unwrap().find_widget(id)
+        if let Some(index) = self.find_child_index(id) {
+            self.get_child(index)
+                .and_then(|child| child.find_widget(id))
         } else if self.eq_id(id) {
             return Some(self.as_widget());
         } else {
@@ -234,8 +235,9 @@ pub trait WidgetChildren: WidgetCore {
     /// This requires that the widget tree has already been configured by
     /// [`ManagerState::configure`].
     fn find_widget_mut(&mut self, id: &WidgetId) -> Option<&mut dyn WidgetConfig> {
-        if let Some(child) = self.find_child_index(id) {
-            self.get_child_mut(child).unwrap().find_widget_mut(id)
+        if let Some(index) = self.find_child_index(id) {
+            self.get_child_mut(index)
+                .and_then(|child| child.find_widget_mut(id))
         } else if self.eq_id(id) {
             return Some(self.as_widget_mut());
         } else {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -66,6 +66,12 @@ pub trait WidgetCore: Any + fmt::Debug {
         self.core_data().id
     }
 
+    /// Get the widget's numeric identifier
+    #[inline]
+    fn id_ref(&self) -> &WidgetId {
+        &self.core_data().id
+    }
+
     /// Get whether the widget is disabled
     #[inline]
     fn is_disabled(&self) -> bool {
@@ -130,19 +136,19 @@ pub trait WidgetCore: Any + fmt::Debug {
     /// widgets are unaffected), unless [`WidgetConfig::hover_highlight`]
     /// returns true.
     fn input_state(&self, mgr: &ManagerState, disabled: bool) -> InputState {
-        let id = self.core_data().id;
+        let id = &self.core_data().id;
         let (char_focus, sel_focus) = mgr.has_char_focus(id);
         let mut state = InputState::empty();
         if self.core_data().disabled || disabled {
             state |= InputState::DISABLED;
         }
-        if mgr.is_hovered(id) {
+        if mgr.is_hovered(&id) {
             state |= InputState::HOVER;
         }
-        if mgr.is_depressed(id) {
+        if mgr.is_depressed(&id) {
             state |= InputState::DEPRESS;
         }
-        if mgr.nav_focus(id) {
+        if mgr.nav_focus(&id) {
             state |= InputState::NAV_FOCUS;
         }
         if char_focus {
@@ -193,7 +199,7 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// This function assumes that `id` is a valid widget.
     #[inline]
-    fn is_ancestor_of(&self, id: WidgetId) -> bool {
+    fn is_ancestor_of(&self, id: &WidgetId) -> bool {
         self.id().is_ancestor_of(id)
     }
 
@@ -205,7 +211,7 @@ pub trait WidgetChildren: WidgetCore {
     /// This requires that the widget tree has already been configured by
     /// [`event::ManagerState::configure`].
     #[inline]
-    fn find_child_index(&self, id: WidgetId) -> Option<usize> {
+    fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
         self.id().index_of_child(id)
     }
 
@@ -213,7 +219,7 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// This requires that the widget tree has already been configured by
     /// [`event::ManagerState::configure`].
-    fn find_widget(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+    fn find_widget(&self, id: &WidgetId) -> Option<&dyn WidgetConfig> {
         if let Some(child) = self.find_child_index(id) {
             self.get_child(child).unwrap().find_widget(id)
         } else if self.eq_id(id) {
@@ -227,7 +233,7 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// This requires that the widget tree has already been configured by
     /// [`ManagerState::configure`].
-    fn find_widget_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
+    fn find_widget_mut(&mut self, id: &WidgetId) -> Option<&mut dyn WidgetConfig> {
         if let Some(child) = self.find_child_index(id) {
             self.get_child_mut(child).unwrap().find_widget_mut(id)
         } else if self.eq_id(id) {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -63,7 +63,7 @@ pub trait WidgetCore: Any + fmt::Debug {
     /// Get the widget's numeric identifier
     #[inline]
     fn id(&self) -> WidgetId {
-        self.core_data().id
+        self.core_data().id.clone()
     }
 
     /// Get the widget's numeric identifier

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -284,7 +284,7 @@ pub trait WidgetConfig: Layout {
     /// method but instead use [`WidgetConfig::configure`]; the exception is
     /// widgets with pop-ups.
     fn configure_recurse(&mut self, mut cmgr: ConfigureManager) {
-        self.core_data_mut().id = cmgr.get_id(self.id());
+        self.core_data_mut().id = cmgr.get_id();
         for i in 0..self.num_children() {
             if let Some(w) = self.get_child_mut(i) {
                 w.configure_recurse(cmgr.child(i));

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -28,7 +28,7 @@ use std::sync::Mutex;
 /// Identifiers are assigned when configured and when re-configured
 /// (via [`crate::TkAction::RECONFIGURE`]). Since user-code is not notified of a
 /// re-configure, user-code should not store a `WidgetId`.
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Eq)]
 pub struct WidgetId(NonZeroU64);
 
 /// Invalid (default) identifier
@@ -533,7 +533,7 @@ mod test {
                 id = id.make_child(*x);
             }
             println!("id={} val={:x} from {:?}", id, id.as_u64(), seq);
-            let mut id2 = id;
+            let mut id2 = id.clone();
             for x in seq2 {
                 id2 = id2.make_child(*x);
             }

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -410,7 +410,9 @@ impl WidgetId {
 
     /// Convert `u64` to `Option<WidgetId>`
     ///
-    /// **Safety:** this may only be called with the output of [`Self::as_u64`],
+    /// # Safety
+    ///
+    /// This may only be called with the output of [`Self::as_u64`],
     /// [`Self::opt_from_u64`], or `0`.
     ///
     /// This always "succeeds", though the result may not identify any widget.

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -8,14 +8,206 @@
 // x << a + b is x << (a + b)
 #![allow(clippy::precedence)]
 
-use crate::cast::{Cast, Conv};
-use std::cmp::PartialEq;
-use std::fmt;
+use crate::cast::Cast;
+use std::cmp::{Eq, PartialEq};
 use std::hash::{Hash, Hasher};
 use std::iter::once;
 use std::mem::size_of;
 use std::num::NonZeroU64;
-use std::sync::Mutex;
+use std::{fmt, slice};
+
+/// Invalid (default) identifier
+const INVALID: u64 = !0;
+
+/// `x & USE_BITS != 0`: rest is a sequence of 4-bit blocks; len is number of blocks used
+const USE_BITS: u64 = 0x01;
+/// Set when using a pointer as a safety feature.
+const USE_PTR: usize = 0x02;
+
+const MASK_LEN: u64 = 0xF0;
+const SHIFT_LEN: u8 = 4;
+const BLOCKS: u8 = 14;
+const MASK_BITS: u64 = 0xFFFF_FFFF_FFFF_FF00;
+
+// TODO: test on 32-bit
+#[cfg(target_pointer_width = "32")]
+const MASK_PTR: usize = 0xFFFF_FFFC;
+#[cfg(target_pointer_width = "64")]
+const MASK_PTR: usize = 0xFFFF_FFFF_FFFF_FFFC;
+
+/// Integer or pointer to a reference-counted slice.
+///
+/// Use `Self::get_ptr` to determine the variant used. When reading a pointer,
+/// mask with MASK_PTR.
+///
+/// `self.x & USE_BITS` is the "flag bit" determining the variant used. This
+/// overlaps with the pointer's lowest bit (which must be zero due to alignment)
+/// or padding (depending on Endianness and implementation).
+/// Note: we shouldn't need `repr(C)`, but the alternative is unspecified.
+#[repr(C)]
+union IntOrPtr {
+    // 8 bytes, platform endianness
+    x: NonZeroU64,
+    // 4 or 8 bytes, platform endianness
+    // 4-LE: overlaps least significant half of x
+    // 4-BE: overlaps most significant half of x
+    // 8 bytes: exactly overlaps x
+    //
+    // This is a *thin* pointer to a ref-counted [usize] slice.
+    // slice[0] is ref_count
+    // slice[1] is length (excluding ref_count and length)
+    // slice[2..2+length] is the rest
+    p: *mut usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Variant<'a> {
+    Invalid,
+    Int(u64),
+    Slice(&'a [usize]),
+}
+
+impl IntOrPtr {
+    const ROOT: Self = IntOrPtr {
+        x: unsafe { NonZeroU64::new_unchecked(USE_BITS) },
+    };
+    const INVALID: Self = IntOrPtr {
+        x: unsafe { NonZeroU64::new_unchecked(INVALID) },
+    };
+
+    #[inline]
+    fn get_ptr(&self) -> Option<*mut usize> {
+        unsafe {
+            if self.x.get() & USE_BITS == 0 {
+                let p = self.p as usize & MASK_PTR;
+                Some(p as *mut usize)
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Construct from an integer
+    ///
+    /// Note: requires `x & USE_BITS != 0`.
+    fn new_int(x: u64) -> Self {
+        assert!(x & USE_BITS != 0);
+        let x = NonZeroU64::new(x).unwrap();
+        let u = IntOrPtr { x };
+        assert!(u.get_ptr().is_none());
+        u
+    }
+
+    /// Construct as a slice from an iterator
+    fn new_iter<I: Clone + Iterator<Item = usize>>(iter: I) -> Self {
+        let ref_count = 1;
+        let len = iter.clone().count();
+        let v: Vec<usize> = once(ref_count).chain(once(len)).chain(iter).collect();
+        let b = v.into_boxed_slice();
+        let p = Box::leak(b) as *mut [usize] as *mut usize;
+        let p = p as usize;
+        debug_assert_eq!(p & 3, 0);
+        let p = (p | USE_PTR) as *mut usize;
+        let u = IntOrPtr { p };
+        assert!(u.get_ptr().is_some());
+        u
+    }
+
+    fn get(&self) -> Variant {
+        unsafe {
+            if let Some(p) = self.get_ptr() {
+                let len = *p.offset(1);
+                let p = p.offset(2);
+                let slice = slice::from_raw_parts(p, len);
+                Variant::Slice(slice)
+            } else if self.x.get() == INVALID {
+                Variant::Invalid
+            } else {
+                Variant::Int(self.x.get())
+            }
+        }
+    }
+
+    fn as_u64(&self) -> u64 {
+        unsafe {
+            // We simply read x. Not portable, but doesn't need to be.
+            self.x.get()
+        }
+    }
+
+    // Compatible with values geneated by `Self::as_u64`
+    unsafe fn opt_from_u64(n: u64) -> Option<IntOrPtr> {
+        if n == 0 {
+            None
+        } else {
+            // We expect either USE_BITS or USE_PTR here; anything else indicates an error
+            let v = n & 3;
+            assert!(v == 1 || v == 2, "WidgetId::opt_from_u64: invalid value");
+            let x = NonZeroU64::new(n).unwrap();
+            Some(IntOrPtr { x })
+        }
+    }
+}
+
+impl Clone for IntOrPtr {
+    fn clone(&self) -> Self {
+        unsafe {
+            if let Some(p) = self.get_ptr() {
+                let ref_count = p;
+                // TODO: should be atomic!
+                *ref_count += 1;
+                IntOrPtr { p }
+            } else {
+                let x = self.x;
+                IntOrPtr { x }
+            }
+        }
+    }
+}
+
+// TODO: check not send & not sync
+impl Drop for IntOrPtr {
+    fn drop(&mut self) {
+        if let Some(p) = self.get_ptr() {
+            unsafe {
+                let ref_count = p;
+                // TODO: should be atomic!
+                *ref_count -= 1;
+                if *ref_count == 0 {
+                    // len+2 because path len does not include ref_count or len "fields"
+                    let len = *p.offset(1) + 2;
+                    let slice = slice::from_raw_parts_mut(p, len);
+                    let _ = Box::<[usize]>::from_raw(slice);
+                }
+            }
+        }
+    }
+}
+
+enum PathIter<'a> {
+    Bits(BitsIter),
+    Slice(std::iter::Cloned<std::slice::Iter<'a, usize>>),
+}
+
+impl<'a> Iterator for PathIter<'a> {
+    type Item = usize;
+
+    #[inline]
+    fn next(&mut self) -> Option<usize> {
+        match self {
+            PathIter::Bits(bits) => bits.next(),
+            PathIter::Slice(slice) => slice.next(),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            PathIter::Bits(bits) => bits.size_hint(),
+            PathIter::Slice(slice) => slice.size_hint(),
+        }
+    }
+}
 
 /// Widget identifier
 ///
@@ -28,22 +220,10 @@ use std::sync::Mutex;
 /// Identifiers are assigned when configured and when re-configured
 /// (via [`crate::TkAction::RECONFIGURE`]). Since user-code is not notified of a
 /// re-configure, user-code should not store a `WidgetId`.
-#[derive(Clone, Eq)]
-pub struct WidgetId(NonZeroU64);
+#[derive(Clone)]
+pub struct WidgetId(IntOrPtr);
 
-/// Invalid (default) identifier
-const INVALID: u64 = !0;
-
-/// `x & USE_BITS != 0`: rest is a sequence of 4-bit blocks; len is number of blocks used
-const USE_BITS: u64 = 0x8000_0000_0000_0000;
-
-const MASK_LEN: u64 = 0x0F00_0000_0000_0000;
-const SHIFT_LEN: u8 = 56;
-const BLOCKS: u8 = 14;
-const MASK_BITS: u64 = 0x00FF_FFFF_FFFF_FFFF;
-
-const MASK_PTR: u64 = 0x7FFF_FFFF_FFFF_FFFF;
-
+// Encode lowest 48 bits of index into the low bits of a u64, returning also the encoded bit-length
 fn encode(index: usize) -> (u64, u8) {
     debug_assert!(8 * size_of::<usize>() as u32 - index.leading_zeros() <= 64);
     let mut x = index as u64 & 0x0000_FFFF_FFFF_FFFF;
@@ -63,7 +243,7 @@ fn block_len(x: u64) -> u8 {
     ((x & MASK_LEN) >> SHIFT_LEN) as u8
 }
 
-// Returns usize read from x plus blocks used
+// Returns usize read from highest bits of x plus blocks used
 fn next_from_bits(mut x: u64) -> (usize, u8) {
     const TAKE: u64 = 0x7000_0000_0000_0000;
     const HIGH: u64 = 0x8000_0000_0000_0000;
@@ -77,12 +257,13 @@ fn next_from_bits(mut x: u64) -> (usize, u8) {
     (y.cast(), c)
 }
 
+#[derive(Clone, Debug)]
 struct BitsIter(u8, u64);
 impl BitsIter {
     fn new(bits: u64) -> Self {
         assert!((bits & USE_BITS) != 0);
-        let len = (bits & MASK_LEN) >> SHIFT_LEN;
-        BitsIter(len as u8, bits << (64 - SHIFT_LEN))
+        let len = block_len(bits);
+        BitsIter(len as u8, bits & MASK_BITS)
     }
 }
 impl Iterator for BitsIter {
@@ -103,9 +284,9 @@ impl Iterator for BitsIter {
 
 impl WidgetId {
     /// Identifier of the window
-    pub(crate) const ROOT: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(USE_BITS) });
+    pub(crate) const ROOT: Self = WidgetId(IntOrPtr::ROOT);
 
-    const INVALID: WidgetId = WidgetId(unsafe { NonZeroU64::new_unchecked(INVALID) });
+    const INVALID: Self = WidgetId(IntOrPtr::INVALID);
 
     /// Is the identifier valid?
     ///
@@ -113,36 +294,33 @@ impl WidgetId {
     /// considered a logic error and thus will panic in debug builds.
     /// This method may be used to check an identifier's validity.
     pub fn is_valid(&self) -> bool {
-        self.0.get() != !0
+        self.0.get() != Variant::Invalid
     }
 
     /// Returns true if `self` equals `id` or if `id` is a descendant of `self`
     pub fn is_ancestor_of(&self, id: &Self) -> bool {
-        let self_id = self.0.get();
-        let child_id = id.0.get();
-        if (child_id & USE_BITS) != 0 {
-            let self_blocks = block_len(self_id);
-            let child_blocks = block_len(child_id);
-            if self_id == !0 || child_id == !0 {
-                return false; // invalid
+        match (self.0.get(), id.0.get()) {
+            (Variant::Invalid, _) | (_, Variant::Invalid) => false,
+            (Variant::Slice(_), Variant::Int(_)) => {
+                // This combo will never be created where id is a child.
+                false
             }
-            if (self_id & USE_BITS) == 0 || self_blocks > child_blocks {
-                return false; // assumption: parent uses bits when child does
+            (Variant::Int(self_x), Variant::Int(child_x)) => {
+                let self_blocks = block_len(self_x);
+                let child_blocks = block_len(child_x);
+                if self_blocks > child_blocks {
+                    return false;
+                }
+
+                // self_blocks == 0 for ROOT, otherwise > 0
+                let shift = 4 * (BLOCKS - self_blocks) + 8;
+                shift == 64 || self_x >> shift == child_x >> shift
             }
-
-            let shift = 4 * (BLOCKS - self_blocks);
-            return (self_id & MASK_BITS) >> shift == (child_id & MASK_BITS) >> shift;
-        }
-
-        let db = DB.lock().unwrap();
-        let child_i = usize::conv(child_id & MASK_PTR);
-
-        if (self_id & USE_BITS) != 0 {
-            let iter = BitsIter::new(self_id);
-            iter.zip(db[child_i].iter()).all(|(a, b)| a == *b)
-        } else {
-            let self_i = usize::conv(self_id & MASK_PTR);
-            db[child_i].starts_with(&db[self_i])
+            (Variant::Int(self_x), Variant::Slice(child)) => {
+                let iter = BitsIter::new(self_x);
+                iter.zip(child.iter()).all(|(a, b)| a == *b)
+            }
+            (Variant::Slice(self_path), Variant::Slice(child)) => child.starts_with(self_path),
         }
     }
 
@@ -150,44 +328,41 @@ impl WidgetId {
     ///
     /// Returns `None` if `child` is not a descendant of `self`.
     pub fn index_of_child(&self, child: &Self) -> Option<usize> {
-        let self_id = self.0.get();
-        let child_id = child.0.get();
-        if (child_id & USE_BITS) != 0 {
-            let self_blocks = block_len(self_id);
-            let child_blocks = block_len(child_id);
-            if self_id == !0 || child_id == !0 {
-                return None; // invalid
-            }
-            if (self_id & USE_BITS) == 0 || self_blocks >= child_blocks {
-                return None;
-            }
+        match (self.0.get(), child.0.get()) {
+            (Variant::Invalid, _) | (_, Variant::Invalid) => None,
+            (Variant::Slice(_), Variant::Int(_)) => None,
+            (Variant::Int(self_x), Variant::Int(child_x)) => {
+                let self_blocks = block_len(self_x);
+                let child_blocks = block_len(child_x);
+                if self_blocks >= child_blocks {
+                    return None;
+                }
 
-            let shift = 4 * (BLOCKS - self_blocks);
-            let child_rest = child_id & MASK_BITS;
-            if (self_id & MASK_BITS) >> shift != child_rest >> shift {
-                return None;
+                // self_blocks == 0 for ROOT, otherwise > 0
+                let shift = 4 * (BLOCKS - self_blocks) + 8;
+                if shift != 64 && self_x >> shift != child_x >> shift {
+                    return None;
+                }
+
+                debug_assert!(child_blocks > 0);
+                let next_bits = (child_x & MASK_BITS) << (4 * self_blocks);
+                Some(next_from_bits(next_bits).0)
             }
-
-            return Some(next_from_bits(child_rest << 8 + 4 * self_blocks).0);
-        }
-
-        let db = DB.lock().unwrap();
-        let child_slice = &db[usize::conv(child_id & MASK_PTR)];
-
-        if (self_id & USE_BITS) != 0 {
-            let iter = BitsIter::new(self_id);
-            let mut child_iter = child_slice.iter();
-            if iter.zip(&mut child_iter).all(|(a, b)| a == *b) {
-                child_iter.next().cloned()
-            } else {
-                None
+            (Variant::Int(self_x), Variant::Slice(child_path)) => {
+                let iter = BitsIter::new(self_x);
+                let mut child_iter = child_path.iter();
+                if iter.zip(&mut child_iter).all(|(a, b)| a == *b) {
+                    child_iter.next().cloned()
+                } else {
+                    None
+                }
             }
-        } else {
-            let self_slice = &db[usize::conv(self_id & MASK_PTR)];
-            if child_slice.starts_with(self_slice) {
-                child_slice[self_slice.len()..].iter().next().cloned()
-            } else {
-                None
+            (Variant::Slice(self_path), Variant::Slice(child_path)) => {
+                if child_path.starts_with(self_path) {
+                    child_path[self_path.len()..].iter().next().cloned()
+                } else {
+                    None
+                }
             }
         }
     }
@@ -198,47 +373,31 @@ impl WidgetId {
     /// `index` may or may not return the same value!
     #[must_use]
     pub fn make_child(&self, index: usize) -> Self {
-        let self_id = self.0.get();
-        let mut path = None;
-        if (self_id & USE_BITS) != 0 {
-            if self_id == !0 {
-                panic!("WidgetId::make_child: invalid id");
-            }
-
-            // TODO(opt): this bit-packing approach is designed for space-optimisation, but it may
-            // be better to use a simpler, less-compressed approach, possibly with u128 type.
-            let block_len = block_len(self_id);
-            let avail_blocks = BLOCKS - block_len;
-            let req_bits = 8 * size_of::<usize>() as u8 - index.leading_zeros() as u8;
-            if req_bits <= 3 * avail_blocks {
-                let (bits, bit_len) = encode(index);
+        match self.0.get() {
+            Variant::Invalid => panic!("WidgetId::make_child: invalid id"),
+            Variant::Int(self_x) => {
+                // TODO(opt): this bit-packing approach is designed for space-optimisation, but it may
+                // be better to use a simpler, less-compressed approach, possibly with u128 type.
+                let block_len = block_len(self_x);
+                let avail_blocks = BLOCKS - block_len;
                 // Note: zero is encoded with 1 block to force bump to len
-                let used_blocks = bit_len / 4;
-                debug_assert_eq!(used_blocks, ((req_bits + 2) / 3).max(1));
-                let len = (block_len as u64 + used_blocks as u64) << SHIFT_LEN;
-                let rest = bits << 4 * avail_blocks - bit_len;
-                let id = USE_BITS | len | (self_id & MASK_BITS) | rest;
-                return WidgetId(NonZeroU64::new(id).unwrap());
-            } else {
-                path = Some(BitsIter::new(self_id).chain(once(index)).collect());
+                let req_bits = (8 * size_of::<usize>() as u8 - index.leading_zeros() as u8).max(1);
+                if req_bits <= 3 * avail_blocks {
+                    let (bits, bit_len) = encode(index);
+                    let used_blocks = bit_len / 4;
+                    debug_assert_eq!(used_blocks, (req_bits + 2) / 3);
+                    let len = (block_len as u64 + used_blocks as u64) << SHIFT_LEN;
+                    let rest = bits << 4 * avail_blocks - bit_len + 8;
+                    let id = (self_x & MASK_BITS) | rest | len | USE_BITS;
+                    WidgetId(IntOrPtr::new_int(id))
+                } else {
+                    WidgetId(IntOrPtr::new_iter(BitsIter::new(self_x).chain(once(index))))
+                }
+            }
+            Variant::Slice(path) => {
+                WidgetId(IntOrPtr::new_iter(path.iter().cloned().chain(once(index))))
             }
         }
-
-        let mut db = DB.lock().unwrap();
-
-        let path = path.unwrap_or_else(|| {
-            let i = usize::conv(self_id & MASK_PTR);
-            db[i].iter().cloned().chain(once(index)).collect()
-        });
-
-        let id = u64::conv(db.len());
-        // We can quite safely assume this:
-        debug_assert_eq!(id & USE_BITS, 0);
-        let id = id & MASK_PTR;
-
-        db.push(path);
-
-        WidgetId(NonZeroU64::new(id).unwrap())
     }
 
     /// Convert to a `u64`
@@ -248,7 +407,7 @@ impl WidgetId {
     /// -   it is guaranteed non-zero
     /// -   it may be passed to [`Self::opt_from_u64`]
     pub fn as_u64(&self) -> u64 {
-        self.0.get()
+        self.0.as_u64()
     }
 
     /// Convert `Option<WidgetId>` to `u64`
@@ -260,56 +419,54 @@ impl WidgetId {
     pub fn opt_to_u64(id: Option<&WidgetId>) -> u64 {
         match id {
             None => 0,
-            Some(id) => id.as_u64(),
+            Some(id) => id.0.as_u64(),
         }
     }
 
     /// Convert `u64` to `Option<WidgetId>`
     ///
+    /// **Safety:** this may only be called with the output of [`Self::as_u64`],
+    /// [`Self::opt_from_u64`], or `0`.
+    ///
     /// This always "succeeds", though the result may not identify any widget.
-    pub fn opt_from_u64(n: u64) -> Option<WidgetId> {
-        NonZeroU64::new(n).map(WidgetId)
+    pub unsafe fn opt_from_u64(n: u64) -> Option<WidgetId> {
+        IntOrPtr::opt_from_u64(n).map(WidgetId)
+    }
+
+    /// Construct an iterator, returning indices
+    ///
+    /// This represents the widget's "path" from the root (window).
+    pub fn iter_path(&self) -> impl Iterator<Item = usize> + '_ {
+        match self.0.get() {
+            Variant::Invalid => panic!("WidgetId::iter_path on invalid"),
+            Variant::Int(x) => PathIter::Bits(BitsIter::new(x)),
+            Variant::Slice(path) => PathIter::Slice(path.iter().cloned()),
+        }
     }
 }
 
 impl PartialEq for WidgetId {
     fn eq(&self, rhs: &Self) -> bool {
-        let lhs = self.0.get();
-        let rhs = rhs.0.get();
-
-        if lhs == !0 || rhs == !0 {
-            panic!("WidgetId::eq: invalid id");
+        match (self.0.get(), rhs.0.get()) {
+            (Variant::Invalid, _) | (_, Variant::Invalid) => panic!("WidgetId::eq: invalid id"),
+            (Variant::Int(x), Variant::Int(y)) => x == y,
+            _ => self.iter_path().eq(rhs.iter_path()),
         }
+    }
+}
+impl Eq for WidgetId {}
 
-        if lhs == rhs {
-            return true;
+impl Hash for WidgetId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self.0.get() {
+            Variant::Invalid => (),
+            Variant::Int(x) => {
+                x.hash(state);
+            }
+            Variant::Slice(path) => {
+                path.hash(state);
+            }
         }
-
-        let use_bits = (lhs & USE_BITS, rhs & USE_BITS);
-        if use_bits.0 != 0 && use_bits.1 != 0 {
-            return false;
-        }
-
-        let db = DB.lock().unwrap();
-
-        let (mut lbi, mut rbi);
-        let (mut lvi, mut rvi);
-        let lpath: &mut dyn Iterator<Item = usize> = if use_bits.0 != 0 {
-            lbi = BitsIter::new(lhs);
-            &mut lbi
-        } else {
-            lvi = db[usize::conv(lhs & MASK_PTR)].iter().cloned();
-            &mut lvi
-        };
-        let rpath: &mut dyn Iterator<Item = usize> = if use_bits.1 != 0 {
-            rbi = BitsIter::new(rhs);
-            &mut rbi
-        } else {
-            rvi = db[usize::conv(rhs & MASK_PTR)].iter().cloned();
-            &mut rvi
-        };
-
-        lpath.eq(rpath)
     }
 }
 
@@ -327,34 +484,17 @@ impl<'a> PartialEq<Option<&'a WidgetId>> for WidgetId {
     }
 }
 
-impl<'a> std::cmp::PartialEq<&'a WidgetId> for WidgetId {
+impl<'a> PartialEq<&'a WidgetId> for WidgetId {
     #[inline]
     fn eq(&self, rhs: &&WidgetId) -> bool {
         self == *rhs
     }
 }
 
-impl<'a> std::cmp::PartialEq<&'a Option<WidgetId>> for WidgetId {
+impl<'a> PartialEq<&'a Option<WidgetId>> for WidgetId {
     #[inline]
     fn eq(&self, rhs: &&Option<WidgetId>) -> bool {
         self == *rhs
-    }
-}
-
-impl Hash for WidgetId {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        let x = self.0.get();
-        if x & USE_BITS != 0 {
-            // Assuming the USE_BITS representation is used whenever possible
-            // (true outside of tests), we can simply hash the bit value.
-            // (Otherwise we must use BitsIter, handling INVALID and ROOT as special cases.)
-            x.hash(state);
-        } else {
-            let db = DB.lock().unwrap();
-            for index in db[usize::conv(x & MASK_PTR)].iter() {
-                index.hash(state);
-            }
-        }
     }
 }
 
@@ -373,32 +513,27 @@ impl fmt::Debug for WidgetId {
 
 impl fmt::Display for WidgetId {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let self_id = self.0.get();
-        if self_id == !0 {
-            write!(f, "#INVALID")
-        } else if self_id & USE_BITS != 0 {
-            let len = block_len(self_id);
-            if len == 0 {
-                write!(f, "#")
-            } else {
-                let bits = (self_id & MASK_BITS) >> (4 * (BLOCKS - len));
-                write!(f, "#{1:0>0$x}", len as usize, bits)
+        match self.0.get() {
+            Variant::Invalid => write!(f, "#INVALID"),
+            Variant::Int(x) => {
+                let len = block_len(x);
+                if len == 0 {
+                    write!(f, "#")
+                } else {
+                    let bits = x >> (4 * (BLOCKS - len) + 8);
+                    write!(f, "#{1:0>0$x}", len as usize, bits)
+                }
             }
-        } else {
-            write!(f, "#")?;
-            let db = DB.lock().unwrap();
-            let seq = &db[usize::conv(self_id & MASK_PTR)];
-            for index in seq {
-                let (bits, bit_len) = encode(*index);
-                write!(f, "{1:0>0$x}", bit_len as usize / 4, bits)?;
+            Variant::Slice(path) => {
+                write!(f, "#")?;
+                for index in path {
+                    let (bits, bit_len) = encode(*index);
+                    write!(f, "{1:0>0$x}", bit_len as usize / 4, bits)?;
+                }
+                Ok(())
             }
-            Ok(())
         }
     }
-}
-
-lazy_static::lazy_static! {
-    static ref DB: Mutex<Vec<Vec<usize>>> = Mutex::new(vec![vec![]]);
 }
 
 #[cfg(test)]
@@ -408,7 +543,8 @@ mod test {
     #[test]
     fn size_of_option_widget_id() {
         use std::mem::size_of;
-        assert_eq!(size_of::<WidgetId>(), size_of::<Option<WidgetId>>());
+        assert_eq!(size_of::<WidgetId>(), 8);
+        // TODO: assert_eq!(size_of::<WidgetId>(), size_of::<Option<WidgetId>>());
     }
 
     #[test]
@@ -425,15 +561,8 @@ mod test {
         assert_eq!(c1, c4);
         assert!(c1 != WidgetId::ROOT);
 
-        fn make_db(v: Vec<usize>) -> WidgetId {
-            let mut db = DB.lock().unwrap();
-            let id = u64::conv(db.len());
-            let id = id & MASK_PTR;
-            db.push(v);
-            WidgetId(NonZeroU64::new(id).unwrap())
-        }
-        let d1 = make_db(vec![0, 15]);
-        let d2 = make_db(vec![1, 15]);
+        let d1 = WidgetId(IntOrPtr::new_iter([0, 15].iter().cloned()));
+        let d2 = WidgetId(IntOrPtr::new_iter([1, 15].iter().cloned()));
         assert_eq!(c1, d1);
         assert_eq!(c2, d2);
         assert!(d1 != d2);
@@ -477,16 +606,16 @@ mod test {
             BitsIter::new(x).collect()
         }
         assert_eq!(as_vec(USE_BITS), Vec::<usize>::new());
-        assert_eq!(as_vec(0x81_31_0000_0000_0000), vec![3]);
-        assert_eq!(as_vec(0x87_1A_9300_7F00_0000), vec![1, 139, 0, 0, 7]);
+        assert_eq!(as_vec(0x3100_0000_0000_0011), vec![3]);
+        assert_eq!(as_vec(0x1A93_007F_0000_0071), vec![1, 139, 0, 0, 7]);
     }
 
     #[test]
     fn test_make_child() {
         fn test(seq: &[usize], x: u64) {
             let mut id = WidgetId::ROOT;
-            for x in seq {
-                id = id.make_child(*x);
+            for index in seq {
+                id = id.make_child(*index);
             }
             let v = id.as_u64();
             if v != x {
@@ -498,10 +627,10 @@ mod test {
         }
 
         test(&[], USE_BITS);
-        test(&[0, 0, 0], USE_BITS | (3 << 56));
-        test(&[0, 1, 0], USE_BITS | (3 << 56) | (1 << 48));
-        test(&[9, 0, 1, 300], 0x879101cd40000000);
-        test(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0], 0x8e12345679091920);
+        test(&[0, 0, 0], (3 << 4) | USE_BITS);
+        test(&[0, 1, 0], (3 << 4) | (1 << 56) | USE_BITS);
+        test(&[9, 0, 1, 300], 0x9101cd4000000071);
+        test(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0], 0x12345679091920e1);
     }
 
     #[test]
@@ -539,8 +668,8 @@ mod test {
             }
             println!("id2={} val={:x} from {:?}", id2, id2.as_u64(), seq2);
             let next = seq2.iter().next().cloned();
-            assert_eq!(id.index_of_child(&id2), next);
             assert_eq!(id.is_ancestor_of(&id2), next.is_some() || id == id2);
+            assert_eq!(id.index_of_child(&id2), next);
         }
 
         test(&[], &[]);
@@ -568,8 +697,8 @@ mod test {
                 id2 = id2.make_child(*x);
             }
             println!("id2={} val={:x} from {:?}", id2, id2.as_u64(), seq2);
-            assert_eq!(id.index_of_child(&id2), None);
             assert_eq!(id.is_ancestor_of(&id2), false);
+            assert_eq!(id.index_of_child(&id2), None);
         }
 
         test(&[0], &[]);

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -70,7 +70,7 @@ impl TextInput {
         use TextInputAction as Action;
         match event {
             Event::PressStart { source, coord, .. } if source.is_primary() => {
-                let grab = mgr.request_grab(w_id, source, coord, GrabMode::Grab, None);
+                let grab = mgr.request_grab(w_id.clone(), source, coord, GrabMode::Grab, None);
                 match source {
                     PressSource::Touch(touch_id) => {
                         if grab && self.touch_phase == TouchPhase::None {

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -136,12 +136,12 @@ impl<'a> Manager<'a> {
                     return Response::Used;
                 }
                 Event::PressMove { source, cur_id, .. } => {
-                    let cond = widget.eq_id(cur_id);
+                    let cond = widget.eq_id(&cur_id);
                     let target = if cond { cur_id } else { None };
                     mgr.set_grab_depress(source, target);
                     return Response::Used;
                 }
-                Event::PressEnd { end_id, .. } if widget.eq_id(end_id) => {
+                Event::PressEnd { end_id, .. } if widget.eq_id(&end_id) => {
                     event = Event::Activate;
                 }
                 _ => (),

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -521,7 +521,6 @@ pub struct ConfigureManager<'a: 'b, 'b> {
     count: &'b mut usize,
     used: bool,
     id: WidgetId,
-    map: &'b mut HashMap<WidgetId, WidgetId>,
     mgr: &'b mut Manager<'a>,
 }
 
@@ -538,7 +537,6 @@ impl<'a: 'b, 'b> ConfigureManager<'a, 'b> {
             count: &mut *self.count,
             used: false,
             id: self.id.make_child(index),
-            map: &mut *self.map,
             mgr: &mut *self.mgr,
         }
     }
@@ -547,17 +545,12 @@ impl<'a: 'b, 'b> ConfigureManager<'a, 'b> {
     ///
     /// Do not call more than once on each instance. Create a new instance with
     /// [`Self::child`].
-    ///
-    /// Pass the old ID (`self.id()`), even if not yet configured.
-    pub fn get_id(&mut self, old_id: WidgetId) -> WidgetId {
+    pub fn get_id(&mut self) -> WidgetId {
         assert!(
             !self.used,
             "multiple use of ConfigureManager::get_id without construction of child"
         );
         self.used = true;
-        if old_id.is_valid() {
-            self.map.insert(old_id, self.id.clone());
-        }
         self.id.clone()
     }
 

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -130,7 +130,9 @@ pub struct ManagerState {
     // or sorted Vec with binary search yielding a range
     handle_updates: HashMap<UpdateHandle, LinearSet<WidgetId>>,
     pending: SmallVec<[Pending; 8]>,
-    action: TkAction,
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
+    pub action: TkAction,
 }
 
 /// internals

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -249,7 +249,7 @@ impl<'a> Manager<'a> {
             trace!("Manager: hover = {:?}", w_id);
             if let Some(id) = self.state.hover {
                 if widget
-                    .find_widget(id)
+                    .find_widget(&id)
                     .map(|w| w.hover_highlight())
                     .unwrap_or(false)
                 {
@@ -260,7 +260,7 @@ impl<'a> Manager<'a> {
 
             if let Some(id) = w_id {
                 let mut icon = Default::default();
-                if let Some(w) = widget.find_widget(id) {
+                if let Some(w) = widget.find_widget(&id) {
                     if w.hover_highlight() {
                         self.redraw(id);
                     }
@@ -365,7 +365,11 @@ impl<'a> Manager<'a> {
         }
 
         if let Some(id) = target {
-            if widget.find_widget(id).map(|w| w.key_nav()).unwrap_or(false) {
+            if widget
+                .find_widget(&id)
+                .map(|w| w.key_nav())
+                .unwrap_or(false)
+            {
                 self.set_nav_focus(id, true);
             }
             self.add_key_depress(scancode, id);

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -5,7 +5,7 @@
 
 //! Event manager — public API
 
-use log::{debug, error, trace};
+use log::{debug, trace};
 use std::time::{Duration, Instant};
 use std::u16;
 
@@ -700,39 +700,11 @@ impl<'a> Manager<'a> {
             focus: Option<&WidgetId>,
             rev: bool,
         ) -> Option<WidgetId> {
-            let last = widget.num_children().wrapping_sub(1);
             if widget.is_disabled() {
                 return None;
-            } else if last == usize::MAX {
-                if !widget.eq_id(focus) && widget.key_nav() {
-                    return Some(widget.id());
-                }
-                return None;
             }
 
-            let mut child = None;
-            if let Some(id) = focus {
-                // Checking is_ancestor_of is just an optimisation
-                if widget.is_ancestor_of(&id) && !widget.eq_id(id) {
-                    // TODO(opt): add WidgetChildren::find_ancestor_of method to
-                    // allow optimisations for widgets with many children?
-                    for index in 0..=last {
-                        if widget
-                            .get_child(index)
-                            .map(|w| w.is_ancestor_of(&id))
-                            .unwrap_or(false)
-                        {
-                            child = Some(index);
-                            break;
-                        }
-                    }
-
-                    if child.is_none() {
-                        error!("unable to find widget {}", id);
-                        return None;
-                    }
-                }
-            }
+            let mut child = focus.and_then(|id| widget.find_child_index(id));
 
             if !rev {
                 if let Some(index) = child {

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -302,8 +302,8 @@ impl ManagerState {
         while let Some(id) = mgr.state.new_popups.pop() {
             while let Some((_, popup, _)) = mgr.state.popups.last() {
                 if widget
-                    .find_widget(popup.parent)
-                    .map(|w| w.is_ancestor_of(id))
+                    .find_widget(&popup.parent)
+                    .map(|w| w.is_ancestor_of(&id))
                     .unwrap_or(false)
                 {
                     break;
@@ -574,7 +574,7 @@ impl<'a> Manager<'a> {
                     // No mouse grab but have a hover target
                     if state == ElementState::Pressed {
                         if self.state.config.borrow().mouse_nav_focus() {
-                            if let Some(w) = widget.find_widget(start_id) {
+                            if let Some(w) = widget.find_widget(&start_id) {
                                 if w.key_nav() {
                                     self.set_nav_focus(w.id(), false);
                                 }
@@ -600,7 +600,7 @@ impl<'a> Manager<'a> {
                     TouchPhase::Started => {
                         if let Some(start_id) = widget.find_id(coord) {
                             if self.state.config.borrow().touch_nav_focus() {
-                                if let Some(w) = widget.find_widget(start_id) {
+                                if let Some(w) = widget.find_widget(&start_id) {
                                     if w.key_nav() {
                                         self.set_nav_focus(w.id(), false);
                                     }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -367,7 +367,7 @@ impl<'a> Manager<'a> {
                         let source = PressSource::Mouse(grab.button, grab.repetitions);
                         let event = Event::PressMove {
                             source,
-                            cur_id: cur_id.clone(),
+                            cur_id,
                             coord,
                             delta,
                         };

--- a/crates/kas-core/src/updatable.rs
+++ b/crates/kas-core/src/updatable.rs
@@ -40,11 +40,6 @@ pub trait Updatable: Debug {
     /// other users of the data of the update, and return that here.
     /// If the data is constant (not updatable) this may simply return `None`.
     fn update_handle(&self) -> Option<UpdateHandle>;
-
-    /// Update self from an update handle
-    fn update_self(&self) -> Option<UpdateHandle> {
-        None
-    }
 }
 
 /// Trait for data objects which can handle messages
@@ -99,9 +94,6 @@ macro_rules! impl_via_deref {
         impl<$t: Updatable + ?Sized> Updatable for $derived {
             fn update_handle(&self) -> Option<UpdateHandle> {
                 self.deref().update_handle()
-            }
-            fn update_self(&self) -> Option<UpdateHandle> {
-                self.deref().update_self()
             }
         }
         impl<K, M, $t: UpdatableHandler<K, M> + ?Sized> UpdatableHandler<K, M> for $derived {

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -417,7 +417,7 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
                 }
 
                 let self_id = self.id();
-                match self_id.index_of_child(id) {
+                match self_id.index_of_child(&id) {
                     #ev_to_num
                     _ if id == self_id => ::kas::event::Manager::handle_generic(self, mgr, event),
                     _ => {

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -350,14 +350,18 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
             let mut ev_to_num = TokenStream::new();
             for (i, child) in args.children.iter().enumerate() {
                 #[cfg(feature = "log")]
+                let id = quote! { id.clone() };
+                #[cfg(feature = "log")]
                 let log_msg = quote! {
-                    log::trace!(
+                    ::log::trace!(
                         "Received by {} from {}: {:?}",
                         self.id(),
                         id,
                         ::kas::util::TryFormat(&msg)
                     );
                 };
+                #[cfg(not(feature = "log"))]
+                let id = quote! { id };
                 #[cfg(not(feature = "log"))]
                 let log_msg = quote! {};
 
@@ -403,7 +407,7 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
 
                 ev_to_num.append_all(quote! {
                     Some(#i) => {
-                        let r = self.#ident.send(mgr, id, event);
+                        let r = self.#ident.send(mgr, #id, event);
                         #update
                         #handler
                     }

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -97,7 +97,7 @@ widget! {
                 let fontdb = fonts_db.db();
                 let font_family = fonts_db
                     .font_family_from_alias("SERIF")
-                    .unwrap_or_else(String::new);
+                    .unwrap_or_default();
                 let font_size = mgr.size_handle(|sh| sh.pixels_from_em(1.0)) as f64;
 
                 // TODO: some options here should be configurable

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -138,6 +138,12 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
                 self.mgr.with(&mut tkw, |mgr| {
                     mgr.handle_winit(widget, event);
                 });
+
+                if self.mgr.action.contains(TkAction::RECONFIGURE) {
+                    // Reconfigure must happen before further event handling
+                    self.reconfigure(shared);
+                    self.mgr.action.remove(TkAction::RECONFIGURE);
+                }
             }
         }
     }

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -54,10 +54,10 @@ widget! {
                 return Response::Unused;
             }
 
-            if self.eq_id(id) {
+            if self.eq_id(&id) {
                 self.handle(mgr, event)
             } else {
-                let r = self.inner.send(mgr, id, event);
+                let r = self.inner.send(mgr, id.clone(), event);
                 r.try_into().unwrap_or_else(|msg| {
                     log::trace!(
                         "Received by {} from {}: {:?}",

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -154,7 +154,7 @@ widget! {
             if self.is_disabled() {
                 return Response::Unused;
             }
-            if self.eq_id(id) {
+            if self.eq_id(&id) {
                 Manager::handle_generic(self, mgr, event)
             } else {
                 debug_assert!(self.inner.id().is_ancestor_of(&id));

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -157,7 +157,7 @@ widget! {
             if self.eq_id(id) {
                 Manager::handle_generic(self, mgr, event)
             } else {
-                debug_assert!(self.inner.id().is_ancestor_of(id));
+                debug_assert!(self.inner.id().is_ancestor_of(&id));
                 self.inner.send(mgr, id, event).void_into()
             }
         }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -110,14 +110,14 @@ widget! {
                     }
                     let cond = self.popup.inner.rect().contains(coord);
                     let target = if cond { cur_id } else { None };
-                    mgr.set_grab_depress(source, target);
+                    mgr.set_grab_depress(source, target.clone());
                     if let Some(id) = target {
                         mgr.set_nav_focus(id, false);
                     }
                     Response::Used
                 }
-                Event::PressEnd { end_id, .. } => {
-                    if let Some(id) = end_id {
+                Event::PressEnd { ref end_id, .. } => {
+                    if let Some(ref id) = end_id {
                         if self.eq_id(id) {
                             if self.opening {
                                 if self.popup_id.is_none() {
@@ -126,8 +126,8 @@ widget! {
                                 return Response::Used;
                             }
                         } else if self.popup_id.is_some() && self.popup.is_ancestor_of(&id) {
-                            let r = self.popup.send(mgr, id, Event::Activate);
-                            return self.map_response(mgr, id, event, r);
+                            let r = self.popup.send(mgr, id.clone(), Event::Activate);
+                            return self.map_response(mgr, id.clone(), event, r);
                         }
                     }
                     if let Some(id) = self.popup_id {
@@ -151,7 +151,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if self.eq_id(id) {
+            if self.eq_id(&id) {
                 Manager::handle_generic(self, mgr, event)
             } else {
                 debug_assert!(self.popup.id().is_ancestor_of(&id));
@@ -166,7 +166,7 @@ widget! {
                     return Response::Used;
                 }
 
-                let r = self.popup.send(mgr, id, event.clone());
+                let r = self.popup.send(mgr, id.clone(), event.clone());
                 self.map_response(mgr, id, event, r)
             }
         }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -85,7 +85,7 @@ widget! {
                     start_id,
                     coord,
                 } => {
-                    if self.is_ancestor_of(start_id) {
+                    if self.is_ancestor_of(&start_id) {
                         if source.is_primary() {
                             mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None);
                             mgr.set_grab_depress(source, Some(start_id));
@@ -125,7 +125,7 @@ widget! {
                                 }
                                 return Response::Used;
                             }
-                        } else if self.popup_id.is_some() && self.popup.is_ancestor_of(id) {
+                        } else if self.popup_id.is_some() && self.popup.is_ancestor_of(&id) {
                             let r = self.popup.send(mgr, id, Event::Activate);
                             return self.map_response(mgr, id, event, r);
                         }
@@ -154,7 +154,7 @@ widget! {
             if self.eq_id(id) {
                 Manager::handle_generic(self, mgr, event)
             } else {
-                debug_assert!(self.popup.id().is_ancestor_of(id));
+                debug_assert!(self.popup.id().is_ancestor_of(&id));
 
                 if let Event::NavFocus(key_focus) = event {
                     if self.popup_id.is_none() {
@@ -365,7 +365,7 @@ impl<M: 'static> ComboBox<M> {
                 if let Some(id) = self.popup_id {
                     mgr.close_window(id, true);
                 }
-                if let Some(index) = self.popup.inner.find_child_index(id) {
+                if let Some(index) = self.popup.inner.find_child_index(&id) {
                     if index != self.active {
                         *mgr |= self.set_active(index);
                         return if let Some(ref f) = self.on_select {

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -125,7 +125,7 @@ widget! {
                                 }
                                 return Response::Used;
                             }
-                        } else if self.popup_id.is_some() && self.popup.is_ancestor_of(&id) {
+                        } else if self.popup_id.is_some() && self.popup.is_ancestor_of(id) {
                             let r = self.popup.send(mgr, id.clone(), Event::Activate);
                             return self.map_response(mgr, id.clone(), event, r);
                         }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -252,7 +252,7 @@ impl<M: 'static> ComboBox<M> {
     /// Set the active choice
     #[inline]
     pub fn set_active(&mut self, index: usize) -> TkAction {
-        if self.active != index {
+        if self.active != index && index < self.popup.inner.len() {
             self.active = index;
             let string = if index < self.len() {
                 self.popup.inner[index].get_string()

--- a/crates/kas-widgets/src/editbox.rs
+++ b/crates/kas-widgets/src/editbox.rs
@@ -431,7 +431,7 @@ widget! {
                         state,
                     );
                 }
-                if mgr.has_char_focus(self.id()).0 {
+                if mgr.has_char_focus(self.id_ref()).0 {
                     draw.edit_marker(
                         self.rect().pos,
                         self.text.as_ref(),

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -85,7 +85,7 @@ widget! {
             if !self.is_disabled() {
                 if let Some(index) = self.id().index_of_child(&id) {
                     if let Some((_, child)) = self.widgets.get_mut(index) {
-                        let r = child.send(mgr, id, event);
+                        let r = child.send(mgr, id.clone(), event);
                         return match Response::try_from(r) {
                             Ok(r) => r,
                             Err(msg) => {

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -83,7 +83,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() {
-                if let Some(index) = self.id().index_of_child(id) {
+                if let Some(index) = self.id().index_of_child(&id) {
                     if let Some((_, child)) = self.widgets.get_mut(index) {
                         let r = child.send(mgr, id, event);
                         return match Response::try_from(r) {

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -97,7 +97,7 @@ pub use list::*;
 pub use menu::*;
 pub use nav_frame::NavFrame;
 pub use progress::ProgressBar;
-pub use radiobox::{RadioBox, RadioBoxBare};
+pub use radiobox::{RadioBox, RadioBoxBare, RadioBoxGroup};
 pub use scroll::{ScrollComponent, ScrollRegion};
 pub use scroll_label::ScrollLabel;
 pub use scrollbar::{ScrollBar, ScrollBarRegion, ScrollBars, Scrollable};

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -206,7 +206,7 @@ widget! {
             if !self.is_disabled() {
                 if let Some(index) = self.id().index_of_child(&id) {
                     if let Some(child) = self.widgets.get_mut(index) {
-                        let r = child.send(mgr, id, event);
+                        let r = child.send(mgr, id.clone(), event);
                         return match Response::try_from(r) {
                             Ok(r) => r,
                             Err(msg) => {

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -204,7 +204,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() {
-                if let Some(index) = self.id().index_of_child(id) {
+                if let Some(index) = self.id().index_of_child(&id) {
                     if let Some(child) = self.widgets.get_mut(index) {
                         let r = child.send(mgr, id, event);
                         return match Response::try_from(r) {

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -37,7 +37,7 @@ pub trait Menu: Widget {
     /// When opening menus and `set_focus` is true, the first navigable child
     /// of the newly opened menu will be given focus. This is used for keyboard
     /// navigation only.
-    fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<WidgetId>, set_focus: bool) {
+    fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<&WidgetId>, set_focus: bool) {
         let _ = (mgr, target, set_focus);
     }
 }
@@ -80,13 +80,13 @@ impl<M: 'static> WidgetChildren for Box<dyn Menu<Msg = M>> {
         self.as_mut().get_child_mut(index)
     }
 
-    fn find_child_index(&self, id: WidgetId) -> Option<usize> {
+    fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
         self.as_ref().find_child_index(id)
     }
-    fn find_widget(&self, id: WidgetId) -> Option<&dyn WidgetConfig> {
+    fn find_widget(&self, id: &WidgetId) -> Option<&dyn WidgetConfig> {
         self.as_ref().find_widget(id)
     }
-    fn find_widget_mut(&mut self, id: WidgetId) -> Option<&mut dyn WidgetConfig> {
+    fn find_widget_mut(&mut self, id: &WidgetId) -> Option<&mut dyn WidgetConfig> {
         self.as_mut().find_widget_mut(id)
     }
 }
@@ -149,7 +149,7 @@ impl<M: 'static> Menu for Box<dyn Menu<Msg = M>> {
     fn menu_is_open(&self) -> bool {
         self.deref().menu_is_open()
     }
-    fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<WidgetId>, set_focus: bool) {
+    fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<&WidgetId>, set_focus: bool) {
         self.deref_mut().set_menu_path(mgr, target, set_focus)
     }
 }

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -62,7 +62,7 @@ widget! {
             match event {
                 Event::TimerUpdate(0) => {
                     if let Some(id) = self.delayed_open {
-                        self.set_menu_path(mgr, Some(id), false);
+                        self.set_menu_path(mgr, Some(&id), false);
                     }
                     Response::Used
                 }
@@ -71,7 +71,7 @@ widget! {
                     start_id,
                     coord,
                 } => {
-                    if self.is_ancestor_of(start_id) {
+                    if self.is_ancestor_of(&start_id) {
                         if source.is_primary()
                             && mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None)
                         {
@@ -85,7 +85,7 @@ widget! {
                                     .any(|w| w.eq_id(start_id) && !w.menu_is_open())
                                 {
                                     self.opening = true;
-                                    self.set_menu_path(mgr, Some(start_id), false);
+                                    self.set_menu_path(mgr, Some(&start_id), false);
                                 } else {
                                     self.set_menu_path(mgr, None, false);
                                 }
@@ -108,11 +108,11 @@ widget! {
                 } => {
                     mgr.set_grab_depress(source, cur_id);
                     if let Some(id) = cur_id {
-                        if !self.eq_id(id) && self.is_ancestor_of(id) {
+                        if !self.eq_id(id) && self.is_ancestor_of(&id) {
                             // We instantly open a sub-menu on motion over the bar,
                             // but delay when over a sub-menu (most intuitive?)
                             if self.rect().contains(coord) {
-                                self.set_menu_path(mgr, Some(id), false);
+                                self.set_menu_path(mgr, Some(&id), false);
                             } else {
                                 mgr.set_nav_focus(id, false);
                                 self.delayed_open = Some(id);
@@ -124,7 +124,7 @@ widget! {
                     Response::Used
                 }
                 Event::PressEnd { coord, end_id, .. } => {
-                    if end_id.map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
+                    if end_id.map(|id| self.is_ancestor_of(&id)).unwrap_or(false) {
                         // end_id is a child of self
                         let id = end_id.unwrap();
 
@@ -164,7 +164,7 @@ widget! {
                                     j = j.rem_euclid(self.bar.len().cast());
                                     self.bar[i].set_menu_path(mgr, None, true);
                                     let w = &mut self.bar[usize::conv(j)];
-                                    w.set_menu_path(mgr, Some(w.id()), true);
+                                    w.set_menu_path(mgr, Some(&w.id()), true);
                                     break;
                                 }
                             }
@@ -208,7 +208,7 @@ widget! {
     }
 
     impl Menu for Self {
-        fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<WidgetId>, set_focus: bool) {
+        fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<&WidgetId>, set_focus: bool) {
             self.delayed_open = None;
             if let Some(id) = target {
                 let mut child = None;

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -61,7 +61,7 @@ widget! {
         fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
             match event {
                 Event::TimerUpdate(0) => {
-                    if let Some(id) = self.delayed_open {
+                    if let Some(id) = self.delayed_open.clone() {
                         self.set_menu_path(mgr, Some(&id), false);
                     }
                     Response::Used
@@ -75,14 +75,14 @@ widget! {
                         if source.is_primary()
                             && mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None)
                         {
-                            mgr.set_grab_depress(source, Some(start_id));
+                            mgr.set_grab_depress(source, Some(start_id.clone()));
                             self.opening = false;
                             let delay = mgr.config().menu_delay();
                             if self.rect().contains(coord) {
                                 if self
                                     .bar
                                     .iter()
-                                    .any(|w| w.eq_id(start_id) && !w.menu_is_open())
+                                    .any(|w| w.eq_id(&start_id) && !w.menu_is_open())
                                 {
                                     self.opening = true;
                                     self.set_menu_path(mgr, Some(&start_id), false);
@@ -106,15 +106,15 @@ widget! {
                     coord,
                     ..
                 } => {
-                    mgr.set_grab_depress(source, cur_id);
+                    mgr.set_grab_depress(source, cur_id.clone());
                     if let Some(id) = cur_id {
-                        if !self.eq_id(id) && self.is_ancestor_of(&id) {
+                        if !self.eq_id(&id) && self.is_ancestor_of(&id) {
                             // We instantly open a sub-menu on motion over the bar,
                             // but delay when over a sub-menu (most intuitive?)
                             if self.rect().contains(coord) {
                                 self.set_menu_path(mgr, Some(&id), false);
                             } else {
-                                mgr.set_nav_focus(id, false);
+                                mgr.set_nav_focus(id.clone(), false);
                                 self.delayed_open = Some(id);
                                 let delay = mgr.config().menu_delay();
                                 mgr.update_on_timer(delay, self.id(), 0);
@@ -124,7 +124,7 @@ widget! {
                     Response::Used
                 }
                 Event::PressEnd { coord, end_id, .. } => {
-                    if end_id.map(|id| self.is_ancestor_of(&id)).unwrap_or(false) {
+                    if end_id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
                         // end_id is a child of self
                         let id = end_id.unwrap();
 
@@ -133,7 +133,7 @@ widget! {
                             if !self.opening {
                                 self.delayed_open = None;
                                 for i in 0..self.bar.len() {
-                                    if self.bar[i].eq_id(id) {
+                                    if self.bar[i].eq_id(&id) {
                                         self.bar[i].set_menu_path(mgr, None, false);
                                     }
                                 }
@@ -188,10 +188,10 @@ widget! {
                 return Response::Unused;
             }
 
-            if self.eq_id(id) {
+            if self.eq_id(&id) {
                 self.handle(mgr, event)
             } else {
-                match self.bar.send(mgr, id, event.clone()) {
+                match self.bar.send(mgr, id.clone(), event.clone()) {
                     Response::Unused => self.handle(mgr, event),
                     r => r.try_into().unwrap_or_else(|(_, msg)| {
                         log::trace!(

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -205,7 +205,7 @@ widget! {
                     Response::Pan(delta) => Response::Pan(delta),
                     Response::Focus(rect) => Response::Focus(rect),
                     Response::Select => {
-                        self.set_menu_path(mgr, Some(id), true);
+                        self.set_menu_path(mgr, Some(&id), true);
                         Response::Used
                     }
                     r @ (Response::Update | Response::Msg(_)) => {
@@ -222,14 +222,14 @@ widget! {
             self.popup_id.is_some()
         }
 
-        fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<WidgetId>, set_focus: bool) {
+        fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<&WidgetId>, set_focus: bool) {
             match target {
-                Some(id) if self.is_ancestor_of(id) => {
+                Some(id) if self.is_ancestor_of(&id) => {
                     if self.popup_id.is_some() {
                         // We should close other sub-menus before opening
                         let mut child = None;
                         for i in 0..self.list.len() {
-                            if self.list[i].is_ancestor_of(id) {
+                            if self.list[i].is_ancestor_of(&id) {
                                 child = Some(i);
                             } else {
                                 self.list[i].set_menu_path(mgr, None, set_focus);

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -224,12 +224,12 @@ widget! {
 
         fn set_menu_path(&mut self, mgr: &mut Manager, target: Option<&WidgetId>, set_focus: bool) {
             match target {
-                Some(id) if self.is_ancestor_of(&id) => {
+                Some(id) if self.is_ancestor_of(id) => {
                     if self.popup_id.is_some() {
                         // We should close other sub-menus before opening
                         let mut child = None;
                         for i in 0..self.list.len() {
-                            if self.list[i].is_ancestor_of(&id) {
+                            if self.list[i].is_ancestor_of(id) {
                                 child = Some(i);
                             } else {
                                 self.list[i].set_menu_path(mgr, None, set_focus);

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -189,10 +189,10 @@ widget! {
                 return Response::Unused;
             }
 
-            if self.eq_id(id) {
+            if self.eq_id(&id) {
                 Manager::handle_generic(self, mgr, event)
             } else {
-                let r = self.list.send(mgr, id, event.clone());
+                let r = self.list.send(mgr, id.clone(), event.clone());
 
                 match r {
                     Response::Unused => match event {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -121,7 +121,7 @@ widget! {
 
     impl WidgetConfig for Self {
         fn configure_recurse(&mut self, mut cmgr: ConfigureManager) {
-            self.core_data_mut().id = cmgr.get_id(self.id());
+            self.core_data_mut().id = cmgr.get_id();
             cmgr.mgr().push_accel_layer(true);
             self.list.configure_recurse(cmgr.child(0));
             let mgr = cmgr.mgr();

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -163,11 +163,11 @@ impl ScrollComponent {
     /// If the returned [`TkAction`] is not `None`, the scroll offset has been
     /// updated and the second return value is `Response::Used`.
     #[inline]
-    pub fn scroll_by_event<PS: FnMut(PressSource, WidgetId, Coord)>(
+    pub fn scroll_by_event<PS: FnOnce(PressSource, WidgetId, Coord)>(
         &mut self,
         event: Event,
         window_size: Size,
-        mut on_press_start: PS,
+        on_press_start: PS,
     ) -> (TkAction, Response<VoidMsg>) {
         let mut action = TkAction::empty();
         let mut response = Response::Used;

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -367,7 +367,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if self.inner.id().is_ancestor_of(id) {
+            if self.inner.id().is_ancestor_of(&id) {
                 let child_event = self.scroll.offset_event(event.clone());
                 match self.inner.send(mgr, id, child_event) {
                     Response::Unused => (),

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -252,7 +252,7 @@ widget! {
                 return Response::Unused;
             }
 
-            let offset = if self.eq_id(id) {
+            let offset = if self.eq_id(&id) {
                 match event {
                     Event::PressStart { source, coord, .. } => {
                         self.handle.handle_press_on_track(mgr, source, coord)

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -260,7 +260,7 @@ widget! {
                     _ => return Response::Unused,
                 }
             } else {
-                debug_assert!(self.handle.id().is_ancestor_of(id));
+                debug_assert!(self.handle.id().is_ancestor_of(&id));
                 match self.handle.send(mgr, id, event).try_into() {
                     Ok(res) => return res,
                     Err(offset) => offset,
@@ -650,7 +650,7 @@ widget! {
                 return Response::Unused;
             }
 
-            match self.id().index_of_child(id) {
+            match self.id().index_of_child(&id) {
                 Some(0) => self.horiz_bar
                     .send(mgr, id, event)
                     .try_into()

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -270,7 +270,7 @@ widget! {
                 return Response::Unused;
             }
 
-            let offset = if self.handle.id().is_ancestor_of(id) {
+            let offset = if self.handle.id().is_ancestor_of(&id) {
                 match event {
                     Event::NavFocus(key_focus) => {
                         mgr.set_nav_focus(self.id(), key_focus);

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -217,7 +217,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() && !self.widgets.is_empty() {
-                if let Some(index) = self.id().index_of_child(id) {
+                if let Some(index) = self.id().index_of_child(&id) {
                     if (index & 1) == 0 {
                         if let Some(w) = self.widgets.get_mut(index >> 1) {
                             return w.send(mgr, id, event);

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -89,7 +89,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() {
-                if let Some(index) = self.id().index_of_child(id) {
+                if let Some(index) = self.id().index_of_child(&id) {
                     if let Some(child) = self.widgets.get_mut(index) {
                         return match child.send(mgr, id, event) {
                             Response::Focus(rect) => {

--- a/crates/kas-widgets/src/view/driver.rs
+++ b/crates/kas-widgets/src/view/driver.rs
@@ -9,7 +9,8 @@
 //! allowing referal to e.g. `driver::Default`.
 
 use crate::{
-    CheckBoxBare, EditBox, EditField, EditGuard, Label, NavFrame, ProgressBar, SliderType,
+    CheckBoxBare, EditBox, EditField, EditGuard, Label, NavFrame, ProgressBar, RadioBoxGroup,
+    SliderType,
 };
 use kas::prelude::*;
 use std::fmt::Debug;
@@ -246,19 +247,19 @@ impl Driver<bool> for CheckBox {
 /// [`crate::RadioBoxBare`] view widget constructor
 #[derive(Clone, Debug, Default)]
 pub struct RadioBoxBare {
-    handle: UpdateHandle,
+    group: RadioBoxGroup,
 }
 impl RadioBoxBare {
-    /// Construct, with given `handle`
-    pub fn new(handle: UpdateHandle) -> Self {
-        RadioBoxBare { handle }
+    /// Construct, with given `group`
+    pub fn new(group: RadioBoxGroup) -> Self {
+        RadioBoxBare { group }
     }
 }
 impl Driver<bool> for RadioBoxBare {
     type Msg = bool;
     type Widget = crate::RadioBoxBare<bool>;
     fn new(&self) -> Self::Widget {
-        crate::RadioBoxBare::new(self.handle).on_select(|_| Some(true))
+        crate::RadioBoxBare::new(self.group.clone()).on_select(|_| Some(true))
     }
     fn set(&self, widget: &mut Self::Widget, data: bool) -> TkAction {
         widget.set_bool(data)
@@ -272,20 +273,20 @@ impl Driver<bool> for RadioBoxBare {
 #[derive(Clone, Debug, Default)]
 pub struct RadioBox {
     label: AccelString,
-    handle: UpdateHandle,
+    group: RadioBoxGroup,
 }
 impl RadioBox {
-    /// Construct, with given `label` and `handle`
-    pub fn new<T: Into<AccelString>>(label: T, handle: UpdateHandle) -> Self {
+    /// Construct, with given `label` and `group`
+    pub fn new<T: Into<AccelString>>(label: T, group: RadioBoxGroup) -> Self {
         let label = label.into();
-        RadioBox { label, handle }
+        RadioBox { label, group }
     }
 }
 impl Driver<bool> for RadioBox {
     type Msg = bool;
     type Widget = crate::RadioBox<bool>;
     fn new(&self) -> Self::Widget {
-        crate::RadioBox::new(self.label.clone(), self.handle).on_select(|_| Some(true))
+        crate::RadioBox::new(self.label.clone(), self.group.clone()).on_select(|_| Some(true))
     }
     fn set(&self, widget: &mut Self::Widget, data: bool) -> TkAction {
         widget.set_bool(data)

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -77,10 +77,6 @@ impl<T: ListData, F: Filter<T::Item>> Updatable for FilteredList<T, F> {
     fn update_handle(&self) -> Option<UpdateHandle> {
         self.filter.update_handle()
     }
-
-    fn update_self(&self) -> Option<UpdateHandle> {
-        self.refresh()
-    }
 }
 impl<K, M, T: ListData + UpdatableHandler<K, M> + 'static, F: Filter<T::Item>>
     UpdatableHandler<K, M> for FilteredList<T, F>

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -548,7 +548,6 @@ widget! {
         type Msg = ChildMsg<T::Key, <V::Widget as Handler>::Msg>;
 
         fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
-            let self_id = self.id();
             match event {
                 Event::HandleUpdate { .. } => {
                     // TODO(opt): use the update payload to indicate which widgets need updating?
@@ -563,7 +562,7 @@ widget! {
                     }
                     match self.press_phase {
                         PressPhase::Pan => {
-                            mgr.update_grab_cursor(self_id, CursorIcon::Grabbing);
+                            mgr.update_grab_cursor(self.id(), CursorIcon::Grabbing);
                             // fall through to scroll handler
                         }
                         _ => return Response::Used,
@@ -639,6 +638,7 @@ widget! {
                 _ => (), // fall through to scroll handler
             }
 
+            let self_id = self.id();
             let (action, response) =
                 self.scroll
                     .scroll_by_event(event, self.core.rect.size, |source, _, coord| {

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -661,7 +661,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if let Some(index) = self.id().index_of_child(id) {
+            if let Some(index) = self.id().index_of_child(&id) {
                 let child_event = self.scroll.offset_event(event.clone());
                 let response;
                 if let Some(child) = self.widgets.get_mut(index) {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -649,7 +649,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if let Some(index) = self.id().index_of_child(id) {
+            if let Some(index) = self.id().index_of_child(&id) {
                 let child_event = self.scroll.offset_event(event.clone());
                 let response;
                 if let Some(child) = self.widgets.get_mut(index) {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -519,7 +519,6 @@ widget! {
         type Msg = ChildMsg<T::Key, <V::Widget as Handler>::Msg>;
 
         fn handle(&mut self, mgr: &mut Manager, event: Event) -> Response<Self::Msg> {
-            let self_id = self.id();
             match event {
                 Event::HandleUpdate { .. } => {
                     self.update_view(mgr);
@@ -533,7 +532,7 @@ widget! {
                     }
                     match self.press_phase {
                         PressPhase::Pan => {
-                            mgr.update_grab_cursor(self_id, CursorIcon::Grabbing);
+                            mgr.update_grab_cursor(self.id(), CursorIcon::Grabbing);
                             // fall through to scroll handler
                         }
                         _ => return Response::Used,
@@ -625,6 +624,7 @@ widget! {
                 _ => (), // fall through to scroll handler
             }
 
+            let self_id = self.id();
             let (action, response) = self.scroll
                 .scroll_by_event(event, self.core.rect.size, |source, _, coord| {
                     if source.is_primary() && mgr.config_enable_mouse_pan() {

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -131,10 +131,10 @@ widget! {
                 return Response::Unused;
             }
 
-            if self.eq_id(id) {
+            if self.eq_id(&id) {
                 self.handle(mgr, event)
             } else {
-                let r = self.child.send(mgr, id, event);
+                let r = self.child.send(mgr, id.clone(), event);
                 if matches!(&r, Response::Update | Response::Msg(_)) {
                     if let Some(value) = self.view.get(&self.child) {
                         if let Some(handle) = self.data.update(value) {

--- a/crates/kas-widgets/src/window.rs
+++ b/crates/kas-widgets/src/window.rs
@@ -41,7 +41,7 @@ widget! {
                 return None;
             }
             for popup in self.popups.iter_mut().rev() {
-                if let Some(id) = self.w.find_widget_mut(popup.1.id).and_then(|w| w.find_id(coord)) {
+                if let Some(id) = self.w.find_widget_mut(&popup.1.id).and_then(|w| w.find_id(coord)) {
                     return Some(id);
                 }
             }
@@ -53,7 +53,7 @@ widget! {
             let disabled = disabled || self.is_disabled();
             self.w.draw(draw, mgr, disabled);
             for (_, popup) in &self.popups {
-                if let Some(widget) = self.w.find_widget_mut(popup.id) {
+                if let Some(widget) = self.w.find_widget_mut(&popup.id) {
                     draw.with_overlay(widget.rect(), &mut |draw| {
                         widget.draw(draw, mgr, disabled);
                     });
@@ -201,7 +201,7 @@ impl<W: Widget> Window<W> {
 // This is like WidgetChildren::find, but returns a translated Rect.
 fn find_rect(widget: &dyn WidgetConfig, id: WidgetId) -> Option<Rect> {
     let wid = widget.id();
-    match wid.index_of_child(id) {
+    match wid.index_of_child(&id) {
         Some(i) => {
             if let Some(w) = widget.get_child(i) {
                 find_rect(w, id).map(|rect| rect - widget.translation())
@@ -222,7 +222,7 @@ impl<W: Widget> Window<W> {
         let popup = &mut self.popups[index].1;
 
         let c = find_rect(self.w.as_widget(), popup.parent).unwrap();
-        let widget = self.w.find_widget_mut(popup.id).unwrap();
+        let widget = self.w.find_widget_mut(&popup.id).unwrap();
         let mut cache = mgr.size_handle(|sh| layout::SolveCache::find_constraints(widget, sh));
         let ideal = cache.ideal(false);
         let m = cache.margins();

--- a/crates/kas-widgets/src/window.rs
+++ b/crates/kas-widgets/src/window.rs
@@ -64,7 +64,7 @@ widget! {
 
     impl SendEvent for Self where W::Msg: Into<VoidMsg> {
         fn send(&mut self, mgr: &mut Manager, id: WidgetId, event: Event) -> Response<Self::Msg> {
-            if self.is_disabled() || self.eq_id(id) {
+            if self.is_disabled() || self.eq_id(&id) {
                 Response::Unused
             } else {
                 self.w.send(mgr, id, event).into()
@@ -221,7 +221,7 @@ impl<W: Widget> Window<W> {
         let r = self.core.rect;
         let popup = &mut self.popups[index].1;
 
-        let c = find_rect(self.w.as_widget(), popup.parent).unwrap();
+        let c = find_rect(self.w.as_widget(), popup.parent.clone()).unwrap();
         let widget = self.w.find_widget_mut(&popup.id).unwrap();
         let mut cache = mgr.size_handle(|sh| layout::SolveCache::find_constraints(widget, sh));
         let ideal = cache.ideal(false);

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -170,7 +170,7 @@ widget! {
 
 #[derive(Debug)]
 struct MyDriver {
-    radio_group: UpdateHandle,
+    radio_group: RadioBoxGroup,
 }
 impl Driver<(usize, bool, String)> for MyDriver {
     type Msg = EntryMsg;
@@ -181,7 +181,7 @@ impl Driver<(usize, bool, String)> for MyDriver {
         ListEntry {
             core: Default::default(),
             label: Label::new(String::default()),
-            radio: RadioBox::new("display this entry", self.radio_group)
+            radio: RadioBox::new("display this entry", self.radio_group.clone())
                 .on_select(move |_| Some(EntryMsg::Select)),
             entry: EditBox::new(String::default()).with_guard(ListEntryGuard),
         }
@@ -234,7 +234,7 @@ fn main() -> Result<(), kas::shell::Error> {
     };
 
     let driver = MyDriver {
-        radio_group: UpdateHandle::new(),
+        radio_group: Default::default(),
     };
     let data = MyData::new(3);
     type MyList = ListView<Direction, MyData, MyDriver>;

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -21,7 +21,7 @@ use kas::prelude::*;
 use kas::widgets::*;
 
 thread_local! {
-    pub static RADIO: UpdateHandle = UpdateHandle::new();
+    pub static RADIO: RadioBoxGroup = Default::default();
 }
 
 #[derive(Clone, Debug, VoidMsg)]
@@ -88,7 +88,7 @@ impl ListEntry {
         ListEntry {
             core: Default::default(),
             label: Label::new(format!("Entry number {}", n + 1)),
-            radio: RadioBox::new("display this entry", RADIO.with(|h| *h))
+            radio: RadioBox::new("display this entry", RADIO.with(|g| g.clone()))
                 .with_state(active)
                 .on_select(move |_| Some(EntryMsg::Select)),
             entry: EditBox::new(format!("Entry #{}", n + 1)).with_guard(ListEntryGuard),

--- a/examples/filter-list.rs
+++ b/examples/filter-list.rs
@@ -10,7 +10,7 @@ use kas::event::ChildMsg;
 use kas::prelude::*;
 use kas::updatable::filter::ContainsCaseInsensitive;
 use kas::widgets::view::{driver, FilterListView, SelectionMode, SingleView};
-use kas::widgets::{EditBox, Label, RadioBox, ScrollBars, Window};
+use kas::widgets::{EditBox, Label, RadioBox, RadioBoxGroup, ScrollBars, Window};
 
 const MONTHS: &[&str] = &[
     "January",
@@ -30,7 +30,7 @@ const MONTHS: &[&str] = &[
 fn main() -> Result<(), kas::shell::Error> {
     env_logger::init();
 
-    let r = UpdateHandle::new();
+    let r = RadioBoxGroup::default();
     let selection_mode = make_widget! {
         #[widget{
             layout = list(right): *;
@@ -38,8 +38,8 @@ fn main() -> Result<(), kas::shell::Error> {
         #[handler(msg = SelectionMode)]
         struct {
             #[widget] _ = Label::new("Selection:"),
-            #[widget] _ = RadioBox::new_msg("none", r, SelectionMode::None).with_state(true),
-            #[widget] _ = RadioBox::new_msg("single", r, SelectionMode::Single),
+            #[widget] _ = RadioBox::new_msg("none", r.clone(), SelectionMode::None).with_state(true),
+            #[widget] _ = RadioBox::new_msg("single", r.clone(), SelectionMode::Single),
             #[widget] _ = RadioBox::new_msg("multiple", r, SelectionMode::Multiple),
         }
     };

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -215,7 +215,7 @@ fn main() -> Result<(), kas::shell::Error> {
 Пример текста на нескольких языках.
 טקסט לדוגמא במספר שפות.";
 
-    let radio = UpdateHandle::new();
+    let radio = RadioBoxGroup::default();
     let widgets = make_widget! {
         // TODO: this would be better expressed with a column layout, though we
         // want better alignment controls first (which are also needed for menus).
@@ -258,7 +258,7 @@ fn main() -> Result<(), kas::shell::Error> {
                 .with_state(true)
                 .on_toggle(|_, check| Some(Item::Check(check))),
             #[widget] rbl = Label::new("RadioBox"),
-            #[widget] rb = RadioBox::new("radio box &1", radio)
+            #[widget] rb = RadioBox::new("radio box &1", radio.clone())
                 .on_select(|_| Some(Item::Radio(1))),
             #[widget] rb2l = Label::new("RadioBox"),
             #[widget] rb2 = RadioBox::new("radio box &2", radio)


### PR DESCRIPTION
Part 2 following #264.

There was a significant question here: what format widget identifiers should take and what properties are required. This was already considered in #264, but to complete part 2 the [design document](https://gist.github.com/dhardy/b08d80815533f9b59d1ca8384fa7a691) was revised. Notable excerpts follow.

We must choose whether event handling happens via **(selective) broadcast** or **targeted search**. Previously targeted search was chosen for performance scaling, but in retrospect this was a poor goal. Detailed review found a couple of subtle issues:

- With a broadcast approach, it is less trivial to test whether an event was unused because its target didn't handle the event or because no target was found. The difference is important for "event stealing", e.g. being able to click-and-drag on a label to scroll.
- Adapting `SendEvent::send` to use selective-broadcast increases complexity slightly, but isn't a big deal.
- If targeted events are sent via broadcast, this could easily be adapted to send actual broadcast events — though currently we don't need this, and perceived uses such as animations should be restricted to *visible* widgets, so this is probably not useful. Shared-data updates could perhaps use this instead of "update handles", but these probably should also be restricted to visible widgets (no need to update an invisible radio-box — until it becomes visible).
- To make <kbd>Tab</kbd> navigation work correctly from a *hidden* item in a view list (which represents only visible items), we need to know the full path of the current navigation target (since the view list cannot iterate over all invisible items looking for a matching hash). This implies either `WidgetId` should *always* represent the full path, or we need a separate "identifier" system for Tab-navigation.
- Using a "path over indices" makes the identifier robust over most modifications, excluding insertion/deletion of children in a list from positions other than the end. To get around this, we can allow `ListView` and similar widgets to not use sequential identifiers and recommend that the plain `List` not be used for insertion/deletion from the middle, though this is not ideal.

With this in mind, three options for `WidgetId` are apparent:

1. Represent the path, allocating when necessary, but never freeing (memory leaks)
2. Represent the path, allocating when necessary, and using a reference count (thus `WidgetId` is not `Copy`)
3. Represent a hash, optionally with partial path information, and use selective-broadcast for event sending

It is possible that new `WidgetId`s would be generated frequently (e.g. scrolling a large `ListView`), thus option (1) is not a good idea. While having `WidgetId: Copy` is (very) nice, clones remain cheap with option (2), and implementation turned out to be less intrusive than feared.

Note: due to reference counting, `WidgetId` is now `!Send` and `!Sync`. This could be fixed with atomic reference counting, but seems unnecessary: the UI is usually restricted to a single thread (other threads can still wake subscribed widgets via update handles).

# Unsolved from #264 :

- "`PartialEq for WidgetId` panics on invalid id": this revealed a subtle bug where input event handling could happen before newly-created widgets are configured. While this had no serious side-effects, it is unintended and could perhaps cause annoying-to-debug issues. Thus, panic on invalid id remains.
- "Paths are never deallocated": fixed
- "Using `WidgetId::opt_from_u64` with a bad value could cause a panic": this method is now marked `unsafe` (since it could now cause a seg-fault). It could be removed entirely (no remaining usage), but is left for now.