### PR TITLE
Work2

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -78,9 +78,8 @@ version = "0.10.1"
 path = "../kas-macros"
 
 [dependencies.kas-text]
-# version = "0.4.0"
-git = "https://github.com/kas-gui/kas-text.git"
-rev = "818515e"
+version = "0.4.2"
+#git = "https://github.com/kas-gui/kas-text.git"
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -315,7 +315,7 @@ impl ScrollComponent {
                 source,
                 start_id,
                 coord,
-            } => on_press_start(mgr, source, start_id, coord),
+            } if self.max_offset != Offset::ZERO => on_press_start(mgr, source, start_id, coord),
             Event::PressMove { mut delta, .. } => {
                 self.glide.move_delta(delta);
                 let old_offset = self.offset;

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -135,8 +135,9 @@ impl EventState {
 
     /// Is mouse panning enabled?
     #[inline]
-    pub fn config_enable_mouse_pan(&self) -> bool {
-        self.config.mouse_pan().is_enabled_with(self.modifiers())
+    pub fn config_enable_pan(&self, source: PressSource) -> bool {
+        source.is_touch()
+            || source.is_primary() && self.config.mouse_pan().is_enabled_with(self.modifiers())
     }
 
     /// Is mouse text panning enabled?

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -406,6 +406,11 @@ impl From<Offset> for Size {
 }
 
 // used for marigns
+impl From<Size> for (u16, u16) {
+    fn from(size: Size) -> (u16, u16) {
+        (size.0.cast(), size.1.cast())
+    }
+}
 impl From<(u16, u16)> for Size {
     fn from(v: (u16, u16)) -> Self {
         Self(i32::conv(v.0), i32::conv(v.1))

--- a/crates/kas-core/src/layout/size_types.rs
+++ b/crates/kas-core/src/layout/size_types.rs
@@ -283,8 +283,8 @@ impl FrameRules {
 
     /// Generate rules for content surrounded by this frame
     ///
-    /// It is assumed that the content's margins apply inside this frame, and
-    /// that the margin is at least as large as self's `inner_margin`.
+    /// The content's margins apply inside this frame. External margins come
+    /// from this type.
     ///
     /// Returns the tuple `(rules, offset, size)`:
     ///

--- a/crates/kas-core/src/layout/size_types.rs
+++ b/crates/kas-core/src/layout/size_types.rs
@@ -6,7 +6,7 @@
 //! Types used by size rules
 
 use super::{Align, AlignHints, AxisInfo, SizeRules};
-use crate::cast::{Cast, CastFloat, Conv, ConvFloat};
+use crate::cast::{CastFloat, Conv, ConvFloat};
 use crate::dir::Directional;
 use crate::geom::{Rect, Size, Vec2};
 
@@ -33,7 +33,7 @@ impl Margins {
     /// Margins with equal size on each edge.
     #[inline]
     pub const fn splat(size: u16) -> Self {
-        Margins::hv_splat(size, size)
+        Margins::hv_splat((size, size))
     }
 
     /// Margins via horizontal and vertical sizes
@@ -44,7 +44,7 @@ impl Margins {
 
     /// Margins via horizontal and vertical sizes
     #[inline]
-    pub const fn hv_splat(h: u16, v: u16) -> Self {
+    pub const fn hv_splat((h, v): (u16, u16)) -> Self {
         Margins {
             horiz: (h, h),
             vert: (v, v),
@@ -83,7 +83,7 @@ impl Margins {
 
 impl From<Size> for Margins {
     fn from(size: Size) -> Self {
-        Margins::hv_splat(size.0.cast(), size.1.cast())
+        Margins::hv_splat(size.into())
     }
 }
 

--- a/crates/kas-core/src/layout/size_types.rs
+++ b/crates/kas-core/src/layout/size_types.rs
@@ -308,7 +308,7 @@ impl FrameRules {
         (rules, offset, size)
     }
 
-    /// Variant: frame surrounds content
+    /// Variant: frame is content margin
     ///
     /// The content's margin is reduced by the size of the frame, with any
     /// residual margin applying outside the frame (using the max of the
@@ -326,6 +326,23 @@ impl FrameRules {
             content.min_size() + size,
             content.ideal_size() + size,
             margins,
+            content.stretch(),
+        );
+        (rules, offset, size)
+    }
+
+    /// Variant: frame replaces content margin
+    ///
+    /// The content's margin is ignored. In other respects,
+    /// this is the same as [`FrameRules::surround_with_margin`].
+    pub fn surround_no_margin(self, content: SizeRules) -> (SizeRules, i32, i32) {
+        let offset = self.offset + self.inner_margin;
+        let size = self.size + 2 * self.inner_margin;
+
+        let rules = SizeRules::new(
+            content.min_size() + size,
+            content.ideal_size() + size,
+            self.m,
             content.stretch(),
         );
         (rules, offset, size)

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -206,7 +206,12 @@ impl<'a> Layout<'a> {
         let frame = |mgr: SizeMgr, child: &mut Layout, storage: &mut FrameStorage, style| {
             let frame_rules = mgr.frame(style, axis.is_vertical());
             let child_rules = child.size_rules_(mgr, axis);
-            let (rules, offset, size) = frame_rules.surround_as_margin(child_rules);
+            let (rules, offset, size) = match style {
+                FrameStyle::InnerMargin | FrameStyle::MenuEntry | FrameStyle::EditBox => {
+                    frame_rules.surround_with_margin(child_rules)
+                }
+                _ => frame_rules.surround_as_margin(child_rules),
+            };
             storage.offset.set_component(axis, offset);
             storage.size.set_component(axis, size);
             rules

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -210,7 +210,8 @@ impl<'a> Layout<'a> {
                 FrameStyle::InnerMargin | FrameStyle::MenuEntry | FrameStyle::EditBox => {
                     frame_rules.surround_with_margin(child_rules)
                 }
-                _ => frame_rules.surround_as_margin(child_rules),
+                FrameStyle::NavFocus => frame_rules.surround_as_margin(child_rules),
+                _ => frame_rules.surround_no_margin(child_rules),
             };
             storage.offset.set_component(axis, offset);
             storage.size.set_component(axis, size);

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -23,7 +23,7 @@ pub use crate::event::{
 #[doc(no_inline)]
 pub use crate::geom::{Coord, Offset, Rect, Size};
 #[doc(no_inline)]
-pub use crate::layout::{Align, AlignHints, AxisInfo, SetRectMgr, SizeRules, Stretch};
+pub use crate::layout::{Align, AlignHints, AxisInfo, Margins, SetRectMgr, SizeRules, Stretch};
 #[doc(no_inline)]
 pub use crate::macros::*;
 #[doc(no_inline)]

--- a/crates/kas-core/src/theme/mod.rs
+++ b/crates/kas-core/src/theme/mod.rs
@@ -7,9 +7,11 @@
 
 mod draw;
 mod size;
+mod style;
 
 pub use draw::{DrawCtx, DrawHandle, DrawMgr};
 pub use size::{SizeHandle, SizeMgr};
+pub use style::*;
 
 #[allow(unused)]
 use crate::event::EventMgr;
@@ -87,40 +89,6 @@ impl InputState {
     #[inline]
     pub fn sel_focus(self) -> bool {
         self.contains(InputState::SEL_FOCUS)
-    }
-}
-
-/// Class of text drawn
-///
-/// Themes choose font, font size, colour, and alignment based on this.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum TextClass {
-    /// Label text is drawn over the background colour
-    Label,
-    /// Scrollable label (same as label except that min height is limited)
-    LabelScroll,
-    /// Button text is drawn over a button
-    Button,
-    /// Class of text drawn in a single-line edit box
-    Edit,
-    /// Class of text drawn in a multi-line edit box
-    EditMulti,
-    /// Menu label (single line, does not stretch)
-    MenuLabel,
-}
-
-impl TextClass {
-    /// True if text should be automatically line-wrapped
-    pub fn line_wrap(self) -> bool {
-        self == TextClass::Label || self == TextClass::EditMulti
-    }
-}
-
-/// Default class: Label
-impl Default for TextClass {
-    fn default() -> Self {
-        TextClass::Label
     }
 }
 

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -110,11 +110,6 @@ impl<'a> SizeMgr<'a> {
         self.0.outer_margins()
     }
 
-    /// The margin around frames and separators
-    pub fn frame_margins(&self) -> Margins {
-        self.0.frame_margins()
-    }
-
     /// The margin around text elements
     ///
     /// Similar to [`Self::outer_margins`], but intended for things like text
@@ -233,9 +228,6 @@ pub trait SizeHandle {
     /// Widgets must not draw in outer margins.
     fn outer_margins(&self) -> Margins;
 
-    /// The margin around frames and separators
-    fn frame_margins(&self) -> Margins;
-
     /// The margin around text elements
     ///
     /// Similar to [`Self::outer_margins`], but intended for things like text
@@ -323,9 +315,6 @@ macro_rules! impl_ {
             }
             fn outer_margins(&self) -> Margins {
                 self.deref().outer_margins()
-            }
-            fn frame_margins(&self) -> Margins {
-                self.deref().frame_margins()
             }
             fn text_margins(&self) -> Margins {
                 self.deref().text_margins()

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -7,9 +7,9 @@
 
 use std::ops::Deref;
 
-use super::TextClass;
 #[allow(unused)]
 use super::{DrawCtx, DrawMgr};
+use super::{FrameStyle, TextClass};
 use crate::geom::Size;
 use crate::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use crate::text::TextApi;
@@ -85,26 +85,14 @@ impl<'a> SizeMgr<'a> {
         self.0.pixels_from_em(em)
     }
 
-    /// Size of a frame around child widget(s)
-    ///
-    /// This already includes the margins specified by [`Self::frame_margins`].
-    pub fn frame(&self, is_vert: bool) -> FrameRules {
-        self.0.frame(is_vert)
-    }
-
-    /// Frame/margin around a menu entry
-    pub fn menu_frame(&self, is_vert: bool) -> FrameRules {
-        self.0.menu_frame(is_vert)
+    /// Size of a frame around another element
+    pub fn frame(&self, style: FrameStyle, is_vert: bool) -> FrameRules {
+        self.0.frame(style, is_vert)
     }
 
     /// Size of a separator frame between items
     pub fn separator(&self) -> Size {
         self.0.separator()
-    }
-
-    /// Size of a navigation highlight margin around a child widget
-    pub fn nav_frame(&self, is_vert: bool) -> FrameRules {
-        self.0.nav_frame(is_vert)
     }
 
     /// The margin around content within a widget
@@ -165,19 +153,6 @@ impl<'a> SizeMgr<'a> {
     /// Width of an edit marker
     pub fn text_cursor_width(&self) -> f32 {
         self.0.text_cursor_width()
-    }
-
-    /// Size of the sides of a button.
-    pub fn button_surround(&self, is_vert: bool) -> FrameRules {
-        self.0.button_surround(is_vert)
-    }
-
-    /// Size of the frame around an edit box, including margin
-    ///
-    /// Note: though text should not be drawn in the margin, the edit cursor
-    /// may be. The margin included here should be large enough!
-    pub fn edit_surround(&self, is_vert: bool) -> FrameRules {
-        self.0.edit_surround(is_vert)
     }
 
     /// Size of the element drawn by [`DrawCtx::checkbox`].
@@ -241,19 +216,11 @@ pub trait SizeHandle {
     /// (This depends on the font size.)
     fn pixels_from_em(&self, em: f32) -> f32;
 
-    /// Size of a frame around child widget(s)
-    ///
-    /// This already includes the margins specified by [`Self::frame_margins`].
-    fn frame(&self, vert: bool) -> FrameRules;
-
-    /// Frame/margin around a menu entry
-    fn menu_frame(&self, vert: bool) -> FrameRules;
+    /// Size of a frame around another element
+    fn frame(&self, style: FrameStyle, is_vert: bool) -> FrameRules;
 
     /// Size of a separator frame between items
     fn separator(&self) -> Size;
-
-    /// Size of a navigation highlight margin around a child widget
-    fn nav_frame(&self, vert: bool) -> FrameRules;
 
     /// The margin around content within a widget
     ///
@@ -295,15 +262,6 @@ pub trait SizeHandle {
 
     /// Width of an edit marker
     fn text_cursor_width(&self) -> f32;
-
-    /// Size of the sides of a button.
-    fn button_surround(&self, vert: bool) -> FrameRules;
-
-    /// Size of the frame around an edit box, including margin
-    ///
-    /// Note: though text should not be drawn in the margin, the edit cursor
-    /// may be. The margin included here should be large enough!
-    fn edit_surround(&self, vert: bool) -> FrameRules;
 
     /// Size of the element drawn by [`DrawCtx::checkbox`].
     fn checkbox(&self) -> Size;
@@ -354,17 +312,11 @@ macro_rules! impl_ {
                 self.deref().pixels_from_em(em)
             }
 
-            fn frame(&self, vert: bool) -> FrameRules {
-                self.deref().frame(vert)
-            }
-            fn menu_frame(&self, vert: bool) -> FrameRules {
-                self.deref().menu_frame(vert)
+            fn frame(&self, style: FrameStyle, is_vert: bool) -> FrameRules {
+                self.deref().frame(style, is_vert)
             }
             fn separator(&self) -> Size {
                 self.deref().separator()
-            }
-            fn nav_frame(&self, vert: bool) -> FrameRules {
-                self.deref().nav_frame(vert)
             }
             fn inner_margin(&self) -> Size {
                 self.deref().inner_margin()
@@ -387,13 +339,6 @@ macro_rules! impl_ {
             }
             fn text_cursor_width(&self) -> f32 {
                 self.deref().text_cursor_width()
-            }
-
-            fn button_surround(&self, vert: bool) -> FrameRules {
-                self.deref().button_surround(vert)
-            }
-            fn edit_surround(&self, vert: bool) -> FrameRules {
-                self.deref().edit_surround(vert)
             }
 
             fn checkbox(&self) -> Size {

--- a/crates/kas-core/src/theme/style.rs
+++ b/crates/kas-core/src/theme/style.rs
@@ -1,0 +1,57 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Theme style components
+
+/// Class of text drawn
+///
+/// Themes choose font, font size, colour, and alignment based on this.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum TextClass {
+    /// Label text is drawn over the background colour
+    Label,
+    /// Scrollable label (same as label except that min height is limited)
+    LabelScroll,
+    /// Button text is drawn over a button
+    Button,
+    /// Class of text drawn in a single-line edit box
+    Edit,
+    /// Class of text drawn in a multi-line edit box
+    EditMulti,
+    /// Menu label (single line, does not stretch)
+    MenuLabel,
+}
+
+impl TextClass {
+    /// True if text should be automatically line-wrapped
+    pub fn line_wrap(self) -> bool {
+        self == TextClass::Label || self == TextClass::EditMulti
+    }
+}
+
+/// Default class: Label
+impl Default for TextClass {
+    fn default() -> Self {
+        TextClass::Label
+    }
+}
+
+/// Style of a frame
+///
+/// A "frame" is an element surrounding another element.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum FrameStyle {
+    /// A frame for grouping content
+    Frame,
+    /// Border around a pop-up menu entry
+    MenuEntry,
+    /// Frame used to indicate navigation focus
+    NavFocus,
+    /// Border of a button
+    Button,
+    /// Box used to contain editable text
+    EditBox,
+}

--- a/crates/kas-core/src/theme/style.rs
+++ b/crates/kas-core/src/theme/style.rs
@@ -44,6 +44,8 @@ impl Default for TextClass {
 /// A "frame" is an element surrounding another element.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum FrameStyle {
+    /// An invisible frame which forces all margins to be interior
+    InnerMargin,
     /// A frame for grouping content
     Frame,
     /// A frame around pop-ups

--- a/crates/kas-core/src/theme/style.rs
+++ b/crates/kas-core/src/theme/style.rs
@@ -46,6 +46,8 @@ impl Default for TextClass {
 pub enum FrameStyle {
     /// A frame for grouping content
     Frame,
+    /// A frame around pop-ups
+    Popup,
     /// Border around a pop-up menu entry
     MenuEntry,
     /// Frame used to indicate navigation focus

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -433,7 +433,7 @@ impl Layout {
                         len = list.len();
                         for item in list {
                             let item = item.generate::<std::iter::Empty<&Member>>(None)?;
-                            items.append_all(quote! { #item, });
+                            items.append_all(quote! {{ #item },});
                         }
                     }
                     List::Glob(span) => {

--- a/crates/kas-theme/src/colors.rs
+++ b/crates/kas-theme/src/colors.rs
@@ -143,7 +143,7 @@ impl ColorsSrgb {
             frame: Rgba8Srgb::from_str("#AAAAAA").unwrap(),
             accent: Rgba8Srgb::from_str("#F74C00").unwrap(),
             accent_soft: Rgba8Srgb::from_str("#E77346").unwrap(),
-            nav_focus: Rgba8Srgb::from_str("#A33100").unwrap(),
+            nav_focus: Rgba8Srgb::from_str("#D03E00").unwrap(),
             edit_bg: Rgba8Srgb::from_str("#303030").unwrap(),
             edit_bg_disabled: Rgba8Srgb::from_str("#606060").unwrap(),
             edit_bg_error: Rgba8Srgb::from_str("#FFBCBC").unwrap(),

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -15,7 +15,7 @@ use kas::cast::{Cast, CastFloat, ConvFloat};
 use kas::geom::{Size, Vec2};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::text::{fonts::FontId, Align, TextApi, TextApiExt};
-use kas::theme::{SizeHandle, TextClass};
+use kas::theme::{FrameStyle, SizeHandle, TextClass};
 
 /// Parameterisation of [`Dimensions`]
 ///
@@ -166,22 +166,32 @@ impl<D: 'static> SizeHandle for Window<D> {
         self.dims.dpp * self.dims.pt_size * em
     }
 
-    fn frame(&self, _vert: bool) -> FrameRules {
-        FrameRules::new_sym(self.dims.frame, 0, self.dims.frame_margin)
-    }
-    fn menu_frame(&self, vert: bool) -> FrameRules {
-        let size = match vert {
-            false => self.dims.text_margin.0,
-            true => self.dims.text_margin.1,
-        };
-        FrameRules::new_sym(size.cast(), 0, 0)
-    }
-    fn separator(&self) -> Size {
-        Size::splat(self.dims.frame)
+    fn frame(&self, style: FrameStyle, is_vert: bool) -> FrameRules {
+        match style {
+            FrameStyle::Frame => FrameRules::new_sym(self.dims.frame, 0, self.dims.frame_margin),
+            FrameStyle::MenuEntry => {
+                let size = match is_vert {
+                    false => self.dims.text_margin.0,
+                    true => self.dims.text_margin.1,
+                };
+                FrameRules::new_sym(size.cast(), 0, 0)
+            }
+            FrameStyle::NavFocus => FrameRules::new_sym(self.dims.inner_margin.into(), 0, 0),
+            FrameStyle::Button => {
+                let inner = self.dims.inner_margin.into();
+                let outer = self.dims.outer_margin;
+                FrameRules::new_sym(self.dims.frame, inner, outer)
+            }
+            FrameStyle::EditBox => {
+                let inner = self.dims.inner_margin.into();
+                let outer = 0;
+                FrameRules::new_sym(self.dims.frame, inner, outer)
+            }
+        }
     }
 
-    fn nav_frame(&self, _vert: bool) -> FrameRules {
-        FrameRules::new_sym(self.dims.inner_margin.into(), 0, 0)
+    fn separator(&self) -> Size {
+        Size::splat(self.dims.frame)
     }
 
     fn inner_margin(&self) -> Size {
@@ -274,18 +284,6 @@ impl<D: 'static> SizeHandle for Window<D> {
 
     fn text_cursor_width(&self) -> f32 {
         self.dims.font_marker_width
-    }
-
-    fn button_surround(&self, _vert: bool) -> FrameRules {
-        let inner = self.dims.inner_margin.into();
-        let outer = self.dims.outer_margin;
-        FrameRules::new_sym(self.dims.frame, inner, outer)
-    }
-
-    fn edit_surround(&self, _vert: bool) -> FrameRules {
-        let inner = self.dims.inner_margin.into();
-        let outer = 0;
-        FrameRules::new_sym(self.dims.frame, inner, outer)
     }
 
     fn checkbox(&self) -> Size {

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -178,6 +178,7 @@ impl<D: 'static> SizeHandle for Window<D> {
 
     fn frame(&self, style: FrameStyle, _is_vert: bool) -> FrameRules {
         match style {
+            FrameStyle::InnerMargin => FrameRules::new_sym(0, 0, 0),
             FrameStyle::Frame => FrameRules::new_sym(self.dims.frame, 0, self.dims.frame_margin),
             FrameStyle::Popup => FrameRules::new_sym(self.dims.popup_frame, 0, 0),
             FrameStyle::MenuEntry => FrameRules::new_sym(self.dims.menu_frame, 0, 0),

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -170,11 +170,11 @@ impl<D: 'static> SizeHandle for Window<D> {
         FrameRules::new_sym(self.dims.frame, 0, self.dims.frame_margin)
     }
     fn menu_frame(&self, vert: bool) -> FrameRules {
-        let mut size = self.dims.frame;
-        if vert {
-            size /= 2;
-        }
-        FrameRules::new_sym(size, 0, 0)
+        let size = match vert {
+            false => self.dims.text_margin.0,
+            true => self.dims.text_margin.1,
+        };
+        FrameRules::new_sym(size.cast(), 0, 0)
     }
     fn separator(&self) -> Size {
         Size::splat(self.dims.frame)

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -35,6 +35,8 @@ pub struct Parameters {
     pub frame_size: f32,
     /// Popup frame size
     pub popup_frame_size: f32,
+    /// MenuEntry frame size (horiz, vert)
+    pub menu_frame: f32,
     /// Button frame size (non-flat outer region)
     pub button_frame: f32,
     /// Checkbox inner size in Points
@@ -66,6 +68,7 @@ pub struct Dimensions {
     pub text_margin: (u16, u16),
     pub frame: i32,
     pub popup_frame: i32,
+    pub menu_frame: i32,
     pub button_frame: i32,
     pub checkbox: i32,
     pub scrollbar: Size,
@@ -93,6 +96,7 @@ impl Dimensions {
         let text_m1 = (params.text_margin.1 * scale_factor).cast_nearest();
         let frame = (params.frame_size * scale_factor).cast_nearest();
         let popup_frame = (params.popup_frame_size * scale_factor).cast_nearest();
+        let menu_frame = (params.menu_frame * scale_factor).cast_nearest();
 
         let shadow_size = params.shadow_size * scale_factor;
         let shadow_offset = shadow_size * params.shadow_rel_offset;
@@ -110,6 +114,7 @@ impl Dimensions {
             text_margin: (text_m0, text_m1),
             frame,
             popup_frame,
+            menu_frame,
             button_frame: (params.button_frame * scale_factor).cast_nearest(),
             checkbox: i32::conv_nearest(params.checkbox_inner * dpp)
                 + 2 * (i32::from(inner_margin) + frame),
@@ -171,17 +176,11 @@ impl<D: 'static> SizeHandle for Window<D> {
         self.dims.dpp * self.dims.pt_size * em
     }
 
-    fn frame(&self, style: FrameStyle, is_vert: bool) -> FrameRules {
+    fn frame(&self, style: FrameStyle, _is_vert: bool) -> FrameRules {
         match style {
             FrameStyle::Frame => FrameRules::new_sym(self.dims.frame, 0, self.dims.frame_margin),
             FrameStyle::Popup => FrameRules::new_sym(self.dims.popup_frame, 0, 0),
-            FrameStyle::MenuEntry => {
-                let size = match is_vert {
-                    false => self.dims.text_margin.0,
-                    true => self.dims.text_margin.1,
-                };
-                FrameRules::new_sym(size.cast(), 0, 0)
-            }
+            FrameStyle::MenuEntry => FrameRules::new_sym(self.dims.menu_frame, 0, 0),
             FrameStyle::NavFocus => FrameRules::new_sym(self.dims.inner_margin.into(), 0, 0),
             FrameStyle::Button => {
                 let inner = self.dims.inner_margin.into();

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -27,8 +27,6 @@ pub struct Parameters {
     pub outer_margin: f32,
     /// Margin inside a frame before contents
     pub inner_margin: f32,
-    /// Margin around frames and seperators
-    pub frame_margin: f32,
     /// Margin between text elements (horiz, vert)
     pub text_margin: (f32, f32),
     /// Frame size
@@ -64,7 +62,6 @@ pub struct Dimensions {
     pub min_line_length: i32,
     pub outer_margin: u16,
     pub inner_margin: u16,
-    pub frame_margin: u16,
     pub text_margin: (u16, u16),
     pub frame: i32,
     pub popup_frame: i32,
@@ -91,7 +88,6 @@ impl Dimensions {
 
         let outer_margin = (params.outer_margin * scale_factor).cast_nearest();
         let inner_margin = (params.inner_margin * scale_factor).cast_nearest();
-        let frame_margin = (params.frame_margin * scale_factor).cast_nearest();
         let text_m0 = (params.text_margin.0 * scale_factor).cast_nearest();
         let text_m1 = (params.text_margin.1 * scale_factor).cast_nearest();
         let frame = (params.frame_size * scale_factor).cast_nearest();
@@ -110,7 +106,6 @@ impl Dimensions {
             min_line_length: (8.0 * dpem).cast_nearest(),
             outer_margin,
             inner_margin,
-            frame_margin,
             text_margin: (text_m0, text_m1),
             frame,
             popup_frame,
@@ -179,7 +174,7 @@ impl<D: 'static> SizeHandle for Window<D> {
     fn frame(&self, style: FrameStyle, _is_vert: bool) -> FrameRules {
         match style {
             FrameStyle::InnerMargin => FrameRules::new_sym(0, 0, 0),
-            FrameStyle::Frame => FrameRules::new_sym(self.dims.frame, 0, self.dims.frame_margin),
+            FrameStyle::Frame => FrameRules::new_sym(self.dims.frame, 0, 0),
             FrameStyle::Popup => FrameRules::new_sym(self.dims.popup_frame, 0, 0),
             FrameStyle::MenuEntry => FrameRules::new_sym(self.dims.menu_frame, 0, 0),
             FrameStyle::NavFocus => FrameRules::new_sym(self.dims.inner_margin.into(), 0, 0),
@@ -206,10 +201,6 @@ impl<D: 'static> SizeHandle for Window<D> {
 
     fn outer_margins(&self) -> Margins {
         Margins::splat(self.dims.outer_margin)
-    }
-
-    fn frame_margins(&self) -> Margins {
-        Margins::splat(self.dims.frame_margin)
     }
 
     fn text_margins(&self) -> Margins {

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -29,8 +29,8 @@ pub struct Parameters {
     pub inner_margin: f32,
     /// Margin around frames and seperators
     pub frame_margin: f32,
-    /// Margin between text elements
-    pub text_margin: f32,
+    /// Margin between text elements (horiz, vert)
+    pub text_margin: (f32, f32),
     /// Frame size
     pub frame_size: f32,
     /// Button frame size (non-flat outer region)
@@ -61,7 +61,7 @@ pub struct Dimensions {
     pub outer_margin: u16,
     pub inner_margin: u16,
     pub frame_margin: u16,
-    pub text_margin: u16,
+    pub text_margin: (u16, u16),
     pub frame: i32,
     pub button_frame: i32,
     pub checkbox: i32,
@@ -86,7 +86,8 @@ impl Dimensions {
         let outer_margin = (params.outer_margin * scale_factor).cast_nearest();
         let inner_margin = (params.inner_margin * scale_factor).cast_nearest();
         let frame_margin = (params.frame_margin * scale_factor).cast_nearest();
-        let text_margin = (params.text_margin * scale_factor).cast_nearest();
+        let text_m0 = (params.text_margin.0 * scale_factor).cast_nearest();
+        let text_m1 = (params.text_margin.1 * scale_factor).cast_nearest();
         let frame = (params.frame_size * scale_factor).cast_nearest();
 
         let shadow_size = params.shadow_size * scale_factor;
@@ -102,7 +103,7 @@ impl Dimensions {
             outer_margin,
             inner_margin,
             frame_margin,
-            text_margin,
+            text_margin: (text_m0, text_m1),
             frame,
             button_frame: (params.button_frame * scale_factor).cast_nearest(),
             checkbox: i32::conv_nearest(params.checkbox_inner * dpp)
@@ -196,7 +197,7 @@ impl<D: 'static> SizeHandle for Window<D> {
     }
 
     fn text_margins(&self) -> Margins {
-        Margins::splat(self.dims.text_margin)
+        Margins::hv_splat(self.dims.text_margin)
     }
 
     fn line_height(&self, _: TextClass) -> i32 {
@@ -231,7 +232,10 @@ impl<D: 'static> SizeHandle for Window<D> {
             }));
         }
 
-        let margin = self.dims.text_margin;
+        let margin = match axis.is_horizontal() {
+            true => self.dims.text_margin.0,
+            false => self.dims.text_margin.1,
+        };
         let margins = (margin, margin);
         if axis.is_horizontal() {
             let min = self.dims.min_line_length;

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -33,6 +33,8 @@ pub struct Parameters {
     pub text_margin: (f32, f32),
     /// Frame size
     pub frame_size: f32,
+    /// Popup frame size
+    pub popup_frame_size: f32,
     /// Button frame size (non-flat outer region)
     pub button_frame: f32,
     /// Checkbox inner size in Points
@@ -63,6 +65,7 @@ pub struct Dimensions {
     pub frame_margin: u16,
     pub text_margin: (u16, u16),
     pub frame: i32,
+    pub popup_frame: i32,
     pub button_frame: i32,
     pub checkbox: i32,
     pub scrollbar: Size,
@@ -89,6 +92,7 @@ impl Dimensions {
         let text_m0 = (params.text_margin.0 * scale_factor).cast_nearest();
         let text_m1 = (params.text_margin.1 * scale_factor).cast_nearest();
         let frame = (params.frame_size * scale_factor).cast_nearest();
+        let popup_frame = (params.popup_frame_size * scale_factor).cast_nearest();
 
         let shadow_size = params.shadow_size * scale_factor;
         let shadow_offset = shadow_size * params.shadow_rel_offset;
@@ -105,6 +109,7 @@ impl Dimensions {
             frame_margin,
             text_margin: (text_m0, text_m1),
             frame,
+            popup_frame,
             button_frame: (params.button_frame * scale_factor).cast_nearest(),
             checkbox: i32::conv_nearest(params.checkbox_inner * dpp)
                 + 2 * (i32::from(inner_margin) + frame),
@@ -169,6 +174,7 @@ impl<D: 'static> SizeHandle for Window<D> {
     fn frame(&self, style: FrameStyle, is_vert: bool) -> FrameRules {
         match style {
             FrameStyle::Frame => FrameRules::new_sym(self.dims.frame, 0, self.dims.frame_margin),
+            FrameStyle::Popup => FrameRules::new_sym(self.dims.popup_frame, 0, 0),
             FrameStyle::MenuEntry => {
                 let size = match is_vert {
                     false => self.dims.text_margin.0,

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -107,7 +107,7 @@ const DIMS: dim::Parameters = dim::Parameters {
     outer_margin: 8.0,
     inner_margin: 1.2,
     frame_margin: 2.4,
-    text_margin: 2.0,
+    text_margin: (3.4, 2.0),
     frame_size: 2.4,
     // NOTE: visual thickness is (button_frame * scale_factor).round() * (1 - BG_SHRINK_FACTOR)
     button_frame: 2.4,

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -111,6 +111,7 @@ const DIMS: dim::Parameters = dim::Parameters {
     text_margin: (3.4, 2.0),
     frame_size: 2.4,
     popup_frame_size: 0.0,
+    menu_frame: 2.4,
     // NOTE: visual thickness is (button_frame * scale_factor).round() * (1 - BG_SHRINK_FACTOR)
     button_frame: 2.4,
     checkbox_inner: 9.0,
@@ -376,7 +377,7 @@ where
                 // We cheat here by using zero-sized popup-frame, but assuming that contents are
                 // all a MenuEntry, and drawing into this space. This might look wrong if other
                 // widgets are used in the popup.
-                let size = self.w.dims.text_margin.1 as f32;
+                let size = self.w.dims.menu_frame as f32;
                 let inner = outer.shrink(size);
                 self.draw
                     .rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
@@ -385,7 +386,7 @@ where
             }
             FrameStyle::MenuEntry => {
                 if let Some(col) = self.cols.menu_entry(state) {
-                    let size = self.w.dims.text_margin.1 as f32;
+                    let size = self.w.dims.menu_frame as f32;
                     let inner = outer.shrink(size);
                     self.draw.rounded_frame(outer, inner, BG_SHRINK_FACTOR, col);
                     let inner = outer.shrink(size * BG_SHRINK_FACTOR);

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -107,7 +107,6 @@ impl FlatTheme {
 const DIMS: dim::Parameters = dim::Parameters {
     outer_margin: 8.0,
     inner_margin: 1.2,
-    frame_margin: 2.4,
     text_margin: (3.4, 2.0),
     frame_size: 2.4,
     popup_frame_size: 0.0,

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -368,6 +368,7 @@ where
     fn frame(&mut self, rect: Rect, style: FrameStyle, state: InputState) {
         let outer = Quad::from(rect);
         match style {
+            FrameStyle::InnerMargin => (),
             FrameStyle::Frame => {
                 let inner = outer.shrink(self.w.dims.frame as f32);
                 self.draw

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -110,7 +110,7 @@ const DIMS: dim::Parameters = dim::Parameters {
     frame_margin: 2.4,
     text_margin: (3.4, 2.0),
     frame_size: 2.4,
-    popup_frame_size: 2.4,
+    popup_frame_size: 0.0,
     // NOTE: visual thickness is (button_frame * scale_factor).round() * (1 - BG_SHRINK_FACTOR)
     button_frame: 2.4,
     checkbox_inner: 9.0,
@@ -373,15 +373,23 @@ where
                     .rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
             }
             FrameStyle::Popup => {
-                let inner = outer.shrink(self.w.dims.popup_frame as f32);
+                // We cheat here by using zero-sized popup-frame, but assuming that contents are
+                // all a MenuEntry, and drawing into this space. This might look wrong if other
+                // widgets are used in the popup.
+                let size = self.w.dims.text_margin.1 as f32;
+                let inner = outer.shrink(size);
                 self.draw
                     .rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
-                let inner = outer.shrink(self.w.dims.popup_frame as f32 * BG_SHRINK_FACTOR);
+                let inner = outer.shrink(size * BG_SHRINK_FACTOR);
                 self.draw.rect(inner, self.cols.background);
             }
             FrameStyle::MenuEntry => {
                 if let Some(col) = self.cols.menu_entry(state) {
-                    self.draw.rect(outer, col);
+                    let size = self.w.dims.text_margin.1 as f32;
+                    let inner = outer.shrink(size);
+                    self.draw.rounded_frame(outer, inner, BG_SHRINK_FACTOR, col);
+                    let inner = outer.shrink(size * BG_SHRINK_FACTOR);
+                    self.draw.rect(inner, col);
                 }
             }
             FrameStyle::NavFocus => {

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -110,6 +110,7 @@ const DIMS: dim::Parameters = dim::Parameters {
     frame_margin: 2.4,
     text_margin: (3.4, 2.0),
     frame_size: 2.4,
+    popup_frame_size: 2.4,
     // NOTE: visual thickness is (button_frame * scale_factor).round() * (1 - BG_SHRINK_FACTOR)
     button_frame: 2.4,
     checkbox_inner: 9.0,
@@ -333,12 +334,10 @@ where
         class: PassType,
         f: &mut dyn FnMut(&mut dyn theme::DrawHandle),
     ) {
-        let mut frame_rect = Default::default();
         let mut shadow = Default::default();
         let mut outer_rect = inner_rect;
         if class == PassType::Overlay {
-            frame_rect = inner_rect.expand(self.w.dims.frame);
-            shadow = Quad::from(frame_rect);
+            shadow = Quad::from(inner_rect);
             shadow.a += self.w.dims.shadow_a * SHADOW_POPUP;
             shadow.b += self.w.dims.shadow_b * SHADOW_POPUP;
             let a = shadow.a.floor();
@@ -349,14 +348,8 @@ where
 
         if class == PassType::Overlay {
             shadow += offset.into();
-            let outer = Quad::from(frame_rect + offset);
-            let inner = Quad::from(inner_rect + offset);
-
+            let inner = Quad::from(inner_rect + offset).shrink(self.w.dims.frame as f32);
             draw.rounded_frame_2col(shadow, inner, Rgba::BLACK, Rgba::TRANSPARENT);
-
-            draw.rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
-            let inner = outer.shrink(self.w.dims.frame as f32 * BG_SHRINK_FACTOR);
-            draw.rect(inner, self.cols.background);
         }
 
         let mut handle = DrawHandle {
@@ -378,6 +371,13 @@ where
                 let inner = outer.shrink(self.w.dims.frame as f32);
                 self.draw
                     .rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
+            }
+            FrameStyle::Popup => {
+                let inner = outer.shrink(self.w.dims.popup_frame as f32);
+                self.draw
+                    .rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
+                let inner = outer.shrink(self.w.dims.popup_frame as f32 * BG_SHRINK_FACTOR);
+                self.draw.rect(inner, self.cols.background);
             }
             FrameStyle::MenuEntry => {
                 if let Some(col) = self.cols.menu_entry(state) {

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -65,6 +65,7 @@ const DIMS: dim::Parameters = dim::Parameters {
     frame_margin: 1.2,
     text_margin: (3.4, 2.0),
     frame_size: 5.0,
+    popup_frame_size: 0.0,
     button_frame: 5.0,
     checkbox_inner: 9.0,
     scrollbar_size: Vec2::splat(8.0),
@@ -258,8 +259,6 @@ where
             shadow += offset.into();
             let inner = Quad::from(inner_rect + offset);
             draw.rounded_frame_2col(shadow, inner, Rgba::BLACK, Rgba::TRANSPARENT);
-
-            draw.rect(inner, self.cols.background);
         }
 
         let mut handle = DrawHandle {
@@ -282,6 +281,10 @@ where
                 let norm = (0.7, -0.7);
                 let col = self.cols.background;
                 self.draw.shaded_round_frame(outer, inner, norm, col);
+            }
+            FrameStyle::Popup => {
+                let outer = Quad::from(rect);
+                self.draw.rect(outer, self.cols.background);
             }
             FrameStyle::Button => self.button(rect, None, state),
             FrameStyle::EditBox => {

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -62,7 +62,7 @@ const DIMS: dim::Parameters = dim::Parameters {
     outer_margin: 6.0,
     inner_margin: 1.2,
     frame_margin: 1.2,
-    text_margin: 2.0,
+    text_margin: (3.4, 2.0),
     frame_size: 5.0,
     button_frame: 5.0,
     checkbox_inner: 9.0,

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -286,6 +286,12 @@ where
                 let outer = Quad::from(rect);
                 self.draw.rect(outer, self.cols.background);
             }
+            FrameStyle::MenuEntry => {
+                if let Some(col) = self.cols.menu_entry(state) {
+                    let outer = Quad::from(rect);
+                    self.draw.rect(outer, col);
+                }
+            }
             FrameStyle::Button => self.button(rect, None, state),
             FrameStyle::EditBox => {
                 state.remove(InputState::DEPRESS);

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -66,6 +66,7 @@ const DIMS: dim::Parameters = dim::Parameters {
     text_margin: (3.4, 2.0),
     frame_size: 5.0,
     popup_frame_size: 0.0,
+    menu_frame: 2.4,
     button_frame: 5.0,
     checkbox_inner: 9.0,
     scrollbar_size: Vec2::splat(8.0),

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -14,7 +14,8 @@ use kas::dir::{Direction, Directional};
 use kas::draw::{color::Rgba, *};
 use kas::geom::*;
 use kas::text::{AccelString, Text, TextApi, TextDisplay};
-use kas::theme::{self, InputState, SizeHandle, TextClass, ThemeControl};
+use kas::theme::{self, InputState, SizeHandle, ThemeControl};
+use kas::theme::{FrameStyle, TextClass};
 use kas::TkAction;
 
 /// A theme using simple shading to give apparent depth to elements
@@ -273,12 +274,23 @@ where
         self.draw.get_clip_rect()
     }
 
-    fn outer_frame(&mut self, rect: Rect) {
-        let outer = Quad::from(rect);
-        let inner = outer.shrink(self.w.dims.frame as f32);
-        let norm = (0.7, -0.7);
-        let col = self.cols.background;
-        self.draw.shaded_round_frame(outer, inner, norm, col);
+    fn frame(&mut self, rect: Rect, style: FrameStyle, mut state: InputState) {
+        match style {
+            FrameStyle::Frame => {
+                let outer = Quad::from(rect);
+                let inner = outer.shrink(self.w.dims.frame as f32);
+                let norm = (0.7, -0.7);
+                let col = self.cols.background;
+                self.draw.shaded_round_frame(outer, inner, norm, col);
+            }
+            FrameStyle::Button => self.button(rect, None, state),
+            FrameStyle::EditBox => {
+                state.remove(InputState::DEPRESS);
+                let bg_col = self.cols.edit_bg(state);
+                self.draw_edit_box(rect, bg_col, self.cols.nav_region(state));
+            }
+            style => self.as_flat().frame(rect, style, state),
+        }
     }
 
     fn separator(&mut self, rect: Rect) {
@@ -287,10 +299,6 @@ where
         let norm = (0.0, -0.7);
         let col = self.cols.background;
         self.draw.shaded_round_frame(outer, inner, norm, col);
-    }
-
-    fn nav_frame(&mut self, rect: Rect, state: InputState) {
-        self.as_flat().nav_frame(rect, state);
     }
 
     fn selection_box(&mut self, rect: Rect) {
@@ -345,10 +353,6 @@ where
         self.as_flat().text_cursor(wid, pos, text, class, byte);
     }
 
-    fn menu_entry(&mut self, rect: Rect, state: InputState) {
-        self.as_flat().menu_entry(rect, state);
-    }
-
     fn button(&mut self, rect: Rect, col: Option<color::Rgb>, state: InputState) {
         let outer = Quad::from(rect);
         let inner = outer.shrink(self.w.dims.button_frame as f32);
@@ -362,12 +366,6 @@ where
             let outer = outer.shrink(self.w.dims.inner_margin as f32);
             self.draw.rounded_frame(outer, inner, 0.6, col);
         }
-    }
-
-    fn edit_box(&mut self, rect: Rect, mut state: InputState) {
-        state.remove(InputState::DEPRESS);
-        let bg_col = self.cols.edit_bg(state);
-        self.draw_edit_box(rect, bg_col, self.cols.nav_region(state));
     }
 
     fn checkbox(&mut self, wid: u64, rect: Rect, checked: bool, state: InputState) {

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -62,7 +62,6 @@ impl ShadedTheme {
 const DIMS: dim::Parameters = dim::Parameters {
     outer_margin: 6.0,
     inner_margin: 1.2,
-    frame_margin: 1.2,
     text_margin: (3.4, 2.0),
     frame_size: 5.0,
     popup_frame_size: 0.0,

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -59,9 +59,8 @@ version = "0.10.0"
 default-features = false
 
 [dependencies.kas-text]
-# version = "0.4.0"
-git = "https://github.com/kas-gui/kas-text.git"
-rev = "818515e"
+version = "0.4.2"
+#git = "https://github.com/kas-gui/kas-text.git"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/src/event_loop.rs
+++ b/crates/kas-wgpu/src/event_loop.rs
@@ -97,14 +97,13 @@ where
                     StartCause::ResumeTimeReached {
                         requested_resume, ..
                     } => {
-                        debug!("Wakeup: timer (requested: {:?})", requested_resume);
-
                         let item = self
                             .resumes
                             .first()
                             .cloned()
                             .unwrap_or_else(|| panic!("timer wakeup without resume"));
                         assert_eq!(item.0, requested_resume);
+                        debug!("Wakeup: timer (window={:?})", item.1);
 
                         let resume = if let Some(w) = self.windows.get_mut(&item.1) {
                             w.update_timer(&mut self.shared)

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -5,7 +5,7 @@
 
 //! Combobox
 
-use super::{IndexedColumn, MenuEntry};
+use super::{IndexedColumn, MenuEntry, PopupFrame};
 use kas::event::{self, Command};
 use kas::layout;
 use kas::prelude::*;
@@ -207,7 +207,7 @@ impl ComboBox<VoidMsg> {
             layout_text: Default::default(),
             popup: ComboPopup {
                 core: Default::default(),
-                inner: IndexedColumn::new(entries),
+                inner: PopupFrame::new(IndexedColumn::new(entries)),
             },
             active,
             opening: false,
@@ -401,6 +401,6 @@ widget! {
         #[widget_core]
         core: CoreData,
         #[widget]
-        inner: IndexedColumn<MenuEntry<()>>,
+        inner: PopupFrame<IndexedColumn<MenuEntry<()>>>,
     }
 }

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -11,7 +11,7 @@ use kas::event::{self, Command, ScrollDelta};
 use kas::geom::Vec2;
 use kas::prelude::*;
 use kas::text::SelectionHelper;
-use kas::theme::TextClass;
+use kas::theme::{FrameStyle, TextClass};
 use std::fmt::Debug;
 use std::ops::Range;
 use unicode_segmentation::{GraphemeCursor, UnicodeSegmentation};
@@ -184,7 +184,7 @@ widget! {
     impl Layout for Self {
         fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
             let child_rules = self.inner.size_rules(mgr.re(), axis);
-            let frame_rules = mgr.edit_surround(axis.is_vertical());
+            let frame_rules = mgr.frame(FrameStyle::EditBox, axis.is_vertical());
             let (rules, offset, size) = frame_rules.surround_with_margin(child_rules);
             self.frame_offset.set_component(axis, offset);
             self.frame_size.set_component(axis, size);
@@ -208,7 +208,14 @@ widget! {
         fn draw(&mut self, mut draw: DrawMgr) {
             let mut draw = draw.with_core(self.core_data());
             let error = self.inner.has_error();
-            draw.re().with_core(self.inner.core_data()).edit_box(self.core.rect, error);
+            {
+                let mut draw = draw.re();
+                let mut draw = draw.with_core(self.inner.core_data());
+                if error {
+                    draw.state.insert(InputState::ERROR);
+                }
+                draw.frame(self.core.rect, FrameStyle::EditBox);
+            }
             self.inner.draw(draw.re());
         }
     }

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -9,7 +9,6 @@ use super::Scrollable;
 use kas::event::components::{TextInput, TextInputAction};
 use kas::event::{self, Command, ScrollDelta};
 use kas::geom::Vec2;
-use kas::layout;
 use kas::prelude::*;
 use kas::text::SelectionHelper;
 use kas::theme::TextClass;
@@ -178,13 +177,32 @@ widget! {
         core: CoreData,
         #[widget]
         inner: EditField<G>,
-        layout_frame: layout::FrameStorage,
+        frame_offset: Offset,
+        frame_size: Size,
     }
 
     impl Layout for Self {
-        fn layout(&mut self) -> layout::Layout<'_> {
-            let inner = layout::Layout::single(&mut self.inner);
-            layout::Layout::frame(&mut self.layout_frame, inner)
+        fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            let child_rules = self.inner.size_rules(mgr.re(), axis);
+            let frame_rules = mgr.edit_surround(axis.is_vertical());
+            let (rules, offset, size) = frame_rules.surround_with_margin(child_rules);
+            self.frame_offset.set_component(axis, offset);
+            self.frame_size.set_component(axis, size);
+            rules
+        }
+
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, mut rect: Rect, align: AlignHints) {
+            self.core_data_mut().rect = rect;
+            rect.pos += self.frame_offset;
+            rect.size -= self.frame_size;
+            self.inner.set_rect(mgr, rect, align);
+        }
+
+        fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
+            if !self.rect().contains(coord) {
+                return None;
+            }
+            self.inner.find_id(coord).or_else(|| Some(self.id()))
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
@@ -203,7 +221,8 @@ impl EditBox<()> {
         EditBox {
             core: Default::default(),
             inner: EditField::new(text),
-            layout_frame: Default::default(),
+            frame_offset: Offset::ZERO,
+            frame_size: Size::ZERO,
         }
     }
 
@@ -220,7 +239,8 @@ impl EditBox<()> {
         EditBox {
             core: self.core,
             inner: self.inner.with_guard(guard),
-            layout_frame: self.layout_frame,
+            frame_offset: self.frame_offset,
+            frame_size: self.frame_size,
         }
     }
 

--- a/crates/kas-widgets/src/frame.rs
+++ b/crates/kas-widgets/src/frame.rs
@@ -37,3 +37,33 @@ widget! {
         }
     }
 }
+
+widget! {
+    /// A frame around pop-ups
+    ///
+    /// It is expected that this be the top-most widget inside any popup.
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
+    #[derive(Clone, Debug, Default)]
+    #[handler(msg = <W as Handler>::Msg)]
+    #[widget{
+        layout = frame(self.inner, kas::theme::FrameStyle::Popup);
+    }]
+    pub struct PopupFrame<W: Widget> {
+        #[widget_core]
+        core: CoreData,
+        #[widget]
+        pub inner: W,
+    }
+
+    impl Self {
+        /// Construct a frame
+        #[inline]
+        pub fn new(inner: W) -> Self {
+            PopupFrame {
+                core: Default::default(),
+                inner,
+            }
+        }
+    }
+}

--- a/crates/kas-widgets/src/frame.rs
+++ b/crates/kas-widgets/src/frame.rs
@@ -5,8 +5,7 @@
 
 //! A simple frame
 
-use kas::macros::make_layout;
-use kas::{layout, prelude::*};
+use kas::prelude::*;
 
 widget! {
     /// A frame around content
@@ -17,6 +16,9 @@ widget! {
     #[autoimpl(class_traits where W: trait on self.inner)]
     #[derive(Clone, Debug, Default)]
     #[handler(msg = <W as Handler>::Msg)]
+    #[widget{
+        layout = frame(self.inner, kas::theme::FrameStyle::Frame);
+    }]
     pub struct Frame<W: Widget> {
         #[widget_core]
         core: CoreData,
@@ -32,12 +34,6 @@ widget! {
                 core: Default::default(),
                 inner,
             }
-        }
-    }
-
-    impl Layout for Self {
-        fn layout(&mut self) -> layout::Layout<'_> {
-            make_layout!(self.core; frame(self.inner))
         }
     }
 }

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -96,7 +96,7 @@ pub use dialog::MessageBox;
 pub use drag::DragHandle;
 pub use edit_field::{EditBox, EditField, EditGuard};
 pub use filler::Filler;
-pub use frame::Frame;
+pub use frame::{Frame, PopupFrame};
 pub use grid::{BoxGrid, Grid};
 pub use label::{AccelLabel, Label, StrLabel, StringLabel};
 pub use list::*;

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -7,7 +7,7 @@
 
 use super::Menu;
 use crate::CheckBoxBare;
-use kas::theme::TextClass;
+use kas::theme::{FrameStyle, TextClass};
 use kas::{layout, prelude::*};
 use std::fmt::Debug;
 
@@ -36,12 +36,12 @@ widget! {
     impl Layout for Self {
         fn layout(&mut self) -> layout::Layout<'_> {
             let inner = layout::Layout::text(&mut self.layout_label, &mut self.label, TextClass::MenuLabel);
-            layout::Layout::menu_frame(&mut self.layout_frame, inner)
+            layout::Layout::frame(&mut self.layout_frame, inner, FrameStyle::MenuEntry)
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
             let mut draw = draw.with_core(self.core_data());
-            draw.menu_entry(self.core.rect);
+            draw.frame(self.core.rect, FrameStyle::MenuEntry);
             draw.text_accel(
                 self.layout_label.pos,
                 &self.label,
@@ -133,7 +133,7 @@ widget! {
                 layout::Layout::text(&mut self.layout_label, &mut self.label, TextClass::MenuLabel),
             ];
             let inner = layout::Layout::list(list.into_iter(), Direction::Right, &mut self.layout_list);
-            layout::Layout::menu_frame(&mut self.layout_frame, inner)
+            layout::Layout::frame(&mut self.layout_frame, inner, FrameStyle::MenuEntry)
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
@@ -145,7 +145,7 @@ widget! {
 
         fn draw(&mut self, mut draw: DrawMgr) {
             let mut draw = draw.with_core(self.checkbox.core_data());
-            draw.menu_entry(self.core.rect);
+            draw.frame(self.core.rect, FrameStyle::MenuEntry);
             self.layout().draw(draw);
         }
     }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -9,7 +9,7 @@ use super::Menu;
 use crate::Column;
 use kas::event::{self, Command};
 use kas::prelude::*;
-use kas::theme::TextClass;
+use kas::theme::{FrameStyle, TextClass};
 use kas::{layout, WindowId};
 
 widget! {
@@ -137,7 +137,7 @@ widget! {
     impl kas::Layout for Self {
         fn layout(&mut self) -> layout::Layout<'_> {
             let label = layout::Layout::text(&mut self.label_store, &mut self.label, TextClass::MenuLabel);
-            layout::Layout::menu_frame(&mut self.frame_store, label)
+            layout::Layout::frame(&mut self.frame_store, label, FrameStyle::MenuEntry)
         }
 
         fn spatial_nav(&mut self, _: &mut SetRectMgr, _: bool, _: Option<usize>) -> Option<usize> {
@@ -150,7 +150,7 @@ widget! {
             if self.popup_id.is_some() && !self.closing_menu {
                 draw.state.insert(InputState::DEPRESS);
             }
-            draw.menu_entry(self.core.rect);
+            draw.frame(self.core.rect, FrameStyle::MenuEntry);
             draw.text_accel(
                 self.label_store.pos,
                 &self.label,

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -6,7 +6,7 @@
 //! Sub-menu
 
 use super::Menu;
-use crate::Column;
+use crate::{Column, PopupFrame};
 use kas::event::{self, Command};
 use kas::prelude::*;
 use kas::theme::{FrameStyle, TextClass};
@@ -24,7 +24,7 @@ widget! {
         label_store: layout::TextStorage,
         frame_store: layout::FrameStorage,
         #[widget]
-        pub list: Column<W>,
+        pub list: PopupFrame<Column<W>>,
         popup_id: Option<WindowId>,
         closing_menu: bool,
     }
@@ -67,7 +67,7 @@ widget! {
                 label: Text::new_single(label.into()),
                 label_store: Default::default(),
                 frame_store: Default::default(),
-                list: Column::new(list),
+                list: PopupFrame::new(Column::new(list)),
                 popup_id: None,
                 closing_menu: false,
             }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -137,7 +137,7 @@ widget! {
     impl kas::Layout for Self {
         fn layout(&mut self) -> layout::Layout<'_> {
             let label = layout::Layout::text(&mut self.label_store, &mut self.label, TextClass::MenuLabel);
-            layout::Layout::frame(&mut self.frame_store, label)
+            layout::Layout::menu_frame(&mut self.frame_store, label)
         }
 
         fn spatial_nav(&mut self, _: &mut SetRectMgr, _: bool, _: Option<usize>) -> Option<usize> {

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -17,7 +17,7 @@ widget! {
     #[derive(Clone, Debug, Default)]
     #[widget{
         key_nav = true;
-        layout = nav_frame(self.inner);
+        layout = frame(self.inner, kas::theme::FrameStyle::NavFocus);
     }]
     pub struct NavFrame<W: Widget> {
         #[widget_core]

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -165,15 +165,9 @@ widget! {
                 debug_assert!(self.eq_id(id), "SendEvent::send: bad WidgetId");
             };
 
-            let id = self.id();
             let (action, response) =
                 self.scroll
-                    .scroll_by_event(mgr, event, self.id(), self.core.rect.size, |mgr, source, _, coord| {
-                        if source.is_primary() && mgr.config_enable_mouse_pan() {
-                            let icon = Some(event::CursorIcon::Grabbing);
-                            mgr.grab_press_unique(id, source, coord, icon);
-                        }
-                    });
+                    .scroll_by_event(mgr, event, self.id(), self.core.rect.size);
             if !action.is_empty() {
                 *mgr |= action;
                 Response::Focus(self.core.rect)

--- a/crates/kas-widgets/src/separator.rs
+++ b/crates/kas-widgets/src/separator.rs
@@ -50,8 +50,7 @@ widget! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            let margins = size_mgr.frame_margins();
-            SizeRules::extract_fixed(axis, size_mgr.separator(), margins)
+            SizeRules::extract_fixed(axis, size_mgr.separator(), Margins::ZERO)
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -713,15 +713,9 @@ widget! {
                 _ => (), // fall through to scroll handler
             }
 
-            let self_id = self.id();
             let (action, response) =
                 self.scroll
-                    .scroll_by_event(mgr, event, self.id(), self.core.rect.size, |mgr, source, _, coord| {
-                        if source.is_primary() && mgr.config_enable_mouse_pan() {
-                            let icon = Some(CursorIcon::Grabbing);
-                            mgr.grab_press_unique(self_id, source, coord, icon);
-                        }
-                    });
+                    .scroll_by_event(mgr, event, self.id(), self.core.rect.size);
             if !action.is_empty() {
                 *mgr |= action;
                 mgr.set_rect_mgr(|mgr| self.update_widgets(mgr));

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -726,14 +726,8 @@ widget! {
                 _ => (), // fall through to scroll handler
             }
 
-            let self_id = self.id();
             let (action, response) = self.scroll
-                .scroll_by_event(mgr, event, self.id(), self.core.rect.size, |mgr, source, _, coord| {
-                    if source.is_primary() && mgr.config_enable_mouse_pan() {
-                        let icon = Some(CursorIcon::Grabbing);
-                        mgr.grab_press_unique(self_id, source, coord, icon);
-                    }
-                });
+                .scroll_by_event(mgr, event, self.id(), self.core.rect.size);
 
             if !action.is_empty() {
                 *mgr |= action;


### PR DESCRIPTION
Improve margins:

- separate horiz/vert margins for text
- ensure `EditBox` has interior margins
- menu entries use interior margins, not exterior
- add `PopupFrame` to fix positioning of pop-up menus
- tweak menu graphics

Add `FrameStyle` enum to reduce the size of the themed size/draw API. Motivation is mixed:

- `SizeMgr`, `SizeHandle`, `DrawMgr`, `DrawHandle`, `layout::Layout` all get simpler APIs
- This *could* be useful for code-share in theme implementations, but current implementations are too dissimilar to benefit much
- This approach means that adding new feature variants to the theme API has low cost

Do not use `CursorIcon::Grabbing` in a non-scrollable scroll-region (e.g. in the Gallery when scrollbars are not visible).