### PR TITLE
macros: require 'self.' in autoimpl; better make_widget code

### DIFF
--- a/crates/kas-macros/src/autoimpl.rs
+++ b/crates/kas-macros/src/autoimpl.rs
@@ -10,7 +10,7 @@ use quote::{quote, quote_spanned, TokenStreamExt};
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::spanned::Spanned;
 use syn::token::Comma;
-use syn::{Field, Fields, Ident, ItemStruct, LitInt, Member, Token};
+use syn::{Field, Fields, Ident, ItemStruct, Member, Token};
 
 #[allow(non_camel_case_types)]
 mod kw {
@@ -164,16 +164,22 @@ impl Parse for AutoImpl {
 
         if matches!(mode, Mode::One) {
             let _: kw::on = input.parse()?;
+            let _ = input.parse::<Token![self]>()?;
+            let _ = input.parse::<Token![.]>()?;
             on = Some(input.parse()?);
             lookahead = input.lookahead1();
         } else if lookahead.peek(kw::skip) {
             let _: kw::skip = input.parse()?;
+            let _ = input.parse::<Token![self]>()?;
+            let _ = input.parse::<Token![.]>()?;
             skip.push(input.parse()?);
             empty_or_trailing = false;
             while !input.is_empty() {
                 let lookahead = input.lookahead1();
                 if empty_or_trailing {
-                    if lookahead.peek(Ident) || lookahead.peek(LitInt) {
+                    if lookahead.peek(Token![self]) {
+                        let _ = input.parse::<Token![self]>()?;
+                        let _ = input.parse::<Token![.]>()?;
                         skip.push(input.parse()?);
                         empty_or_trailing = false;
                         continue;

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -56,7 +56,7 @@ mod widget;
 /// # Multi-field traits
 ///
 /// Some trait implementations make use of all fields by default. Individual
-/// fields may be skipped via the `skip x, y` syntax (after any `where`
+/// fields may be skipped via the `skip self.x, self.y` syntax (after any `where`
 /// clauses). The following traits may be derived this way:
 ///
 /// -   `Clone` — implements `std::clone::Clone`; skipped fields are
@@ -66,7 +66,7 @@ mod widget;
 /// # Single-field traits
 ///
 /// Other trait implementations make use of a single field, identified via the
-/// `on x` syntax (after any `where` clauses). The following traits may be
+/// `on self.x` syntax (after any `where` clauses). The following traits may be
 /// derived in this way:
 ///
 /// -   `Deref` — implements `std::ops::Deref`
@@ -91,7 +91,7 @@ mod widget;
 /// use kas_macros::autoimpl;
 /// use std::fmt::Debug;
 ///
-/// #[autoimpl(Debug where X: Debug skip z)]
+/// #[autoimpl(Debug where X: Debug skip self.z)]
 /// struct S<X, Z> {
 ///     x: X,
 ///     y: String,
@@ -102,7 +102,7 @@ mod widget;
 /// Implement `Deref` and `DerefMut`, dereferencing to the given field:
 /// ```rust
 /// # use kas_macros::autoimpl;
-/// #[autoimpl(Deref, DerefMut on 0)]
+/// #[autoimpl(Deref, DerefMut on self.0)]
 /// struct MyWrapper<T>(T);
 /// ```
 #[proc_macro_attribute]

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -184,7 +184,9 @@ pub fn widget(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn make_widget(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as args::MakeWidget);
-    make_widget::make_widget(args).into()
+    make_widget::make_widget(args)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 /// Macro to make a `kas::layout::Layout`

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -36,6 +36,7 @@ pub struct Input {
     pub layout: Tree,
 }
 
+#[derive(Debug)]
 pub struct Tree(Layout);
 impl Tree {
     pub fn generate<'a, I: ExactSizeIterator<Item = &'a Member>>(
@@ -46,6 +47,7 @@ impl Tree {
     }
 }
 
+#[derive(Debug)]
 enum Layout {
     Align(Box<Layout>, Align),
     AlignSingle(Expr, Align),
@@ -58,11 +60,13 @@ enum Layout {
     Grid(GridDimensions, Vec<(CellInfo, Layout)>),
 }
 
+#[derive(Debug)]
 enum List {
     List(Vec<Layout>),
     Glob(Span),
 }
 
+#[derive(Debug)]
 enum Direction {
     Left,
     Right,
@@ -71,18 +75,20 @@ enum Direction {
     Expr(Toks),
 }
 
+#[derive(Debug)]
 enum Align {
     Center,
     Stretch,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct GridDimensions {
     rows: u32,
     cols: u32,
     row_spans: u32,
     col_spans: u32,
 }
+#[derive(Debug)]
 struct CellInfo {
     row: u32,
     row_end: u32,

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -17,7 +17,7 @@ use tiny_skia::Pixmap;
 widget! {
     /// An SVG image loaded from a path
     #[cfg_attr(doc_cfg, doc(cfg(feature = "svg")))]
-    #[autoimpl(Debug skip tree)]
+    #[autoimpl(Debug skip self.tree)]
     #[derive(Clone)]
     pub struct Svg {
         #[widget_core]

--- a/crates/kas-widgets/src/adapter/label.rs
+++ b/crates/kas-widgets/src/adapter/label.rs
@@ -16,7 +16,7 @@ widget! {
     /// usage.
     ///
     /// Mouse/touch input on the label sends events to the inner widget.
-    #[autoimpl(Deref, DerefMut on inner)]
+    #[autoimpl(Deref, DerefMut on self.inner)]
     #[derive(Clone, Default, Debug)]
     #[handler(msg = W::Msg)]
     pub struct WithLabel<W: Widget, D: Directional> {

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -10,9 +10,9 @@ use std::rc::Rc;
 
 widget! {
     /// Wrapper to map messages from the inner widget
-    #[autoimpl(Debug skip map)]
-    #[autoimpl(Deref, DerefMut on inner)]
-    #[autoimpl(class_traits where W: trait on inner)]
+    #[autoimpl(Debug skip self.map)]
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
     #[derive(Clone)]
     #[widget{
         layout = single;

--- a/crates/kas-widgets/src/adapter/reserve.rs
+++ b/crates/kas-widgets/src/adapter/reserve.rs
@@ -22,9 +22,9 @@ widget! {
     /// In a few cases it is desirable to reserve more space for a widget than
     /// required for the current content, e.g. if a label's text may change. This
     /// widget can be used for this by wrapping the base widget.
-    #[autoimpl(Debug skip reserve)]
-    #[autoimpl(Deref, DerefMut on inner)]
-    #[autoimpl(class_traits where W: trait on inner)]
+    #[autoimpl(Debug skip self.reserve)]
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
     #[derive(Clone, Default)]
     #[handler(msg = <W as Handler>::Msg)]
     pub struct Reserve<W: Widget, R: FnMut(SizeMgr, AxisInfo) -> SizeRules + 'static> {

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -17,8 +17,8 @@ widget! {
     ///
     /// Default alignment is centred. Content (label) alignment is derived from the
     /// button alignment.
-    #[autoimpl(Debug skip on_push)]
-    #[autoimpl(class_traits where W: trait on inner)]
+    #[autoimpl(Debug skip self.on_push)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
     #[derive(Clone)]
     pub struct Button<W: Widget<Msg = VoidMsg>, M: 'static> {
         #[widget_core]
@@ -175,7 +175,7 @@ widget! {
     /// Default alignment of the button is to stretch horizontally and centre
     /// vertically. The text label is always centred (irrespective of alignment
     /// parameters).
-    #[autoimpl(Debug skip on_push)]
+    #[autoimpl(Debug skip self.on_push)]
     #[derive(Clone)]
     pub struct TextButton<M: 'static> {
         #[widget_core]

--- a/crates/kas-widgets/src/checkbox.rs
+++ b/crates/kas-widgets/src/checkbox.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 
 widget! {
     /// A bare checkbox (no label)
-    #[autoimpl(Debug skip on_toggle)]
+    #[autoimpl(Debug skip self.on_toggle)]
     #[derive(Clone, Default)]
     #[widget{
         key_nav = true;
@@ -134,7 +134,7 @@ widget! {
 widget! {
     /// A checkbox with label
     #[autoimpl(Debug)]
-    #[autoimpl(HasBool on checkbox)]
+    #[autoimpl(HasBool on self.checkbox)]
     #[derive(Clone, Default)]
     #[widget{
         layout = row: *;

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -17,7 +17,7 @@ widget! {
     /// A pop-up multiple choice menu
     ///
     /// A combobox presents a menu with a fixed set of choices when clicked.
-    #[autoimpl(Debug skip on_select)]
+    #[autoimpl(Debug skip self.on_select)]
     #[derive(Clone)]
     #[widget{
         key_nav = true;

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -111,7 +111,7 @@ impl EditGuard for () {
 }
 
 /// An [`EditGuard`] impl which calls a closure when activated
-#[autoimpl(Debug skip 0)]
+#[autoimpl(Debug skip self.0)]
 #[derive(Clone)]
 pub struct EditActivate<F: FnMut(&str, &mut EventMgr) -> Option<M>, M>(pub F);
 impl<F, M: 'static> EditGuard for EditActivate<F, M>
@@ -125,7 +125,7 @@ where
 }
 
 /// An [`EditGuard`] impl which calls a closure when activated or focus is lost
-#[autoimpl(Debug skip 0)]
+#[autoimpl(Debug skip self.0)]
 #[derive(Clone)]
 pub struct EditAFL<F: FnMut(&str, &mut EventMgr) -> Option<M>, M>(pub F);
 impl<F, M: 'static> EditGuard for EditAFL<F, M>
@@ -142,7 +142,7 @@ where
 }
 
 /// An [`EditGuard`] impl which calls a closure when edited
-#[autoimpl(Debug skip 0)]
+#[autoimpl(Debug skip self.0)]
 #[derive(Clone)]
 pub struct EditEdit<F: FnMut(&str, &mut EventMgr) -> Option<M>, M>(pub F);
 impl<F, M: 'static> EditGuard for EditEdit<F, M>
@@ -156,7 +156,7 @@ where
 }
 
 /// An [`EditGuard`] impl which calls a closure when updated
-#[autoimpl(Debug skip 0)]
+#[autoimpl(Debug skip self.0)]
 #[derive(Clone)]
 pub struct EditUpdate<F: FnMut(&str)>(pub F);
 impl<F: FnMut(&str) + 'static> EditGuard for EditUpdate<F> {
@@ -170,7 +170,7 @@ widget! {
     /// A text-edit box
     ///
     /// This is just a wrapper around [`EditField`] adding a frame.
-    #[autoimpl(Deref, DerefMut, HasStr, HasString on inner)]
+    #[autoimpl(Deref, DerefMut, HasStr, HasString on self.inner)]
     #[derive(Clone, Default, Debug)]
     #[handler(msg = G::Msg)]
     pub struct EditBox<G: EditGuard = ()> {

--- a/crates/kas-widgets/src/frame.rs
+++ b/crates/kas-widgets/src/frame.rs
@@ -13,8 +13,8 @@ widget! {
     ///
     /// This widget provides a simple abstraction: drawing a frame around its
     /// contents.
-    #[autoimpl(Deref, DerefMut on inner)]
-    #[autoimpl(class_traits where W: trait on inner)]
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
     #[derive(Clone, Debug, Default)]
     #[handler(msg = <W as Handler>::Msg)]
     pub struct Frame<W: Widget> {

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -107,7 +107,7 @@ widget! {
 widget! {
     /// A menu entry which can be toggled
     #[autoimpl(Debug)]
-    #[autoimpl(HasBool on checkbox)]
+    #[autoimpl(HasBool on self.checkbox)]
     #[derive(Clone, Default)]
     pub struct MenuToggle<M: 'static> {
         #[widget_core]

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -12,8 +12,8 @@ widget! {
     ///
     /// This widget is a wrapper that can be used to make a static widget such as a
     /// `Label` navigable with the keyboard.
-    #[autoimpl(Deref, DerefMut on inner)]
-    #[autoimpl(class_traits where W: trait on inner)]
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
     #[derive(Clone, Debug, Default)]
     #[widget{
         key_nav = true;

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -16,7 +16,7 @@ pub type RadioBoxGroup = SharedRc<WidgetId>;
 
 widget! {
     /// A bare radiobox (no label)
-    #[autoimpl(Debug skip on_select)]
+    #[autoimpl(Debug skip self.on_select)]
     #[derive(Clone)]
     pub struct RadioBoxBare<M: 'static> {
         #[widget_core]
@@ -180,7 +180,7 @@ widget! {
 widget! {
     /// A radiobox with label
     #[autoimpl(Debug)]
-    #[autoimpl(HasBool on radiobox)]
+    #[autoimpl(HasBool on self.radiobox)]
     #[derive(Clone)]
     #[widget{
         find_id = Some(self.radiobox.id());

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -19,8 +19,8 @@ widget! {
     /// Scrollbars are not included; use [`ScrollBarRegion`] if you want those.
     ///
     /// [`ScrollBarRegion`]: crate::ScrollBarRegion
-    #[autoimpl(Deref, DerefMut on inner)]
-    #[autoimpl(class_traits where W: trait on inner)]
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
     #[derive(Clone, Debug, Default)]
     #[handler(msg = <W as event::Handler>::Msg)]
     pub struct ScrollRegion<W: Widget> {

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -327,8 +327,8 @@ widget! {
     /// This is essentially a `ScrollBars<ScrollRegion<W>>`:
     /// [`ScrollRegion`] handles the actual scrolling and wheel/touch events,
     /// while [`ScrollBars`] adds scrollbar controls.
-    #[autoimpl(Deref, DerefMut on 0)]
-    #[autoimpl(class_traits where W: trait on 0)]
+    #[autoimpl(Deref, DerefMut on self.0)]
+    #[autoimpl(class_traits where W: trait on self.0)]
     #[derive(Clone, Debug, Default)]
     #[widget{
         derive = self.0;
@@ -425,8 +425,8 @@ widget! {
     /// the result looks poor when content is scrolled. Instead the content should
     /// force internal margins by wrapping contents with a (zero-sized) frame.
     /// [`ScrollRegion`] already does this.
-    #[autoimpl(Deref, DerefMut on inner)]
-    #[autoimpl(class_traits where W: trait on inner)]
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
     #[derive(Clone, Debug, Default)]
     #[handler(msg = <W as event::Handler>::Msg)]
     pub struct ScrollBars<W: Scrollable> {

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -23,7 +23,7 @@ widget! {
     /// The driver `V` must implement [`Driver`], with data type
     /// `<T as SingleData>::Item`. Several implementations are available in the
     /// [`driver`] module or a custom implementation may be used.
-    #[autoimpl(Debug skip view)]
+    #[autoimpl(Debug skip self.view)]
     #[derive(Clone)]
     #[widget{
         layout = single;

--- a/crates/kas-widgets/src/window.rs
+++ b/crates/kas-widgets/src/window.rs
@@ -15,8 +15,8 @@ use std::path::Path;
 
 widget! {
     /// The main instantiation of the [`Window`] trait.
-    #[autoimpl(Clone where W: Clone skip popups, drop)]
-    #[autoimpl(Debug skip drop, icon)]
+    #[autoimpl(Clone where W: Clone skip self.popups, self.drop)]
+    #[autoimpl(Debug skip self.drop, self.icon)]
     pub struct Window<W: Widget + 'static> {
         #[widget_core]
         core: CoreData,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -279,8 +279,8 @@
 //! # use kas::prelude::*;
 //! # use kas::widgets::{ScrollBars, ScrollRegion};
 //! widget! {
-//!     #[autoimpl(Deref, DerefMut on 0)]
-//!     #[autoimpl(class_traits where W: trait on 0)]
+//!     #[autoimpl(Deref, DerefMut on self.0)]
+//!     #[autoimpl(class_traits where W: trait on self.0)]
 //!     #[derive(Clone, Debug, Default)]
 //!     #[widget{
 //!         derive = self.0;


### PR DESCRIPTION
- `autoimpl` macro has slightly different syntax: `on self.field` or `skip self.field`
- `make_widget` macro now directly generates input struct for `widget` macro instead of generating code to be parsed again. This sped up `cargo check --examples` by about 2%.