### PR TITLE
Theme animations + misc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,10 +59,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [stable]
+        toolchain: [beta] # TODO: stable
         include:
           - os: ubuntu-latest
-            toolchain: "1.56.0"
+            toolchain: "1.59.0"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Getting started
 
 ### Dependencies
 
-KAS requires a recent [Rust] compiler. Currently, version 1.56 or greater is
+KAS requires a recent [Rust] compiler. Currently, version 1.59 or greater is
 required. Using the **nightly** channel does have a few advantages:
 
 -   Proceedural macros emit better diagnostics. In some cases, diagnostics are

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -91,8 +91,8 @@ impl<M: 'static> Layout for Box<dyn Widget<Msg = M>> {
         self.as_mut().find_id(coord)
     }
 
-    fn draw(&mut self, draw: DrawMgr, disabled: bool) {
-        self.as_mut().draw(draw, disabled);
+    fn draw(&mut self, draw: DrawMgr) {
+        self.as_mut().draw(draw);
     }
 }
 

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -75,6 +75,15 @@ pub trait WidgetCore: Any + fmt::Debug {
         &self.core_data().id
     }
 
+    /// Get the `u64` version of the widget identifier
+    ///
+    /// This may be used to approximately test identity (see notes on
+    /// [`WidgetId::as_u64`]).
+    #[inline]
+    fn id_u64(&self) -> u64 {
+        self.core_data().id.as_u64()
+    }
+
     /// Get whether the widget is disabled
     #[inline]
     fn is_disabled(&self) -> bool {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -484,9 +484,9 @@ pub trait Layout: WidgetChildren {
     /// [`crate::theme::InputState`] to determine active visual effects.
     ///
     /// The default impl draws elements as defined by [`Self::layout`].
-    fn draw(&mut self, draw: DrawMgr, disabled: bool) {
-        let state = draw.input_state(self, disabled);
-        self.layout().draw(draw, state);
+    fn draw(&mut self, mut draw: DrawMgr) {
+        let draw = draw.with_core(self.core_data());
+        self.layout().draw(draw);
     }
 }
 

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -8,13 +8,13 @@
 use std::any::Any;
 use std::fmt;
 
-#[allow(unused)]
-use crate::event::EventState;
 use crate::event::{self, ConfigureManager, EventMgr};
 use crate::geom::{Coord, Offset, Rect};
 use crate::layout::{self, AlignHints, AxisInfo, SetRectMgr, SizeRules};
 use crate::theme::{DrawMgr, SizeMgr};
 use crate::util::IdentifyWidget;
+#[allow(unused)]
+use crate::{event::EventState, theme::DrawCtx};
 use crate::{CoreData, TkAction, WidgetId};
 
 impl dyn WidgetCore {
@@ -395,7 +395,7 @@ pub trait Layout: WidgetChildren {
     ///
     /// Affects event handling via [`Self::find_id`] and affects the positioning
     /// of pop-up menus. [`Self::draw`] must be implemented directly using
-    /// [`crate::theme::DrawMgr::with_clip_region`] to offset contents.
+    /// [`DrawCtx::with_clip_region`] to offset contents.
     #[inline]
     fn translation(&self) -> Offset {
         Offset::ZERO
@@ -476,12 +476,8 @@ pub trait Layout: WidgetChildren {
     /// This method is invoked each frame to draw visible widgets. It should
     /// draw itself and recurse into all visible children.
     ///
-    /// The `disabled` argument is passed in from the *parent*; a widget should
-    /// use `let disabled = disabled || self.is_disabled();` to determine its
-    /// own disabled state, then pass this value on to children.
-    ///
-    /// [`DrawMgr::input_state`] may be used to obtain an
-    /// [`crate::theme::InputState`] to determine active visual effects.
+    /// One should use `let draw = draw.with_core(self.core_data());` to obtain
+    /// a [`DrawCtx`], enabling further drawing.
     ///
     /// The default impl draws elements as defined by [`Self::layout`].
     fn draw(&mut self, mut draw: DrawMgr) {

--- a/crates/kas-core/src/draw/mod.rs
+++ b/crates/kas-core/src/draw/mod.rs
@@ -51,6 +51,33 @@ pub use draw::{Draw, DrawIface, DrawImpl};
 pub use draw_rounded::{DrawRounded, DrawRoundedImpl};
 pub use draw_shared::{DrawShared, DrawSharedImpl, SharedState};
 pub use images::{ImageError, ImageFormat, ImageId};
+use std::time::Instant;
+
+/// Animation status
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+#[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AnimationState {
+    /// No frames are queued
+    None,
+    /// Animation in progress: draw at the next frame time
+    Animate,
+    /// Timed-animation in progress: draw at the given time
+    Timed(Instant),
+}
+
+impl AnimationState {
+    /// Merge two states (take earliest)
+    pub fn merge_in(&mut self, rhs: AnimationState) {
+        use AnimationState::*;
+        *self = match (*self, rhs) {
+            (Animate, _) | (_, Animate) => Animate,
+            (Timed(t1), Timed(t2)) => Timed(t1.min(t2)),
+            (Timed(t), _) | (_, Timed(t)) => Timed(t),
+            (None, None) => None,
+        }
+    }
+}
 
 /// Draw pass identifier
 ///

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -256,7 +256,7 @@ impl ScrollComponent {
     /// If the returned [`TkAction`] is not `None`, the scroll offset has been
     /// updated and the second return value is `Response::Used`.
     #[inline]
-    pub fn scroll_by_event<PS: FnOnce(&mut EventMgr, PressSource, WidgetId, Coord)>(
+    pub fn scroll_by_event<PS: FnOnce(&mut EventMgr, PressSource, Option<WidgetId>, Coord)>(
         &mut self,
         mgr: &mut EventMgr,
         event: Event,

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -6,7 +6,7 @@
 //! Event handling components
 
 use super::ScrollDelta::{LineDelta, PixelDelta};
-use super::{Command, Event, EventMgr, GrabMode, PressSource, Response, VoidMsg};
+use super::{Command, Event, EventMgr, PressSource, Response, VoidMsg};
 use crate::cast::CastFloat;
 use crate::geom::{Coord, Offset, Rect, Size, Vec2};
 #[allow(unused)]
@@ -243,7 +243,7 @@ impl ScrollComponent {
     ///         window_size,
     ///         |mgr, source, _, coord| if source.is_primary() {
     ///             let icon = Some(event::CursorIcon::Grabbing);
-    ///             mgr.request_grab(id, source, coord, event::GrabMode::Grab, icon);
+    ///             mgr.grab_press_unique(id, source, coord, icon);
     ///         }
     ///     );
     ///     *mgr |= action;
@@ -410,7 +410,7 @@ impl TextInput {
         use TextInputAction as Action;
         match event {
             Event::PressStart { source, coord, .. } if source.is_primary() => {
-                let grab = mgr.request_grab(w_id.clone(), source, coord, GrabMode::Grab, None);
+                mgr.grab_press_unique(w_id.clone(), source, coord, None);
                 match source {
                     PressSource::Touch(touch_id) => {
                         self.touch_phase = TouchPhase::Start(touch_id, coord);

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -114,7 +114,7 @@ pub enum Event {
     /// A mouse button was pressed or touch event started
     PressStart {
         source: PressSource,
-        start_id: WidgetId,
+        start_id: Option<WidgetId>,
         coord: Coord,
     },
     /// Movement of mouse or a touch press

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -112,6 +112,17 @@ pub enum Event {
         delta: DVec2,
     },
     /// A mouse button was pressed or touch event started
+    ///
+    /// This event is sent in exactly two cases, in this order:
+    ///
+    /// 1.  When a pop-up layer is active ([`EventMgr::add_popup`]), the owner
+    ///     of the top-most layer will receive this event. If the event is not
+    ///     used, then the pop-up will be closed and the event sent again.
+    /// 2.  If a widget is found under the mouse when pressed or where a touch
+    ///     event starts, this event is sent to the widget.
+    ///
+    /// If `start_id` is `None`, then no widget was found at the coordinate and
+    /// the event will only be delivered to pop-up layer owners.
     PressStart {
         source: PressSource,
         start_id: Option<WidgetId>,
@@ -119,7 +130,16 @@ pub enum Event {
     },
     /// Movement of mouse or a touch press
     ///
-    /// Received only given a [press grab](EventMgr::request_grab).
+    /// This event is sent in exactly two cases, in this order:
+    ///
+    /// 1.  Given a grab ([`EventMgr::request_grab`]), motion events for the
+    ///     grabbed mouse pointer or touched finger will be sent.
+    /// 2.  When a pop-up layer is active ([`EventMgr::add_popup`]), the owner
+    ///     of the top-most layer will receive this event. If the event is not
+    ///     used, then the pop-up will be closed and the event sent again.
+    ///
+    /// If `cur_id` is `None`, no widget was found at the coordinate (either
+    /// outside the window or [`crate::Layout::find_id`] failed).
     PressMove {
         source: PressSource,
         cur_id: Option<WidgetId>,
@@ -128,10 +148,13 @@ pub enum Event {
     },
     /// End of a click/touch press
     ///
-    /// Received only given a [press grab](EventMgr::request_grab).
+    /// This event is sent in exactly one case:
     ///
-    /// When `end_id == None`, this is a "cancelled press": the end of the press
-    /// is outside the application window.
+    /// 1.  Given a grab ([`EventMgr::request_grab`]), release/cancel events
+    ///     for the same mouse button or touched finger will be sent.
+    ///
+    /// If `cur_id` is `None`, no widget was found at the coordinate (either
+    /// outside the window or [`crate::Layout::find_id`] failed).
     PressEnd {
         source: PressSource,
         end_id: Option<WidgetId>,

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -132,7 +132,7 @@ pub enum Event {
     ///
     /// This event is sent in exactly two cases, in this order:
     ///
-    /// 1.  Given a grab ([`EventMgr::request_grab`]), motion events for the
+    /// 1.  Given a grab ([`EventMgr::grab_press`]), motion events for the
     ///     grabbed mouse pointer or touched finger will be sent.
     /// 2.  When a pop-up layer is active ([`EventMgr::add_popup`]), the owner
     ///     of the top-most layer will receive this event. If the event is not
@@ -157,7 +157,7 @@ pub enum Event {
     ///
     /// This event is sent in exactly one case:
     ///
-    /// 1.  Given a grab ([`EventMgr::request_grab`]), release/cancel events
+    /// 1.  Given a grab ([`EventMgr::grab_press`]), release/cancel events
     ///     for the same mouse button or touched finger will be sent.
     ///
     /// If `cur_id` is `None`, no widget was found at the coordinate (either

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -148,6 +148,13 @@ pub enum Event {
     },
     /// End of a click/touch press
     ///
+    /// If `success`, this is a button-release or touch finish; otherwise this
+    /// is a cancelled/interrupted grab. "Activation events" (e.g. clicking of a
+    /// button or menu item) should only happen on `success`. "Movement events"
+    /// such as panning, moving a slider or opening a menu should not be undone
+    /// when cancelling: the panned item or slider should be released as is, or
+    /// the menu should remain open.
+    ///
     /// This event is sent in exactly one case:
     ///
     /// 1.  Given a grab ([`EventMgr::request_grab`]), release/cancel events
@@ -159,6 +166,7 @@ pub enum Event {
         source: PressSource,
         end_id: Option<WidgetId>,
         coord: Coord,
+        success: bool,
     },
     /// Update from a timer
     ///

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -141,9 +141,12 @@ impl<'a> EventMgr<'a> {
                     mgr.set_grab_depress(source, target);
                     return Response::Used;
                 }
-                Event::PressEnd { end_id, .. } if widget.eq_id(&end_id) => {
+                Event::PressEnd {
+                    end_id, success, ..
+                } if success && widget.eq_id(&end_id) => {
                     event = Event::Activate;
                 }
+                Event::PressEnd { .. } => return Response::Used,
                 _ => (),
             };
         }

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -132,7 +132,7 @@ impl<'a> EventMgr<'a> {
             // Translate press events
             match event {
                 Event::PressStart { source, coord, .. } if source.is_primary() => {
-                    mgr.request_grab(widget.id(), source, coord, GrabMode::Grab, None);
+                    mgr.grab_press(widget.id(), source, coord, GrabMode::Grab, None);
                     return Response::Used;
                 }
                 Event::PressMove { source, cur_id, .. } => {

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -451,24 +451,6 @@ impl<'a> EventMgr<'a> {
         self.state.mouse_grab.as_mut()
     }
 
-    fn end_mouse_grab(&mut self, button: MouseButton) {
-        if self
-            .state
-            .mouse_grab
-            .as_ref()
-            .map(|grab| grab.button != button)
-            .unwrap_or(true)
-        {
-            return;
-        }
-        if let Some(grab) = self.state.mouse_grab.take() {
-            trace!("EventMgr: end mouse grab by {}", grab.start_id);
-            self.shell.set_cursor_icon(self.state.hover_icon);
-            self.redraw(grab.start_id);
-            self.state.remove_pan_grab(grab.pan_grab);
-        }
-    }
-
     #[inline]
     fn get_touch(&mut self, touch_id: u64) -> Option<&mut TouchGrab> {
         for grab in self.state.touch_grab.iter_mut() {

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -529,7 +529,10 @@ impl<'a> EventMgr<'a> {
         !matches!(r, Response::Unused)
     }
 
-    fn send_popup_first<W: Widget + ?Sized>(&mut self, widget: &mut W, id: WidgetId, event: Event) {
+    fn send_popup_first<W>(&mut self, widget: &mut W, id: Option<WidgetId>, event: Event)
+    where
+        W: Widget + ?Sized,
+    {
         while let Some((wid, parent)) = self
             .state
             .popups
@@ -543,7 +546,9 @@ impl<'a> EventMgr<'a> {
             }
             self.close_window(wid, false);
         }
-        self.send_event(widget, id, event);
+        if let Some(id) = id {
+            self.send_event(widget, id, event);
+        }
     }
 }
 

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -28,10 +28,10 @@ use crate::{ShellWindow, TkAction, Widget, WidgetId, WindowId};
 mod mgr_pub;
 mod mgr_shell;
 
-/// Controls the types of events delivered by [`EventMgr::request_grab`]
+/// Controls the types of events delivered by [`EventMgr::grab_press`]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GrabMode {
-    /// Deliver [`Event::PressMove`] and [`Event::PressEnd`] for each press
+    /// Deliver [`Event::PressMove`] and [`Event::PressEnd`] for each grabbed press
     Grab,
     /// Deliver [`Event::Pan`] events, with scaling and rotation
     PanFull,

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -587,7 +587,7 @@ impl<'a> EventMgr<'a> {
         let mut pan_grab = (u16::MAX, 0);
         match source {
             PressSource::Mouse(button, repetitions) => {
-                if self.state.mouse_grab.take().is_some() {
+                if self.remove_mouse_grab().is_some() {
                     #[cfg(debug_assertions)]
                     log::error!("grab_press: existing mouse grab!");
                 }
@@ -648,7 +648,7 @@ impl<'a> EventMgr<'a> {
         cursor: Option<CursorIcon>,
     ) {
         if id == self.state.mouse_grab.as_ref().map(|grab| &grab.start_id) {
-            self.state.mouse_grab = None;
+            self.remove_mouse_grab();
         }
         self.state.touch_grab.retain(|grab| id != grab.start_id);
 

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -546,9 +546,12 @@ impl<'a> EventMgr<'a> {
     /// Request a grab on the given input `source`
     ///
     /// On success, this method returns true and corresponding mouse/touch
-    /// events will be forwarded to widget `id`. The grab terminates
-    /// automatically when the press is released.
-    /// Returns false when the grab-request fails.
+    /// events will be forwarded to widget `id`. This excludes events from a
+    /// different mouse button or a different finger.
+    /// The grab terminates automatically when the press is released.
+    ///
+    /// Returns false when the grab-request fails (this should never be the
+    /// case, but we reserve the option to change this in a future version).
     ///
     /// Each grab can optionally visually depress one widget, and initially
     /// depresses the widget owning the grab (the `id` passed here). Call
@@ -589,6 +592,8 @@ impl<'a> EventMgr<'a> {
         match source {
             PressSource::Mouse(button, repetitions) => {
                 if self.state.mouse_grab.is_some() {
+                    #[cfg(debug_assertions)]
+                    log::warn!("request_grab failed: existing mouse grab!");
                     return false;
                 }
                 if mode != GrabMode::Grab {
@@ -612,6 +617,8 @@ impl<'a> EventMgr<'a> {
             }
             PressSource::Touch(touch_id) => {
                 if self.get_touch(touch_id).is_some() {
+                    #[cfg(debug_assertions)]
+                    log::warn!("request_grab failed: existing touch grab!");
                     return false;
                 }
                 if mode != GrabMode::Grab {

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -543,26 +543,29 @@ impl<'a> EventMgr<'a> {
         true
     }
 
-    /// Request a grab on the given input `source`
+    /// Grab "press" events for `source` (a mouse or finger)
     ///
-    /// On success, this method returns true and corresponding mouse/touch
-    /// events will be forwarded to widget `id`. This excludes events from a
-    /// different mouse button or a different finger.
-    /// The grab terminates automatically when the press is released.
+    /// When a "press" source is "grabbed", events for this source will be sent
+    /// to the grabbing widget. Notes:
     ///
-    /// Returns false when the grab-request fails (this should never be the
-    /// case, but we reserve the option to change this in a future version).
+    /// -   For mouse sources, a click-press event from another button will
+    ///     cancel this grab; [`Event::PressEnd`] will be sent (with mode
+    ///     [`GrabMode::Grab`]), then [`Event::PressStart`] will be sent to the
+    ///     widget under the mouse like normal.
+    /// -   For touch-screen sources, events are delivered until the finger is
+    ///     removed or the touch is cancelled (e.g. by dragging off-screen).
+    /// -   [`Self::grab_press_unique`] is a variant of this method which
+    ///     cancels grabs of other sources by the same widget.
     ///
     /// Each grab can optionally visually depress one widget, and initially
     /// depresses the widget owning the grab (the `id` passed here). Call
     /// [`EventMgr::set_grab_depress`] to update the grab's depress target.
     /// This is cleared automatically when the grab ends.
     ///
-    /// Behaviour depends on the `mode`:
+    /// The events sent depends on the `mode`:
     ///
     /// -   [`GrabMode::Grab`]: simple / low-level interpretation of input
     ///     which delivers [`Event::PressMove`] and [`Event::PressEnd`] events.
-    ///     Multiple event sources may be grabbed simultaneously.
     /// -   All other [`GrabMode`] values: generates [`Event::Pan`] events.
     ///     Requesting additional grabs on the same widget from the same source
     ///     (i.e. multiple touches) allows generation of rotation and scale
@@ -572,29 +575,21 @@ impl<'a> EventMgr<'a> {
     /// Since these events are *requested*, the widget should consume them even
     /// if not required, although in practice this
     /// only affects parents intercepting [`Response::Unused`] events.
-    ///
-    /// This method normally succeeds, but fails when
-    /// multiple widgets attempt a grab the same press source simultaneously
-    /// (only the first grab is successful).
-    ///
-    /// This method automatically cancels any active character grab
-    /// on other widgets and updates keyboard navigation focus.
-    pub fn request_grab(
+    pub fn grab_press(
         &mut self,
         id: WidgetId,
         source: PressSource,
         coord: Coord,
         mode: GrabMode,
         cursor: Option<CursorIcon>,
-    ) -> bool {
+    ) {
         let start_id = id.clone();
         let mut pan_grab = (u16::MAX, 0);
         match source {
             PressSource::Mouse(button, repetitions) => {
-                if self.state.mouse_grab.is_some() {
+                if self.state.mouse_grab.take().is_some() {
                     #[cfg(debug_assertions)]
-                    log::warn!("request_grab failed: existing mouse grab!");
-                    return false;
+                    log::error!("grab_press: existing mouse grab!");
                 }
                 if mode != GrabMode::Grab {
                     pan_grab = self.state.set_pan_on(id.clone(), mode, false, coord);
@@ -616,10 +611,9 @@ impl<'a> EventMgr<'a> {
                 }
             }
             PressSource::Touch(touch_id) => {
-                if self.get_touch(touch_id).is_some() {
+                if self.remove_touch(touch_id).is_some() {
                     #[cfg(debug_assertions)]
-                    log::warn!("request_grab failed: existing touch grab!");
-                    return false;
+                    log::error!("grab_press: existing touch grab!");
                 }
                 if mode != GrabMode::Grab {
                     pan_grab = self.state.set_pan_on(id.clone(), mode, true, coord);
@@ -639,13 +633,32 @@ impl<'a> EventMgr<'a> {
         }
 
         self.redraw(start_id);
-        true
+    }
+
+    /// A variant of [`Self::grab_press`], where a unique grab is desired
+    ///
+    /// This removes any existing press-grabs by widget `id`, then calls
+    /// [`Self::grab_press`] with `mode = GrabMode::Grab` to create a new grab.
+    /// Previous grabs are discarded without delivering [`Event::PressEnd`].
+    pub fn grab_press_unique(
+        &mut self,
+        id: WidgetId,
+        source: PressSource,
+        coord: Coord,
+        cursor: Option<CursorIcon>,
+    ) {
+        if id == self.state.mouse_grab.as_ref().map(|grab| &grab.start_id) {
+            self.state.mouse_grab = None;
+        }
+        self.state.touch_grab.retain(|grab| id != grab.start_id);
+
+        self.grab_press(id, source, coord, GrabMode::Grab, cursor);
     }
 
     /// Update the mouse cursor used during a grab
     ///
     /// This only succeeds if widget `id` has an active mouse-grab (see
-    /// [`EventMgr::request_grab`]). The cursor will be reset when the mouse-grab
+    /// [`EventMgr::grab_press`]). The cursor will be reset when the mouse-grab
     /// ends.
     pub fn update_grab_cursor(&mut self, id: WidgetId, icon: CursorIcon) {
         if let Some(ref grab) = self.state.mouse_grab {
@@ -658,7 +671,7 @@ impl<'a> EventMgr<'a> {
     /// Set a grab's depress target
     ///
     /// When a grab on mouse or touch input is in effect
-    /// ([`EventMgr::request_grab`]), the widget owning the grab may set itself
+    /// ([`EventMgr::grab_press`]), the widget owning the grab may set itself
     /// or any other widget as *depressed* ("pushed down"). Each grab depresses
     /// at most one widget, thus setting a new depress target clears any
     /// existing target. Initially a grab depresses its owner.

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -45,12 +45,8 @@ impl EventState {
     /// Note that `char_focus` implies `sel_focus`.
     #[inline]
     pub fn has_char_focus(&self, w_id: &WidgetId) -> (bool, bool) {
-        if let Some(id) = self.sel_focus.as_ref() {
-            if id == w_id {
-                return (self.char_focus, true);
-            }
-        }
-        (false, false)
+        let sel_focus = *w_id == self.sel_focus;
+        (sel_focus && self.char_focus, sel_focus)
     }
 
     /// Get whether this widget has keyboard navigation focus

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -444,7 +444,7 @@ impl<'a> EventMgr<'a> {
                             coord,
                             success: state == ElementState::Released,
                         };
-                        self.send_event(widget, grab.start_id.clone(), event);
+                        self.send_event(widget, grab.start_id, event);
                     }
                     // Pan events do not receive Start/End notifications
                 }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -457,9 +457,9 @@ impl<'a> EventMgr<'a> {
 
                     // We ignore other mouse buttons during a grab (this may be
                     // revised in the future).
-                } else if let Some(start_id) = self.state.hover.clone() {
-                    // No mouse grab but have a hover target
-                    if state == ElementState::Pressed {
+                } else if state == ElementState::Pressed {
+                    if let Some(start_id) = self.state.hover.clone() {
+                        // No mouse grab but have a hover target
                         if self.state.config.mouse_nav_focus() {
                             if let Some(w) = widget.find_widget(&start_id) {
                                 if w.key_nav() {
@@ -467,15 +467,15 @@ impl<'a> EventMgr<'a> {
                                 }
                             }
                         }
-
-                        let source = PressSource::Mouse(button, self.state.last_click_repetitions);
-                        let event = Event::PressStart {
-                            source,
-                            start_id: start_id.clone(),
-                            coord,
-                        };
-                        self.send_popup_first(widget, start_id, event);
                     }
+
+                    let source = PressSource::Mouse(button, self.state.last_click_repetitions);
+                    let event = Event::PressStart {
+                        source,
+                        start_id: self.state.hover.clone(),
+                        coord,
+                    };
+                    self.send_popup_first(widget, self.state.hover.clone(), event);
                 }
             }
             // TouchpadPressure { pressure: f32, stage: i64, },
@@ -485,22 +485,23 @@ impl<'a> EventMgr<'a> {
                 let coord = touch.location.into();
                 match touch.phase {
                     TouchPhase::Started => {
-                        if let Some(start_id) = widget.find_id(coord) {
+                        let start_id = widget.find_id(coord);
+                        if let Some(id) = start_id.as_ref() {
                             if self.state.config.touch_nav_focus() {
-                                if let Some(w) = widget.find_widget(&start_id) {
+                                if let Some(w) = widget.find_widget(id) {
                                     if w.key_nav() {
                                         self.set_nav_focus(w.id(), false);
                                     }
                                 }
                             }
-
-                            let event = Event::PressStart {
-                                source,
-                                start_id: start_id.clone(),
-                                coord,
-                            };
-                            self.send_popup_first(widget, start_id, event);
                         }
+
+                        let event = Event::PressStart {
+                            source,
+                            start_id: start_id.clone(),
+                            coord,
+                        };
+                        self.send_popup_first(widget, start_id, event);
                     }
                     TouchPhase::Moved => {
                         let cur_id = widget.find_id(coord);

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -38,7 +38,7 @@
 //! events, which may occur with any number of mouse buttons pressed.
 //!
 //! Motion and release events are only delivered when a "press grab" is active.
-//! This is achieved by calling [`EventMgr::request_grab`] and allows receiving
+//! This is achieved by calling [`EventMgr::grab_press`] and allows receiving
 //! both relative and absolute press coordinates.
 //! A special "pan" grab allows receiving two-finger scroll/scale/rotate input.
 //!

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -142,7 +142,7 @@ macro_rules! impl_common {
 ///
 /// A coordinate (or point) is an absolute position. One cannot add a point to
 /// a point. The difference between two points is an [`Offset`].
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Coord(pub i32, pub i32);
 
@@ -278,7 +278,7 @@ impl<X: Pixel> From<Coord> for PhysicalPosition<X> {
 /// (similar to overflow checks on integers).
 ///
 /// This may be converted to [`Offset`] with `from` / `into`.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Size(pub i32, pub i32);
 
@@ -479,7 +479,7 @@ impl From<Size> for winit::dpi::Size {
 /// negative. It can be multiplied by a scalar.
 ///
 /// This may be converted to [`Size`] with `from` / `into`.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Offset(pub i32, pub i32);
 
@@ -583,7 +583,7 @@ impl From<Offset> for kas_text::Vec2 {
 ///
 /// The region is defined by a point `pos` and an extent `size`, allowing easy
 /// translations. It is empty unless `size` is positive on both axes.
-#[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rect {
     pub pos: Coord,

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -25,6 +25,10 @@ use crate::{TkAction, WidgetCore};
 /// Most methods draw some feature. Corresponding size properties may be
 /// obtained through a [`SizeMgr`], e.g. through [`Self::size_mgr`].
 ///
+/// Draw methods take a `wid: u64` parameter. This is used to identify the
+/// widget being drawn, allowing themes to animate transitions. Pass the value
+/// of [`WidgetCore::id_u64`] or [`crate::WidgetId::as_u64`].
+///
 /// Other notable methods:
 ///
 /// -   [`Self::with_clip_region`] constructs a new pass with clipping
@@ -232,8 +236,15 @@ impl<'a> DrawMgr<'a> {
     ///
     /// [`SizeMgr::text_bound`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
-    pub fn text_cursor(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
-        self.0.text_cursor(pos, text, class, byte);
+    pub fn text_cursor(
+        &mut self,
+        wid: u64,
+        pos: Coord,
+        text: &TextDisplay,
+        class: TextClass,
+        byte: usize,
+    ) {
+        self.0.text_cursor(wid, pos, text, class, byte);
     }
 
     /// Draw the background of a menu entry
@@ -410,7 +421,14 @@ pub trait DrawHandle {
     ///
     /// [`SizeMgr::text_bound`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
-    fn text_cursor(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize);
+    fn text_cursor(
+        &mut self,
+        wid: u64,
+        pos: Coord,
+        text: &TextDisplay,
+        class: TextClass,
+        byte: usize,
+    );
 
     /// Draw the background of a menu entry
     fn menu_entry(&mut self, rect: Rect, state: InputState);
@@ -530,8 +548,8 @@ macro_rules! impl_ {
                 self.deref_mut()
                     .text_selected_range(pos, text, range, class, state);
             }
-            fn text_cursor(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
-                self.deref_mut().text_cursor(pos, text, class, byte)
+            fn text_cursor(&mut self, wid: u64, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
+                self.deref_mut().text_cursor(wid, pos, text, class, byte)
             }
             fn menu_entry(&mut self, rect: Rect, state: InputState) {
                 self.deref_mut().menu_entry(rect, state)

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -669,10 +669,10 @@ mod test {
         // But we don't need to: we just want to test that methods are callable.
 
         let _scale = draw.size_mgr().scale_factor();
+        let mut draw = draw.with_core(&Default::default());
 
         let text = crate::text::Text::new_single("sample");
         let class = TextClass::Label;
-        let state = InputState::empty();
-        draw.text_selected(Coord::ZERO, &text, .., class, state)
+        draw.text_selected(Coord::ZERO, &text, .., class)
     }
 }

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -232,8 +232,8 @@ impl<'a> DrawMgr<'a> {
     ///
     /// [`SizeMgr::text_bound`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
-    pub fn edit_marker(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
-        self.0.edit_marker(pos, text, class, byte);
+    pub fn text_cursor(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
+        self.0.text_cursor(pos, text, class, byte);
     }
 
     /// Draw the background of a menu entry
@@ -410,7 +410,7 @@ pub trait DrawHandle {
     ///
     /// [`SizeMgr::text_bound`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
-    fn edit_marker(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize);
+    fn text_cursor(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize);
 
     /// Draw the background of a menu entry
     fn menu_entry(&mut self, rect: Rect, state: InputState);
@@ -530,8 +530,8 @@ macro_rules! impl_ {
                 self.deref_mut()
                     .text_selected_range(pos, text, range, class, state);
             }
-            fn edit_marker(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
-                self.deref_mut().edit_marker(pos, text, class, byte)
+            fn text_cursor(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
+                self.deref_mut().text_cursor(pos, text, class, byte)
             }
             fn menu_entry(&mut self, rect: Rect, state: InputState) {
                 self.deref_mut().menu_entry(rect, state)

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -22,7 +22,7 @@ use crate::{CoreData, TkAction};
 /// This interface is provided to widgets in [`crate::Layout::draw`].
 /// Lower-level interfaces may be accessed through [`Self::draw_device`].
 ///
-/// Use [`DrawMgr::with_ctx`] to access draw methods.
+/// Use [`DrawMgr::with_core`] to access draw methods.
 pub struct DrawMgr<'a> {
     h: &'a mut dyn DrawHandle,
     ev: &'a mut EventState,
@@ -184,7 +184,7 @@ impl<'a> DrawCtx<'a> {
     ///
     /// The theme is permitted to enlarge the `rect` for the purpose of drawing
     /// a frame or shadow around this overlay, thus the
-    /// [`DrawMgr::get_clip_rect`] may be larger than expected.
+    /// [`DrawCtx::get_clip_rect`] may be larger than expected.
     pub fn with_overlay<F: FnMut(DrawCtx)>(&mut self, rect: Rect, mut f: F) {
         let ev = &mut *self.ev;
         let wid = self.wid;
@@ -198,8 +198,8 @@ impl<'a> DrawCtx<'a> {
     /// Target area for drawing
     ///
     /// Drawing is restricted to this [`Rect`], which may be the whole window, a
-    /// [clip region](DrawMgr::with_clip_region) or an
-    /// [overlay](DrawMgr::with_overlay). This may be used to cull hidden
+    /// [clip region](DrawCtx::with_clip_region) or an
+    /// [overlay](DrawCtx::with_overlay). This may be used to cull hidden
     /// items from lists inside a scrollable view.
     pub fn get_clip_rect(&self) -> Rect {
         self.h.get_clip_rect()
@@ -244,7 +244,7 @@ impl<'a> DrawCtx<'a> {
 
     /// Draw text with effects
     ///
-    /// [`DrawMgr::text`] already supports *font* effects: bold,
+    /// [`DrawCtx::text`] already supports *font* effects: bold,
     /// emphasis, text size. In addition, this method supports underline and
     /// strikethrough effects.
     ///
@@ -273,7 +273,7 @@ impl<'a> DrawCtx<'a> {
     /// Draw some text using the standard font, with a subset selected
     ///
     /// Other than visually highlighting the selection, this method behaves
-    /// identically to [`DrawMgr::text`]. It is likely to be replaced in the
+    /// identically to [`DrawCtx::text`]. It is likely to be replaced in the
     /// future by a higher-level API.
     pub fn text_selected<T: AsRef<TextDisplay>, R: RangeBounds<usize>>(
         &mut self,
@@ -382,6 +382,13 @@ impl<'a> DrawCtx<'a> {
 }
 
 impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
+    #[inline]
+    fn bitor_assign(&mut self, action: TkAction) {
+        self.ev.send_action(action);
+    }
+}
+
+impl<'a> std::ops::BitOrAssign<TkAction> for DrawCtx<'a> {
     #[inline]
     fn bitor_assign(&mut self, action: TkAction) {
         self.ev.send_action(action);

--- a/crates/kas-core/src/theme/mod.rs
+++ b/crates/kas-core/src/theme/mod.rs
@@ -8,7 +8,7 @@
 mod draw;
 mod size;
 
-pub use draw::{DrawHandle, DrawMgr};
+pub use draw::{DrawCtx, DrawHandle, DrawMgr};
 pub use size::{SizeHandle, SizeMgr};
 
 #[allow(unused)]

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -7,9 +7,9 @@
 
 use std::ops::Deref;
 
-#[allow(unused)]
-use super::DrawMgr;
 use super::TextClass;
+#[allow(unused)]
+use super::{DrawCtx, DrawMgr};
 use crate::geom::Size;
 use crate::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use crate::text::TextApi;
@@ -20,11 +20,11 @@ use crate::text::TextApiExt;
 /// Size and scale interface
 ///
 /// This interface is provided to widgets in [`crate::Layout::size_rules`].
-/// It may also be accessed through [`crate::event::EventMgr::size_mgr`] and
-/// [`DrawMgr::size_mgr`].
+/// It may also be accessed through [`crate::event::EventMgr::size_mgr`],
+/// [`DrawMgr::size_mgr`] and [`DrawCtx::size_mgr`].
 ///
 /// Most methods get or calculate the size of some feature. These same features
-/// may be drawn through [`DrawMgr`].
+/// may be drawn through [`DrawCtx`].
 pub struct SizeMgr<'a>(&'a dyn SizeHandle);
 
 impl<'a> SizeMgr<'a> {
@@ -180,12 +180,12 @@ impl<'a> SizeMgr<'a> {
         self.0.edit_surround(is_vert)
     }
 
-    /// Size of the element drawn by [`DrawMgr::checkbox`].
+    /// Size of the element drawn by [`DrawCtx::checkbox`].
     pub fn checkbox(&self) -> Size {
         self.0.checkbox()
     }
 
-    /// Size of the element drawn by [`DrawMgr::radiobox`].
+    /// Size of the element drawn by [`DrawCtx::radiobox`].
     pub fn radiobox(&self) -> Size {
         self.0.radiobox()
     }
@@ -305,10 +305,10 @@ pub trait SizeHandle {
     /// may be. The margin included here should be large enough!
     fn edit_surround(&self, vert: bool) -> FrameRules;
 
-    /// Size of the element drawn by [`DrawMgr::checkbox`].
+    /// Size of the element drawn by [`DrawCtx::checkbox`].
     fn checkbox(&self) -> Size;
 
-    /// Size of the element drawn by [`DrawMgr::radiobox`].
+    /// Size of the element drawn by [`DrawCtx::radiobox`].
     fn radiobox(&self) -> Size;
 
     /// Dimensions for a scrollbar

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -163,8 +163,8 @@ impl<'a> SizeMgr<'a> {
     }
 
     /// Width of an edit marker
-    pub fn edit_marker_width(&self) -> f32 {
-        self.0.edit_marker_width()
+    pub fn text_cursor_width(&self) -> f32 {
+        self.0.text_cursor_width()
     }
 
     /// Size of the sides of a button.
@@ -294,7 +294,7 @@ pub trait SizeHandle {
     fn text_bound(&self, text: &mut dyn TextApi, class: TextClass, axis: AxisInfo) -> SizeRules;
 
     /// Width of an edit marker
-    fn edit_marker_width(&self) -> f32;
+    fn text_cursor_width(&self) -> f32;
 
     /// Size of the sides of a button.
     fn button_surround(&self, vert: bool) -> FrameRules;
@@ -385,8 +385,8 @@ macro_rules! impl_ {
             fn text_bound(&self, text: &mut dyn TextApi, class: TextClass, axis: AxisInfo) -> SizeRules {
                 self.deref().text_bound(text, class, axis)
             }
-            fn edit_marker_width(&self) -> f32 {
-                self.deref().edit_marker_width()
+            fn text_cursor_width(&self) -> f32 {
+                self.deref().text_cursor_width()
             }
 
             fn button_surround(&self, vert: bool) -> FrameRules {

--- a/crates/kas-core/src/toolkit.rs
+++ b/crates/kas-core/src/toolkit.rs
@@ -56,11 +56,6 @@ bitflags! {
         /// Note that [`event::EventMgr::redraw`] can instead be used for more
         /// selective redrawing.
         const REDRAW = 1 << 0;
-        /// An animation is active; redraw for the next monitor frame
-        ///
-        /// This should be requested during draw. If encountered during event
-        /// handling, it is handled identically to `REDRAW`.
-        const ANIMATE = 1 << 1;
         /// Some widgets within a region moved
         ///
         /// Used when a pop-up is closed or a region adjusted (e.g. scroll or switch

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -267,9 +267,8 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
                 fn draw(
                     &mut self,
                     draw: ::kas::theme::DrawMgr,
-                    disabled: bool,
                 ) {
-                    self.#inner.draw(draw, disabled);
+                    self.#inner.draw(draw);
                 }
             }
         });

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -137,7 +137,8 @@ widget! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, _: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             let (redraw, animate) = self.program.do_redraw_animate();
             if redraw {
                 draw.set_rect_mgr(|mgr| self.redraw(mgr));

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -143,7 +143,7 @@ widget! {
                 draw.set_rect_mgr(|mgr| self.redraw(mgr));
             }
             if animate {
-                draw |= TkAction::ANIMATE;
+                draw.draw_device().animate();
             }
             if let Some(id) = self.image_id {
                 draw.image(id, self.rect());

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -182,7 +182,8 @@ widget! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, _: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             if let Some(id) = self.image_id {
                 draw.image(id, self.rect());
             }

--- a/crates/kas-theme/src/anim.rs
+++ b/crates/kas-theme/src/anim.rs
@@ -6,7 +6,7 @@
 //! Animation helpers
 
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// State of edit cursor
 #[derive(Clone, Copy, Debug)]
@@ -20,4 +20,14 @@ pub struct TextCursor {
 #[derive(Debug, Default)]
 pub struct AnimState {
     pub text_cursor: HashMap<u64, TextCursor>,
+}
+
+impl AnimState {
+    /// Garbage collect
+    ///
+    /// It is recommended to call this method sometimes.
+    pub fn garbage_collect(&mut self, longest_animation: Duration) {
+        let old = Instant::now() - longest_animation;
+        self.text_cursor.retain(|_, v| v.time >= old);
+    }
 }

--- a/crates/kas-theme/src/anim.rs
+++ b/crates/kas-theme/src/anim.rs
@@ -1,0 +1,23 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Animation helpers
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+/// State of edit cursor
+#[derive(Clone, Copy, Debug)]
+pub struct TextCursor {
+    pub byte: usize,
+    pub state: bool,
+    pub time: Instant,
+}
+
+/// State holding theme animation data
+#[derive(Debug, Default)]
+pub struct AnimState {
+    pub text_cursor: HashMap<u64, TextCursor>,
+}

--- a/crates/kas-theme/src/config.rs
+++ b/crates/kas-theme/src/config.rs
@@ -168,6 +168,11 @@ impl Config {
     pub fn cursor_blink_rate(&self) -> Duration {
         Duration::from_millis(self.cursor_blink_rate_ms as u64)
     }
+
+    /// Get the longest animation time
+    pub fn longest_animation(&self) -> Duration {
+        self.cursor_blink_rate()
+    }
 }
 
 /// Setters

--- a/crates/kas-theme/src/config.rs
+++ b/crates/kas-theme/src/config.rs
@@ -10,6 +10,7 @@ use kas::text::fonts::{fonts, AddMode, FontSelector};
 use kas::theme::TextClass;
 use kas::TkAction;
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 /// Event handling configuration
 #[derive(Clone, Debug, PartialEq)]
@@ -29,7 +30,7 @@ pub struct Config {
     /// All colour schemes
     /// TODO: possibly we should not save default schemes and merge when
     /// loading (perhaps via a `PartialConfig` type).
-    #[cfg_attr(feature = "config", serde(default = "defaults::color_schemes",))]
+    #[cfg_attr(feature = "config", serde(default = "defaults::color_schemes"))]
     color_schemes: BTreeMap<String, ColorsSrgb>,
 
     /// Font aliases, used when searching for a font family matching the key.
@@ -39,6 +40,10 @@ pub struct Config {
     /// Standard fonts
     #[cfg_attr(feature = "config", serde(default))]
     fonts: BTreeMap<TextClass, FontSelector<'static>>,
+
+    /// Text cursor blink rate: delay between switching states
+    #[cfg_attr(feature = "config", serde(default = "defaults::cursor_blink_rate_ms"))]
+    cursor_blink_rate_ms: u32,
 
     /// Text glyph rastering settings
     #[cfg_attr(feature = "config", serde(default))]
@@ -54,6 +59,7 @@ impl Default for Config {
             color_schemes: defaults::color_schemes(),
             font_aliases: Default::default(),
             fonts: defaults::fonts(),
+            cursor_blink_rate_ms: defaults::cursor_blink_rate_ms(),
             raster: Default::default(),
         }
     }
@@ -156,6 +162,12 @@ impl Config {
     pub fn iter_fonts(&self) -> impl Iterator<Item = (&TextClass, &FontSelector<'static>)> {
         self.fonts.iter()
     }
+
+    /// Get the cursor blink rate (delay)
+    #[inline]
+    pub fn cursor_blink_rate(&self) -> Duration {
+        Duration::from_millis(self.cursor_blink_rate_ms as u64)
+    }
 }
 
 /// Setters
@@ -256,6 +268,10 @@ mod defaults {
             (TextClass::EditMulti, selector),
         ];
         list.iter().cloned().collect()
+    }
+
+    pub fn cursor_blink_rate_ms() -> u32 {
+        600
     }
 
     pub fn scale_steps() -> u8 {

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -9,6 +9,7 @@ use linear_map::LinearMap;
 use std::any::Any;
 use std::f32;
 use std::rc::Rc;
+use std::time::Duration;
 
 use kas::cast::{Cast, CastFloat, ConvFloat};
 use kas::geom::{Size, Vec2};
@@ -119,23 +120,27 @@ impl Dimensions {
 pub struct Window {
     pub dims: Dimensions,
     pub fonts: Rc<LinearMap<TextClass, FontId>>,
+    pub anim: crate::anim::AnimState,
+    pub cursor_blink_rate: Duration,
 }
 
 impl Window {
     pub fn new(
         dims: &Parameters,
-        pt_size: f32,
+        config: &crate::Config,
         scale_factor: f32,
         fonts: Rc<LinearMap<TextClass, FontId>>,
     ) -> Self {
         Window {
-            dims: Dimensions::new(dims, pt_size, scale_factor),
+            dims: Dimensions::new(dims, config.font_size(), scale_factor),
             fonts,
+            anim: Default::default(),
+            cursor_blink_rate: config.cursor_blink_rate(),
         }
     }
 
-    pub fn update(&mut self, dims: &Parameters, pt_size: f32, scale_factor: f32) {
-        self.dims = Dimensions::new(dims, pt_size, scale_factor);
+    pub fn update(&mut self, dims: &Parameters, config: &crate::Config, scale_factor: f32) {
+        self.dims = Dimensions::new(dims, config.font_size(), scale_factor);
     }
 }
 

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -256,7 +256,7 @@ impl SizeHandle for Window {
         }
     }
 
-    fn edit_marker_width(&self) -> f32 {
+    fn text_cursor_width(&self) -> f32 {
         self.dims.font_marker_width
     }
 

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -145,6 +145,10 @@ impl Window {
 }
 
 impl crate::Window for Window {
+    fn garbage_collect(&mut self) {
+        self.anim.garbage_collect(self.cursor_blink_rate);
+    }
+
     fn size_handle(&self) -> &dyn SizeHandle {
         self
     }

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -445,7 +445,7 @@ where
         self.draw.text_effects(pos, text, &effects);
     }
 
-    fn edit_marker(&mut self, pos: Coord, text: &TextDisplay, _: TextClass, byte: usize) {
+    fn text_cursor(&mut self, pos: Coord, text: &TextDisplay, _: TextClass, byte: usize) {
         let width = self.w.dims.font_marker_width;
         let pos = Vec2::from(pos);
 

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -605,14 +605,24 @@ where
             outer = outer.shrink_vec(Vec2(0.0, outer.size().1 * (1.0 / 3.0)));
             first = outer;
             second = outer;
-            first.b.0 = mid.0;
-            second.a.0 = mid.0;
+            if !dir.is_reversed() {
+                first.b.0 = mid.0;
+                second.a.0 = mid.0;
+            } else {
+                first.a.0 = mid.0;
+                second.b.0 = mid.0;
+            }
         } else {
             outer = outer.shrink_vec(Vec2(outer.size().0 * (1.0 / 3.0), 0.0));
             first = outer;
             second = outer;
-            first.b.1 = mid.1;
-            second.a.1 = mid.1;
+            if !dir.is_reversed() {
+                first.b.1 = mid.1;
+                second.a.1 = mid.1;
+            } else {
+                first.a.1 = mid.1;
+                second.b.1 = mid.1;
+            }
         };
 
         let dist = outer.size().min_comp() / 2.0;

--- a/crates/kas-theme/src/lib.rs
+++ b/crates/kas-theme/src/lib.rs
@@ -18,6 +18,7 @@
 #![cfg_attr(feature = "gat", feature(generic_associated_types))]
 #![cfg_attr(feature = "unsize", feature(unsize))]
 
+mod anim;
 mod colors;
 mod config;
 mod draw_shaded;

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -105,11 +105,11 @@ where
 
     fn new_window(&self, dpi_factor: f32) -> Self::Window {
         let fonts = self.flat.fonts.as_ref().unwrap().clone();
-        dim::Window::new(&DIMS, self.flat.config.font_size(), dpi_factor, fonts)
+        dim::Window::new(&DIMS, &self.flat.config, dpi_factor, fonts)
     }
 
     fn update_window(&self, w: &mut Self::Window, dpi_factor: f32) {
-        w.update(&DIMS, self.flat.config.font_size(), dpi_factor);
+        w.update(&DIMS, &self.flat.config, dpi_factor);
     }
 
     #[cfg(not(feature = "gat"))]
@@ -330,8 +330,15 @@ where
             .text_selected_range(pos, text, range, class, state);
     }
 
-    fn text_cursor(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
-        self.as_flat().text_cursor(pos, text, class, byte);
+    fn text_cursor(
+        &mut self,
+        wid: u64,
+        pos: Coord,
+        text: &TextDisplay,
+        class: TextClass,
+        byte: usize,
+    ) {
+        self.as_flat().text_cursor(wid, pos, text, class, byte);
     }
 
     fn menu_entry(&mut self, rect: Rect, state: InputState) {

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -330,8 +330,8 @@ where
             .text_selected_range(pos, text, range, class, state);
     }
 
-    fn edit_marker(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
-        self.as_flat().edit_marker(pos, text, class, byte);
+    fn text_cursor(&mut self, pos: Coord, text: &TextDisplay, class: TextClass, byte: usize) {
+        self.as_flat().text_cursor(pos, text, class, byte);
     }
 
     fn menu_entry(&mut self, rect: Rect, state: InputState) {

--- a/crates/kas-theme/src/theme_dst.rs
+++ b/crates/kas-theme/src/theme_dst.rs
@@ -205,6 +205,10 @@ impl<'a, DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T {
 }
 
 impl Window for StackDst<dyn Window> {
+    fn garbage_collect(&mut self) {
+        self.deref_mut().garbage_collect();
+    }
+
     fn size_handle(&self) -> &dyn SizeHandle {
         self.deref().size_handle()
     }

--- a/crates/kas-theme/src/traits.rs
+++ b/crates/kas-theme/src/traits.rs
@@ -132,6 +132,12 @@ pub trait Theme<DS: DrawSharedImpl>: ThemeControl {
 /// The main reason for this separation is to allow proper handling of
 /// multi-window applications across screens with differing DPIs.
 pub trait Window: 'static {
+    /// Garbage collect
+    ///
+    /// It is recommended to call this method sometimes (every few seconds
+    /// or redraws, whichever is longer).
+    fn garbage_collect(&mut self);
+
     /// Construct a [`SizeHandle`] object
     fn size_handle(&self) -> &dyn SizeHandle;
 
@@ -191,6 +197,10 @@ impl<T: Theme<DS>, DS: DrawSharedImpl> Theme<DS> for Box<T> {
 }
 
 impl<W: Window> Window for Box<W> {
+    fn garbage_collect(&mut self) {
+        self.deref_mut().garbage_collect();
+    }
+
     fn size_handle(&self) -> &dyn SizeHandle {
         self.deref().size_handle()
     }

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -102,6 +102,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         let custom = self.custom.new_window(&self.device);
 
         DrawWindow {
+            animation: AnimationState::None,
             scale: Default::default(),
             clip_regions: vec![Default::default()],
             images: Default::default(),
@@ -379,6 +380,10 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
 }
 
 impl<CW: CustomWindow> DrawImpl for DrawWindow<CW> {
+    fn animation_mut(&mut self) -> &mut AnimationState {
+        &mut self.animation
+    }
+
     fn new_pass(
         &mut self,
         parent_pass: PassId,

--- a/crates/kas-wgpu/src/draw/mod.rs
+++ b/crates/kas-wgpu/src/draw/mod.rs
@@ -19,6 +19,7 @@ mod shaded_square;
 mod shaders;
 mod text_pipe;
 
+use kas::draw::AnimationState;
 use kas::geom::{Offset, Rect};
 use shaders::ShaderManager;
 use wgpu::TextureFormat;
@@ -53,6 +54,7 @@ pub struct DrawPipe<C> {
 
 /// Per-window pipeline data
 pub struct DrawWindow<CW: CustomWindow> {
+    pub(crate) animation: AnimationState,
     scale: Scale,
     clip_regions: Vec<(Rect, Offset)>,
     images: images::Window,

--- a/crates/kas-wgpu/src/event_loop.rs
+++ b/crates/kas-wgpu/src/event_loop.rs
@@ -133,6 +133,7 @@ where
             MainEventsCleared => {
                 let mut close_all = false;
                 let mut to_close = SmallVec::<[ww::WindowId; 4]>::new();
+                self.resumes.clear();
                 for (window_id, window) in self.windows.iter_mut() {
                     let (action, resume) = window.update(&mut self.shared);
                     if action.contains(TkAction::EXIT) {
@@ -141,16 +142,7 @@ where
                         to_close.push(*window_id);
                     }
                     if let Some(instant) = resume {
-                        if let Some((i, _)) = self
-                            .resumes
-                            .iter()
-                            .enumerate()
-                            .find(|item| (item.1).1 == *window_id)
-                        {
-                            self.resumes[i].0 = instant;
-                        } else {
-                            self.resumes.push((instant, *window_id));
-                        }
+                        self.resumes.push((instant, *window_id));
                     }
                 }
 
@@ -193,7 +185,24 @@ where
                 }
             }
 
-            RedrawEventsCleared | LoopDestroyed | Suspended | Resumed => return,
+            RedrawEventsCleared => {
+                self.resumes.clear();
+                for (window_id, window) in self.windows.iter() {
+                    if let Some(instant) = window.next_resume() {
+                        self.resumes.push((instant, *window_id));
+                    }
+                }
+                self.resumes.sort_by_key(|item| item.0);
+
+                if matches!(control_flow, ControlFlow::Wait | ControlFlow::WaitUntil(_)) {
+                    *control_flow = match self.resumes.first() {
+                        Some((instant, _)) => ControlFlow::WaitUntil(*instant),
+                        None => ControlFlow::Wait,
+                    };
+                }
+            }
+
+            LoopDestroyed | Suspended | Resumed => return,
         };
 
         // Create and init() any new windows.

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -350,14 +350,14 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
             unsafe {
                 // Safety: lifetimes do not escape the returned draw_handle value.
                 let mut draw_handle = shared.theme.draw_handle(draw, &mut self.theme_window);
-                let draw_mgr = DrawMgr::new(&mut draw_handle, &mut self.mgr);
-                self.widget.draw(draw_mgr, false);
+                let draw_mgr = DrawMgr::new(&mut draw_handle, &mut self.mgr, false);
+                self.widget.draw(draw_mgr);
             }
             #[cfg(feature = "gat")]
             {
                 let mut draw_handle = shared.theme.draw_handle(draw, &mut self.theme_window);
-                let draw_mgr = DrawMgr::new(&mut draw_handle, &mut self.mgr);
-                self.widget.draw(draw_mgr, false);
+                let draw_mgr = DrawMgr::new(&mut draw_handle, &mut self.mgr, false);
+                self.widget.draw(draw_mgr);
             }
         }
 

--- a/crates/kas-widgets/src/checkbox.rs
+++ b/crates/kas-widgets/src/checkbox.rs
@@ -39,8 +39,8 @@ widget! {
             self.core.rect = rect;
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            draw.checkbox(self.core.rect, self.state, draw.input_state(self, disabled));
+        fn draw(&mut self, mut draw: DrawMgr) {
+            draw.with_core(self.core_data()).checkbox(self.core.rect, self.state);
         }
     }
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -116,7 +116,7 @@ widget! {
                     }
                     Response::Used
                 }
-                Event::PressEnd { ref end_id, .. } => {
+                Event::PressEnd { ref end_id, success, .. } if success => {
                     if let Some(ref id) = end_id {
                         if self.eq_id(id) {
                             if self.opening {
@@ -135,6 +135,7 @@ widget! {
                     }
                     Response::Used
                 }
+                Event::PressEnd { .. } =>Response::Used,
                 Event::PopupRemoved(id) => {
                     debug_assert_eq!(Some(id), self.popup_id);
                     self.popup_id = None;

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -6,7 +6,7 @@
 //! Combobox
 
 use super::{IndexedColumn, MenuEntry};
-use kas::event::{self, Command, GrabMode};
+use kas::event::{self, Command};
 use kas::layout;
 use kas::prelude::*;
 use kas::theme::TextClass;
@@ -87,7 +87,7 @@ widget! {
                 } => {
                     if start_id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
                         if source.is_primary() {
-                            mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None);
+                            mgr.grab_press_unique(self.id(), source, coord, None);
                             mgr.set_grab_depress(source, start_id);
                             self.opening = self.popup_id.is_none();
                         }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -85,10 +85,10 @@ widget! {
                     start_id,
                     coord,
                 } => {
-                    if self.is_ancestor_of(&start_id) {
+                    if start_id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
                         if source.is_primary() {
                             mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None);
-                            mgr.set_grab_depress(source, Some(start_id));
+                            mgr.set_grab_depress(source, start_id);
                             self.opening = self.popup_id.is_none();
                         }
                         Response::Used

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -48,12 +48,12 @@ widget! {
             None
         }
 
-        fn draw(&mut self, draw: DrawMgr, disabled: bool) {
-            let mut state = draw.input_state(self, disabled);
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             if self.popup_id.is_some() {
-                state.insert(InputState::DEPRESS);
+                draw.state.insert(InputState::DEPRESS);
             }
-            self.layout().draw(draw, state);
+            self.layout().draw(draw);
         }
     }
 

--- a/crates/kas-widgets/src/drag.rs
+++ b/crates/kas-widgets/src/drag.rs
@@ -56,7 +56,7 @@ widget! {
             self.track = rect;
         }
 
-        fn draw(&mut self, _: DrawMgr, _: bool) {}
+        fn draw(&mut self, _: DrawMgr) {}
     }
 
     impl event::Handler for DragHandle {

--- a/crates/kas-widgets/src/drag.rs
+++ b/crates/kas-widgets/src/drag.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Debug;
 
-use kas::event::{self, PressSource};
+use kas::event::{CursorIcon, GrabMode, PressSource};
 use kas::prelude::*;
 
 widget! {
@@ -29,14 +29,14 @@ widget! {
     #[derive(Clone, Debug, Default)]
     #[widget{
         hover_highlight = true;
-        cursor_icon = event::CursorIcon::Grab;
+        cursor_icon = CursorIcon::Grab;
     }]
     pub struct DragHandle {
         #[widget_core]
         core: CoreData,
         // The track is the area within which this DragHandle may move
         track: Rect,
-        press_source: Option<event::PressSource>,
+        press_source: Option<PressSource>,
         press_coord: Coord,
     }
 
@@ -59,7 +59,7 @@ widget! {
         fn draw(&mut self, _: DrawMgr) {}
     }
 
-    impl event::Handler for DragHandle {
+    impl Handler for DragHandle {
         type Msg = Offset;
 
         fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {
@@ -175,8 +175,8 @@ impl DragHandle {
     }
 
     fn grab_press(&mut self, mgr: &mut EventMgr, source: PressSource, coord: Coord) -> bool {
-        let cur = Some(event::CursorIcon::Grabbing);
-        if mgr.request_grab(self.id(), source, coord, event::GrabMode::Grab, cur) {
+        let cur = Some(CursorIcon::Grabbing);
+        if mgr.request_grab(self.id(), source, coord, GrabMode::Grab, cur) {
             // Interacting with a scrollbar with multiple presses
             // does not make sense. Any other gets aborted.
             self.press_source = Some(source);

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -438,6 +438,7 @@ widget! {
                 }
                 if draw.ev_state().has_char_focus(self.id_ref()).0 {
                     draw.text_cursor(
+                        self.id_u64(),
                         self.rect().pos,
                         self.text.as_ref(),
                         class,

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -437,7 +437,7 @@ widget! {
                     );
                 }
                 if draw.ev_state().has_char_focus(self.id_ref()).0 {
-                    draw.edit_marker(
+                    draw.text_cursor(
                         self.rect().pos,
                         self.text.as_ref(),
                         class,

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -433,7 +433,6 @@ widget! {
                 }
                 if draw.ev_state().has_char_focus(self.id_ref()).0 {
                     draw.text_cursor(
-                        self.id_u64(),
                         self.rect().pos,
                         self.text.as_ref(),
                         class,

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -187,15 +187,11 @@ widget! {
             layout::Layout::frame(&mut self.layout_frame, inner)
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            // We draw highlights for input state of inner:
-            let disabled = disabled || self.is_disabled() || self.inner.is_disabled();
-            let mut input_state = draw.input_state(&self.inner, disabled);
-            if self.inner.has_error() {
-                input_state.insert(InputState::ERROR);
-            }
-            draw.edit_box(self.core.rect, input_state);
-            self.inner.draw(draw, disabled);
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
+            let error = self.inner.has_error();
+            draw.re().with_core(self.inner.core_data()).edit_box(self.core.rect, error);
+            self.inner.draw(draw.re());
         }
     }
 }
@@ -414,16 +410,16 @@ widget! {
             self.scroll_offset()
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
             let class = if self.multi_line {
                 TextClass::EditMulti
             } else {
                 TextClass::Edit
             };
-            let state = draw.input_state(self, disabled);
+            let mut draw = draw.with_core(self.core_data());
             draw.with_clip_region(self.rect(), self.view_offset, |mut draw| {
                 if self.selection.is_empty() {
-                    draw.text(self.rect().pos, self.text.as_ref(), class, state);
+                    draw.text(self.rect().pos, self.text.as_ref(), class);
                 } else {
                     // TODO(opt): we could cache the selection rectangles here to make
                     // drawing more efficient (self.text.highlight_lines(range) output).
@@ -433,7 +429,6 @@ widget! {
                         &self.text,
                         self.selection.range(),
                         class,
-                        state,
                     );
                 }
                 if draw.ev_state().has_char_focus(self.id_ref()).0 {

--- a/crates/kas-widgets/src/filler.rs
+++ b/crates/kas-widgets/src/filler.rs
@@ -30,7 +30,7 @@ widget! {
             SizeRules::empty(stretch)
         }
 
-        fn draw(&mut self, _: DrawMgr, _: bool) {}
+        fn draw(&mut self, _: DrawMgr) {}
     }
 }
 

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -36,14 +36,14 @@ widget! {
         }
 
         #[cfg(feature = "min_spec")]
-        default fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let state = draw.input_state(self, disabled);
-            draw.text_effects(self.core.rect.pos, &self.label, TextClass::Label, state);
+        default fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
+            draw.text_effects(self.core.rect.pos, &self.label, TextClass::Label);
         }
         #[cfg(not(feature = "min_spec"))]
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let state = draw.input_state(self, disabled);
-            draw.text_effects(self.core.rect.pos, &self.label, TextClass::Label, state);
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
+            draw.text_effects(self.core.rect.pos, &self.label, TextClass::Label);
         }
     }
 
@@ -65,42 +65,26 @@ widget! {
 
 #[cfg(feature = "min_spec")]
 impl Layout for AccelLabel {
-    fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-        let state = draw.input_state(self, disabled);
+    fn draw(&mut self, mut draw: DrawMgr) {
+        let draw = draw.with_core(self.core_data());
         let accel = draw.ev_state().show_accel_labels();
-        draw.text_accel(
-            self.core.rect.pos,
-            &self.label,
-            accel,
-            TextClass::Label,
-            state,
-        );
+        draw.text_accel(self.core.rect.pos, &self.label, accel, TextClass::Label);
     }
 }
 
 // Str/String representations have no effects, so use simpler draw call
 #[cfg(feature = "min_spec")]
 impl<'a> Layout for Label<&'a str> {
-    fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-        let state = draw.input_state(self, disabled);
-        draw.text(
-            self.core.rect.pos,
-            self.label.as_ref(),
-            TextClass::Label,
-            state,
-        );
+    fn draw(&mut self, mut draw: DrawMgr) {
+        let draw = draw.with_core(self.core_data());
+        draw.text(self.core.rect.pos, self.label.as_ref(), TextClass::Label);
     }
 }
 #[cfg(feature = "min_spec")]
 impl Layout for StringLabel {
-    fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-        let state = draw.input_state(self, disabled);
-        draw.text(
-            self.core.rect.pos,
-            self.label.as_ref(),
-            TextClass::Label,
-            state,
-        );
+    fn draw(&mut self, mut draw: DrawMgr) {
+        let draw = draw.with_core(self.core_data());
+        draw.text(self.core.rect.pos, self.label.as_ref(), TextClass::Label);
     }
 }
 

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -66,7 +66,7 @@ widget! {
 #[cfg(feature = "min_spec")]
 impl Layout for AccelLabel {
     fn draw(&mut self, mut draw: DrawMgr) {
-        let draw = draw.with_core(self.core_data());
+        let mut draw = draw.with_core(self.core_data());
         let accel = draw.ev_state().show_accel_labels();
         draw.text_accel(self.core.rect.pos, &self.label, accel, TextClass::Label);
     }
@@ -76,14 +76,14 @@ impl Layout for AccelLabel {
 #[cfg(feature = "min_spec")]
 impl<'a> Layout for Label<&'a str> {
     fn draw(&mut self, mut draw: DrawMgr) {
-        let draw = draw.with_core(self.core_data());
+        let mut draw = draw.with_core(self.core_data());
         draw.text(self.core.rect.pos, self.label.as_ref(), TextClass::Label);
     }
 }
 #[cfg(feature = "min_spec")]
 impl Layout for StringLabel {
     fn draw(&mut self, mut draw: DrawMgr) {
-        let draw = draw.with_core(self.core_data());
+        let mut draw = draw.with_core(self.core_data());
         draw.text(self.core.rect.pos, self.label.as_ref(), TextClass::Label);
     }
 }

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -120,8 +120,8 @@ impl<M: 'static> Layout for Box<dyn Menu<Msg = M>> {
         self.as_mut().find_id(coord)
     }
 
-    fn draw(&mut self, draw: DrawMgr, disabled: bool) {
-        self.as_mut().draw(draw, disabled);
+    fn draw(&mut self, draw: DrawMgr) {
+        self.as_mut().draw(draw);
     }
 }
 

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -39,15 +39,14 @@ widget! {
             layout::Layout::frame(&mut self.layout_frame, inner)
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let state = draw.input_state(self, disabled);
-            draw.menu_entry(self.core.rect, state);
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
+            draw.menu_entry(self.core.rect);
             draw.text_accel(
                 self.layout_label.pos,
                 &self.label,
                 draw.ev_state().show_accel_labels(),
                 TextClass::MenuLabel,
-                state,
             );
         }
     }
@@ -138,11 +137,11 @@ widget! {
             Some(self.checkbox.id())
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let state = draw.input_state(&self.checkbox, disabled);
-            draw.menu_entry(self.core.rect, state);
-            self.checkbox.draw(draw.re(), state.disabled());
-            self.label.draw(draw.re(), state.disabled());
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
+            draw.menu_entry(self.core.rect);
+            self.checkbox.draw(draw.re());
+            self.label.draw(draw.re());
         }
     }
 

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -73,11 +73,11 @@ widget! {
                     start_id,
                     coord,
                 } => {
-                    if self.is_ancestor_of(&start_id) {
+                    if start_id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
                         if source.is_primary()
                             && mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None)
                         {
-                            mgr.set_grab_depress(source, Some(start_id.clone()));
+                            mgr.set_grab_depress(source, start_id.clone());
                             self.opening = false;
                             if self.rect().contains(coord) {
                                 if self
@@ -86,14 +86,14 @@ widget! {
                                     .any(|w| w.eq_id(&start_id) && !w.menu_is_open())
                                 {
                                     self.opening = true;
-                                    self.set_menu_path(mgr, Some(&start_id), false);
+                                    self.set_menu_path(mgr, start_id.as_ref(), false);
                                 } else {
                                     self.set_menu_path(mgr, None, false);
                                 }
                             } else {
                                 let delay = mgr.config().menu_delay();
-                                mgr.update_on_timer(delay, self.id(), start_id.as_u64());
-                                self.delayed_open = Some(start_id);
+                                mgr.update_on_timer(delay, self.id(), WidgetId::opt_to_u64(start_id.as_ref()));
+                                self.delayed_open = start_id;
                             }
                         }
                         Response::Used

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -125,7 +125,7 @@ widget! {
                     }
                     Response::Used
                 }
-                Event::PressEnd { coord, end_id, .. } => {
+                Event::PressEnd { coord, end_id, success, .. } if success => {
                     if end_id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
                         // end_id is a child of self
                         let id = end_id.unwrap();
@@ -151,6 +151,7 @@ widget! {
                     }
                     Response::Used
                 }
+                Event::PressEnd { .. } => Response::Used,
                 Event::Command(cmd, _) => {
                     // Arrow keys can switch to the next / previous menu
                     // as well as to the first / last item of an open menu.

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -7,7 +7,7 @@
 
 use super::{Menu, SubMenu};
 use crate::IndexedList;
-use kas::event::{self, Command, GrabMode};
+use kas::event::{self, Command};
 use kas::prelude::*;
 
 widget! {
@@ -74,9 +74,8 @@ widget! {
                     coord,
                 } => {
                     if start_id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
-                        if source.is_primary()
-                            && mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None)
-                        {
+                        if source.is_primary() {
+                            mgr.grab_press_unique(self.id(), source, coord, None);
                             mgr.set_grab_depress(source, start_id.clone());
                             self.opening = false;
                             if self.rect().contains(coord) {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -145,18 +145,17 @@ widget! {
             None
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let mut state = draw.input_state(self, disabled);
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             if self.popup_id.is_some() {
-                state.insert(InputState::DEPRESS);
+                draw.state.insert(InputState::DEPRESS);
             }
-            draw.menu_entry(self.core.rect, state);
+            draw.menu_entry(self.core.rect);
             draw.text_accel(
                 self.label_store.pos,
                 &self.label,
                 draw.ev_state().show_accel_labels(),
                 TextClass::MenuLabel,
-                state,
             );
         }
     }

--- a/crates/kas-widgets/src/progress.rs
+++ b/crates/kas-widgets/src/progress.rs
@@ -99,10 +99,10 @@ widget! {
             self.core.rect = rect;
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             let dir = self.direction.as_direction();
-            let state = draw.input_state(self, disabled);
-            draw.progress_bar(self.core.rect, dir, state, self.value);
+            draw.progress_bar(self.core.rect, dir, self.value);
         }
     }
 }

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -94,8 +94,9 @@ widget! {
             self.core.rect = rect;
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            draw.radiobox(self.core.rect, self.state, draw.input_state(self, disabled));
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
+            draw.radiobox(self.core.rect, self.state);
         }
     }
 

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -171,7 +171,7 @@ widget! {
                     .scroll_by_event(mgr, event, self.id(), self.core.rect.size, |mgr, source, _, coord| {
                         if source.is_primary() && mgr.config_enable_mouse_pan() {
                             let icon = Some(event::CursorIcon::Grabbing);
-                            mgr.request_grab(id, source, coord, event::GrabMode::Grab, icon);
+                            mgr.grab_press_unique(id, source, coord, icon);
                         }
                     });
             if !action.is_empty() {

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -130,10 +130,10 @@ widget! {
             self.scroll_offset()
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let disabled = disabled || self.is_disabled();
-            draw.with_clip_region(self.core.rect, self.scroll_offset(), |handle| {
-                self.inner.draw(handle, disabled)
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
+            draw.with_clip_region(self.core.rect, self.scroll_offset(), |mut draw| {
+                self.inner.draw(draw.re())
             });
         }
     }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -53,12 +53,12 @@ widget! {
             self.scroll_offset()
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             let class = TextClass::LabelScroll;
-            let state = draw.input_state(self, disabled);
             draw.with_clip_region(self.rect(), self.view_offset, |mut draw| {
                 if self.selection.is_empty() {
-                    draw.text(self.rect().pos, self.text.as_ref(), class, state);
+                    draw.text(self.rect().pos, self.text.as_ref(), class);
                 } else {
                     // TODO(opt): we could cache the selection rectangles here to make
                     // drawing more efficient (self.text.highlight_lines(range) output).
@@ -68,7 +68,6 @@ widget! {
                         &self.text,
                         self.selection.range(),
                         class,
-                        state,
                     );
                 }
             });

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -235,10 +235,10 @@ widget! {
             self.handle.find_id(coord).or(Some(self.id()))
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.handle.core_data());
             let dir = self.direction.as_direction();
-            let state = draw.input_state(&self.handle, disabled);
-            draw.scrollbar(self.core.rect, self.handle.rect(), dir, state);
+            draw.scrollbar(self.core.rect, self.handle.rect(), dir);
         }
     }
 
@@ -515,15 +515,15 @@ widget! {
             &mut self.inner
         }
 
-        fn draw_(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let disabled = disabled || self.is_disabled();
+        fn draw_(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             if self.show_bars.0 {
-                self.horiz_bar.draw(draw.re(), disabled);
+                self.horiz_bar.draw(draw.re());
             }
             if self.show_bars.1 {
-                self.vert_bar.draw(draw.re(), disabled);
+                self.vert_bar.draw(draw.re());
             }
-            self.inner.draw(draw.re(), disabled);
+            self.inner.draw(draw.re());
         }
     }
 
@@ -611,30 +611,30 @@ widget! {
         }
 
         #[cfg(feature = "min_spec")]
-        default fn draw(&mut self, draw: DrawMgr, disabled: bool) {
-            self.draw_(draw, disabled);
+        default fn draw(&mut self, draw: DrawMgr) {
+            self.draw_(draw);
         }
         #[cfg(not(feature = "min_spec"))]
-        fn draw(&mut self, draw: DrawMgr, disabled: bool) {
-            self.draw_(draw, disabled);
+        fn draw(&mut self, draw: DrawMgr) {
+            self.draw_(draw);
         }
     }
 
     #[cfg(feature = "min_spec")]
     impl<W: Widget> Layout for ScrollBars<ScrollRegion<W>> {
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let disabled = disabled || self.is_disabled() || self.inner.is_disabled();
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let draw = draw.with_core(self.core_data());
             // Enlarge clip region to *our* rect:
-            draw.with_clip_region(self.core.rect, self.inner.scroll_offset(), |handle| {
-                self.inner.inner_mut().draw(handle, disabled)
+            draw.with_clip_region(self.core.rect, self.inner.scroll_offset(), |draw| {
+                self.inner.inner_mut().draw(draw.re())
             });
             // Use a second clip region to force draw order:
             draw.with_clip_region(self.core.rect, Offset::ZERO, |mut draw| {
                 if self.show_bars.0 {
-                    self.horiz_bar.draw(draw.re(), disabled);
+                    self.horiz_bar.draw(draw.re());
                 }
                 if self.show_bars.1 {
-                    self.vert_bar.draw(draw.re(), disabled);
+                    self.vert_bar.draw(draw.re());
                 }
             });
         }

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -623,9 +623,9 @@ widget! {
     #[cfg(feature = "min_spec")]
     impl<W: Widget> Layout for ScrollBars<ScrollRegion<W>> {
         fn draw(&mut self, mut draw: DrawMgr) {
-            let draw = draw.with_core(self.core_data());
+            let mut draw = draw.with_core(self.core_data());
             // Enlarge clip region to *our* rect:
-            draw.with_clip_region(self.core.rect, self.inner.scroll_offset(), |draw| {
+            draw.with_clip_region(self.core.rect, self.inner.scroll_offset(), |mut draw| {
                 self.inner.inner_mut().draw(draw.re())
             });
             // Use a second clip region to force draw order:

--- a/crates/kas-widgets/src/separator.rs
+++ b/crates/kas-widgets/src/separator.rs
@@ -54,7 +54,8 @@ widget! {
             SizeRules::extract_fixed(axis, size_mgr.separator(), margins)
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, _: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             draw.separator(self.core.rect);
         }
     }

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -253,10 +253,13 @@ widget! {
             self.handle.find_id(coord).or(Some(self.id()))
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
+            if draw.ev_state().is_hovered(self.handle.id_ref()) {
+                draw.state.insert(InputState::HOVER);
+            }
             let dir = self.direction.as_direction();
-            let state = draw.input_state(self, disabled) | draw.input_state(&self.handle, disabled);
-            draw.slider(self.core.rect, self.handle.rect(), dir, state);
+            draw.slider(self.core.rect, self.handle.rect(), dir);
         }
     }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -194,13 +194,13 @@ widget! {
             Some(self.id())
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             // as with find_id, there's not much harm in invoking the solver twice
 
             let solver = layout::RowPositionSolver::new(self.direction);
-            let disabled = disabled || self.is_disabled();
             solver.for_children(&mut self.widgets, draw.get_clip_rect(), |w| {
-                w.draw(draw.re(), disabled)
+                w.draw(draw.re())
             });
 
             let solver = layout::RowPositionSolver::new(self.direction);

--- a/crates/kas-widgets/src/sprite.rs
+++ b/crates/kas-widgets/src/sprite.rs
@@ -48,7 +48,8 @@ widget! {
             self.core_data_mut().rect = self.sprite.align_rect(rect, align);
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, _: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             if let Some(id) = self.id {
                 draw.image(id, self.rect());
             }

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -78,10 +78,10 @@ widget! {
             None
         }
 
-        fn draw(&mut self, draw: DrawMgr, disabled: bool) {
-            let disabled = disabled || self.is_disabled();
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             if self.active < self.widgets.len() {
-                self.widgets[self.active].draw(draw, disabled);
+                self.widgets[self.active].draw(draw.re());
             }
         }
     }

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -307,28 +307,28 @@ widget! {
         /// Clear all selected items
         ///
         /// Does not send [`ChildMsg`] responses.
-        pub fn clear_selected(&mut self) {
+        pub fn clear_selected(&mut self) -> TkAction {
             self.list.clear_selected()
         }
 
         /// Directly select an item
         ///
-        /// Returns `true` if selected, `false` if already selected.
-        /// Fails if selection mode does not permit selection or if the key is
-        /// invalid or filtered out.
+        /// Returns `TkAction::REDRAW` if newly selected, `TkAction::empty()` if
+        /// already selected. Fails if selection mode does not permit selection
+        /// or if the key is invalid.
         ///
         /// Does not send [`ChildMsg`] responses.
-        pub fn select(&mut self, key: T::Key) -> Result<bool, SelectionError> {
+        pub fn select(&mut self, key: T::Key) -> Result<TkAction, SelectionError> {
             self.list.select(key)
         }
 
         /// Directly deselect an item
         ///
-        /// Returns `true` if deselected, `false` if not previously selected.
-        /// Also returns `false` on invalid and filtered-out keys.
+        /// Returns `TkAction::REDRAW` if deselected, `TkAction::empty()` if not
+        /// previously selected or if the key is invalid.
         ///
         /// Does not send [`ChildMsg`] responses.
-        pub fn deselect(&mut self, key: &T::Key) -> bool {
+        pub fn deselect(&mut self, key: &T::Key) -> TkAction {
             self.list.deselect(key)
         }
 

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -538,12 +538,12 @@ widget! {
             Some(self.id())
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let disabled = disabled || self.is_disabled();
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             let offset = self.scroll_offset();
             draw.with_clip_region(self.core.rect, offset, |mut draw| {
                 for child in &mut self.widgets[..self.cur_len.cast()] {
-                    child.widget.draw(draw.re(), disabled);
+                    child.widget.draw(draw.re());
                     if let Some(ref key) = child.key {
                         if self.selection.contains(key) {
                             draw.selection_box(child.widget.rect());

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -192,18 +192,23 @@ widget! {
         /// Clear all selected items
         ///
         /// Does not send [`ChildMsg`] responses.
-        pub fn clear_selected(&mut self) {
-            self.selection.clear();
+        pub fn clear_selected(&mut self) -> TkAction {
+            if self.selection.is_empty() {
+                TkAction::empty()
+            } else {
+                self.selection.clear();
+                TkAction::REDRAW
+            }
         }
 
         /// Directly select an item
         ///
-        /// Returns `true` if selected, `false` if already selected.
-        /// Fails if selection mode does not permit selection or if the key is
-        /// invalid.
+        /// Returns `TkAction::REDRAW` if newly selected, `TkAction::empty()` if
+        /// already selected. Fails if selection mode does not permit selection
+        /// or if the key is invalid.
         ///
         /// Does not send [`ChildMsg`] responses.
-        pub fn select(&mut self, key: T::Key) -> Result<bool, SelectionError> {
+        pub fn select(&mut self, key: T::Key) -> Result<TkAction, SelectionError> {
             match self.sel_mode {
                 SelectionMode::None => return Err(SelectionError::Disabled),
                 SelectionMode::Single => self.selection.clear(),
@@ -212,17 +217,23 @@ widget! {
             if !self.data.contains(&key) {
                 return Err(SelectionError::Key);
             }
-            Ok(self.selection.insert(key))
+            match self.selection.insert(key) {
+                true => Ok(TkAction::REDRAW),
+                false => Ok(TkAction::empty()),
+            }
         }
 
         /// Directly deselect an item
         ///
-        /// Returns `true` if deselected, `false` if not previously selected.
-        /// Also returns `false` on invalid keys.
+        /// Returns `TkAction::REDRAW` if deselected, `TkAction::empty()` if not
+        /// previously selected or if the key is invalid.
         ///
         /// Does not send [`ChildMsg`] responses.
-        pub fn deselect(&mut self, key: &T::Key) -> bool {
-            self.selection.remove(key)
+        pub fn deselect(&mut self, key: &T::Key) -> TkAction {
+            match self.selection.remove(key) {
+                true => TkAction::REDRAW,
+                false => TkAction::empty(),
+            }
         }
 
         /// Manually trigger an update to handle changed data
@@ -545,6 +556,7 @@ widget! {
                         return match self.sel_mode {
                             SelectionMode::None => Response::Used,
                             SelectionMode::Single => {
+                                mgr.redraw(self.id());
                                 self.selection.clear();
                                 if let Some(ref key) = self.press_target {
                                     self.selection.insert(key.clone());
@@ -555,6 +567,7 @@ widget! {
                             }
                             SelectionMode::Multiple => {
                                 if let Some(ref key) = self.press_target {
+                                    mgr.redraw(self.id());
                                     if self.selection.remove(key) {
                                         ChildMsg::Deselect(key.clone()).into()
                                     } else {
@@ -705,11 +718,13 @@ widget! {
                         match self.sel_mode {
                             SelectionMode::None => Response::Used,
                             SelectionMode::Single => {
+                                mgr.redraw(self.id());
                                 self.selection.clear();
                                 self.selection.insert(key.clone());
                                 Response::Msg(ChildMsg::Select(key))
                             }
                             SelectionMode::Multiple => {
+                                mgr.redraw(self.id());
                                 if self.selection.remove(&key) {
                                     Response::Msg(ChildMsg::Deselect(key))
                                 } else {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -508,14 +508,14 @@ widget! {
             Some(self.id())
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let disabled = disabled || self.is_disabled();
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
             let offset = self.scroll_offset();
             let num = usize::conv(self.cur_len.cols) * usize::conv(self.cur_len.rows);
             draw.with_clip_region(self.core.rect, offset, |mut draw| {
                 for child in &mut self.widgets[..num] {
                     if let Some(ref key) = child.key {
-                        child.widget.draw(draw.re(), disabled);
+                        child.widget.draw(draw.re());
                         if self.selection.contains(key) {
                             draw.selection_box(child.widget.rect());
                         }

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -10,7 +10,7 @@ use super::{driver, Driver, PressPhase, SelectionError, SelectionMode};
 use crate::ScrollBars;
 use crate::Scrollable;
 use kas::event::components::ScrollComponent;
-use kas::event::{ChildMsg, Command, CursorIcon, GrabMode, PressSource};
+use kas::event::{ChildMsg, Command, CursorIcon};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
 use kas::updatable::{MatrixData, UpdatableHandler};
@@ -71,7 +71,6 @@ widget! {
         sel_mode: SelectionMode,
         // TODO(opt): replace selection list with RangeOrSet type?
         selection: LinearSet<T::Key>,
-        press_event: Option<PressSource>,
         press_phase: PressPhase,
         press_target: Option<T::Key>,
     }
@@ -103,7 +102,6 @@ widget! {
                 scroll: Default::default(),
                 sel_mode: SelectionMode::None,
                 selection: Default::default(),
-                press_event: None,
                 press_phase: PressPhase::None,
                 press_target: None,
             }
@@ -534,7 +532,7 @@ widget! {
                     self.update_view(mgr);
                     return Response::Update;
                 }
-                Event::PressMove { source, coord, .. } if self.press_event == Some(source) => {
+                Event::PressMove { coord, .. } => {
                     if let PressPhase::Start(start_coord) = self.press_phase {
                         if mgr.config_test_pan_thresh(coord - start_coord) {
                             self.press_phase = PressPhase::Pan;
@@ -548,11 +546,10 @@ widget! {
                         _ => return Response::Used,
                     }
                 }
-                Event::PressEnd { source, .. } if self.press_event == Some(source) => {
-                    self.press_event = None;
+                Event::PressEnd { ref end_id, .. } => {
                     if self.press_phase == PressPhase::Pan {
                         // fall through to scroll handler
-                    } else {
+                    } else if end_id.is_some() {
                         if let Some(ref key) = self.press_target {
                             if mgr.config().mouse_nav_focus() {
                                 for w in &self.widgets {
@@ -583,9 +580,10 @@ widget! {
                                     }
                                 }
                             }
-                        } else {
-                            return Response::Used;
                         }
+                        return Response::Used;
+                    } else {
+                        return Response::Used;
                     }
                 }
                 Event::Command(cmd, _) => {
@@ -649,7 +647,7 @@ widget! {
                 .scroll_by_event(mgr, event, self.id(), self.core.rect.size, |mgr, source, _, coord| {
                     if source.is_primary() && mgr.config_enable_mouse_pan() {
                         let icon = Some(CursorIcon::Grabbing);
-                        mgr.request_grab(self_id, source, coord, GrabMode::Grab, icon);
+                        mgr.grab_press_unique(self_id, source, coord, icon);
                     }
                 });
 
@@ -696,11 +694,9 @@ widget! {
                             if source.is_primary() {
                                 // We request a grab with our ID, hence the
                                 // PressMove/PressEnd events are matched in handle().
-                                if mgr.request_grab(self.id(), source, coord, GrabMode::Grab, None) {
-                                    self.press_event = Some(source);
-                                    self.press_phase = PressPhase::Start(coord);
-                                    self.press_target = key;
-                                }
+                                mgr.grab_press_unique(self.id(), source, coord, None);
+                                self.press_phase = PressPhase::Start(coord);
+                                self.press_target = key;
                                 Response::Used
                             } else {
                                 Response::Unused

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -553,20 +553,27 @@ widget! {
                     if self.press_phase == PressPhase::Pan {
                         // fall through to scroll handler
                     } else {
-                        return match self.sel_mode {
-                            SelectionMode::None => Response::Used,
-                            SelectionMode::Single => {
-                                mgr.redraw(self.id());
-                                self.selection.clear();
-                                if let Some(ref key) = self.press_target {
-                                    self.selection.insert(key.clone());
-                                    ChildMsg::Select(key.clone()).into()
-                                } else {
-                                    Response::Used
+                        if let Some(ref key) = self.press_target {
+                            if mgr.config().mouse_nav_focus() {
+                                for w in &self.widgets {
+                                    if w.key.as_ref().map(|k| k == key).unwrap_or(false) {
+                                        if w.widget.key_nav() {
+                                            mgr.set_nav_focus(w.widget.id(), false);
+                                        }
+                                        break;
+                                    }
                                 }
                             }
-                            SelectionMode::Multiple => {
-                                if let Some(ref key) = self.press_target {
+
+                            return match self.sel_mode {
+                                SelectionMode::None => Response::Used,
+                                SelectionMode::Single => {
+                                    mgr.redraw(self.id());
+                                    self.selection.clear();
+                                    self.selection.insert(key.clone());
+                                    ChildMsg::Select(key.clone()).into()
+                                }
+                                SelectionMode::Multiple => {
                                     mgr.redraw(self.id());
                                     if self.selection.remove(key) {
                                         ChildMsg::Deselect(key.clone()).into()
@@ -574,11 +581,11 @@ widget! {
                                         self.selection.insert(key.clone());
                                         ChildMsg::Select(key.clone()).into()
                                     }
-                                } else {
-                                    Response::Used
                                 }
                             }
-                        };
+                        } else {
+                            return Response::Used;
+                        }
                     }
                 }
                 Event::Command(cmd, _) => {

--- a/crates/kas-widgets/src/window.rs
+++ b/crates/kas-widgets/src/window.rs
@@ -49,13 +49,13 @@ widget! {
         }
 
         #[inline]
-        fn draw(&mut self, mut draw: DrawMgr, disabled: bool) {
-            let disabled = disabled || self.is_disabled();
-            self.w.draw(draw.re(), disabled);
+        fn draw(&mut self, mut draw: DrawMgr) {
+            let mut draw = draw.with_core(self.core_data());
+            self.w.draw(draw.re());
             for (_, popup) in &self.popups {
                 if let Some(widget) = self.w.find_widget_mut(&popup.id) {
-                    draw.with_overlay(widget.rect(), |draw| {
-                        widget.draw(draw, disabled);
+                    draw.with_overlay(widget.rect(), |mut draw| {
+                        widget.draw(draw.re());
                     });
                 }
             }

--- a/examples/async-event.rs
+++ b/examples/async-event.rs
@@ -63,7 +63,7 @@ widget! {
             let factor = size_mgr.scale_factor();
             SizeRules::fixed_scaled(100.0, 10.0, factor)
         }
-        fn draw(&mut self, mut draw: DrawMgr, _: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
             let draw = draw.draw_device();
             let col = *self.colour.lock().unwrap();
             draw.rect((self.rect()).into(), col);

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -66,7 +66,7 @@ widget! {
             self.time_pos = pos;
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, _: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
             let col_face = color::Rgba::grey(0.4);
             let col_time = color::Rgba::grey(0.0);
             let col_date = color::Rgba::grey(0.2);

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -5,7 +5,7 @@
 
 //! Clock example
 //!
-//! Note that two forms of animation are possible: setting `draw |= TkAction::ANIMATE`
+//! Note that two forms of animation are possible: calling `draw.draw_device().animate();`
 //! in `fn Clock::draw`, or using `Event::TimerUpdate`. We use the latter since
 //! it lets us draw at 1 FPS with exactly the right frame time.
 

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -340,7 +340,7 @@ widget! {
             self.rel_width = rel_width.0 as f32;
         }
 
-        fn draw(&mut self, mut draw: DrawMgr, _: bool) {
+        fn draw(&mut self, mut draw: DrawMgr) {
             let draw = draw.draw_device();
             let draw = DrawIface::<DrawPipe<Pipe>>::downcast_from(draw).unwrap();
             let p = (self.alpha, self.delta, self.rel_width, self.iter);

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -401,7 +401,7 @@ widget! {
                     Response::Msg(())
                 }
                 Event::PressStart { source, coord, .. } => {
-                    mgr.request_grab(
+                    mgr.grab_press(
                         self.id(),
                         source,
                         coord,


### PR DESCRIPTION
- Remove `TkAction::ANIMATE`
- Rename `edit_marker` → `text_cursor`
- Make `text_cursor` blink
- Add `DrawCtx`
- Events: in `PressStart`, `start_id` is now `Optional<..>`; `PressEnd` has new field: `success`
- Replace `EventMgr::request_grab` with `grab_press` and `grab_press_unique`

Misc. fixes:

- `FlatTheme::slider` highlight with reversed direction
- `kas_wgpu` timer handling
- Ensure redraw and set nav-focus when list/matrix view selection changes

Possible future extension: possibly add `WidgetId` to `DrawCtx` and `&EventMgr` to `DrawHandle`s, letting the theme calculate needed parts of `InputState` directly. *But* a few widgets currently mutate `InputState` before passing; we'd need an alternative.