### PR TITLE
Add shift+mwheel scrolling

### DIFF
--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -297,7 +297,7 @@ impl ScrollComponent {
             Event::Scroll(delta) => {
                 let d = match delta {
                     LineDelta(x, y) => Offset(
-                        (-self.scroll_rate * x).cast_nearest(),
+                        (self.scroll_rate * x).cast_nearest(),
                         (self.scroll_rate * y).cast_nearest(),
                     ),
                     PixelDelta(d) => d,

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -403,13 +403,25 @@ impl<'a> EventMgr<'a> {
 
                 self.state.last_click_button = FAKE_MOUSE_BUTTON;
 
+                // Shift key forces horisontal scrolling
+                let shift_pressed = self.state.modifiers.shift();
+
                 let event = Event::Scroll(match delta {
-                    MouseScrollDelta::LineDelta(x, y) => ScrollDelta::LineDelta(x, y),
+                    MouseScrollDelta::LineDelta(x, y) =>
+                        if shift_pressed {
+                            ScrollDelta::LineDelta(y, x)
+                        } else {
+                            ScrollDelta::LineDelta(x, y)
+                        },
                     MouseScrollDelta::PixelDelta(pos) => {
                         // The delta is given as a PhysicalPosition, so we need
                         // to convert to our vector type (Offset) here.
                         let coord = Coord::from(pos);
-                        ScrollDelta::PixelDelta(Offset(coord.0, coord.1))
+                        if shift_pressed {
+                            ScrollDelta::PixelDelta(Offset(coord.1, coord.0))
+                        } else {
+                            ScrollDelta::PixelDelta(Offset(coord.0, coord.1))
+                        }
                     }
                 });
                 if let Some(id) = self.state.hover.clone() {


### PR DESCRIPTION
Shift+MWheel scrolls horizontally. Tested on ListView, EditBox and ScrollLabel (but i wasn't able to test horizontal scrolling in the last one, it wraps text)

Compared to Firefox scrolling looks same.