### PR TITLE
Shared-data versioning with check on draw

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -67,7 +67,7 @@ pub trait WidgetCore: Any + fmt::Debug {
 
     /// Set disabled state (chaining)
     ///
-    /// This is identical to [`WidgetCore::set_disabled`], but can be called in
+    /// This is identical to [`WidgetExt::set_disabled`], but can be called in
     /// chaining fashion. Example:
     /// ```ignore
     /// use kas::{WidgetCore, widget::MenuEntry};

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -228,6 +228,15 @@ impl EventState {
             .insert(w_id);
     }
 
+    /// Force redraw of all windows
+    ///
+    /// This may be used to synchronise views over shared data.
+    pub fn redraw_all_windows(&mut self) {
+        // NOTE: if the ShellWindow trait allowed pushing pending actions, we
+        // could just send REDRAW that way and remove REDRAW_ALL.
+        self.send_action(TkAction::REDRAW_ALL);
+    }
+
     /// Notify that a widget must be redrawn
     ///
     /// Currently the entire window is redrawn on any redraw request and the

--- a/crates/kas-core/src/toolkit.rs
+++ b/crates/kas-core/src/toolkit.rs
@@ -56,6 +56,8 @@ bitflags! {
         /// Note that [`event::EventMgr::redraw`] can instead be used for more
         /// selective redrawing.
         const REDRAW = 1 << 0;
+        /// All windows require redrawing
+        const REDRAW_ALL = 1 << 1;
         /// Some widgets within a region moved
         ///
         /// Used when a pop-up is closed or a region adjusted (e.g. scroll or switch

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -6,7 +6,6 @@
 //! Impls for data traits
 
 use super::*;
-use crate::event::UpdateHandle;
 use crate::WidgetId;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
@@ -38,9 +37,9 @@ impl<T: Clone + Debug> ListData for [T] {
         self.get(*key).cloned()
     }
 
-    fn update(&self, _: &Self::Key, _: Self::Item) -> Option<UpdateHandle> {
+    fn update(&self, _: &Self::Key, _: Self::Item) -> bool {
         // Note: plain [T] does not support update, but SharedRc<[T]> does.
-        None
+        false
     }
 
     fn iter_vec(&self, limit: usize) -> Vec<Self::Key> {
@@ -73,7 +72,7 @@ macro_rules! impl_via_deref {
             fn get_cloned(&self) -> Self::Item {
                 self.deref().get_cloned()
             }
-            fn update(&self, value: Self::Item) -> Option<UpdateHandle> {
+            fn update(&self, value: Self::Item) -> bool {
                 self.deref().update(value)
             }
         }
@@ -103,7 +102,7 @@ macro_rules! impl_via_deref {
                 self.deref().get_cloned(key)
             }
 
-            fn update(&self, key: &Self::Key, value: Self::Item) -> Option<UpdateHandle> {
+            fn update(&self, key: &Self::Key, value: Self::Item) -> bool {
                 self.deref().update(key, value)
             }
 
@@ -145,7 +144,7 @@ macro_rules! impl_via_deref {
                 self.deref().get_cloned(key)
             }
 
-            fn update(&self, key: &Self::Key, value: Self::Item) -> Option<UpdateHandle> {
+            fn update(&self, key: &Self::Key, value: Self::Item) -> bool {
                 self.deref().update(key, value)
             }
 

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -15,7 +15,7 @@ impl<T: Clone + Debug> ListData for [T] {
     type Item = T;
 
     fn version(&self) -> u64 {
-        0
+        1
     }
 
     fn len(&self) -> usize {

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -19,8 +19,11 @@ pub trait SingleData: Debug {
 
     /// Get the data version
     ///
-    /// Views over shared data must check the data's `version` and update if
-    /// necessary each time they are drawn.
+    /// Views over shared data must check the data's `version` when drawn,
+    /// comparing to a local cached version and updating the view if out-dated.
+    ///
+    /// Data structures may update themselves when `version` is called (by using
+    /// an internal [`RefCell`], as required to support [`Self::update`]).
     ///
     /// The initial version number must be at least 1 (allowing 0 to represent
     /// an uninitialized state). Each modification of the data structure must
@@ -65,8 +68,11 @@ pub trait ListData: Debug {
 
     /// Get the data version
     ///
-    /// Views over shared data must check the data's `version` and update if
-    /// necessary each time they are drawn.
+    /// Views over shared data must check the data's `version` when drawn,
+    /// comparing to a local cached version and updating the view if out-dated.
+    ///
+    /// Data structures may update themselves when `version` is called (by using
+    /// an internal [`RefCell`], as required to support [`Self::update`]).
     ///
     /// The initial version number must be at least 1 (allowing 0 to represent
     /// an uninitialized state). Each modification of the data structure must
@@ -152,8 +158,11 @@ pub trait MatrixData: Debug {
 
     /// Get the data version
     ///
-    /// Views over shared data must check the data's `version` and update if
-    /// necessary each time they are drawn.
+    /// Views over shared data must check the data's `version` when drawn,
+    /// comparing to a local cached version and updating the view if out-dated.
+    ///
+    /// Data structures may update themselves when `version` is called (by using
+    /// an internal [`RefCell`], as required to support [`Self::update`]).
     ///
     /// The initial version number must be at least 1 (allowing 0 to represent
     /// an uninitialized state). Each modification of the data structure must

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -19,8 +19,12 @@ pub trait SingleData: Debug {
 
     /// Get the data version
     ///
-    /// This number starts from 0 and is increased by every call to `update` on
-    /// this data structure.
+    /// Views over shared data must check the data's `version` and update if
+    /// necessary each time they are drawn.
+    ///
+    /// The initial version number must be at least 1 (allowing 0 to represent
+    /// an uninitialized state). Each modification of the data structure must
+    /// increase the version number (allowing change detection).
     fn version(&self) -> u64;
 
     // TODO(gat): add get<'a>(&self) -> Self::ItemRef<'a> and get_mut
@@ -61,8 +65,12 @@ pub trait ListData: Debug {
 
     /// Get the data version
     ///
-    /// This number starts from 0 and is increased by every call to `update` on
-    /// this data structure.
+    /// Views over shared data must check the data's `version` and update if
+    /// necessary each time they are drawn.
+    ///
+    /// The initial version number must be at least 1 (allowing 0 to represent
+    /// an uninitialized state). Each modification of the data structure must
+    /// increase the version number (allowing change detection).
     fn version(&self) -> u64;
 
     /// Number of data items available
@@ -145,8 +153,12 @@ pub trait MatrixData: Debug {
 
     /// Get the data version
     ///
-    /// This number starts from 0 and is increased by every call to `update` on
-    /// this data structure.
+    /// Views over shared data must check the data's `version` and update if
+    /// necessary each time they are drawn.
+    ///
+    /// The initial version number must be at least 1 (allowing 0 to represent
+    /// an uninitialized state). Each modification of the data structure must
+    /// increase the version number (allowing change detection).
     fn version(&self) -> u64;
 
     /// No data is available

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -5,9 +5,6 @@
 
 //! Traits for shared data objects
 
-use crate::event::UpdateHandle;
-#[allow(unused)] // doc links
-use crate::updatable::Updatable;
 use crate::WidgetId;
 #[allow(unused)] // doc links
 use std::cell::RefCell;
@@ -34,16 +31,14 @@ pub trait SingleData: Debug {
     /// Update data, if supported
     ///
     /// This is optional and required only to support data updates through view
-    /// widgets. If implemented, then [`Updatable::update_handle`] should
-    /// return a copy of the same update handle.
+    /// widgets.
     ///
-    /// Updates the [`Self::version`] number and returns an [`UpdateHandle`] if
-    /// an update occurred. Returns `None` if updates are unsupported.
+    /// Updates the [`Self::version`] number and returns `true` if
+    /// an update occurred. Returns `false` if updates are unsupported.
     ///
     /// This method takes only `&self`, thus some mechanism such as [`RefCell`]
-    /// is required to obtain `&mut` and lower to [`SingleDataMut::set`]. The
-    /// provider of this lowering should also provide an [`UpdateHandle`].
-    fn update(&self, value: Self::Item) -> Option<UpdateHandle>;
+    /// is required to obtain `&mut` and lower to [`SingleDataMut::set`].
+    fn update(&self, value: Self::Item) -> bool;
 }
 
 /// Trait for writable single data items
@@ -100,8 +95,7 @@ pub trait ListData: Debug {
     /// Update data, if supported
     ///
     /// This is optional and required only to support data updates through view
-    /// widgets. If implemented, then [`Updatable::update_handle`] should
-    /// return a copy of the same update handle.
+    /// widgets.
     ///
     /// Updates the [`Self::version`] number and returns an [`UpdateHandle`] if
     /// an update occurred. Returns `None` if updates are unsupported.
@@ -109,7 +103,7 @@ pub trait ListData: Debug {
     /// This method takes only `&self`, thus some mechanism such as [`RefCell`]
     /// is required to obtain `&mut` and lower to [`ListDataMut::set`]. The
     /// provider of this lowering should also provide an [`UpdateHandle`].
-    fn update(&self, key: &Self::Key, value: Self::Item) -> Option<UpdateHandle>;
+    fn update(&self, key: &Self::Key, value: Self::Item) -> bool;
 
     // TODO(gat): replace with an iterator
     /// Iterate over keys as a vec
@@ -188,8 +182,7 @@ pub trait MatrixData: Debug {
     /// Update data, if supported
     ///
     /// This is optional and required only to support data updates through view
-    /// widgets. If implemented, then [`Updatable::update_handle`] should
-    /// return a copy of the same update handle.
+    /// widgets.
     ///
     /// Updates the [`Self::version`] number and returns an [`UpdateHandle`] if
     /// an update occurred. Returns `None` if updates are unsupported.
@@ -197,7 +190,7 @@ pub trait MatrixData: Debug {
     /// This method takes only `&self`, thus some mechanism such as [`RefCell`]
     /// is required to obtain `&mut` and lower to [`ListDataMut::set`]. The
     /// provider of this lowering should also provide an [`UpdateHandle`].
-    fn update(&self, key: &Self::Key, value: Self::Item) -> Option<UpdateHandle>;
+    fn update(&self, key: &Self::Key, value: Self::Item) -> bool;
 
     // TODO(gat): replace with an iterator
     /// Iterate over column keys as a vec

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -105,12 +105,11 @@ pub trait ListData: Debug {
     /// This is optional and required only to support data updates through view
     /// widgets.
     ///
-    /// Updates the [`Self::version`] number and returns an [`UpdateHandle`] if
-    /// an update occurred. Returns `None` if updates are unsupported.
+    /// Updates the [`Self::version`] number and returns `true` if
+    /// an update occurred. Returns `false` if updates are unsupported.
     ///
     /// This method takes only `&self`, thus some mechanism such as [`RefCell`]
-    /// is required to obtain `&mut` and lower to [`ListDataMut::set`]. The
-    /// provider of this lowering should also provide an [`UpdateHandle`].
+    /// is required to obtain `&mut` and lower to [`ListDataMut::set`].
     fn update(&self, key: &Self::Key, value: Self::Item) -> bool;
 
     // TODO(gat): replace with an iterator
@@ -196,12 +195,11 @@ pub trait MatrixData: Debug {
     /// This is optional and required only to support data updates through view
     /// widgets.
     ///
-    /// Updates the [`Self::version`] number and returns an [`UpdateHandle`] if
-    /// an update occurred. Returns `None` if updates are unsupported.
+    /// Updates the [`Self::version`] number and returns `true` if
+    /// an update occurred. Returns `false` if updates are unsupported.
     ///
     /// This method takes only `&self`, thus some mechanism such as [`RefCell`]
-    /// is required to obtain `&mut` and lower to [`ListDataMut::set`]. The
-    /// provider of this lowering should also provide an [`UpdateHandle`].
+    /// is required to obtain `&mut` and lower to [`ListDataMut::set`].
     fn update(&self, key: &Self::Key, value: Self::Item) -> bool;
 
     // TODO(gat): replace with an iterator

--- a/crates/kas-core/src/updatable/filter.rs
+++ b/crates/kas-core/src/updatable/filter.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 /// Types usable as a filter
-pub trait Filter<T>: Updatable + 'static {
+pub trait Filter<T>: Debug + 'static {
     /// Returns true if the given item matches this filter
     // TODO: once Accessor::get returns a reference, this should take item: &T where T: ?Sized
     fn matches(&self, item: T) -> bool;
@@ -30,19 +30,14 @@ impl ContainsString {
         ContainsString(Rc::new((handle, data)))
     }
 }
-impl Updatable for ContainsString {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        Some((self.0).0)
-    }
-}
-impl UpdatableHandler<(), String> for ContainsString {
-    fn handle(&self, _: &(), msg: &String) -> Option<UpdateHandle> {
+impl Updatable<(), String> for ContainsString {
+    fn handle(&self, _: &(), msg: &String) -> bool {
         self.update(msg.clone())
     }
 }
-impl UpdatableHandler<(), VoidMsg> for ContainsString {
-    fn handle(&self, _: &(), _: &VoidMsg) -> Option<UpdateHandle> {
-        None
+impl Updatable<(), VoidMsg> for ContainsString {
+    fn handle(&self, _: &(), _: &VoidMsg) -> bool {
+        false
     }
 }
 impl SingleData for ContainsString {
@@ -53,11 +48,11 @@ impl SingleData for ContainsString {
     fn get_cloned(&self) -> Self::Item {
         (self.0).1.borrow().0.to_owned()
     }
-    fn update(&self, value: Self::Item) -> Option<UpdateHandle> {
+    fn update(&self, value: Self::Item) -> bool {
         let mut cell = (self.0).1.borrow_mut();
         cell.0 = value;
         cell.1 += 1;
-        Some((self.0).0)
+        true
     }
 }
 impl SingleDataMut for ContainsString {
@@ -99,19 +94,14 @@ impl ContainsCaseInsensitive {
         ContainsCaseInsensitive(Rc::new((handle, data)))
     }
 }
-impl Updatable for ContainsCaseInsensitive {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        Some((self.0).0)
-    }
-}
-impl UpdatableHandler<(), String> for ContainsCaseInsensitive {
-    fn handle(&self, _: &(), msg: &String) -> Option<UpdateHandle> {
+impl Updatable<(), String> for ContainsCaseInsensitive {
+    fn handle(&self, _: &(), msg: &String) -> bool {
         self.update(msg.clone())
     }
 }
-impl UpdatableHandler<(), VoidMsg> for ContainsCaseInsensitive {
-    fn handle(&self, _: &(), _: &VoidMsg) -> Option<UpdateHandle> {
-        None
+impl Updatable<(), VoidMsg> for ContainsCaseInsensitive {
+    fn handle(&self, _: &(), _: &VoidMsg) -> bool {
+        false
     }
 }
 impl SingleData for ContainsCaseInsensitive {
@@ -122,12 +112,12 @@ impl SingleData for ContainsCaseInsensitive {
     fn get_cloned(&self) -> Self::Item {
         (self.0).1.borrow().0.clone()
     }
-    fn update(&self, value: Self::Item) -> Option<UpdateHandle> {
+    fn update(&self, value: Self::Item) -> bool {
         let mut cell = (self.0).1.borrow_mut();
         cell.0 = value;
         cell.1 = cell.0.to_uppercase();
         cell.2 += 1;
-        Some((self.0).0)
+        true
     }
 }
 impl SingleDataMut for ContainsCaseInsensitive {

--- a/crates/kas-core/src/updatable/filter.rs
+++ b/crates/kas-core/src/updatable/filter.rs
@@ -5,7 +5,7 @@
 
 //! Filters over data
 
-use crate::event::{UpdateHandle, VoidMsg};
+use crate::event::VoidMsg;
 use crate::updatable::*;
 use std::cell::RefCell;
 use std::fmt::Debug;
@@ -20,14 +20,13 @@ pub trait Filter<T>: Debug + 'static {
 
 /// Filter: target contains self (case-sensitive string match)
 #[derive(Debug, Default, Clone)]
-pub struct ContainsString(Rc<(UpdateHandle, RefCell<(String, u64)>)>);
+pub struct ContainsString(Rc<RefCell<(String, u64)>>);
 
 impl ContainsString {
     /// Construct with given string
     pub fn new<S: ToString>(s: S) -> Self {
-        let handle = UpdateHandle::new();
         let data = RefCell::new((s.to_string(), 1));
-        ContainsString(Rc::new((handle, data)))
+        ContainsString(Rc::new(data))
     }
 }
 impl Updatable<(), String> for ContainsString {
@@ -43,13 +42,13 @@ impl Updatable<(), VoidMsg> for ContainsString {
 impl SingleData for ContainsString {
     type Item = String;
     fn version(&self) -> u64 {
-        (self.0).1.borrow().1
+        self.0.borrow().1
     }
     fn get_cloned(&self) -> Self::Item {
-        (self.0).1.borrow().0.to_owned()
+        self.0.borrow().0.to_owned()
     }
     fn update(&self, value: Self::Item) -> bool {
-        let mut cell = (self.0).1.borrow_mut();
+        let mut cell = self.0.borrow_mut();
         cell.0 = value;
         cell.1 += 1;
         true
@@ -57,7 +56,7 @@ impl SingleData for ContainsString {
 }
 impl SingleDataMut for ContainsString {
     fn set(&mut self, value: Self::Item) {
-        let mut cell = (self.0).1.borrow_mut();
+        let mut cell = self.0.borrow_mut();
         cell.0 = value;
         cell.1 += 1;
     }
@@ -82,16 +81,15 @@ impl Filter<String> for ContainsString {
 //
 // [question on StackOverflow]: https://stackoverflow.com/questions/47298336/case-insensitive-string-matching-in-rust
 #[derive(Debug, Default, Clone)]
-pub struct ContainsCaseInsensitive(Rc<(UpdateHandle, RefCell<(String, String, u64)>)>);
+pub struct ContainsCaseInsensitive(Rc<RefCell<(String, String, u64)>>);
 
 impl ContainsCaseInsensitive {
     /// Construct with given string
     pub fn new<S: ToString>(s: S) -> Self {
-        let handle = UpdateHandle::new();
         let s = s.to_string();
         let u = s.to_uppercase();
         let data = RefCell::new((s, u, 1));
-        ContainsCaseInsensitive(Rc::new((handle, data)))
+        ContainsCaseInsensitive(Rc::new(data))
     }
 }
 impl Updatable<(), String> for ContainsCaseInsensitive {
@@ -107,13 +105,13 @@ impl Updatable<(), VoidMsg> for ContainsCaseInsensitive {
 impl SingleData for ContainsCaseInsensitive {
     type Item = String;
     fn version(&self) -> u64 {
-        (self.0).1.borrow().2
+        self.0.borrow().2
     }
     fn get_cloned(&self) -> Self::Item {
-        (self.0).1.borrow().0.clone()
+        self.0.borrow().0.clone()
     }
     fn update(&self, value: Self::Item) -> bool {
-        let mut cell = (self.0).1.borrow_mut();
+        let mut cell = self.0.borrow_mut();
         cell.0 = value;
         cell.1 = cell.0.to_uppercase();
         cell.2 += 1;
@@ -122,7 +120,7 @@ impl SingleData for ContainsCaseInsensitive {
 }
 impl SingleDataMut for ContainsCaseInsensitive {
     fn set(&mut self, value: Self::Item) {
-        let mut cell = (self.0).1.borrow_mut();
+        let mut cell = self.0.borrow_mut();
         cell.0 = value;
         cell.1 = cell.0.to_uppercase();
         cell.2 += 1;
@@ -136,6 +134,6 @@ impl<'a> Filter<&'a str> for ContainsCaseInsensitive {
 }
 impl Filter<String> for ContainsCaseInsensitive {
     fn matches(&self, item: String) -> bool {
-        item.to_uppercase().contains(&(self.0).1.borrow().1)
+        item.to_uppercase().contains(&self.0.borrow().1)
     }
 }

--- a/crates/kas-core/src/updatable/filter.rs
+++ b/crates/kas-core/src/updatable/filter.rs
@@ -26,7 +26,7 @@ impl ContainsString {
     /// Construct with given string
     pub fn new<S: ToString>(s: S) -> Self {
         let handle = UpdateHandle::new();
-        let data = RefCell::new((s.to_string(), 0));
+        let data = RefCell::new((s.to_string(), 1));
         ContainsString(Rc::new((handle, data)))
     }
 }
@@ -90,7 +90,7 @@ impl ContainsCaseInsensitive {
         let handle = UpdateHandle::new();
         let s = s.to_string();
         let u = s.to_uppercase();
-        let data = RefCell::new((s, u, 0));
+        let data = RefCell::new((s, u, 1));
         ContainsCaseInsensitive(Rc::new((handle, data)))
     }
 }

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -30,7 +30,7 @@ impl<T: Debug> SharedRc<T> {
     /// Construct with given data
     pub fn new(data: T) -> Self {
         let handle = UpdateHandle::new();
-        let data = RefCell::new((data, 0));
+        let data = RefCell::new((data, 1));
         SharedRc(Rc::new((handle, data)))
     }
 }

--- a/crates/kas-core/src/util.rs
+++ b/crates/kas-core/src/util.rs
@@ -10,7 +10,7 @@ use std::fmt;
 
 /// Helper to display widget identification (e.g. `MyWidget#01`)
 ///
-/// Constructed by [`crate::WidgetCore::identify`].
+/// Constructed by [`crate::WidgetExt::identify`].
 pub struct IdentifyWidget(pub(crate) &'static str, pub(crate) WidgetId);
 impl fmt::Display for IdentifyWidget {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/crates/kas-wgpu/src/event_loop.rs
+++ b/crates/kas-wgpu/src/event_loop.rs
@@ -140,6 +140,11 @@ where
                     } else if action.contains(TkAction::CLOSE) {
                         to_close.push(*window_id);
                     }
+                    if !close_all && action.contains(TkAction::REDRAW_ALL) {
+                        self.shared
+                            .pending
+                            .push(PendingAction::TkAction(TkAction::REDRAW));
+                    }
                     if let Some(instant) = resume {
                         self.resumes.push((instant, *window_id));
                     }

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -7,7 +7,7 @@
 
 use super::AccelLabel;
 use kas::prelude::*;
-use kas::updatable::{SharedRc, SingleData, Updatable};
+use kas::updatable::{SharedRc, SingleData};
 use log::trace;
 use std::rc::Rc;
 
@@ -27,12 +27,6 @@ widget! {
     }
 
     impl WidgetConfig for Self {
-        fn configure(&mut self, mgr: &mut SetRectMgr) {
-            if let Some(handle) = self.group.update_handle() {
-                mgr.update_on_handle(handle, self.id());
-            }
-        }
-
         fn key_nav(&self) -> bool {
             true
         }
@@ -55,10 +49,8 @@ widget! {
                     if !self.state {
                         trace!("RadioBoxBare: set {}", self.id());
                         self.state = true;
-                        mgr.redraw(self.id());
-                        if let Some(handle) = self.group.update(self.id()) {
-                            mgr.trigger_update(handle, 0);
-                        }
+                        self.group.update(self.id());
+                        mgr.redraw_all_windows();
                         Response::update_or_msg(self.on_select.as_ref().and_then(|f| f(mgr)))
                     } else {
                         Response::Used

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -23,6 +23,7 @@ widget! {
         core: CoreData,
         state: bool,
         group: RadioBoxGroup,
+        group_ver: u64,
         on_select: Option<Rc<dyn Fn(&mut EventMgr) -> Option<M>>>,
     }
 
@@ -56,16 +57,6 @@ widget! {
                         Response::Used
                     }
                 }
-                Event::HandleUpdate { .. } => {
-                    if self.state && !self.eq_id(self.group.get_cloned()) {
-                        trace!("RadioBoxBare: unset {}", self.id());
-                        self.state = false;
-                        mgr.redraw(self.id());
-                        Response::Update
-                    } else {
-                        Response::Used
-                    }
-                }
                 _ => Response::Unused,
             }
         }
@@ -87,6 +78,12 @@ widget! {
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
+            let ver = self.group.version();
+            if ver > self.group_ver {
+                self.state = self.eq_id(self.group.get_cloned());
+                self.group_ver = ver;
+            }
+
             let mut draw = draw.with_core(self.core_data());
             draw.radiobox(self.core.rect, self.state);
         }
@@ -103,6 +100,7 @@ widget! {
                 core: Default::default(),
                 state: false,
                 group,
+                group_ver: 0,
                 on_select: None,
             }
         }
@@ -124,6 +122,7 @@ widget! {
                 core: self.core,
                 state: self.state,
                 group: self.group,
+                group_ver: self.group_ver,
                 on_select: Some(Rc::new(f)),
             }
         }

--- a/crates/kas-widgets/src/view/driver.rs
+++ b/crates/kas-widgets/src/view/driver.rs
@@ -53,7 +53,7 @@ pub trait Driver<T>: Debug + 'static {
     /// `update` method to update the model.
     ///
     /// Note that, additionally, when [`Response::Msg`] is returned,
-    /// [`kas::updatable::UpdatableHandler`] may be used to observe the message.
+    /// [`kas::updatable::Updatable`] may be used to observe the message.
     /// Often it will be sufficient to implement custom handling/update logic
     /// in only one of these places.
     fn get(&self, widget: &Self::Widget) -> Option<T>;

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -22,9 +22,6 @@ use std::fmt::Debug;
 /// Note: the key and item types are the same as those in the underlying list,
 /// thus one can also retrieve values from the underlying list directly.
 ///
-/// Note: only `Rc<FilteredList<T, F>>` implements [`ListData`]; the [`Rc`]
-/// wrapper is required!
-///
 /// Warning: this implementation is `O(n)` where `n = data.len()` and not well
 /// optimised, thus is expected to be slow on large data lists.
 #[derive(Clone, Debug)]

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -5,10 +5,6 @@
 
 //! Filter-list view widget
 
-use super::{driver, Driver, ListView, SelectionError, SelectionMode};
-use crate::Scrollable;
-use kas::event::ChildMsg;
-use kas::layout;
 use kas::prelude::*;
 use kas::updatable::filter::Filter;
 use kas::updatable::{ListData, SingleData, Updatable};
@@ -32,7 +28,7 @@ use std::fmt::Debug;
 /// Warning: this implementation is `O(n)` where `n = data.len()` and not well
 /// optimised, thus is expected to be slow on large data lists.
 #[derive(Clone, Debug)]
-struct FilteredList<T: ListData, F: Filter<T::Item> + SingleData> {
+pub struct FilteredList<T: ListData, F: Filter<T::Item> + SingleData> {
     /// Direct access to unfiltered data
     data: T,
     /// Direct access to the filter
@@ -41,9 +37,9 @@ struct FilteredList<T: ListData, F: Filter<T::Item> + SingleData> {
 }
 
 impl<T: ListData, F: Filter<T::Item> + SingleData> FilteredList<T, F> {
-    /// Construct and apply filter
+    /// Construct from `data` and a `filter`
     #[inline]
-    fn new(data: T, filter: F) -> Self {
+    pub fn new(data: T, filter: F) -> Self {
         let len = data.len();
         let view = RefCell::new((0, Vec::with_capacity(len)));
         FilteredList { data, filter, view }
@@ -128,240 +124,5 @@ impl<T: ListData + 'static, F: Filter<T::Item> + SingleData> ListData for Filter
     fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::Key> {
         let end = self.len().min(start + limit);
         self.view.borrow().1[start..end].to_vec()
-    }
-}
-
-widget! {
-    /// Filter-list view widget
-    ///
-    /// This widget is a wrapper around [`ListView`] which applies a filter to the
-    /// data list.
-    ///
-    /// Why is a data-filter a widget and not a pure-data item, you ask? The answer
-    /// is that a filter-list must be updated when the filter or the data changes,
-    /// and, since filtering a list is not especially cheap, the filtering must be
-    /// cached and updated when required, not every time the list view asks for more
-    /// data. Although it is possible to do this with a data-view, that requires
-    /// machinery for recursive-updates on data-structures and/or a mechanism to
-    /// test whether the underlying list-data changed. Implementing as a widget
-    /// avoids this.
-    // TODO: impl Clone
-    #[derive(Debug)]
-    #[handler(msg = ChildMsg<T::Key, <V::Widget as Handler>::Msg>)]
-    pub struct FilterListView<
-        D: Directional,
-        T: ListData + Updatable<T::Key, V::Msg> + 'static,
-        F: Filter<T::Item> + SingleData,
-        V: Driver<T::Item> = driver::Default,
-    > {
-        #[widget_core]
-        core: CoreData,
-        #[widget]
-        list: ListView<D, FilteredList<T, F>, V>,
-        data_ver: u64,
-    }
-
-    impl Self where D: Default, V: Default {
-        /// Construct a new instance
-        ///
-        /// This constructor is available where the direction is determined by the
-        /// type: for `D: Directional + Default`. In other cases, use
-        /// [`FilterListView::new_with_direction`].
-        pub fn new(data: T, filter: F) -> Self {
-            Self::new_with_dir_driver(D::default(), <V as Default>::default(), data, filter)
-        }
-    }
-    impl Self where V: Default {
-        /// Construct a new instance with explicit direction
-        pub fn new_with_direction(direction: D, data: T, filter: F) -> Self {
-            Self::new_with_dir_driver(direction, <V as Default>::default(), data, filter)
-        }
-    }
-    impl Self where D: Default {
-        /// Construct a new instance with explicit view
-        pub fn new_with_driver(view: V, data: T, filter: F) -> Self {
-            Self::new_with_dir_driver(D::default(), view, data, filter)
-        }
-    }
-    impl<
-            T: ListData + Updatable<T::Key, V::Msg>,
-            F: Filter<T::Item> + SingleData,
-            V: Driver<T::Item> + Default,
-        > FilterListView<Direction, T, F, V>
-    {
-        /// Set the direction of contents
-        pub fn set_direction(&mut self, direction: Direction) -> TkAction {
-            self.list.set_direction(direction)
-        }
-    }
-    impl Self {
-        /// Construct a new instance with explicit direction and view
-        pub fn new_with_dir_driver(direction: D, view: V, data: T, filter: F) -> Self {
-            let data = FilteredList::new(data, filter);
-            FilterListView {
-                core: Default::default(),
-                list: ListView::new_with_dir_driver(direction, view, data),
-                data_ver: 0,
-            }
-        }
-
-        /// Access the stored data (pre-filter)
-        pub fn unfiltered_data(&self) -> &T {
-            &self.list.data().data
-        }
-
-        /// Mutably access the stored data (pre-filter)
-        pub fn unfiltered_data_mut(&mut self) -> &mut T {
-            &mut self.list.data_mut().data
-        }
-
-        /// Access the stored data (post-filter)
-        pub fn data(&self) -> &T {
-            &self.list.data().data
-        }
-
-        /// Mutably access the stored data (post-filter)
-        pub fn data_mut(&mut self) -> &mut T {
-            &mut self.list.data_mut().data
-        }
-
-        /// Check whether a key has data (post-filter)
-        pub fn contains_key(&self, key: &T::Key) -> bool {
-            self.data().contains_key(key)
-        }
-
-        /// Get a copy of the shared value at `key` (post-filter)
-        pub fn get_value(&self, key: &T::Key) -> Option<T::Item> {
-            self.data().get_cloned(key)
-        }
-
-        /// Set shared data (post-filter)
-        ///
-        /// This method updates the shared data, if supported (see
-        /// [`ListData::update`]). Other widgets sharing this data are notified
-        /// of the update, if data is changed.
-        pub fn set_value(&self, mgr: &mut EventMgr, key: &T::Key, data: T::Item) {
-            if self.data().update(key, data) {
-                mgr.redraw_all_windows();
-            }
-        }
-
-        /// Update shared data (post-filter)
-        ///
-        /// This is purely a convenience method over [`FilterListView::set_value`].
-        /// It does nothing if no value is found at `key`.
-        /// It notifies other widgets of updates to the shared data.
-        pub fn update_value<G: Fn(T::Item) -> T::Item>(&self, mgr: &mut EventMgr, key: &T::Key, f: G) {
-            if let Some(item) = self.get_value(key) {
-                self.set_value(mgr, key, f(item));
-            }
-        }
-
-        /// Get the current selection mode
-        pub fn selection_mode(&self) -> SelectionMode {
-            self.list.selection_mode()
-        }
-        /// Set the current selection mode
-        pub fn set_selection_mode(&mut self, mode: SelectionMode) -> TkAction {
-            self.list.set_selection_mode(mode)
-        }
-        /// Set the selection mode (inline)
-        #[must_use]
-        pub fn with_selection_mode(mut self, mode: SelectionMode) -> Self {
-            let _ = self.set_selection_mode(mode);
-            self
-        }
-
-        /// Read the list of selected entries
-        ///
-        /// With mode [`SelectionMode::Single`] this may contain zero or one entry;
-        /// use `selected_iter().next()` to extract only the first (optional) entry.
-        pub fn selected_iter(&'_ self) -> impl Iterator<Item = &'_ T::Key> + '_ {
-            self.list.selected_iter()
-        }
-
-        /// Check whether an entry is selected
-        pub fn is_selected(&self, key: &T::Key) -> bool {
-            self.list.is_selected(key)
-        }
-
-        /// Clear all selected items
-        ///
-        /// Does not send [`ChildMsg`] responses.
-        pub fn clear_selected(&mut self) -> TkAction {
-            self.list.clear_selected()
-        }
-
-        /// Directly select an item
-        ///
-        /// Returns `TkAction::REDRAW` if newly selected, `TkAction::empty()` if
-        /// already selected. Fails if selection mode does not permit selection
-        /// or if the key is invalid.
-        ///
-        /// Does not send [`ChildMsg`] responses.
-        pub fn select(&mut self, key: T::Key) -> Result<TkAction, SelectionError> {
-            self.list.select(key)
-        }
-
-        /// Directly deselect an item
-        ///
-        /// Returns `TkAction::REDRAW` if deselected, `TkAction::empty()` if not
-        /// previously selected or if the key is invalid.
-        ///
-        /// Does not send [`ChildMsg`] responses.
-        pub fn deselect(&mut self, key: &T::Key) -> TkAction {
-            self.list.deselect(key)
-        }
-
-        /// Get the direction of contents
-        pub fn direction(&self) -> Direction {
-            self.list.direction()
-        }
-
-        /// Set the preferred number of items visible (inline)
-        ///
-        /// This affects the (ideal) size request and whether children are sized
-        /// according to their ideal or minimum size but not the minimum size.
-        #[must_use]
-        pub fn with_num_visible(mut self, number: i32) -> Self {
-            self.list = self.list.with_num_visible(number);
-            self
-        }
-    }
-
-    // TODO: support derive(Scrollable)?
-    impl Scrollable for Self {
-        #[inline]
-        fn scroll_axes(&self, size: Size) -> (bool, bool) {
-            self.list.scroll_axes(size)
-        }
-
-        #[inline]
-        fn max_scroll_offset(&self) -> Offset {
-            self.list.max_scroll_offset()
-        }
-
-        #[inline]
-        fn scroll_offset(&self) -> Offset {
-            self.list.scroll_offset()
-        }
-
-        #[inline]
-        fn set_scroll_offset(&mut self, mgr: &mut EventMgr, offset: Offset) -> Offset {
-            self.list.set_scroll_offset(mgr, offset)
-        }
-    }
-
-    impl Layout for Self {
-        fn layout(&mut self) -> layout::Layout<'_> {
-            layout::Layout::single(&mut self.list)
-        }
-
-        fn draw(&mut self, mut draw: DrawMgr) {
-            self.data_ver = self.list.data().version();
-
-            let draw = draw.with_core(self.core_data());
-            self.layout().draw(draw);
-        }
     }
 }

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -46,9 +46,7 @@ impl<T: ListData, F: Filter<T::Item> + SingleData> FilteredList<T, F> {
     fn new(data: T, filter: F) -> Self {
         let len = data.len();
         let view = RefCell::new(Vec::with_capacity(len));
-        let s = FilteredList { data, filter, view };
-        let _ = s.refresh();
-        s
+        FilteredList { data, filter, view }
     }
 
     /// Refresh the view

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -13,11 +13,10 @@ use kas::event::components::ScrollComponent;
 use kas::event::{ChildMsg, Command, CursorIcon};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
-use kas::updatable::{ListData, UpdatableHandler};
+use kas::updatable::{ListData, Updatable};
 use linear_map::set::LinearSet;
 use log::{debug, trace};
 use std::time::Instant;
-use UpdatableHandler as UpdHandler;
 
 #[derive(Clone, Debug, Default)]
 struct WidgetData<K, W> {
@@ -31,7 +30,7 @@ widget! {
     /// This widget supports a view over a list of shared data items.
     ///
     /// The shared data type `T` must support [`ListData`] and
-    /// [`UpdatableHandler`], the latter with key type `T::Key` and message type
+    /// [`Updatable`], the latter with key type `T::Key` and message type
     /// matching the widget's message. One may use [`kas::updatable::SharedRc`]
     /// or a custom shared data type.
     ///
@@ -44,7 +43,7 @@ widget! {
     #[derive(Clone, Debug)]
     pub struct ListView<
         D: Directional,
-        T: ListData + UpdHandler<T::Key, V::Msg> + 'static,
+        T: ListData + Updatable<T::Key, V::Msg> + 'static,
         V: Driver<T::Item> = driver::Default,
     > {
         #[widget_core]
@@ -94,7 +93,7 @@ widget! {
             Self::new_with_dir_driver(D::default(), view, data)
         }
     }
-    impl<T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> ListView<Direction, T, V> {
+    impl<T: ListData + Updatable<T::Key, V::Msg>, V: Driver<T::Item>> ListView<Direction, T, V> {
         /// Set the direction of contents
         pub fn set_direction(&mut self, direction: Direction) -> TkAction {
             self.direction = direction;
@@ -134,8 +133,6 @@ widget! {
         }
 
         /// Mutably access the stored data
-        ///
-        /// It may be necessary to use [`ListView::update_view`] to update the view of this data.
         pub fn data_mut(&mut self) -> &mut T {
             &mut self.data
         }
@@ -151,8 +148,8 @@ widget! {
         /// [`ListData::update`]). Other widgets sharing this data are notified
         /// of the update, if data is changed.
         pub fn set_value(&self, mgr: &mut EventMgr, key: &T::Key, data: T::Item) {
-            if let Some(handle) = self.data.update(key, data) {
-                mgr.trigger_update(handle, 0);
+            if self.data.update(key, data) {
+                mgr.redraw_all_windows();
             }
         }
 
@@ -256,13 +253,13 @@ widget! {
         }
 
         /// Manually trigger an update to handle changed data
-        pub fn update_view(&mut self, mgr: &mut EventMgr) {
+        fn update_view(&mut self, mgr: &mut SetRectMgr) {
             let data = &self.data;
             self.selection.retain(|key| data.contains_key(key));
             for w in &mut self.widgets {
                 w.key = None;
             }
-            mgr.set_rect_mgr(|mgr| self.update_widgets(mgr));
+            self.update_widgets(mgr);
             // Force SET_SIZE so that scroll-bar wrappers get updated
             trace!("update_view triggers SET_SIZE");
             *mgr |= TkAction::SET_SIZE;
@@ -428,9 +425,6 @@ widget! {
 
     impl WidgetConfig for Self {
         fn configure(&mut self, mgr: &mut SetRectMgr) {
-            if let Some(handle) = self.data.update_handle() {
-                mgr.update_on_handle(handle, self.id());
-            }
             mgr.register_nav_fallback(self.id());
         }
     }
@@ -592,6 +586,12 @@ widget! {
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
+            let data_ver = self.data.version();
+            if data_ver > self.data_ver {
+                draw.set_rect_mgr(|mgr| self.update_view(mgr));
+                self.data_ver = data_ver;
+            }
+
             let mut draw = draw.with_core(self.core_data());
             let offset = self.scroll_offset();
             draw.with_clip_region(self.core.rect, offset, |mut draw| {
@@ -612,16 +612,6 @@ widget! {
 
         fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {
             match event {
-                Event::HandleUpdate { .. } => {
-                    let data_ver = self.data.version();
-                    if data_ver > self.data_ver {
-                        // TODO(opt): use the update payload to indicate which widgets need updating?
-                        self.update_view(mgr);
-                        self.data_ver = data_ver;
-                        return Response::Update;
-                    }
-                    return Response::Used;
-                }
                 Event::PressMove { coord, .. } => {
                     if let PressPhase::Start(start_coord) = self.press_phase {
                         if mgr.config_test_pan_thresh(coord - start_coord) {
@@ -761,8 +751,8 @@ widget! {
 
             if matches!(&response, Response::Update | Response::Msg(_)) {
                 if let Some(value) = self.view.get(&self.widgets[index].widget) {
-                    if let Some(handle) = self.data.update(&key, value) {
-                        mgr.trigger_update(handle, 0);
+                    if self.data.update(&key, value) {
+                        mgr.redraw_all_windows();
                     }
                 }
             }
@@ -824,8 +814,8 @@ widget! {
                         &key,
                         kas::util::TryFormat(&msg)
                     );
-                    if let Some(handle) = self.data.handle(&key, &msg) {
-                        mgr.trigger_update(handle, 0);
+                    if self.data.handle(&key, &msg) {
+                        mgr.redraw_all_windows();
                     }
                     Response::Msg(ChildMsg::Child(key, msg))
                 }

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -53,6 +53,7 @@ widget! {
         frame_size: Size,
         view: V,
         data: T,
+        data_ver: u64,
         widgets: Vec<WidgetData<T::Key, V::Widget>>,
         /// The number of widgets in use (cur_len ≤ widgets.len())
         cur_len: u32,
@@ -109,6 +110,7 @@ widget! {
                 frame_size: Default::default(),
                 view,
                 data,
+                data_ver: 0,
                 widgets: Default::default(),
                 cur_len: 0,
                 direction,
@@ -611,9 +613,14 @@ widget! {
         fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {
             match event {
                 Event::HandleUpdate { .. } => {
-                    // TODO(opt): use the update payload to indicate which widgets need updating?
-                    self.update_view(mgr);
-                    return Response::Update;
+                    let data_ver = self.data.version();
+                    if data_ver > self.data_ver {
+                        // TODO(opt): use the update payload to indicate which widgets need updating?
+                        self.update_view(mgr);
+                        self.data_ver = data_ver;
+                        return Response::Update;
+                    }
+                    return Response::Used;
                 }
                 Event::PressMove { coord, .. } => {
                     if let PressPhase::Start(start_coord) = self.press_phase {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -58,6 +58,7 @@ widget! {
         frame_size: Size,
         view: V,
         data: T,
+        data_ver: u64,
         widgets: Vec<WidgetData<T::Key, V::Widget>>,
         align_hints: AlignHints,
         ideal_len: Dim,
@@ -91,6 +92,7 @@ widget! {
                 frame_size: Default::default(),
                 view,
                 data,
+                data_ver: 0,
                 widgets: Default::default(),
                 align_hints: Default::default(),
                 ideal_len: Dim { rows: 3, cols: 5 },
@@ -612,8 +614,13 @@ widget! {
         fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {
             match event {
                 Event::HandleUpdate { .. } => {
-                    self.update_view(mgr);
-                    return Response::Update;
+                    let data_ver = self.data.version();
+                    if data_ver > self.data_ver {
+                        self.update_view(mgr);
+                        self.data_ver = data_ver;
+                        return Response::Update;
+                    }
+                    return Response::Used;
                 }
                 Event::PressMove { coord, .. } => {
                     if let PressPhase::Start(start_coord) = self.press_phase {

--- a/crates/kas-widgets/src/view/mod.rs
+++ b/crates/kas-widgets/src/view/mod.rs
@@ -78,7 +78,7 @@ mod single_view;
 pub mod driver;
 
 pub use driver::Driver;
-pub use filter_list::FilterListView;
+pub use filter_list::FilteredList;
 pub use list_view::ListView;
 pub use matrix_view::MatrixView;
 pub use single_view::SingleView;

--- a/crates/kas-widgets/src/view/mod.rs
+++ b/crates/kas-widgets/src/view/mod.rs
@@ -19,7 +19,7 @@
 //! For simpler cases it is not always necessary to implement your own shared
 //! data type, for example `SharedRc<i32>` implements [`SingleData`] and
 //! `&'static [&'static str]` implements [`ListData`]. The [`SharedRc`] type
-//! provides an `update` method and the [`UpdateHandle`] required to synchronise
+//! provides an `update` method and the version counter required to synchronise
 //! views; `&[T]` does not (data is constant).
 //!
 //! # View widgets and drivers
@@ -65,8 +65,6 @@
 //!     or selection support)
 //! -   [`ListView`] creates a scrollable list view over a [`ListData`] object
 
-#[allow(unused)]
-use kas::event::UpdateHandle;
 use kas::macros::VoidMsg;
 #[allow(unused)]
 use kas::updatable::{ListData, MatrixData, SharedRc, SingleData};

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -36,6 +36,7 @@ widget! {
         core: CoreData,
         view: V,
         data: T,
+        data_ver: u64,
         #[widget]
         child: V::Widget,
     }
@@ -64,6 +65,7 @@ widget! {
                 core: Default::default(),
                 view,
                 data,
+                data_ver: 0,
                 child,
             }
         }
@@ -116,9 +118,15 @@ widget! {
         fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {
             match event {
                 Event::HandleUpdate { .. } => {
-                    let value = self.data.get_cloned();
-                    *mgr |= self.view.set(&mut self.child, value);
-                    Response::Update
+                    let data_ver = self.data.version();
+                    if data_ver > self.data_ver {
+                        let value = self.data.get_cloned();
+                        *mgr |= self.view.set(&mut self.child, value);
+                        self.data_ver = data_ver;
+                        Response::Update
+                    } else {
+                        Response::Used
+                    }
                 }
                 _ => Response::Unused,
             }

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -48,7 +48,7 @@ struct MyData {
 impl MyData {
     fn new(len: usize) -> Self {
         MyData {
-            ver: 0,
+            ver: 1,
             len,
             data: Default::default(),
             handle: UpdateHandle::new(),

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -39,6 +39,7 @@ enum EntryMsg {
 
 #[derive(Debug)]
 struct MyData {
+    ver: u64,
     len: usize,
     // (active index, map of strings)
     data: RefCell<(usize, HashMap<usize, String>)>,
@@ -47,12 +48,14 @@ struct MyData {
 impl MyData {
     fn new(len: usize) -> Self {
         MyData {
+            ver: 0,
             len,
             data: Default::default(),
             handle: UpdateHandle::new(),
         }
     }
     fn set_len(&mut self, len: usize) -> (Option<String>, UpdateHandle) {
+        self.ver += 1;
         self.len = len;
         let mut new_text = None;
         let mut data = self.data.borrow_mut();
@@ -70,6 +73,7 @@ impl MyData {
     // Note: in general this method should update the data source and return
     // self.handle, but for our uses this is sufficient.
     fn set_active(&mut self, active: usize) -> String {
+        self.ver += 1;
         self.data.borrow_mut().0 = active;
         self.get(active).1
     }
@@ -105,7 +109,7 @@ impl ListData for MyData {
     type Item = (usize, bool, String);
 
     fn version(&self) -> u64 {
-        0
+        self.ver
     }
 
     fn len(&self) -> usize {

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -85,21 +85,16 @@ impl MyData {
         (is_active, text)
     }
 }
-impl Updatable for MyData {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        Some(self.handle)
-    }
-}
-impl UpdatableHandler<usize, EntryMsg> for MyData {
-    fn handle(&self, key: &usize, msg: &EntryMsg) -> Option<UpdateHandle> {
+impl Updatable<usize, EntryMsg> for MyData {
+    fn handle(&self, key: &usize, msg: &EntryMsg) -> bool {
         match msg {
             EntryMsg::Select => {
                 self.data.borrow_mut().0 = *key;
-                Some(self.handle)
+                true
             }
             EntryMsg::Update(text) => {
                 self.data.borrow_mut().1.insert(*key, text.clone());
-                Some(self.handle)
+                true
             }
         }
     }
@@ -131,7 +126,7 @@ impl ListData for MyData {
         Some((*key, is_active, text))
     }
 
-    fn update(&self, _: &Self::Key, _: Self::Item) -> Option<UpdateHandle> {
+    fn update(&self, _: &Self::Key, _: Self::Item) -> bool {
         unimplemented!()
     }
 

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -61,11 +61,6 @@ widget! {
     // Use of a compound listing here with five child widgets (RadioBox is a
     // compound widget) slows down list resizing significantly (more so in debug
     // builds).
-    //
-    // Use of an embedded RadioBox demonstrates another performance issue:
-    // activating any RadioBox sends a message to all others using the same
-    // UpdateHandle, which is quite slow with thousands of entries!
-    // (This issue does not occur when RadioBoxes are independent.)
     #[derive(Clone, Debug)]
     #[widget{
         layout = column: *;

--- a/examples/filter-list.rs
+++ b/examples/filter-list.rs
@@ -9,7 +9,7 @@ use kas::dir::Down;
 use kas::event::ChildMsg;
 use kas::prelude::*;
 use kas::updatable::filter::ContainsCaseInsensitive;
-use kas::widgets::view::{driver, FilterListView, SelectionMode, SingleView};
+use kas::widgets::view::{self, driver, SelectionMode, SingleView};
 use kas::widgets::{EditBox, Label, RadioBox, RadioBoxGroup, ScrollBars, Window};
 
 const MONTHS: &[&str] = &[
@@ -48,36 +48,31 @@ fn main() -> kas::shell::Result<()> {
     println!("filter-list: {} entries", data.len());
     let filter = ContainsCaseInsensitive::new("");
     let filter_driver = driver::Widget::<EditBox>::default();
+    type FilteredList = view::FilteredList<&'static [&'static str], ContainsCaseInsensitive>;
+    type ListView = view::ListView<Down, FilteredList, driver::DefaultNav>;
+    let filtered = FilteredList::new(data, filter.clone());
 
-    let window = Window::new(
-        "Filter-list",
-        make_widget! {
-            #[widget{
-                layout = list(down): *;
-            }]
-            #[handler(msg = VoidMsg)]
-            struct {
-                #[widget(use_msg = set_selection_mode)] _ = selection_mode,
-                #[widget] filter = SingleView::new_with_driver(filter_driver, filter.clone()),
-                #[widget(use_msg = select)] list:
-                    ScrollBars<FilterListView<
-                        Down,
-                        &'static [&'static str],
-                        ContainsCaseInsensitive,
-                        driver::DefaultNav,
-                    >> =
-                    ScrollBars::new(FilterListView::new(data, filter)),
+    let widget = make_widget! {
+        #[widget{
+            layout = list(down): *;
+        }]
+        #[handler(msg = VoidMsg)]
+        struct {
+            #[widget(use_msg = set_selection_mode)] _ = selection_mode,
+            #[widget] filter = SingleView::new_with_driver(filter_driver, filter),
+            #[widget(use_msg = select)] list: ScrollBars<ListView> =
+                ScrollBars::new(ListView::new(filtered)),
+        }
+        impl Self {
+            fn set_selection_mode(&mut self, mgr: &mut EventMgr, mode: SelectionMode) {
+                *mgr |= self.list.set_selection_mode(mode);
             }
-            impl Self {
-                fn set_selection_mode(&mut self, mgr: &mut EventMgr, mode: SelectionMode) {
-                    *mgr |= self.list.set_selection_mode(mode);
-                }
-                fn select(&mut self, _: &mut EventMgr, msg: ChildMsg<usize, VoidMsg>) {
-                    println!("Selection message: {:?}", msg);
-                }
+            fn select(&mut self, _: &mut EventMgr, msg: ChildMsg<usize, VoidMsg>) {
+                println!("Selection message: {:?}", msg);
             }
-        },
-    );
+        }
+    };
+    let window = Window::new("Filter-list", widget);
 
     let theme = kas::theme::ShadedTheme::new();
     kas::shell::Toolkit::new(theme)?.with(window)?.run()

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -65,7 +65,7 @@ impl MatrixData for TableData {
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
-    let table = MatrixView::new(TableData(0, 12))
+    let table = MatrixView::new(TableData(1, 12))
         .with_num_visible(12, 12)
         .with_selection_mode(SelectionMode::Single);
     let table = ScrollBars::new(table);

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -1,20 +1,15 @@
 //! Do you know your times tables?
 
 use kas::prelude::*;
-use kas::updatable::{MatrixData, Updatable, UpdatableHandler};
+use kas::updatable::{MatrixData, Updatable};
 use kas::widgets::view::{driver::DefaultNav, MatrixView, SelectionMode};
 use kas::widgets::{EditBox, ScrollBars, StrLabel, Window};
 
 #[derive(Debug)]
 struct TableData(u64, usize);
-impl Updatable for TableData {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        None
-    }
-}
-impl UpdatableHandler<(usize, usize), VoidMsg> for TableData {
-    fn handle(&self, _: &(usize, usize), _: &VoidMsg) -> Option<UpdateHandle> {
-        None
+impl Updatable<(usize, usize), VoidMsg> for TableData {
+    fn handle(&self, _: &(usize, usize), _: &VoidMsg) -> bool {
+        false
     }
 }
 impl MatrixData for TableData {
@@ -51,8 +46,8 @@ impl MatrixData for TableData {
         self.contains(key).then(|| (key.0 + 1) * (key.1 + 1))
     }
 
-    fn update(&self, _: &Self::Key, _: Self::Item) -> Option<UpdateHandle> {
-        None
+    fn update(&self, _: &Self::Key, _: Self::Item) -> bool {
+        false
     }
 
     fn col_iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::ColKey> {


### PR DESCRIPTION
Shared-data updates now rely on data versioning. Data version-numbers were already added in 89639f729e9edaeaea2b35c1d880df996310033d but not previously used. Now (possible since `fn draw` takes `&mut self`, due to the addition of `Layout::layout`) data versions are checked on draw and updated if necessary.

### Proposed change

Advantages:

- (Minor) No need for data to have an `UpdateHandle`
- (Trivial) No need for view widgets to subscribe to updates
- (Major) Recursive data structures with automatic updates are trivial where before they were a big pain (hence the `FilterListView` widget is no longer needed). This is quite significant: the `FilterListView` widget was a hack (to avoid an even more convoluted system for recursive data updates before this).
- (Minor) Where many views over the same data exist (e.g. the `RadioBox` in `examples/data-list.rs`), we now only update entries when visible, avoiding lag on data-update

Disadvantages:

- (Minor) All data needs a version number. This is usually easy to implement. `u64` is large enough that simply counting all values at one-per-cycle would require about 30 CPU-years at 5 GHz. Nevertheless, there *could* still be issues.
- (Minor) View-widgets need to check the data version in `Layout::draw` and update their view if outdated
- (Minor) Hidden widgets which view shared data do not get updated until visible, thus for example if a `RadioBox` is selected, hidden, de-selected via another `RadioBox`, then made visible again, animation based on this state-change will start when the first `RadioBox` becomes visible again. (Given that this animation is driven entirely through the theme, this would happen anyway before this change, but this change makes it harder to fix — it would require the shared-data object to track (recent) change history, which *is* possible.)
- (Minor) On data update, we need to force redrawing everything to ensure necessary updates happen.

Summary: 320 insertions, 643 deletions

### Alternative: remove data versioning

None of the points above apply. But since version numbers were already added, we still have a changeset.

Summary: 73 insertions, 133 deletions

### Alternative: use data versioning *and* update notifications

This keeps the major advantage (recursive data structure updates) and first disadvantage (needing version numbers) but none of the other points.

Summary: 122 insertions, 341 deletions