### PR TITLE
Fix key-nav for List/Matrix-View; add examples/times-tables.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This is a small patch:
 -   `WidgetId` has been completely re-written, and now represents a path
 -   `Ord for WidgetId` now considers a parent to come *before* its children.
     Note: previously ordering was used in `send` logic; this is no longer
-    recommended (use e.g. `WidgetId::index_of_child` instead).
+    recommended (use e.g. `Widget::find_child_index` instead).
 
 ## [0.10.0] — 2021-09-05
 

--- a/crates/kas-core/src/core/mod.rs
+++ b/crates/kas-core/src/core/mod.rs
@@ -12,7 +12,7 @@ mod widget_id;
 
 pub use data::*;
 pub use widget::*;
-pub use widget_id::WidgetId;
+pub use widget_id::*;
 
 /// Provides a convenient `.boxed()` method on implementors
 pub trait Boxed<T: ?Sized> {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -170,6 +170,22 @@ pub trait WidgetChildren: WidgetCore {
     /// index.
     fn num_children(&self) -> usize;
 
+    /// Get the [`WidgetId`] for this child
+    ///
+    /// Note: the result should be generated relative to `self.id`.
+    /// Most widgets may use the default implementation.
+    ///
+    /// This must return `Some(..)` when `index` is valid; in other cases the
+    /// result does not matter.
+    ///
+    /// If a custom implementation is used, then [`Self::find_child_index`]
+    /// must be implemented to do the inverse of `make_child_id`, and
+    /// probably a custom implementation of [`Layout::spatial_nav`] is needed.
+    #[inline]
+    fn make_child_id(&self, index: usize) -> Option<WidgetId> {
+        Some(self.id_ref().make_child(index))
+    }
+
     /// Get a reference to a child widget by index, or `None` if the index is
     /// out of bounds.
     ///

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -353,8 +353,7 @@ impl WidgetId {
 
     pub fn iter_keys_after(&self, id: &Self) -> WidgetPathIter {
         let mut self_iter = self.iter();
-        let mut id_iter = id.iter();
-        while let Some(v) = id_iter.next() {
+        for v in id.iter() {
             if self_iter.next() != Some(v) {
                 return WidgetPathIter(PathIter::Bits(BitsIter(0, 0)));
             }

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -192,15 +192,16 @@ impl<'a> Iterator for PathIter<'a> {
 /// Widget identifier
 ///
 /// All widgets are assigned an identifier which is unique within the window.
-/// This type may be tested for equality, ancestry, and to determine the "index"
-/// of a child.
+/// This type may be tested for equality and order and may be iterated over as
+/// a "path" of "key" values.
 ///
 /// This type is small (64-bit) and non-zero: `Option<WidgetId>` has the same
 /// size as `WidgetId`. It is also very cheap to `Clone`: usually only one `if`
 /// check, and in the worst case a pointer dereference and ref-count increment.
+/// Bit-packing is used allowing up to 14 keys (depending on the values)
+/// internally; beyond this limit a reference-counted stack allocation is used.
 ///
-/// `WidgetId` is neither `Send` nor `Sync` since it may use non-atomic
-/// reference counting internally.
+/// `WidgetId` is neither `Send` nor `Sync`.
 ///
 /// Identifiers are assigned when configured and when re-configured
 /// (via [`crate::TkAction::RECONFIGURE`] or [`crate::layout::SetRectMgr::configure`]).
@@ -209,10 +210,10 @@ impl<'a> Iterator for PathIter<'a> {
 #[derive(Clone)]
 pub struct WidgetId(IntOrPtr);
 
-// Encode lowest 48 bits of index into the low bits of a u64, returning also the encoded bit-length
-fn encode(index: usize) -> (u64, u8) {
-    debug_assert!(8 * size_of::<usize>() as u32 - index.leading_zeros() <= 64);
-    let mut x = index as u64 & 0x0000_FFFF_FFFF_FFFF;
+// Encode lowest 48 bits of key into the low bits of a u64, returning also the encoded bit-length
+fn encode(key: usize) -> (u64, u8) {
+    debug_assert!(8 * size_of::<usize>() as u32 - key.leading_zeros() <= 64);
+    let mut x = key as u64 & 0x0000_FFFF_FFFF_FFFF;
     let mut y = x & 7;
     x >>= 3;
     let mut shift = 4;
@@ -310,32 +311,34 @@ impl WidgetId {
         }
     }
 
-    /// Get index of `child` relative to `self`
+    /// Get first key in path of `self` path after `id`
     ///
-    /// Returns `None` if `child` is not a descendant of `self`.
-    pub fn index_of_child(&self, child: &Self) -> Option<usize> {
-        match (self.0.get(), child.0.get()) {
+    /// If the path of `self` starts with the path of `id`
+    /// (`id.is_ancestor_of(self)`) then this returns the *next* key in
+    /// `self`'s path (if any). Otherwise, this returns `None`.
+    pub fn next_key_after(&self, id: &Self) -> Option<usize> {
+        match (id.0.get(), self.0.get()) {
             (Variant::Invalid, _) | (_, Variant::Invalid) => None,
             (Variant::Slice(_), Variant::Int(_)) => None,
-            (Variant::Int(self_x), Variant::Int(child_x)) => {
-                let self_blocks = block_len(self_x);
+            (Variant::Int(parent_x), Variant::Int(child_x)) => {
+                let parent_blocks = block_len(parent_x);
                 let child_blocks = block_len(child_x);
-                if self_blocks >= child_blocks {
+                if parent_blocks >= child_blocks {
                     return None;
                 }
 
-                // self_blocks == 0 for ROOT, otherwise > 0
-                let shift = 4 * (BLOCKS - self_blocks) + 8;
-                if shift != 64 && self_x >> shift != child_x >> shift {
+                // parent_blocks == 0 for ROOT, otherwise > 0
+                let shift = 4 * (BLOCKS - parent_blocks) + 8;
+                if shift != 64 && parent_x >> shift != child_x >> shift {
                     return None;
                 }
 
                 debug_assert!(child_blocks > 0);
-                let next_bits = (child_x & MASK_BITS) << (4 * self_blocks);
+                let next_bits = (child_x & MASK_BITS) << (4 * parent_blocks);
                 Some(next_from_bits(next_bits).0)
             }
-            (Variant::Int(self_x), Variant::Slice(child_path)) => {
-                let iter = BitsIter::new(self_x);
+            (Variant::Int(parent_x), Variant::Slice(child_path)) => {
+                let iter = BitsIter::new(parent_x);
                 let mut child_iter = child_path.iter();
                 if iter.zip(&mut child_iter).all(|(a, b)| a == *b) {
                     child_iter.next().cloned()
@@ -343,9 +346,9 @@ impl WidgetId {
                     None
                 }
             }
-            (Variant::Slice(self_path), Variant::Slice(child_path)) => {
-                if child_path.starts_with(self_path) {
-                    child_path[self_path.len()..].iter().next().cloned()
+            (Variant::Slice(parent_path), Variant::Slice(child_path)) => {
+                if child_path.starts_with(parent_path) {
+                    child_path[parent_path.len()..].iter().next().cloned()
                 } else {
                     None
                 }
@@ -353,12 +356,12 @@ impl WidgetId {
         }
     }
 
-    /// Make an identifier for the child with the given `index`
+    /// Make an identifier for the child with the given `key`
     ///
     /// Note: this is not a getter method. Calling multiple times with the same
-    /// `index` may or may not return the same value!
+    /// `key` may or may not return the same value!
     #[must_use]
-    pub fn make_child(&self, index: usize) -> Self {
+    pub fn make_child(&self, key: usize) -> Self {
         match self.0.get() {
             Variant::Invalid => panic!("WidgetId::make_child: invalid id"),
             Variant::Int(self_x) => {
@@ -367,9 +370,9 @@ impl WidgetId {
                 let block_len = block_len(self_x);
                 let avail_blocks = BLOCKS - block_len;
                 // Note: zero is encoded with 1 block to force bump to len
-                let req_bits = (8 * size_of::<usize>() as u8 - index.leading_zeros() as u8).max(1);
+                let req_bits = (8 * size_of::<usize>() as u8 - key.leading_zeros() as u8).max(1);
                 if req_bits <= 3 * avail_blocks {
-                    let (bits, bit_len) = encode(index);
+                    let (bits, bit_len) = encode(key);
                     let used_blocks = bit_len / 4;
                     debug_assert_eq!(used_blocks, (req_bits + 2) / 3);
                     let len = (block_len as u64 + used_blocks as u64) << SHIFT_LEN;
@@ -377,11 +380,11 @@ impl WidgetId {
                     let id = (self_x & MASK_BITS) | rest | len | USE_BITS;
                     WidgetId(IntOrPtr::new_int(id))
                 } else {
-                    WidgetId(IntOrPtr::new_iter(BitsIter::new(self_x).chain(once(index))))
+                    WidgetId(IntOrPtr::new_iter(BitsIter::new(self_x).chain(once(key))))
                 }
             }
             Variant::Slice(path) => {
-                WidgetId(IntOrPtr::new_iter(path.iter().cloned().chain(once(index))))
+                WidgetId(IntOrPtr::new_iter(path.iter().cloned().chain(once(key))))
             }
         }
     }
@@ -538,8 +541,8 @@ impl fmt::Display for WidgetId {
             }
             Variant::Slice(path) => {
                 write!(f, "#")?;
-                for index in path {
-                    let (bits, bit_len) = encode(*index);
+                for key in path {
+                    let (bits, bit_len) = encode(*key);
                     write!(f, "{1:0>0$x}", bit_len as usize / 4, bits)?;
                 }
                 Ok(())
@@ -654,8 +657,8 @@ mod test {
     fn test_make_child() {
         fn test(seq: &[usize], x: u64) {
             let mut id = WidgetId::ROOT;
-            for index in seq {
-                id = id.make_child(*index);
+            for key in seq {
+                id = id.make_child(*key);
             }
             let v = id.as_u64();
             if v != x {
@@ -709,7 +712,7 @@ mod test {
             println!("id2={} val={:x} from {:?}", id2, id2.as_u64(), seq2);
             let next = seq2.iter().next().cloned();
             assert_eq!(id.is_ancestor_of(&id2), next.is_some() || id == id2);
-            assert_eq!(id.index_of_child(&id2), next);
+            assert_eq!(id2.next_key_after(&id), next);
         }
 
         test(&[], &[]);
@@ -738,7 +741,7 @@ mod test {
             }
             println!("id2={} val={:x} from {:?}", id2, id2.as_u64(), seq2);
             assert_eq!(id.is_ancestor_of(&id2), false);
-            assert_eq!(id.index_of_child(&id2), None);
+            assert_eq!(id2.next_key_after(&id), None);
         }
 
         test(&[0], &[]);

--- a/crates/kas-core/src/dir.rs
+++ b/crates/kas-core/src/dir.rs
@@ -26,12 +26,15 @@ pub trait Directional: Copy + Sized + std::fmt::Debug + 'static {
     type Reversed: Directional;
 
     /// Flip over diagonal (i.e. Down ↔ Right)
+    #[must_use = "method does not modify self but returns a new value"]
     fn flipped(self) -> Self::Flipped;
 
     /// Reverse along axis (i.e. Left ↔ Right)
+    #[must_use = "method does not modify self but returns a new value"]
     fn reversed(self) -> Self::Reversed;
 
     /// Convert to the [`Direction`] enum
+    #[must_use = "method does not modify self but returns a new value"]
     fn as_direction(self) -> Direction;
 
     /// Up or Down

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -337,8 +337,14 @@ impl ScrollComponent {
                 let decay = mgr.config().scroll_flick_decay();
                 if let Some(delta) = self.glide.step(decay) {
                     action = self.set_offset(self.offset - delta);
-                    mgr.update_on_timer(Duration::from_millis(GLIDE_POLL_MS), id, PAYLOAD_GLIDE);
-                    response = Response::Scrolled;
+                    if delta == Offset::ZERO || !action.is_empty() {
+                        // Note: when FPS > pixels/sec, delta may be zero while
+                        // still scrolling. Glide returns None when we're done,
+                        // but we're also done if unable to scroll further.
+                        let dur = Duration::from_millis(GLIDE_POLL_MS);
+                        mgr.update_on_timer(dur, id, PAYLOAD_GLIDE);
+                        response = Response::Scrolled;
+                    }
                 }
             }
             _ => response = Response::Unused,

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -155,7 +155,7 @@ impl ScrollComponent {
     /// or [`TkAction::REGION_MOVED`] if the offset changes.
     #[inline]
     pub fn set_offset(&mut self, offset: Offset) -> TkAction {
-        let offset = offset.clamp(Offset::ZERO, self.max_offset);
+        let offset = offset.min(self.max_offset).max(Offset::ZERO);
         if offset == self.offset {
             TkAction::empty()
         } else {

--- a/crates/kas-core/src/event/handler.rs
+++ b/crates/kas-core/src/event/handler.rs
@@ -95,7 +95,7 @@ pub trait SendEvent: Handler {
     /// if self.is_disabled() {
     ///     return Response::Unused;
     /// }
-    /// match self.id().index_of_child(id) {
+    /// match self.find_child_index(&id) {
     ///     Some(0) => self.child0.send(mgr, id, event).into(),
     ///     Some(1) => self.child1.send(mgr, id, event).into(),
     ///     // ...

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -87,7 +87,7 @@ impl EventState {
             widget: &mut dyn WidgetConfig,
             count: &mut usize,
         ) {
-            widget.pre_configure(mgr, id.clone());
+            widget.pre_configure(mgr, id);
             *count += 1;
             for i in 0..widget.num_children() {
                 if let Some(id) = widget.make_child_id(i) {

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -90,8 +90,10 @@ impl EventState {
             widget.pre_configure(mgr, id.clone());
             *count += 1;
             for i in 0..widget.num_children() {
-                if let Some(w) = widget.get_child_mut(i) {
-                    recurse(mgr, id.make_child(i), w, count);
+                if let Some(id) = widget.make_child_id(i) {
+                    if let Some(w) = widget.get_child_mut(i) {
+                        recurse(mgr, id, w, count);
+                    }
                 }
             }
             widget.configure(mgr);

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -63,15 +63,6 @@ macro_rules! impl_common {
                 Self(self.0.max(other.0), self.1.max(other.1))
             }
 
-            /// Return the value clamped to the given `min` and `max`
-            ///
-            /// In the case that `min > max`, the `min` value is returned.
-            #[inline]
-            #[must_use = "method does not modify self but returns a new value"]
-            pub fn clamp(self, min: Self, max: Self) -> Self {
-                self.min(max).max(min)
-            }
-
             /// Return the transpose (swap x and y values)
             #[inline]
             #[must_use = "method does not modify self but returns a new value"]

--- a/crates/kas-core/src/layout/sizer.rs
+++ b/crates/kas-core/src/layout/sizer.rs
@@ -61,16 +61,16 @@ pub trait RulesSetter {
 
 /// Solve size rules for a widget
 ///
-/// Widget layout is normally a two-step process: (1) `size_rules` is called
-/// (twice: once for each axis), with parent widgets querying child size as part
-/// of this step, then (2) `set_rect` is called.
+/// It is required that a widget's `size_rules` method is called, for each axis,
+/// before `set_rect`. This method may be used to call `size_rules` in case the
+/// parent's own `size_rules` method may not.
 ///
-/// Some parent widgets do not call `size_rules` for all their children within
-/// their own `size_rules` method (perhaps because the children do not exist
-/// yet); in this case they should use this method to perform step (1) for
-/// those children before calling `set_rect` on them. (It is acceptable though
-/// not useful to perform step (1) multiple times. It is also acceptable never
-/// to do this if `set_rect` is also never called and the widget never drawn.)
+/// Note: it is not necessary to solve size rules again before calling
+/// `set_rect` a second time, although if the widget's content changes then it
+/// is recommended.
+///
+/// Note: it is not necessary to ever call `size_rules` *or* `set_rect` if the
+/// widget is never drawn and never receives events.
 ///
 /// Parameters `x_size` and `y_size` should be passed where this dimension is
 /// fixed and are used e.g. for text wrapping.

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -5,6 +5,9 @@
 
 //! Layout visitor
 
+// Methods have to take `&mut self`
+#![allow(clippy::wrong_self_convention)]
+
 use super::{AlignHints, AxisInfo, RulesSetter, RulesSolver, SetRectMgr, SizeRules, Storage};
 use super::{DynRowStorage, RowPositionSolver, RowSetter, RowSolver, RowStorage};
 use super::{GridChildInfo, GridDimensions, GridSetter, GridSolver, GridStorage};

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -129,11 +129,8 @@ macro_rules! impl_via_deref {
                 self.deref().version()
             }
 
-            fn col_len(&self) -> usize {
-                self.deref().col_len()
-            }
-            fn row_len(&self) -> usize {
-                self.deref().row_len()
+            fn len(&self) -> (usize, usize) {
+                self.deref().len()
             }
             fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {
                 self.deref().make_id(parent, key)

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -54,47 +54,6 @@ impl<T: Clone + Debug> ListDataMut for [T] {
     }
 }
 
-impl<K: Ord + Eq + Clone + Debug, T: Clone + Debug> ListData for std::collections::BTreeMap<K, T> {
-    type Key = K;
-    type Item = T;
-
-    fn version(&self) -> u64 {
-        0
-    }
-
-    fn len(&self) -> usize {
-        (*self).len()
-    }
-
-    fn contains_key(&self, key: &Self::Key) -> bool {
-        (*self).contains_key(key)
-    }
-
-    fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
-        (*self).get(key).cloned()
-    }
-
-    fn update(&self, _: &Self::Key, _: Self::Item) -> Option<UpdateHandle> {
-        // Note: plain BTreeMap does not support update, but SharedRc<..> does.
-        None
-    }
-
-    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
-        self.iter()
-            .take(limit)
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
-    }
-
-    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
-        self.iter()
-            .skip(start)
-            .take(limit)
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
-    }
-}
-
 // TODO(spec): implement using Deref; for now can't since it "might" conflict
 // with a RefCell impl on a derived type downstream, according to the solver.
 // impl<T: Deref + Debug> SingleData for T

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -135,6 +135,13 @@ macro_rules! impl_via_deref {
             fn row_len(&self) -> usize {
                 self.deref().row_len()
             }
+            fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {
+                self.deref().make_id(parent, key)
+            }
+            fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key> {
+                self.deref().reconstruct_key(parent, child)
+            }
+
             fn contains(&self, key: &Self::Key) -> bool {
                 self.deref().contains(key)
             }

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -125,6 +125,9 @@ macro_rules! impl_via_deref {
                 self.deref().version()
             }
 
+            fn is_empty(&self) -> bool {
+                self.deref().is_empty()
+            }
             fn len(&self) -> (usize, usize) {
                 self.deref().len()
             }

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -43,17 +43,13 @@ impl<T: Clone + Debug> ListData for [T] {
         None
     }
 
-    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
-        self.iter().cloned().enumerate().take(limit).collect()
+    fn iter_vec(&self, limit: usize) -> Vec<Self::Key> {
+        (0..limit.min((*self).len())).collect()
     }
 
-    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
-        self.iter()
-            .cloned()
-            .enumerate()
-            .skip(start)
-            .take(limit)
-            .collect()
+    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::Key> {
+        let len = (*self).len();
+        (start.min(len)..(start + limit).min(len)).collect()
     }
 }
 impl<T: Clone + Debug> ListDataMut for [T] {
@@ -111,10 +107,10 @@ macro_rules! impl_via_deref {
                 self.deref().update(key, value)
             }
 
-            fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+            fn iter_vec(&self, limit: usize) -> Vec<Self::Key> {
                 self.deref().iter_vec(limit)
             }
-            fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+            fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::Key> {
                 self.deref().iter_vec_from(start, limit)
             }
         }

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -160,8 +160,8 @@ macro_rules! impl_via_deref {
                 self.deref().row_iter_vec_from(start, limit)
             }
 
-            fn make_key(row: &Self::RowKey, col: &Self::ColKey) -> Self::Key {
-                <$t>::make_key(row, col)
+            fn make_key(col: &Self::ColKey, row: &Self::RowKey) -> Self::Key {
+                <$t>::make_key(col, row)
             }
         }
     };

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -7,6 +7,7 @@
 
 use super::*;
 use crate::event::UpdateHandle;
+use crate::WidgetId;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
@@ -20,6 +21,13 @@ impl<T: Clone + Debug> ListData for [T] {
 
     fn len(&self) -> usize {
         (*self).len()
+    }
+
+    fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {
+        parent.make_child(*key)
+    }
+    fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key> {
+        child.next_key_after(parent)
     }
 
     fn contains_key(&self, key: &Self::Key) -> bool {
@@ -85,6 +93,13 @@ macro_rules! impl_via_deref {
             fn len(&self) -> usize {
                 self.deref().len()
             }
+            fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {
+                self.deref().make_id(parent, key)
+            }
+            fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key> {
+                self.deref().reconstruct_key(parent, child)
+            }
+
             fn contains_key(&self, key: &Self::Key) -> bool {
                 self.deref().contains_key(key)
             }

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -224,7 +224,7 @@ pub trait MatrixData: Debug {
     fn row_iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::RowKey>;
 
     /// Make a key from parts
-    fn make_key(row: &Self::RowKey, col: &Self::ColKey) -> Self::Key;
+    fn make_key(col: &Self::ColKey, row: &Self::RowKey) -> Self::Key;
 }
 
 /// Trait for writable data matrices

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -8,6 +8,7 @@
 use crate::event::UpdateHandle;
 #[allow(unused)] // doc links
 use crate::updatable::Updatable;
+use crate::WidgetId;
 #[allow(unused)] // doc links
 use std::cell::RefCell;
 use std::fmt::Debug;
@@ -73,6 +74,20 @@ pub trait ListData: Debug {
     ///
     /// Note: users may assume this is `O(1)`.
     fn len(&self) -> usize;
+
+    /// Make a [`WidgetId`] for a key
+    ///
+    /// The `parent` identifier is used as a reference.
+    fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId;
+
+    /// Reconstruct a key from a [`WidgetId`]
+    ///
+    /// The `parent` identifier is used as a reference.
+    ///
+    /// If the `child` identifier is one returned by [`Self::make_id`] for the
+    /// same `parent`, *or descended from that*, this should return a copy of
+    /// the `key` passed to `make_id`.
+    fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key>;
 
     // TODO(gat): add get<'a>(&self) -> Self::ItemRef<'a> and get_mut
 

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -155,15 +155,10 @@ pub trait MatrixData: Debug {
     /// this data structure.
     fn version(&self) -> u64;
 
-    /// Number of columns available
+    /// Number of `(cols, rows)` available
     ///
     /// Note: users may assume this is `O(1)`.
-    fn col_len(&self) -> usize;
-
-    /// Number of rows available
-    ///
-    /// Note: users may assume this is `O(1)`.
-    fn row_len(&self) -> usize;
+    fn len(&self) -> (usize, usize);
 
     /// Make a [`WidgetId`] for a key
     ///

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -165,6 +165,20 @@ pub trait MatrixData: Debug {
     /// Note: users may assume this is `O(1)`.
     fn row_len(&self) -> usize;
 
+    /// Make a [`WidgetId`] for a key
+    ///
+    /// The `parent` identifier is used as a reference.
+    fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId;
+
+    /// Reconstruct a key from a [`WidgetId`]
+    ///
+    /// The `parent` identifier is used as a reference.
+    ///
+    /// If the `child` identifier is one returned by [`Self::make_id`] for the
+    /// same `parent`, *or descended from that*, this should return a copy of
+    /// the `key` passed to `make_id`.
+    fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key>;
+
     /// Check whether an item with these keys exists
     fn contains(&self, key: &Self::Key) -> bool;
 

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -155,6 +155,9 @@ pub trait MatrixData: Debug {
     /// this data structure.
     fn version(&self) -> u64;
 
+    /// No data is available
+    fn is_empty(&self) -> bool;
+
     /// Number of `(cols, rows)` available
     ///
     /// Note: users may assume this is `O(1)`.

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -112,19 +112,19 @@ pub trait ListData: Debug {
     fn update(&self, key: &Self::Key, value: Self::Item) -> Option<UpdateHandle>;
 
     // TODO(gat): replace with an iterator
-    /// Iterate over (key, value) pairs as a vec
+    /// Iterate over keys as a vec
     ///
     /// The result will be in deterministic implementation-defined order, with
     /// a length of `max(limit, data_len)` where `data_len` is the number of
     /// items available.
-    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+    fn iter_vec(&self, limit: usize) -> Vec<Self::Key> {
         self.iter_vec_from(0, limit)
     }
 
-    /// Iterate over (key, value) pairs as a vec
+    /// Iterate over keys as a vec
     ///
     /// The result is the same as `self.iter_vec(start + limit).skip(start)`.
-    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)>;
+    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::Key>;
 }
 
 /// Trait for writable data lists

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -137,6 +137,14 @@ impl<T: MatrixDataMut> MatrixData for SharedRc<T> {
     fn row_len(&self) -> usize {
         (self.0).1.borrow().0.row_len()
     }
+
+    fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {
+        (self.0).1.borrow().0.make_id(parent, key)
+    }
+    fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key> {
+        (self.0).1.borrow().0.reconstruct_key(parent, child)
+    }
+
     fn contains(&self, key: &Self::Key) -> bool {
         (self.0).1.borrow().0.contains(key)
     }

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -131,6 +131,9 @@ impl<T: MatrixDataMut> MatrixData for SharedRc<T> {
         cell.0.version() + cell.1
     }
 
+    fn is_empty(&self) -> bool {
+        (self.0).1.borrow().0.is_empty()
+    }
     fn len(&self) -> (usize, usize) {
         (self.0).1.borrow().0.len()
     }

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -106,11 +106,11 @@ impl<T: ListDataMut> ListData for SharedRc<T> {
         Some((self.0).0)
     }
 
-    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+    fn iter_vec(&self, limit: usize) -> Vec<Self::Key> {
         (self.0).1.borrow().0.iter_vec(limit)
     }
 
-    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
+    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::Key> {
         (self.0).1.borrow().0.iter_vec_from(start, limit)
     }
 }

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -131,11 +131,8 @@ impl<T: MatrixDataMut> MatrixData for SharedRc<T> {
         cell.0.version() + cell.1
     }
 
-    fn col_len(&self) -> usize {
-        (self.0).1.borrow().0.col_len()
-    }
-    fn row_len(&self) -> usize {
-        (self.0).1.borrow().0.row_len()
+    fn len(&self) -> (usize, usize) {
+        (self.0).1.borrow().0.len()
     }
 
     fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -14,6 +14,7 @@
 use crate::event::EventMgr;
 use crate::event::UpdateHandle;
 use crate::updatable::*;
+use crate::WidgetId;
 use std::cell::RefCell;
 use std::fmt::Debug;
 use std::rc::Rc;
@@ -81,6 +82,13 @@ impl<T: ListDataMut> ListData for SharedRc<T> {
 
     fn len(&self) -> usize {
         (self.0).1.borrow().0.len()
+    }
+
+    fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {
+        (self.0).1.borrow().0.make_id(parent, key)
+    }
+    fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key> {
+        (self.0).1.borrow().0.reconstruct_key(parent, child)
     }
 
     fn contains_key(&self, key: &Self::Key) -> bool {

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -170,8 +170,8 @@ impl<T: MatrixDataMut> MatrixData for SharedRc<T> {
         (self.0).1.borrow().0.row_iter_vec_from(start, limit)
     }
 
-    fn make_key(row: &Self::RowKey, col: &Self::ColKey) -> Self::Key {
-        T::make_key(row, col)
+    fn make_key(col: &Self::ColKey, row: &Self::RowKey) -> Self::Key {
+        T::make_key(col, row)
     }
 }
 impl<T: MatrixDataMut> MatrixDataMut for SharedRc<T> {

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -412,15 +412,14 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
             }
 
             quote! {
-                use ::kas::{WidgetCore, event::Response};
+                use ::kas::{WidgetCore, WidgetChildren, event::Response};
                 if self.is_disabled() {
                     return Response::Unused;
                 }
 
-                let self_id = self.id();
-                match self_id.index_of_child(&id) {
+                match self.find_child_index(&id) {
                     #ev_to_num
-                    _ if id == self_id => ::kas::event::EventMgr::handle_generic(self, mgr, event),
+                    _ if id == self.core_data().id => ::kas::event::EventMgr::handle_generic(self, mgr, event),
                     _ => {
                         debug_assert!(false, "SendEvent::send: bad WidgetId");
                         Response::Unused

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -291,7 +291,7 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
         toks.append_all(quote! {
             impl #impl_generics ::kas::Layout for #name #ty_generics #where_clause {
                 fn layout<'a>(&'a mut self) -> ::kas::layout::Layout<'a> {
-                    use ::kas::WidgetCore;
+                    use ::kas::{WidgetCore, layout};
                     let mut _chain = &mut self.#core.layout;
                     #layout
                 }

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -14,7 +14,7 @@ use crate::anim::AnimState;
 use kas::cast::{Cast, CastFloat, ConvFloat};
 use kas::geom::{Size, Vec2};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, Stretch};
-use kas::text::{fonts::FontId, TextApi, TextApiExt};
+use kas::text::{fonts::FontId, Align, TextApi, TextApiExt};
 use kas::theme::{SizeHandle, TextClass};
 
 /// Parameterisation of [`Dimensions`]
@@ -222,6 +222,7 @@ impl<D: 'static> SizeHandle for Window<D> {
                     bounds.0 = size.cast();
                 }
                 env.set_bounds(bounds);
+                env.set_align((Align::TL, Align::TL)); // force top-left alignment for sizing
 
                 env.set_wrap(matches!(
                     class,

--- a/crates/kas-widgets/src/drag.rs
+++ b/crates/kas-widgets/src/drag.rs
@@ -131,7 +131,7 @@ impl DragHandle {
     /// the handle hasn't moved; `REDRAW` if it has (though this widget is
     /// not directly responsible for drawing, so this may not be accurate).
     pub fn set_offset(&mut self, offset: Offset) -> (Offset, TkAction) {
-        let offset = offset.clamp(Offset::ZERO, self.max_offset());
+        let offset = offset.min(self.max_offset()).max(Offset::ZERO);
         let handle_pos = self.track.pos + offset;
         if handle_pos != self.core.rect.pos {
             self.core.rect.pos = handle_pos;

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -578,7 +578,7 @@ widget! {
         }
 
         fn set_scroll_offset(&mut self, mgr: &mut EventMgr, offset: Offset) -> Offset {
-            let new_offset = offset.clamp(Offset::ZERO, self.max_scroll_offset());
+            let new_offset = offset.min(self.max_scroll_offset()).max(Offset::ZERO);
             if new_offset != self.view_offset {
                 self.view_offset = new_offset;
                 // No widget moves so do not need to report TkAction::REGION_MOVED
@@ -1089,7 +1089,9 @@ impl<G: EditGuard> EditField<G> {
 
     // Pan by given delta. Return `Response::Scrolled` or `Response::Pan(remaining)`.
     fn pan_delta<U>(&mut self, mgr: &mut EventMgr, mut delta: Offset) -> Response<U> {
-        let new_offset = (self.view_offset - delta).clamp(Offset::ZERO, self.max_scroll_offset());
+        let new_offset = (self.view_offset - delta)
+            .min(self.max_scroll_offset())
+            .max(Offset::ZERO);
         if new_offset != self.view_offset {
             delta -= self.view_offset - new_offset;
             self.view_offset = new_offset;

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -393,13 +393,11 @@ widget! {
 
             self.core.rect = rect;
             let size = rect.size;
-            let multi_line = self.multi_line;
             self.required = self
                 .text
                 .update_env(|env| {
                     env.set_align(align.unwrap_or(Align::Default, valign));
                     env.set_bounds(size.into());
-                    env.set_wrap(multi_line);
                 })
                 .into();
             self.set_view_offset_from_edit_pos();

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -83,7 +83,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut EventMgr, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() {
-                if let Some(index) = self.id().index_of_child(&id) {
+                if let Some(index) = self.find_child_index(&id) {
                     if let Some((_, child)) = self.widgets.get_mut(index) {
                         let r = child.send(mgr, id.clone(), event);
                         return match Response::try_from(r) {

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -48,8 +48,14 @@
 //! -   [`DragHandle`]: a handle (e.g. for a slider, splitter or scrollbar)
 
 // Use ``never_loop`` until: https://github.com/rust-lang/rust-clippy/issues/7397 is fixed
-#![allow(clippy::or_fun_call, clippy::never_loop, clippy::comparison_chain)]
-#![allow(clippy::needless_late_init)]
+#![allow(
+    clippy::or_fun_call,
+    clippy::never_loop,
+    clippy::comparison_chain,
+    clippy::needless_late_init,
+    clippy::collapsible_else_if,
+    clippy::len_zero
+)]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(feature = "min_spec", feature(min_specialization))]
 

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -204,7 +204,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut EventMgr, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() {
-                if let Some(index) = self.id().index_of_child(&id) {
+                if let Some(index) = self.find_child_index(&id) {
                     if let Some(child) = self.widgets.get_mut(index) {
                         let r = child.send(mgr, id.clone(), event);
                         return match Response::try_from(r) {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -98,7 +98,7 @@ widget! {
 
         // Pan by given delta. Return `Response::Scrolled` or `Response::Pan(remaining)`.
         fn pan_delta<U>(&mut self, mgr: &mut EventMgr, mut delta: Offset) -> Response<U> {
-            let new_offset = (self.view_offset - delta).clamp(Offset::ZERO, self.max_scroll_offset());
+            let new_offset = (self.view_offset - delta).min(self.max_scroll_offset()).max(Offset::ZERO);
             if new_offset != self.view_offset {
                 delta -= self.view_offset - new_offset;
                 self.view_offset = new_offset;
@@ -230,7 +230,7 @@ widget! {
         }
 
         fn set_scroll_offset(&mut self, mgr: &mut EventMgr, offset: Offset) -> Offset {
-            let new_offset = offset.clamp(Offset::ZERO, self.max_scroll_offset());
+            let new_offset = offset.min(self.max_scroll_offset()).max(Offset::ZERO);
             if new_offset != self.view_offset {
                 self.view_offset = new_offset;
                 // No widget moves so do not need to report TkAction::REGION_MOVED

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -646,7 +646,7 @@ widget! {
                 return Response::Unused;
             }
 
-            match self.id().index_of_child(&id) {
+            match self.find_child_index(&id) {
                 Some(0) => self.horiz_bar
                     .send(mgr, id, event)
                     .try_into()

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -213,7 +213,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut EventMgr, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() && !self.widgets.is_empty() {
-                if let Some(index) = self.id().index_of_child(&id) {
+                if let Some(index) = self.find_child_index(&id) {
                     if (index & 1) == 0 {
                         if let Some(w) = self.widgets.get_mut(index >> 1) {
                             return w.send(mgr, id, event);

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -89,7 +89,7 @@ widget! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut EventMgr, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if !self.is_disabled() {
-                if let Some(index) = self.id().index_of_child(&id) {
+                if let Some(index) = self.find_child_index(&id) {
                     if let Some(child) = self.widgets.get_mut(index) {
                         return match child.send(mgr, id, event) {
                             Response::Focus(rect) => {

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -98,6 +98,12 @@ impl<T: ListData + 'static, F: Filter<T::Item>> ListData for FilteredList<T, F> 
     fn len(&self) -> usize {
         self.view.borrow().len()
     }
+    fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {
+        self.data.make_id(parent, key)
+    }
+    fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key> {
+        self.data.reconstruct_key(parent, child)
+    }
 
     fn contains_key(&self, key: &Self::Key) -> bool {
         self.get_cloned(key).is_some()

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -142,7 +142,7 @@ impl<T: ListData + 'static, F: Filter<T::Item>> ListData for FilteredList<T, F> 
 
     fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::Key> {
         let end = self.len().min(start + limit);
-        (&self.view.borrow()[start..end]).into()
+        self.view.borrow()[start..end].to_vec()
     }
 }
 

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -651,7 +651,7 @@ widget! {
                         mgr.set_nav_focus(self.widgets[index % len].widget.id(), true);
                         Response::Focus(rect)
                     } else {
-                        Response::Used
+                        Response::Unused
                     };
                 }
                 _ => (), // fall through to scroll handler

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -342,11 +342,15 @@ widget! {
                     w.key = key;
                     mgr.configure(id, &mut w.widget);
                     action |= self.view.set(&mut w.widget, item.1);
+                    solve_size_rules(
+                        &mut w.widget,
+                        mgr.size_mgr(),
+                        Some(self.child_size.0),
+                        Some(self.child_size.1),
+                    );
                 }
                 let rect = solver.rect(i);
-                if w.widget.rect() != rect {
-                    w.widget.set_rect(mgr, rect, self.align_hints);
-                }
+                w.widget.set_rect(mgr, rect, self.align_hints);
             }
             *mgr |= action;
             let dur = (Instant::now() - time).as_micros();
@@ -483,15 +487,7 @@ widget! {
                 debug!("allocating widgets (old len = {}, new = {})", old_num, num);
                 self.widgets.reserve(num - old_num);
                 for _ in old_num..num {
-                    let id = self.id_ref().make_child(self.widgets.len());
-                    let mut widget = self.view.make();
-                    mgr.configure(id, &mut widget);
-                    solve_size_rules(
-                        &mut widget,
-                        mgr.size_mgr(),
-                        Some(child_size.0),
-                        Some(child_size.1),
-                    );
+                    let widget = self.view.make();
                     self.widgets.push(WidgetData { key: None, widget });
                 }
             } else if num + 64 <= old_num {

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -459,20 +459,16 @@ widget! {
 
             let mut child_size = rect.size - self.frame_size;
             let num = if self.direction.is_horizontal() {
-                if child_size.0 >= self.ideal_visible * self.child_size_ideal {
-                    child_size.0 = self.child_size_ideal;
-                } else {
-                    child_size.0 = self.child_size_min;
-                }
+                child_size.0 = (child_size.0 / self.ideal_visible)
+                    .min(self.child_size_ideal)
+                    .max(self.child_size_min);
                 let skip = child_size.0 + self.child_inter_margin;
                 align.horiz = None;
                 (rect.size.0 + skip - 1) / skip + 1
             } else {
-                if child_size.1 >= self.ideal_visible * self.child_size_ideal {
-                    child_size.1 = self.child_size_ideal;
-                } else {
-                    child_size.1 = self.child_size_min;
-                }
+                child_size.1 = (child_size.1 / self.ideal_visible)
+                    .min(self.child_size_ideal)
+                    .max(self.child_size_min);
                 let skip = child_size.1 + self.child_inter_margin;
                 align.vert = None;
                 (rect.size.1 + skip - 1) / skip + 1

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -349,8 +349,7 @@ widget! {
                         Some(self.child_size.1),
                     );
                 }
-                let rect = solver.rect(i);
-                w.widget.set_rect(mgr, rect, self.align_hints);
+                w.widget.set_rect(mgr, solver.rect(i), self.align_hints);
             }
             *mgr |= action;
             let dur = (Instant::now() - time).as_micros();

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -680,7 +680,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if let Some(index) = self.id().index_of_child(&id) {
+            if let Some(index) = self.find_child_index(&id) {
                 let child_event = self.scroll.offset_event(event.clone());
                 let response;
                 if let Some(child) = self.widgets.get_mut(index) {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -297,14 +297,18 @@ widget! {
                             w.key = Some(key.clone());
                             mgr.configure(id, &mut w.widget);
                             action |= self.view.set(&mut w.widget, item);
+                            solve_size_rules(
+                                &mut w.widget,
+                                mgr.size_mgr(),
+                                Some(self.child_size.0),
+                                Some(self.child_size.1),
+                            );
                         } else {
                             w.key = None; // disables drawing and clicking
                         }
                     }
                     rect.pos = pos_start + skip.cwise_mul(Size(ci.cast(), ri.cast()));
-                    if w.widget.rect() != rect {
-                        w.widget.set_rect(mgr, rect, self.align_hints);
-                    }
+                    w.widget.set_rect(mgr, rect, self.align_hints);
                 }
             }
             *mgr |= action;
@@ -441,15 +445,7 @@ widget! {
                 debug!("allocating widgets (old len = {}, new = {})", old_num, num);
                 self.widgets.reserve(num - old_num);
                 for _ in old_num..num {
-                    let id = self.id_ref().make_child(self.widgets.len());
-                    let mut widget = self.view.make();
-                    mgr.configure(id, &mut widget);
-                    solve_size_rules(
-                        &mut widget,
-                        mgr.size_mgr(),
-                        Some(child_size.0),
-                        Some(child_size.1),
-                    );
+                    let widget = self.view.make();
                     self.widgets.push(WidgetData { key: None, widget });
                 }
             } else if num + 64 <= self.widgets.len() {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -418,8 +418,7 @@ widget! {
 
             // If data is already available, create some widgets and ensure
             // that the ideal size meets all expectations of these children.
-            let (d_cols, d_rows) = self.data.len();
-            if self.widgets.len() == 0 && d_cols * d_rows > 0 {
+            if self.widgets.len() == 0 && !self.data.is_empty() {
                 let cols = self.data.col_iter_vec(self.ideal_len.cols.cast());
                 let rows = self.data.row_iter_vec(self.ideal_len.rows.cast());
                 let len = cols.len() * rows.len();
@@ -671,10 +670,10 @@ widget! {
                     }
                 }
                 Event::Command(cmd, _) => {
-                    let (d_cols, d_rows) = self.data.len();
-                    if d_cols * d_rows == 0 || !self.widgets[0].widget.key_nav() {
+                    if self.data.is_empty() || !self.widgets[0].widget.key_nav() {
                         return Response::Unused;
                     }
+                    let (d_cols, d_rows) = self.data.len();
                     let (last_col, last_row) = (d_cols.wrapping_sub(1), d_rows.wrapping_sub(1));
 
                     let mut solver = mgr.set_rect_mgr(|mgr| self.position_solver(mgr));

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -670,7 +670,7 @@ widget! {
                 return Response::Unused;
             }
 
-            if let Some(index) = self.id().index_of_child(&id) {
+            if let Some(index) = self.find_child_index(&id) {
                 let child_event = self.scroll.offset_event(event.clone());
                 let response;
                 if let Some(child) = self.widgets.get_mut(index) {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -315,7 +315,7 @@ widget! {
                     let w = &mut self.widgets[i];
                     if w.key.as_ref() != Some(&key) {
                         if let Some(item) = self.data.get_cloned(&key) {
-                            w.key = Some(key.clone());
+                            w.key = Some(key);
                             mgr.configure(id, &mut w.widget);
                             action |= self.view.set(&mut w.widget, item);
                             solve_size_rules(

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -418,17 +418,9 @@ widget! {
         fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
 
-            let mut child_size = rect.size - self.frame_size;
-            if child_size.0 >= self.ideal_len.cols * self.child_size_ideal.0 {
-                child_size.0 = self.child_size_ideal.0;
-            } else {
-                child_size.0 = self.child_size_min.0;
-            }
-            if child_size.1 >= self.ideal_len.rows * self.child_size_ideal.1 {
-                child_size.1 = self.child_size_ideal.1;
-            } else {
-                child_size.1 = self.child_size_min.1;
-            }
+            let avail = rect.size - self.frame_size;
+            let child_size = Size(avail.0 / self.ideal_len.cols, avail.1 / self.ideal_len.rows)
+                .min(self.child_size_ideal).max(self.child_size_min);
             self.child_size = child_size;
             self.align_hints = align;
 

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -335,11 +335,14 @@ widget! {
 
     impl Scrollable for Self {
         fn scroll_axes(&self, size: Size) -> (bool, bool) {
-            let item_min = self.child_size_min + self.child_inter_margin;
+            let avail = size - self.frame_size;
+            let m = self.child_inter_margin;
+            let child_size = Size(avail.0 / self.ideal_len.cols, avail.1 / self.ideal_len.rows)
+                .min(self.child_size_ideal).max(self.child_size_min);
             let (d_cols, d_rows) = self.data.len();
             let data_len = Size(d_cols.cast(), d_rows.cast());
-            let min_size = (item_min.cwise_mul(data_len) - self.child_inter_margin).max(Size::ZERO);
-            (min_size.0 > size.0, min_size.1 > size.1)
+            let content_size = ((child_size + m).cwise_mul(data_len) - m).max(Size::ZERO);
+            (content_size.0 > size.0, content_size.1 > size.1)
         }
 
         #[inline]

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -632,13 +632,15 @@ widget! {
                         }
                         _ => None,
                     };
-                    if let Some((ci, ri)) = data {
+                    return if let Some((ci, ri)) = data {
                         // Set nav focus to index and update scroll position
-                        // Note: we update nav focus before updating widgets; this is fine
+                        // TODO: update position
                         let index = (ci % cols) + (ri % rows) * cols;
                         mgr.set_nav_focus(self.widgets[index].widget.id(), true);
-                    }
-                    return Response::Used;
+                        Response::Used
+                    } else {
+                        Response::Unused
+                    };
                 }
                 _ => (), // fall through to scroll handler
             }

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -310,7 +310,7 @@ widget! {
                 for (rn, row) in rows.iter().enumerate() {
                     let ri = solver.first_row + rn;
                     let i = solver.data_to_child(ci, ri);
-                    let key = T::make_key(row, col);
+                    let key = T::make_key(col, row);
                     let id = self.data.make_id(self.id_ref(), &key);
                     let w = &mut self.widgets[i];
                     if w.key.as_ref() != Some(&key) {
@@ -427,7 +427,7 @@ widget! {
                 self.widgets.reserve(cols.len() * rows.len());
                 for col in cols.iter() {
                     for row in rows.iter(){
-                        let key = T::make_key(row, col);
+                        let key = T::make_key(col, row);
                         let mut widget = self.view.make();
                         if let Some(item) = self.data.get_cloned(&key) {
                             // Note: we cannot call configure here, but it needs
@@ -693,7 +693,7 @@ widget! {
                         #[cfg(debug_assertions)] {
                             let rk = &self.data.row_iter_vec_from(ri, 1)[0];
                             let ck = &self.data.col_iter_vec_from(ci, 1)[0];
-                            let key = T::make_key(rk, ck);
+                            let key = T::make_key(ck, rk);
                             assert_eq!(id, self.data.make_id(self.id_ref(), &key));
                         }
 

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -289,11 +289,13 @@ widget! {
                 for (rn, row) in rows.iter().enumerate() {
                     let ri = first_row + rn;
                     let i = (ci % cols.len()) + (ri % rows.len()) * cols.len();
-                    let w = &mut self.widgets[i];
                     let key = T::make_key(row, col);
+                    let id = self.data.make_id(self.id_ref(), &key);
+                    let w = &mut self.widgets[i];
                     if w.key.as_ref() != Some(&key) {
                         if let Some(item) = self.data.get_cloned(&key) {
                             w.key = Some(key.clone());
+                            mgr.configure(id, &mut w.widget);
                             action |= self.view.set(&mut w.widget, item);
                         } else {
                             w.key = None; // disables drawing and clicking
@@ -342,6 +344,11 @@ widget! {
         fn num_children(&self) -> usize {
             self.widgets.len()
         }
+        fn make_child_id(&self, index: usize) -> Option<WidgetId> {
+            self.widgets.get(index)
+                .and_then(|w| w.key.as_ref())
+                .map(|key| self.data.make_id(self.id_ref(), key))
+        }
         #[inline]
         fn get_child(&self, index: usize) -> Option<&dyn WidgetConfig> {
             self.widgets.get(index).map(|w| w.widget.as_widget())
@@ -351,6 +358,18 @@ widget! {
             self.widgets
                 .get_mut(index)
                 .map(|w| w.widget.as_widget_mut())
+        }
+        fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
+            let key = self.data.reconstruct_key(self.id_ref(), id);
+            if key.is_some() {
+                self.widgets
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, w)| (key == w.key).then(|| i))
+                    .next()
+            } else {
+                None
+            }
         }
     }
 
@@ -670,99 +689,98 @@ widget! {
                 return Response::Unused;
             }
 
-            if let Some(index) = self.find_child_index(&id) {
-                let child_event = self.scroll.offset_event(event.clone());
-                let response;
-                if let Some(child) = self.widgets.get_mut(index) {
-                    let r = child.widget.send(mgr, id, child_event);
-                    response = (child.key.clone(), r);
-                } else {
-                    return Response::Unused;
-                };
+            if self.eq_id(&id) {
+                return self.handle(mgr, event);
+            }
 
-                if matches!(&response.1, Response::Update | Response::Msg(_)) {
-                    let wd = &self.widgets[index];
-                    if let Some(key) = wd.key.as_ref() {
-                        if let Some(value) = self.view.get(&wd.widget) {
-                            if let Some(handle) = self.data.update(key, value) {
-                                mgr.trigger_update(handle, 0);
-                            }
-                        }
+            let key = match self.data.reconstruct_key(self.id_ref(), &id) {
+                Some(key) => key,
+                None => return Response::Unused,
+            };
+
+            let (index, response);
+            'outer: loop {
+                for i in 0..self.widgets.len() {
+                    if self.widgets[i].key.as_ref() == Some(&key) {
+                        index = i;
+                        let child_event = self.scroll.offset_event(event.clone());
+                        response = self.widgets[i].widget.send(mgr, id, child_event);
+                        break 'outer;
                     }
                 }
+                return Response::Unused;
+            }
 
-                match response {
-                    (key, Response::Unused) => {
-                        if let Event::PressStart { source, coord, .. } = event {
-                            if source.is_primary() {
-                                // We request a grab with our ID, hence the
-                                // PressMove/PressEnd events are matched in handle().
-                                mgr.grab_press_unique(self.id(), source, coord, None);
-                                self.press_phase = PressPhase::Start(coord);
-                                self.press_target = key;
-                                Response::Used
-                            } else {
-                                Response::Unused
-                            }
+            if matches!(&response, Response::Update | Response::Msg(_)) {
+                if let Some(value) = self.view.get(&self.widgets[index].widget) {
+                    if let Some(handle) = self.data.update(&key, value) {
+                        mgr.trigger_update(handle, 0);
+                    }
+                }
+            }
+
+            match response {
+                Response::Unused => {
+                    if let Event::PressStart { source, coord, .. } = event {
+                        if source.is_primary() {
+                            // We request a grab with our ID, hence the
+                            // PressMove/PressEnd events are matched in handle().
+                            mgr.grab_press_unique(self.id(), source, coord, None);
+                            self.press_phase = PressPhase::Start(coord);
+                            self.press_target = Some(key);
+                            Response::Used
                         } else {
-                            self.handle(mgr, event)
+                            Response::Unused
                         }
+                    } else {
+                        self.handle(mgr, event)
                     }
-                    (_, Response::Used) => Response::Used,
-                    (_, Response::Pan(delta)) => match self.scroll_by_delta(mgr, delta) {
-                        delta if delta == Offset::ZERO => Response::Scrolled,
-                        delta => Response::Pan(delta),
-                    }
-                    (_, Response::Scrolled) => Response::Scrolled,
-                    (_, Response::Focus(rect)) => {
-                        let (rect, action) = self.scroll.focus_rect(rect, self.core.rect);
-                        *mgr |= action;
-                        mgr.set_rect_mgr(|mgr| self.update_widgets(mgr));
-                        Response::Focus(rect)
-                    }
-                    (Some(key), Response::Select) => {
-                        match self.sel_mode {
-                            SelectionMode::None => Response::Used,
-                            SelectionMode::Single => {
-                                mgr.redraw(self.id());
-                                self.selection.clear();
+                }
+                Response::Used => Response::Used,
+                Response::Pan(delta) => match self.scroll_by_delta(mgr, delta) {
+                    delta if delta == Offset::ZERO => Response::Scrolled,
+                    delta => Response::Pan(delta),
+                }
+                Response::Scrolled => Response::Scrolled,
+                Response::Focus(rect) => {
+                    let (rect, action) = self.scroll.focus_rect(rect, self.core.rect);
+                    *mgr |= action;
+                    mgr.set_rect_mgr(|mgr| self.update_widgets(mgr));
+                    Response::Focus(rect)
+                }
+                Response::Select => {
+                    match self.sel_mode {
+                        SelectionMode::None => Response::Used,
+                        SelectionMode::Single => {
+                            mgr.redraw(self.id());
+                            self.selection.clear();
+                            self.selection.insert(key.clone());
+                            Response::Msg(ChildMsg::Select(key))
+                        }
+                        SelectionMode::Multiple => {
+                            mgr.redraw(self.id());
+                            if self.selection.remove(&key) {
+                                Response::Msg(ChildMsg::Deselect(key))
+                            } else {
                                 self.selection.insert(key.clone());
                                 Response::Msg(ChildMsg::Select(key))
                             }
-                            SelectionMode::Multiple => {
-                                mgr.redraw(self.id());
-                                if self.selection.remove(&key) {
-                                    Response::Msg(ChildMsg::Deselect(key))
-                                } else {
-                                    self.selection.insert(key.clone());
-                                    Response::Msg(ChildMsg::Select(key))
-                                }
-                            }
-                        }
-                    }
-                    (None, Response::Select) => Response::Used,
-                    (_, Response::Update) => Response::Used,
-                    (key, Response::Msg(msg)) => {
-                        trace!(
-                            "Received by {} from {:?}: {:?}",
-                            self.id(),
-                            &key,
-                            kas::util::TryFormat(&msg)
-                        );
-                        if let Some(key) = key {
-                            if let Some(handle) = self.data.handle(&key, &msg) {
-                                mgr.trigger_update(handle, 0);
-                            }
-                            Response::Msg(ChildMsg::Child(key, msg))
-                        } else {
-                            log::warn!("MatrixView: response from widget with no key");
-                            Response::Used
                         }
                     }
                 }
-            } else {
-                debug_assert!(self.eq_id(id), "SendEvent::send: bad WidgetId");
-                self.handle(mgr, event)
+                Response::Update => Response::Used,
+                Response::Msg(msg) => {
+                    trace!(
+                        "Received by {} from {:?}: {:?}",
+                        self.id(),
+                        &key,
+                        kas::util::TryFormat(&msg)
+                    );
+                    if let Some(handle) = self.data.handle(&key, &msg) {
+                        mgr.trigger_update(handle, 0);
+                    }
+                    Response::Msg(ChildMsg::Child(key, msg))
+                }
             }
         }
     }

--- a/crates/kas-widgets/src/window.rs
+++ b/crates/kas-widgets/src/window.rs
@@ -200,8 +200,7 @@ impl<W: Widget> Window<W> {
 
 // This is like WidgetChildren::find, but returns a translated Rect.
 fn find_rect(widget: &dyn WidgetConfig, id: WidgetId) -> Option<Rect> {
-    let wid = widget.id();
-    match wid.index_of_child(&id) {
+    match widget.find_child_index(&id) {
         Some(i) => {
             if let Some(w) = widget.get_child(i) {
                 find_rect(w, id).map(|rect| rect - widget.translation())
@@ -209,7 +208,7 @@ fn find_rect(widget: &dyn WidgetConfig, id: WidgetId) -> Option<Rect> {
                 None
             }
         }
-        None if wid == id => Some(widget.rect()),
+        None if widget.eq_id(&id) => Some(widget.rect()),
         _ => None,
     }
 }

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -131,19 +131,12 @@ impl ListData for MyData {
         unimplemented!()
     }
 
-    fn iter_vec(&self, limit: usize) -> Vec<(Self::Key, Self::Item)> {
-        (0..limit.min(self.len))
-            .map(|n| (n, self.get_cloned(&n).unwrap()))
-            .collect()
+    fn iter_vec(&self, limit: usize) -> Vec<Self::Key> {
+        (0..limit.min(self.len)).collect()
     }
 
-    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<(Self::Key, Self::Item)> {
-        (start..self.len.min(start + limit))
-            .map(|n| {
-                let (is_active, text) = self.get(n);
-                (n, (n, is_active, text))
-            })
-            .collect()
+    fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::Key> {
+        (start.min(self.len)..(start + limit).min(self.len)).collect()
     }
 }
 

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -211,7 +211,7 @@ fn main() -> kas::shell::Result<()> {
         #[handler(msg = Control)]
         struct {
             #[widget] _ = Label::new("Number of rows:"),
-            #[widget(map_msg = activate)] edit: impl HasString = EditBox::new("3")
+            #[widget(flatmap_msg = activate)] edit: impl HasString = EditBox::new("3")
                 .on_afl(|text, _| text.parse::<usize>().ok()),
             #[widget(map_msg = button)] _ = TextButton::new_msg("Set", Button::Set),
             #[widget(map_msg = button)] _ = TextButton::new_msg("−", Button::Decr),
@@ -220,9 +220,13 @@ fn main() -> kas::shell::Result<()> {
             n: usize = 3,
         }
         impl Self {
-            fn activate(&mut self, _: &mut EventMgr, n: usize) -> Control {
-                self.n = n;
-                Control::Set(n)
+            fn activate(&mut self, _: &mut EventMgr, n: usize) -> Response<Control> {
+                if n == self.n {
+                    Response::Used
+                } else {
+                    self.n = n;
+                    Response::Msg(Control::Set(n))
+                }
             }
             fn button(&mut self, mgr: &mut EventMgr, msg: Button) -> Control {
                 let n = match msg {

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -111,6 +111,12 @@ impl ListData for MyData {
     fn len(&self) -> usize {
         self.len
     }
+    fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {
+        parent.make_child(*key)
+    }
+    fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key> {
+        child.next_key_after(parent)
+    }
 
     fn contains_key(&self, key: &Self::Key) -> bool {
         *key < self.len

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -1,0 +1,102 @@
+//! Do you know your times tables?
+
+use kas::prelude::*;
+use kas::updatable::{MatrixData, Updatable, UpdatableHandler};
+use kas::widgets::{view::MatrixView, EditBox, StrLabel, Window};
+
+#[derive(Debug)]
+struct TableData(u64, usize);
+impl Updatable for TableData {
+    fn update_handle(&self) -> Option<UpdateHandle> {
+        None
+    }
+}
+impl UpdatableHandler<(usize, usize), VoidMsg> for TableData {
+    fn handle(&self, _: &(usize, usize), _: &VoidMsg) -> Option<UpdateHandle> {
+        None
+    }
+}
+impl MatrixData for TableData {
+    type ColKey = usize;
+    type RowKey = usize;
+    type Key = (usize, usize);
+    type Item = usize;
+
+    fn version(&self) -> u64 {
+        self.0
+    }
+
+    fn col_len(&self) -> usize {
+        self.1
+    }
+    fn row_len(&self) -> usize {
+        self.1
+    }
+
+    fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {
+        parent.make_child(key.0).make_child(key.1)
+    }
+    fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key> {
+        let mut iter = child.iter_keys_after(parent);
+        let row = iter.next();
+        let col = iter.next();
+        row.zip(col)
+    }
+
+    fn contains(&self, key: &Self::Key) -> bool {
+        key.0 < self.1 && key.1 < self.1
+    }
+    fn get_cloned(&self, key: &Self::Key) -> Option<Self::Item> {
+        self.contains(key).then(|| (key.0 + 1) * (key.1 + 1))
+    }
+
+    fn update(&self, _: &Self::Key, _: Self::Item) -> Option<UpdateHandle> {
+        None
+    }
+
+    fn col_iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::ColKey> {
+        (start..limit).collect()
+    }
+    fn row_iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::RowKey> {
+        (start..limit).collect()
+    }
+
+    fn make_key(row: &Self::RowKey, col: &Self::ColKey) -> Self::Key {
+        (*row, *col)
+    }
+}
+
+fn main() -> kas::shell::Result<()> {
+    env_logger::init();
+
+    let layout = make_widget! {
+        #[widget{
+            layout = column: [
+                row: [self.label, self.max],
+                align(right): self.table,
+            ];
+        }]
+        #[handler(msg = VoidMsg)]
+        struct {
+            #[widget] label = StrLabel::new("From 1 to"),
+            #[widget(use_msg = set_max)] max: impl HasString = EditBox::new("12")
+                .on_afl(|text, _| text.parse::<usize>().ok()),
+            #[widget(discard_msg)] table: MatrixView<TableData> =
+                MatrixView::new(TableData(0, 12)),
+        }
+        impl Self {
+            fn set_max(&mut self, mgr: &mut EventMgr, max: usize) {
+                let data = self.table.data_mut();
+                if data.1 != max {
+                    data.0 += 1;
+                    data.1 = max;
+                    self.table.update_view(mgr);
+                }
+            }
+        }
+    };
+    let window = Window::new("Times-Tables", layout);
+
+    let theme = kas::theme::ShadedTheme::new().with_font_size(16.0);
+    kas::shell::Toolkit::new(theme)?.with(window)?.run()
+}

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -36,9 +36,9 @@ impl MatrixData for TableData {
     }
     fn reconstruct_key(&self, parent: &WidgetId, child: &WidgetId) -> Option<Self::Key> {
         let mut iter = child.iter_keys_after(parent);
-        let row = iter.next();
         let col = iter.next();
-        row.zip(col)
+        let row = iter.next();
+        col.zip(row)
     }
 
     fn contains(&self, key: &Self::Key) -> bool {
@@ -59,8 +59,8 @@ impl MatrixData for TableData {
         (start..(start + limit)).collect()
     }
 
-    fn make_key(row: &Self::RowKey, col: &Self::ColKey) -> Self::Key {
-        (*row, *col)
+    fn make_key(col: &Self::ColKey, row: &Self::RowKey) -> Self::Key {
+        (*col, *row)
     }
 }
 

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -27,6 +27,9 @@ impl MatrixData for TableData {
         self.0
     }
 
+    fn is_empty(&self) -> bool {
+        self.1 == 0
+    }
     fn len(&self) -> (usize, usize) {
         (self.1, self.1)
     }

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -70,7 +70,9 @@ impl MatrixData for TableData {
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
-    let table = MatrixView::new(TableData(0, 12)).with_selection_mode(SelectionMode::Single);
+    let table = MatrixView::new(TableData(0, 12))
+        .with_num_visible(12, 12)
+        .with_selection_mode(SelectionMode::Single);
     let table = ScrollBars::new(table);
 
     let layout = make_widget! {

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -56,10 +56,10 @@ impl MatrixData for TableData {
     }
 
     fn col_iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::ColKey> {
-        (start..limit).collect()
+        (start..(start + limit)).collect()
     }
     fn row_iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::RowKey> {
-        (start..limit).collect()
+        (start..(start + limit)).collect()
     }
 
     fn make_key(row: &Self::RowKey, col: &Self::ColKey) -> Self::Key {

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -27,11 +27,8 @@ impl MatrixData for TableData {
         self.0
     }
 
-    fn col_len(&self) -> usize {
-        self.1
-    }
-    fn row_len(&self) -> usize {
-        self.1
+    fn len(&self) -> (usize, usize) {
+        (self.1, self.1)
     }
 
     fn make_id(&self, parent: &WidgetId, key: &Self::Key) -> WidgetId {

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -2,7 +2,8 @@
 
 use kas::prelude::*;
 use kas::updatable::{MatrixData, Updatable, UpdatableHandler};
-use kas::widgets::{view::MatrixView, EditBox, StrLabel, Window};
+use kas::widgets::view::{driver::DefaultNav, MatrixView, SelectionMode};
+use kas::widgets::{EditBox, ScrollBars, StrLabel, Window};
 
 #[derive(Debug)]
 struct TableData(u64, usize);
@@ -69,6 +70,9 @@ impl MatrixData for TableData {
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
+    let table = MatrixView::new(TableData(0, 12)).with_selection_mode(SelectionMode::Single);
+    let table = ScrollBars::new(table);
+
     let layout = make_widget! {
         #[widget{
             layout = column: [
@@ -81,8 +85,7 @@ fn main() -> kas::shell::Result<()> {
             #[widget] label = StrLabel::new("From 1 to"),
             #[widget(use_msg = set_max)] max: impl HasString = EditBox::new("12")
                 .on_afl(|text, _| text.parse::<usize>().ok()),
-            #[widget(discard_msg)] table: MatrixView<TableData> =
-                MatrixView::new(TableData(0, 12)),
+            #[widget(discard_msg)] table: ScrollBars<MatrixView<TableData, DefaultNav>> = table,
         }
         impl Self {
             fn set_max(&mut self, mgr: &mut EventMgr, max: usize) {


### PR DESCRIPTION
The List/Matrix View widgets now construct child keys from data entries, thus making navigation targets persistent when a view widget is scrolled.

The `make_layout` macro now supports `align(top)`, etc. (`bottom`, `left`, `right`, `default`).

Add `WidgetId::iter`

New `times-tables` example for testing `MatrixView`:
![Screenshot_20220209_162651](https://user-images.githubusercontent.com/134893/153244638-466a2649-9e23-40e2-bcd5-d38fb9b3eeea.png)

Initial size of `ListView` and `MatrixView` is now determined using data: if any child widgets already exist, use them as-is; otherwise load initial data entries up to ideal-size and use that. The result still isn't perfect, but it's a lot better than without. It isn't obvious how to improve further (other than by loading even more data in advance).

Simplify `SizeRules::solve_seq` by removing "squashing" behaviour if target < min-required-size; instead use the minimum. In practice we never see this behaviour anyway, but it was messing up width-for-height calculations with view widgets.

Several fixes to `MatrixView` and a few tweaks to `ListView` (to keep things consistent).