### PR TITLE
WidgetExt; shared-data versioning model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,11 +58,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [beta] # TODO: stable
+        os: [macos-latest, windows-latest]
+        toolchain: [stable]
         include:
           - os: ubuntu-latest
-            toolchain: "1.59.0"
+            toolchain: "1.56.0"
+          - os: ubuntu-latest
+            toolchain: beta
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Getting started
 
 ### Dependencies
 
-KAS requires a recent [Rust] compiler. Currently, version 1.59 or greater is
+KAS requires a recent [Rust] compiler. Currently, version 1.56 or greater is
 required. Using the **nightly** channel does have a few advantages:
 
 -   Proceedural macros emit better diagnostics. In some cases, diagnostics are

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -7,8 +7,8 @@
 
 use super::*;
 use crate::event::{self, Event, EventMgr, Response};
-use crate::geom::{Coord, Rect};
-use crate::layout::{AlignHints, AxisInfo, SetRectMgr, SizeRules};
+use crate::geom::{Coord, Offset, Rect};
+use crate::layout::{self, AlignHints, AxisInfo, SetRectMgr, SizeRules};
 use crate::theme::{DrawMgr, SizeMgr};
 use crate::{CoreData, WidgetId};
 use std::any::Any;
@@ -51,18 +51,18 @@ impl<M: 'static> WidgetChildren for Box<dyn Widget<Msg = M>> {
         self.as_mut().get_child_mut(index)
     }
 
+    fn make_child_id(&self, index: usize) -> Option<WidgetId> {
+        self.as_ref().make_child_id(index)
+    }
     fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
         self.as_ref().find_child_index(id)
-    }
-    fn find_widget(&self, id: &WidgetId) -> Option<&dyn WidgetConfig> {
-        self.as_ref().find_widget(id)
-    }
-    fn find_widget_mut(&mut self, id: &WidgetId) -> Option<&mut dyn WidgetConfig> {
-        self.as_mut().find_widget_mut(id)
     }
 }
 
 impl<M: 'static> WidgetConfig for Box<dyn Widget<Msg = M>> {
+    fn pre_configure(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
+        self.as_mut().pre_configure(mgr, id);
+    }
     fn configure(&mut self, mgr: &mut SetRectMgr) {
         self.as_mut().configure(mgr);
     }
@@ -79,12 +79,29 @@ impl<M: 'static> WidgetConfig for Box<dyn Widget<Msg = M>> {
 }
 
 impl<M: 'static> Layout for Box<dyn Widget<Msg = M>> {
+    fn layout(&mut self) -> layout::Layout<'_> {
+        self.as_mut().layout()
+    }
+
     fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
         self.as_mut().size_rules(size_mgr, axis)
     }
 
     fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
         self.as_mut().set_rect(mgr, rect, align);
+    }
+
+    fn translation(&self) -> Offset {
+        self.as_ref().translation()
+    }
+
+    fn spatial_nav(
+        &mut self,
+        mgr: &mut SetRectMgr,
+        reverse: bool,
+        from: Option<usize>,
+    ) -> Option<usize> {
+        self.as_mut().spatial_nav(mgr, reverse, from)
     }
 
     fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
@@ -101,6 +118,10 @@ impl<M: 'static> event::Handler for Box<dyn Widget<Msg = M>> {
 
     fn activation_via_press(&self) -> bool {
         self.as_ref().activation_via_press()
+    }
+
+    fn focus_on_key_nav(&self) -> bool {
+        self.as_ref().focus_on_key_nav()
     }
 
     fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -24,7 +24,7 @@ use crate::cast::Cast;
 use crate::geom::{Coord, Offset};
 #[allow(unused)]
 use crate::WidgetConfig; // for doc-links
-use crate::{ShellWindow, TkAction, Widget, WidgetId, WindowId};
+use crate::{ShellWindow, TkAction, Widget, WidgetExt, WidgetId, WindowId};
 
 mod mgr_pub;
 mod mgr_shell;

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -17,7 +17,7 @@
 //! integer types, use [`CastApprox`] or [`CastFloat`] to specify the rounding
 //! mode.
 
-use crate::cast::{Cast, Conv, Result};
+use crate::cast::*;
 use crate::dir::Directional;
 
 mod vector;

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -12,7 +12,7 @@ use super::{Align, AlignHints, AxisInfo, SizeRules};
 use super::{RowStorage, RowTemp, RulesSetter, RulesSolver};
 use crate::dir::{Direction, Directional};
 use crate::geom::{Coord, Rect};
-use crate::WidgetConfig;
+use crate::{WidgetConfig, WidgetExt};
 
 /// A [`RulesSolver`] for rows (and, without loss of generality, for columns).
 ///

--- a/crates/kas-core/src/layout/sizer.rs
+++ b/crates/kas-core/src/layout/sizer.rs
@@ -12,7 +12,7 @@ use super::{AlignHints, AxisInfo, Margins, SetRectMgr, SizeRules};
 use crate::cast::Conv;
 use crate::geom::{Rect, Size};
 use crate::theme::SizeMgr;
-use crate::{Widget, WidgetConfig};
+use crate::{Widget, WidgetConfig, WidgetExt};
 
 /// A [`SizeRules`] solver for layouts
 ///

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -3,6 +3,8 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
+//! KAS macros
+
 #![recursion_limit = "128"]
 #![allow(clippy::let_and_return)]
 

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -412,7 +412,7 @@ pub(crate) fn widget(mut args: Widget) -> Result<TokenStream> {
             }
 
             quote! {
-                use ::kas::{WidgetCore, WidgetChildren, event::Response};
+                use ::kas::{event::Response, WidgetCore, WidgetChildren, WidgetExt};
                 if self.is_disabled() {
                     return Response::Unused;
                 }

--- a/crates/kas-theme/src/anim.rs
+++ b/crates/kas-theme/src/anim.rs
@@ -84,7 +84,15 @@ impl<D: DrawImpl> AnimState<D> {
             entry => {
                 let time = self.now + self.c.cursor_blink_rate;
                 let state = true;
-                entry.insert_entry(TextCursor { byte, state, time });
+                let v = TextCursor { byte, state, time };
+                match entry {
+                    Entry::Occupied(mut entry) => {
+                        entry.insert(v);
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(v);
+                    }
+                }
                 draw.animate_at(time);
                 true
             }
@@ -131,11 +139,19 @@ impl<D: DrawImpl> AnimState<D> {
                 }
             }
             entry => {
-                entry.insert_entry(FadeBool {
+                let v = FadeBool {
                     state,
                     time: self.now,
                     time_end: self.now,
-                });
+                };
+                match entry {
+                    Entry::Occupied(mut entry) => {
+                        entry.insert(v);
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(v);
+                    }
+                }
             }
         }
         !out_state as u8 as f32

--- a/crates/kas-widgets/src/adapter/adapt_widget.rs
+++ b/crates/kas-widgets/src/adapter/adapt_widget.rs
@@ -16,7 +16,7 @@ use kas::Layout;
 use kas::Widget;
 
 /// Provides some convenience methods on widgets
-pub trait WidgetExt: Widget {
+pub trait AdaptWidget: Widget {
     /// Construct a wrapper widget which maps messages from this widget
     ///
     /// Responses from this widget with a message payload are mapped with `f`.
@@ -59,7 +59,7 @@ pub trait WidgetExt: Widget {
     /// [`Layout::size_rules`]. This can be done by instantiating a temporary
     /// widget, for example:
     ///```
-    /// # use kas_widgets::adapter::WidgetExt;
+    /// # use kas_widgets::adapter::AdaptWidget;
     /// use kas_widgets::Label;
     /// use kas::prelude::*;
     ///
@@ -69,7 +69,7 @@ pub trait WidgetExt: Widget {
     ///```
     /// Alternatively one may use virtual pixels:
     ///```
-    /// # use kas_widgets::adapter::WidgetExt;
+    /// # use kas_widgets::adapter::AdaptWidget;
     /// use kas_widgets::Filler;
     /// use kas::prelude::*;
     ///
@@ -100,4 +100,4 @@ pub trait WidgetExt: Widget {
         WithLabel::new_with_direction(direction, self, label)
     }
 }
-impl<W: Widget + ?Sized> WidgetExt for W {}
+impl<W: Widget + ?Sized> AdaptWidget for W {}

--- a/crates/kas-widgets/src/adapter/mod.rs
+++ b/crates/kas-widgets/src/adapter/mod.rs
@@ -5,12 +5,12 @@
 
 //! Adapter widgets (wrappers)
 
+mod adapt_widget;
 mod label;
 mod map;
 mod reserve;
-mod widget_ext;
 
+pub use adapt_widget::*;
 pub use label::WithLabel;
 pub use map::MapResponse;
 pub use reserve::{Reserve, ReserveP};
-pub use widget_ext::*;

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -5,6 +5,8 @@
 
 //! Menus
 
+use kas::{event, layout, prelude::*};
+use std::any::Any;
 use std::ops::{Deref, DerefMut};
 
 mod menu_entry;
@@ -14,8 +16,6 @@ mod submenu;
 pub use menu_entry::{MenuEntry, MenuToggle};
 pub use menubar::MenuBar;
 pub use submenu::SubMenu;
-
-use kas::{event, prelude::*};
 
 /// Trait governing menus, sub-menus and menu-entries
 pub trait Menu: Widget {
@@ -43,10 +43,10 @@ pub trait Menu: Widget {
 }
 
 impl<M: 'static> WidgetCore for Box<dyn Menu<Msg = M>> {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn Any {
         self.as_ref().as_any()
     }
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self.as_mut().as_any_mut()
     }
 
@@ -80,18 +80,18 @@ impl<M: 'static> WidgetChildren for Box<dyn Menu<Msg = M>> {
         self.as_mut().get_child_mut(index)
     }
 
+    fn make_child_id(&self, index: usize) -> Option<WidgetId> {
+        self.as_ref().make_child_id(index)
+    }
     fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
         self.as_ref().find_child_index(id)
-    }
-    fn find_widget(&self, id: &WidgetId) -> Option<&dyn WidgetConfig> {
-        self.as_ref().find_widget(id)
-    }
-    fn find_widget_mut(&mut self, id: &WidgetId) -> Option<&mut dyn WidgetConfig> {
-        self.as_mut().find_widget_mut(id)
     }
 }
 
 impl<M: 'static> WidgetConfig for Box<dyn Menu<Msg = M>> {
+    fn pre_configure(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
+        self.as_mut().pre_configure(mgr, id);
+    }
     fn configure(&mut self, mgr: &mut SetRectMgr) {
         self.as_mut().configure(mgr);
     }
@@ -108,12 +108,29 @@ impl<M: 'static> WidgetConfig for Box<dyn Menu<Msg = M>> {
 }
 
 impl<M: 'static> Layout for Box<dyn Menu<Msg = M>> {
+    fn layout(&mut self) -> layout::Layout<'_> {
+        self.as_mut().layout()
+    }
+
     fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
         self.as_mut().size_rules(size_mgr, axis)
     }
 
     fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
         self.as_mut().set_rect(mgr, rect, align);
+    }
+
+    fn translation(&self) -> Offset {
+        self.as_ref().translation()
+    }
+
+    fn spatial_nav(
+        &mut self,
+        mgr: &mut SetRectMgr,
+        reverse: bool,
+        from: Option<usize>,
+    ) -> Option<usize> {
+        self.as_mut().spatial_nav(mgr, reverse, from)
     }
 
     fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
@@ -130,6 +147,10 @@ impl<M: 'static> event::Handler for Box<dyn Menu<Msg = M>> {
 
     fn activation_via_press(&self) -> bool {
         self.as_ref().activation_via_press()
+    }
+
+    fn focus_on_key_nav(&self) -> bool {
+        self.as_ref().focus_on_key_nav()
     }
 
     fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -12,7 +12,7 @@ use kas::event::{Event, EventMgr, Handler, Response, VoidMsg};
 use kas::layout::SetRectMgr;
 use kas::macros::make_widget;
 use kas::widgets::{Frame, Label, TextButton, Window};
-use kas::WidgetCore;
+use kas::WidgetExt;
 
 // Unlike most examples, we encapsulate the GUI configuration into a function.
 // There's no reason for this, but it demonstrates usage of Toolkit::add_boxed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,17 +33,7 @@ pub mod prelude;
 // macro re-exports
 pub mod macros;
 
-// include most of kas_core, excluding macros and prelude:
-#[cfg(feature = "config")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "config")))]
-pub use kas_core::config;
-#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-#[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-pub use kas_core::ShellWindow;
-pub use kas_core::{cast, class, dir, draw, event, geom, layout, text, updatable, util};
-pub use kas_core::{Boxed, Layout, Window};
-pub use kas_core::{CoreData, Future, Popup, TkAction, WidgetId, WindowId};
-pub use kas_core::{Widget, WidgetChildren, WidgetConfig, WidgetCore};
+pub use kas_core::*;
 
 pub use kas_widgets as widgets;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,4 +16,4 @@
 #[doc(no_inline)]
 pub use kas_core::prelude::*;
 #[doc(no_inline)]
-pub use kas_widgets::adapter::WidgetExt;
+pub use kas_widgets::adapter::AdaptWidget;


### PR DESCRIPTION
Widget methods which are not intended to support custom implementations were moved to `WidgetExt`, preventing custom implementation and reducing the size of a boxed widget's vtable.

Since `kas_widgets::adapter` *also* had a `WidgetExt` trait, the latter was renamed to `AdaptWidget`.

Edit: removed shared-data updates from this commit
<details>
Shared-data updates now rely on data versioning. Data version-numbers were already added in 89639f729e9edaeaea2b35c1d880df996310033d but not previously used. Now (possible since `fn draw` takes `&mut self`, due to the addition of `Layout::layout`) data versions are checked on draw and updated if necessary.

Advantages:

- (Minor) No need for data to have an `UpdateHandle`
- (Trivial) No need for view widgets to subscribe to updates
- (Major) Recursive data structures with automatic updates are trivial where before they were a big pain (hence the `FilterListView` widget is no longer needed). This is quite significant: the `FilterListView` widget was a hack (to avoid an even more convoluted system for recursive data updates before this).
- (Minor) Where many views over the same data exist (e.g. the `RadioBox` in `examples/data-list.rs`), we now only update entries when visible, avoiding lag on data-update

Disadvantages:

- (Minor) All data needs a version number. This is usually easy to implement. `u64` is large enough that simply counting all values at one-per-cycle would require about 30 CPU-years at 5 GHz. Nevertheless, there *could* still be issues.
- (Minor) View-widgets need to check the data version in `Layout::draw` and update their view if outdated
- (Minor) Hidden widgets which view shared data do not get updated until visible, thus for example if a `RadioBox` is selected, hidden, de-selected via another `RadioBox`, then made visible again, animation based on this state-change will start when the first `RadioBox` becomes visible again. (Given that this animation is driven entirely through the theme, this would happen anyway before this change, but this change makes it harder to fix — it would require the shared-data object to track (recent) change history, which *is* possible.)
- (Minor) On data update, we need to force redrawing everything to ensure necessary updates happen.

Third option: use data versioning *and* update notifications. This keeps the major advantage (recursive data structure updates) and first disadvantage (needing version numbers) but not the other points.
</details>