### PR TITLE
Shared data: version counter and UpdateHandle

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -67,7 +67,7 @@ pub trait WidgetCore: Any + fmt::Debug {
 
     /// Set disabled state (chaining)
     ///
-    /// This is identical to [`WidgetCore::set_disabled`], but can be called in
+    /// This is identical to [`WidgetExt::set_disabled`], but can be called in
     /// chaining fashion. Example:
     /// ```ignore
     /// use kas::{WidgetCore, widget::MenuEntry};

--- a/crates/kas-core/src/updatable.rs
+++ b/crates/kas-core/src/updatable.rs
@@ -8,12 +8,8 @@
 //! These traits are used for "view widgets", enabling views (and editing) over
 //! shared data.
 //!
-//! Shared data must implement these traits:
-//!
-//! -   [`Updatable`]: used to expose the [`UpdateHandle`] on which widgets and
-//!     other data may request updates; may also implement self-updates
-//! -   [`UpdatableHandler`]: allows data updates from widget messages (or
-//!     potentially from other message sources)
+//! Shared data must implement [`Updatable`] to allows data updates
+//! from widget messages (or potentially from other message sources).
 
 mod data_impls;
 mod data_traits;
@@ -31,25 +27,12 @@ pub use data_traits::{
 };
 pub use shared_rc::SharedRc;
 
-/// Shared (data) objects which may notify of updates
-pub trait Updatable: Debug {
-    /// Get any update handles used to notify of updates
-    ///
-    /// If the data supports updates through shared references (e.g. via an
-    /// internal [`RefCell`]), then it should have an [`UpdateHandle`] for
-    /// notifying other users of the data of the update. All [`UpdateHandle`]s
-    /// used should be returned here. View widgets should check the data version
-    /// and update their view when any of these [`UpdateHandle`]s is triggreed.
-    fn update_handles(&self) -> Vec<UpdateHandle>;
-}
-
 /// Trait for data objects which can handle messages
-pub trait UpdatableHandler<K, M>: Updatable {
+pub trait Updatable<K, M> {
     /// Update data, if supported
     ///
     /// This is optional and required only to support data updates through view
-    /// widgets. If implemented, then [`Updatable::update_handle`] should
-    /// return a copy of the same update handle.
+    /// widgets.
     ///
     /// This method should return some [`UpdateHandle`] if the data was changed
     /// by this method, or `None` if nothing happened.
@@ -60,29 +43,19 @@ pub trait UpdatableHandler<K, M>: Updatable {
 }
 
 // TODO(spec): can we add this?
-// impl<K, T> UpdatableHandler<K, VoidMsg> for T {
+// impl<K, T> Updatable<K, VoidMsg> for T {
 //     fn handle(&self, _: &K, msg: &VoidMsg) -> Option<UpdateHandle> {
 //         match *msg {}
 //     }
 // }
 
-impl<T: Debug> Updatable for [T] {
-    fn update_handles(&self) -> Vec<UpdateHandle> {
-        vec![]
-    }
-}
-impl<T: Debug, M> UpdatableHandler<usize, M> for [T] {
+impl<T: Debug, M> Updatable<usize, M> for [T] {
     fn handle(&self, _: &usize, _: &M) -> Option<UpdateHandle> {
         None
     }
 }
 
-impl<K: Ord + Eq + Clone + Debug, T: Clone + Debug> Updatable for std::collections::BTreeMap<K, T> {
-    fn update_handles(&self) -> Vec<UpdateHandle> {
-        vec![]
-    }
-}
-impl<K: Ord + Eq + Clone + Debug, T: Clone + Debug, M> UpdatableHandler<K, M>
+impl<K: Ord + Eq + Clone + Debug, T: Clone + Debug, M> Updatable<K, M>
     for std::collections::BTreeMap<K, T>
 {
     fn handle(&self, _: &K, _: &M) -> Option<UpdateHandle> {
@@ -92,12 +65,7 @@ impl<K: Ord + Eq + Clone + Debug, T: Clone + Debug, M> UpdatableHandler<K, M>
 
 macro_rules! impl_via_deref {
     ($t: ident: $derived:ty) => {
-        impl<$t: Updatable + ?Sized> Updatable for $derived {
-            fn update_handles(&self) -> Vec<UpdateHandle> {
-                self.deref().update_handles()
-            }
-        }
-        impl<K, M, $t: UpdatableHandler<K, M> + ?Sized> UpdatableHandler<K, M> for $derived {
+        impl<K, M, $t: Updatable<K, M> + ?Sized> Updatable<K, M> for $derived {
             fn handle(&self, key: &K, msg: &M) -> Option<UpdateHandle> {
                 self.deref().handle(key, msg)
             }

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -16,7 +16,7 @@ impl<T: Clone + Debug> ListData for [T] {
     type Item = T;
 
     fn version(&self) -> u64 {
-        0
+        1
     }
 
     fn len(&self) -> usize {

--- a/crates/kas-core/src/updatable/data_impls.rs
+++ b/crates/kas-core/src/updatable/data_impls.rs
@@ -15,6 +15,9 @@ impl<T: Clone + Debug> ListData for [T] {
     type Key = usize;
     type Item = T;
 
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![]
+    }
     fn version(&self) -> u64 {
         1
     }
@@ -67,6 +70,9 @@ macro_rules! impl_via_deref {
     ($t: ident: $derived:ty) => {
         impl<$t: SingleData + ?Sized> SingleData for $derived {
             type Item = $t::Item;
+            fn update_handles(&self) -> Vec<UpdateHandle> {
+                self.deref().update_handles()
+            }
             fn version(&self) -> u64 {
                 self.deref().version()
             }
@@ -82,6 +88,9 @@ macro_rules! impl_via_deref {
             type Key = $t::Key;
             type Item = $t::Item;
 
+            fn update_handles(&self) -> Vec<UpdateHandle> {
+                self.deref().update_handles()
+            }
             fn version(&self) -> u64 {
                 self.deref().version()
             }
@@ -121,6 +130,9 @@ macro_rules! impl_via_deref {
             type Key = $t::Key;
             type Item = $t::Item;
 
+            fn update_handles(&self) -> Vec<UpdateHandle> {
+                self.deref().update_handles()
+            }
             fn version(&self) -> u64 {
                 self.deref().version()
             }

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -7,7 +7,6 @@
 
 use crate::event::UpdateHandle;
 #[allow(unused)] // doc links
-use crate::updatable::Updatable;
 use crate::WidgetId;
 #[allow(unused)] // doc links
 use std::cell::RefCell;
@@ -19,6 +18,15 @@ use std::fmt::Debug;
 pub trait SingleData: Debug {
     /// Output type
     type Item: Clone;
+
+    /// Get any update handles used to notify of updates
+    ///
+    /// If the data supports updates through shared references (e.g. via an
+    /// internal [`RefCell`]), then it should have an [`UpdateHandle`] for
+    /// notifying other users of the data of the update. All [`UpdateHandle`]s
+    /// used should be returned here. View widgets should check the data version
+    /// and update their view when any of these [`UpdateHandle`]s is triggreed.
+    fn update_handles(&self) -> Vec<UpdateHandle>;
 
     /// Get the data version
     ///
@@ -41,7 +49,7 @@ pub trait SingleData: Debug {
     /// Update data, if supported
     ///
     /// This is optional and required only to support data updates through view
-    /// widgets. If implemented, then [`Updatable::update_handle`] should
+    /// widgets. If implemented, then [`Self::update_handles`] should
     /// return a copy of the same update handle.
     ///
     /// Updates the [`Self::version`] number and returns an [`UpdateHandle`] if
@@ -70,6 +78,15 @@ pub trait ListData: Debug {
 
     /// Item type
     type Item: Clone;
+
+    /// Get any update handles used to notify of updates
+    ///
+    /// If the data supports updates through shared references (e.g. via an
+    /// internal [`RefCell`]), then it should have an [`UpdateHandle`] for
+    /// notifying other users of the data of the update. All [`UpdateHandle`]s
+    /// used should be returned here. View widgets should check the data version
+    /// and update their view when any of these [`UpdateHandle`]s is triggreed.
+    fn update_handles(&self) -> Vec<UpdateHandle>;
 
     /// Get the data version
     ///
@@ -114,7 +131,7 @@ pub trait ListData: Debug {
     /// Update data, if supported
     ///
     /// This is optional and required only to support data updates through view
-    /// widgets. If implemented, then [`Updatable::update_handle`] should
+    /// widgets. If implemented, then [`Self::update_handles`] should
     /// return a copy of the same update handle.
     ///
     /// Updates the [`Self::version`] number and returns an [`UpdateHandle`] if
@@ -163,6 +180,15 @@ pub trait MatrixData: Debug {
     /// Item type
     type Item: Clone;
 
+    /// Get any update handles used to notify of updates
+    ///
+    /// If the data supports updates through shared references (e.g. via an
+    /// internal [`RefCell`]), then it should have an [`UpdateHandle`] for
+    /// notifying other users of the data of the update. All [`UpdateHandle`]s
+    /// used should be returned here. View widgets should check the data version
+    /// and update their view when any of these [`UpdateHandle`]s is triggreed.
+    fn update_handles(&self) -> Vec<UpdateHandle>;
+
     /// Get the data version
     ///
     /// Views over shared data must check the data's `version` before first
@@ -209,7 +235,7 @@ pub trait MatrixData: Debug {
     /// Update data, if supported
     ///
     /// This is optional and required only to support data updates through view
-    /// widgets. If implemented, then [`Updatable::update_handle`] should
+    /// widgets. If implemented, then [`Self::update_handles`] should
     /// return a copy of the same update handle.
     ///
     /// Updates the [`Self::version`] number and returns an [`UpdateHandle`] if

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -22,8 +22,15 @@ pub trait SingleData: Debug {
 
     /// Get the data version
     ///
-    /// This number starts from 0 and is increased by every call to `update` on
-    /// this data structure.
+    /// Views over shared data must check the data's `version` before first
+    /// reading from the data and whenever an [`UpdateHandle`] from the data is
+    /// triggered. The view may track the last known data version and refresh
+    /// its view of the data only when the version number is increased, or may
+    /// refresh its view whenever an [`UpdateHandle`] is triggered.
+    ///
+    /// The initial version number must be at least 1 (allowing 0 to represent
+    /// an uninitialized state). Each modification of the data structure must
+    /// increase the version number (allowing change detection).
     fn version(&self) -> u64;
 
     // TODO(gat): add get<'a>(&self) -> Self::ItemRef<'a> and get_mut
@@ -66,8 +73,15 @@ pub trait ListData: Debug {
 
     /// Get the data version
     ///
-    /// This number starts from 0 and is increased by every call to `update` on
-    /// this data structure.
+    /// Views over shared data must check the data's `version` before first
+    /// reading from the data and whenever an [`UpdateHandle`] from the data is
+    /// triggered. The view may track the last known data version and refresh
+    /// its view of the data only when the version number is increased, or may
+    /// refresh its view whenever an [`UpdateHandle`] is triggered.
+    ///
+    /// The initial version number must be at least 1 (allowing 0 to represent
+    /// an uninitialized state). Each modification of the data structure must
+    /// increase the version number (allowing change detection).
     fn version(&self) -> u64;
 
     /// Number of data items available
@@ -151,8 +165,15 @@ pub trait MatrixData: Debug {
 
     /// Get the data version
     ///
-    /// This number starts from 0 and is increased by every call to `update` on
-    /// this data structure.
+    /// Views over shared data must check the data's `version` before first
+    /// reading from the data and whenever an [`UpdateHandle`] from the data is
+    /// triggered. The view may track the last known data version and refresh
+    /// its view of the data only when the version number is increased, or may
+    /// refresh its view whenever an [`UpdateHandle`] is triggered.
+    ///
+    /// The initial version number must be at least 1 (allowing 0 to represent
+    /// an uninitialized state). Each modification of the data structure must
+    /// increase the version number (allowing change detection).
     fn version(&self) -> u64;
 
     /// No data is available

--- a/crates/kas-core/src/updatable/filter.rs
+++ b/crates/kas-core/src/updatable/filter.rs
@@ -26,7 +26,7 @@ impl ContainsString {
     /// Construct with given string
     pub fn new<S: ToString>(s: S) -> Self {
         let handle = UpdateHandle::new();
-        let data = RefCell::new((s.to_string(), 0));
+        let data = RefCell::new((s.to_string(), 1));
         ContainsString(Rc::new((handle, data)))
     }
 }
@@ -95,7 +95,7 @@ impl ContainsCaseInsensitive {
         let handle = UpdateHandle::new();
         let s = s.to_string();
         let u = s.to_uppercase();
-        let data = RefCell::new((s, u, 0));
+        let data = RefCell::new((s, u, 1));
         ContainsCaseInsensitive(Rc::new((handle, data)))
     }
 }

--- a/crates/kas-core/src/updatable/filter.rs
+++ b/crates/kas-core/src/updatable/filter.rs
@@ -70,7 +70,7 @@ impl SingleDataMut for ContainsString {
 
 impl<'a> Filter<&'a str> for ContainsString {
     fn matches(&self, item: &str) -> bool {
-        item.contains(&self.get_cloned())
+        item.contains(&(self.0).1.borrow().0)
     }
 }
 impl Filter<String> for ContainsString {

--- a/crates/kas-core/src/updatable/filter.rs
+++ b/crates/kas-core/src/updatable/filter.rs
@@ -31,8 +31,8 @@ impl ContainsString {
     }
 }
 impl Updatable for ContainsString {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        Some((self.0).0)
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![(self.0).0]
     }
 }
 impl UpdatableHandler<(), String> for ContainsString {
@@ -100,8 +100,8 @@ impl ContainsCaseInsensitive {
     }
 }
 impl Updatable for ContainsCaseInsensitive {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        Some((self.0).0)
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![(self.0).0]
     }
 }
 impl UpdatableHandler<(), String> for ContainsCaseInsensitive {

--- a/crates/kas-core/src/updatable/filter.rs
+++ b/crates/kas-core/src/updatable/filter.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 /// Types usable as a filter
-pub trait Filter<T>: Updatable + 'static {
+pub trait Filter<T>: 'static {
     /// Returns true if the given item matches this filter
     // TODO: once Accessor::get returns a reference, this should take item: &T where T: ?Sized
     fn matches(&self, item: T) -> bool;
@@ -30,26 +30,26 @@ impl ContainsString {
         ContainsString(Rc::new((handle, data)))
     }
 }
-impl Updatable for ContainsString {
-    fn update_handles(&self) -> Vec<UpdateHandle> {
-        vec![(self.0).0]
-    }
-}
-impl UpdatableHandler<(), String> for ContainsString {
+impl Updatable<(), String> for ContainsString {
     fn handle(&self, _: &(), msg: &String) -> Option<UpdateHandle> {
         self.update(msg.clone())
     }
 }
-impl UpdatableHandler<(), VoidMsg> for ContainsString {
+impl Updatable<(), VoidMsg> for ContainsString {
     fn handle(&self, _: &(), _: &VoidMsg) -> Option<UpdateHandle> {
         None
     }
 }
 impl SingleData for ContainsString {
     type Item = String;
+
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![(self.0).0]
+    }
     fn version(&self) -> u64 {
         (self.0).1.borrow().1
     }
+
     fn get_cloned(&self) -> Self::Item {
         (self.0).1.borrow().0.to_owned()
     }
@@ -99,26 +99,26 @@ impl ContainsCaseInsensitive {
         ContainsCaseInsensitive(Rc::new((handle, data)))
     }
 }
-impl Updatable for ContainsCaseInsensitive {
-    fn update_handles(&self) -> Vec<UpdateHandle> {
-        vec![(self.0).0]
-    }
-}
-impl UpdatableHandler<(), String> for ContainsCaseInsensitive {
+impl Updatable<(), String> for ContainsCaseInsensitive {
     fn handle(&self, _: &(), msg: &String) -> Option<UpdateHandle> {
         self.update(msg.clone())
     }
 }
-impl UpdatableHandler<(), VoidMsg> for ContainsCaseInsensitive {
+impl Updatable<(), VoidMsg> for ContainsCaseInsensitive {
     fn handle(&self, _: &(), _: &VoidMsg) -> Option<UpdateHandle> {
         None
     }
 }
 impl SingleData for ContainsCaseInsensitive {
     type Item = String;
+
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![(self.0).0]
+    }
     fn version(&self) -> u64 {
         (self.0).1.borrow().2
     }
+
     fn get_cloned(&self) -> Self::Item {
         (self.0).1.borrow().0.clone()
     }

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -31,7 +31,7 @@ impl<T: Debug> SharedRc<T> {
     /// Construct with given data
     pub fn new(data: T) -> Self {
         let handle = UpdateHandle::new();
-        let data = RefCell::new((data, 0));
+        let data = RefCell::new((data, 1));
         SharedRc(Rc::new((handle, data)))
     }
 }

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -21,8 +21,8 @@ use std::rc::Rc;
 
 /// Wrapper for single-thread shared data
 ///
-/// This wrapper adds an [`UpdateHandle`] and implements the [`Updatable`] and
-/// [`UpdatableHandler`] traits (the latter with a dummy implementation —
+/// This wrapper adds an [`UpdateHandle`] and implements the
+/// [`Updatable`] traits (the latter with a dummy implementation —
 /// if you need custom handlers you will need your own shared data type).
 #[derive(Clone, Debug, Default)]
 pub struct SharedRc<T: Debug>(Rc<(UpdateHandle, RefCell<(T, u64)>)>);
@@ -35,13 +35,8 @@ impl<T: Debug> SharedRc<T> {
         SharedRc(Rc::new((handle, data)))
     }
 }
-impl<T: Debug> Updatable for SharedRc<T> {
-    fn update_handles(&self) -> Vec<UpdateHandle> {
-        vec![(self.0).0]
-    }
-}
 
-impl<T: Clone + Debug, K, M> UpdatableHandler<K, M> for SharedRc<T> {
+impl<T: Clone + Debug, K, M> Updatable<K, M> for SharedRc<T> {
     fn handle(&self, _: &K, _: &M) -> Option<UpdateHandle> {
         None
     }
@@ -50,6 +45,9 @@ impl<T: Clone + Debug, K, M> UpdatableHandler<K, M> for SharedRc<T> {
 impl<T: Clone + Debug> SingleData for SharedRc<T> {
     type Item = T;
 
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![(self.0).0]
+    }
     fn version(&self) -> u64 {
         (self.0).1.borrow().1
     }
@@ -75,6 +73,9 @@ impl<T: ListDataMut> ListData for SharedRc<T> {
     type Key = T::Key;
     type Item = T::Item;
 
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![(self.0).0]
+    }
     fn version(&self) -> u64 {
         let cell = (self.0).1.borrow();
         cell.0.version() + cell.1
@@ -126,6 +127,9 @@ impl<T: MatrixDataMut> MatrixData for SharedRc<T> {
     type Key = T::Key;
     type Item = T::Item;
 
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![(self.0).0]
+    }
     fn version(&self) -> u64 {
         let cell = (self.0).1.borrow();
         cell.0.version() + cell.1

--- a/crates/kas-core/src/updatable/shared_rc.rs
+++ b/crates/kas-core/src/updatable/shared_rc.rs
@@ -36,8 +36,8 @@ impl<T: Debug> SharedRc<T> {
     }
 }
 impl<T: Debug> Updatable for SharedRc<T> {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        Some((self.0).0)
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![(self.0).0]
     }
 }
 

--- a/crates/kas-core/src/util.rs
+++ b/crates/kas-core/src/util.rs
@@ -10,7 +10,7 @@ use std::fmt;
 
 /// Helper to display widget identification (e.g. `MyWidget#01`)
 ///
-/// Constructed by [`crate::WidgetCore::identify`].
+/// Constructed by [`crate::WidgetExt::identify`].
 pub struct IdentifyWidget(pub(crate) &'static str, pub(crate) WidgetId);
 impl fmt::Display for IdentifyWidget {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -28,7 +28,7 @@ widget! {
 
     impl WidgetConfig for Self {
         fn configure(&mut self, mgr: &mut SetRectMgr) {
-            if let Some(handle) = self.group.update_handle() {
+            for handle in self.group.update_handles().into_iter() {
                 mgr.update_on_handle(handle, self.id());
             }
         }

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -7,7 +7,7 @@
 
 use super::AccelLabel;
 use kas::prelude::*;
-use kas::updatable::{SharedRc, SingleData, Updatable};
+use kas::updatable::{SharedRc, SingleData};
 use log::trace;
 use std::rc::Rc;
 

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -12,7 +12,7 @@ use log::trace;
 use std::rc::Rc;
 
 /// Type of radiobox group
-pub type RadioBoxGroup = SharedRc<WidgetId>;
+pub type RadioBoxGroup = SharedRc<Option<WidgetId>>;
 
 widget! {
     /// A bare radiobox (no label)
@@ -22,7 +22,7 @@ widget! {
         #[widget_core]
         core: CoreData,
         state: bool,
-        group: SharedRc<WidgetId>,
+        group: RadioBoxGroup,
         on_select: Option<Rc<dyn Fn(&mut EventMgr) -> Option<M>>>,
     }
 
@@ -56,7 +56,7 @@ widget! {
                         trace!("RadioBoxBare: set {}", self.id());
                         self.state = true;
                         mgr.redraw(self.id());
-                        if let Some(handle) = self.group.update(self.id()) {
+                        if let Some(handle) = self.group.update(Some(self.id())) {
                             mgr.trigger_update(handle, 0);
                         }
                         Response::update_or_msg(self.on_select.as_ref().and_then(|f| f(mgr)))
@@ -106,7 +106,7 @@ widget! {
         /// All instances of [`RadioBoxBare`] and [`RadioBox`] constructed over the
         /// same `group` will be considered part of a single group.
         #[inline]
-        pub fn new(group: SharedRc<WidgetId>) -> Self {
+        pub fn new(group: RadioBoxGroup) -> Self {
             RadioBoxBare {
                 core: Default::default(),
                 state: false,
@@ -149,7 +149,7 @@ widget! {
         ///
         /// No handler is called on deselection, but [`Response::Update`] is returned.
         #[inline]
-        pub fn new_on<F>(group: SharedRc<WidgetId>, f: F) -> Self
+        pub fn new_on<F>(group: RadioBoxGroup, f: F) -> Self
         where
             F: Fn(&mut EventMgr) -> Option<M> + 'static,
         {
@@ -162,6 +162,16 @@ widget! {
         pub fn with_state(mut self, state: bool) -> Self {
             self.state = state;
             self
+        }
+
+        /// Unset all radioboxes in the group
+        ///
+        /// Note: state will not update until the next draw.
+        #[inline]
+        pub fn unset_all(&self, mgr: &mut EventMgr) {
+            if let Some(handle) = self.group.update(None) {
+                mgr.trigger_update(handle, 0);
+            }
         }
     }
 
@@ -214,7 +224,7 @@ widget! {
         /// All instances of [`RadioBoxBare`] and [`RadioBox`] constructed over the
         /// same `group` will be considered part of a single group.
         #[inline]
-        pub fn new<T: Into<AccelString>>(label: T, group: SharedRc<WidgetId>) -> Self {
+        pub fn new<T: Into<AccelString>>(label: T, group: RadioBoxGroup) -> Self {
             RadioBox {
                 core: Default::default(),
                 radiobox: RadioBoxBare::new(group),
@@ -258,7 +268,7 @@ widget! {
         ///
         /// No handler is called on deselection, but [`Response::Update`] is returned.
         #[inline]
-        pub fn new_on<T: Into<AccelString>, F>(label: T, group: SharedRc<WidgetId>, f: F) -> Self
+        pub fn new_on<T: Into<AccelString>, F>(label: T, group: RadioBoxGroup, f: F) -> Self
         where
             F: Fn(&mut EventMgr) -> Option<M> + 'static,
         {
@@ -278,7 +288,7 @@ widget! {
         ///
         /// No handler is called on deselection, but [`Response::Update`] is returned.
         #[inline]
-        pub fn new_msg<S: Into<AccelString>>(label: S, group: SharedRc<WidgetId>, msg: M) -> Self
+        pub fn new_msg<S: Into<AccelString>>(label: S, group: RadioBoxGroup, msg: M) -> Self
         where
             M: Clone,
         {
@@ -291,6 +301,14 @@ widget! {
         pub fn with_state(mut self, state: bool) -> Self {
             self.radiobox = self.radiobox.with_state(state);
             self
+        }
+
+        /// Unset all radioboxes in the group
+        ///
+        /// Note: state will not update until the next draw.
+        #[inline]
+        pub fn unset_all(&self, mgr: &mut EventMgr) {
+            self.radiobox.unset_all(mgr)
         }
     }
 }

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -22,9 +22,6 @@ use std::fmt::Debug;
 /// Note: the key and item types are the same as those in the underlying list,
 /// thus one can also retrieve values from the underlying list directly.
 ///
-/// Note: only `Rc<FilteredList<T, F>>` implements [`ListData`]; the [`Rc`]
-/// wrapper is required!
-///
 /// Warning: this implementation is `O(n)` where `n = data.len()` and not well
 /// optimised, thus is expected to be slow on large data lists.
 #[derive(Clone, Debug)]

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -50,9 +50,7 @@ impl<T: ListData + 'static, F: Filter<T::Item> + SingleData> FilteredList<T, F> 
     ///
     /// Re-applies the filter (`O(n)` where `n` is the number of data elements).
     /// Calling this directly may be useful in case the data is modified.
-    ///
-    /// An update should be triggered using the returned handle.
-    fn refresh(&self, ver: u64) -> Option<UpdateHandle> {
+    fn refresh(&self, ver: u64) {
         let mut view = self.view.borrow_mut();
         view.0 = ver;
         view.1.clear();
@@ -63,13 +61,14 @@ impl<T: ListData + 'static, F: Filter<T::Item> + SingleData> FilteredList<T, F> 
                 }
             }
         }
-        self.filter.update_handle()
     }
 }
 
-impl<T: ListData, F: Filter<T::Item> + SingleData> Updatable for FilteredList<T, F> {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        self.filter.update_handle()
+impl<T: Updatable + ListData, F: Filter<T::Item> + SingleData> Updatable for FilteredList<T, F> {
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        let mut v = self.data.update_handles();
+        v.append(&mut self.filter.update_handles());
+        v
     }
 }
 impl<K, M, T: ListData + UpdatableHandler<K, M> + 'static, F: Filter<T::Item> + SingleData>

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -5,15 +5,11 @@
 
 //! Filter-list view widget
 
-use super::{driver, Driver, ListView, SelectionError, SelectionMode};
-use crate::Scrollable;
-use kas::event::ChildMsg;
 use kas::prelude::*;
 use kas::updatable::filter::Filter;
 use kas::updatable::{ListData, SingleData, Updatable, UpdatableHandler};
 use std::cell::RefCell;
 use std::fmt::Debug;
-use UpdatableHandler as UpdHandler;
 
 /// Filter accessor over another accessor
 ///
@@ -32,7 +28,7 @@ use UpdatableHandler as UpdHandler;
 /// Warning: this implementation is `O(n)` where `n = data.len()` and not well
 /// optimised, thus is expected to be slow on large data lists.
 #[derive(Clone, Debug)]
-struct FilteredList<T: ListData, F: Filter<T::Item> + SingleData> {
+pub struct FilteredList<T: ListData, F: Filter<T::Item> + SingleData> {
     /// Direct access to unfiltered data
     ///
     /// If adjusting this, one should call [`FilteredList::refresh`] after.
@@ -45,9 +41,9 @@ struct FilteredList<T: ListData, F: Filter<T::Item> + SingleData> {
 }
 
 impl<T: ListData + 'static, F: Filter<T::Item> + SingleData> FilteredList<T, F> {
-    /// Construct and apply filter
+    /// Construct from `data` and a `filter`
     #[inline]
-    fn new(data: T, filter: F) -> Self {
+    pub fn new(data: T, filter: F) -> Self {
         let len = data.len();
         let view = RefCell::new((0, Vec::with_capacity(len)));
         FilteredList { data, filter, view }
@@ -139,263 +135,5 @@ impl<T: ListData + 'static, F: Filter<T::Item> + SingleData> ListData for Filter
     fn iter_vec_from(&self, start: usize, limit: usize) -> Vec<Self::Key> {
         let end = self.len().min(start + limit);
         self.view.borrow().1[start..end].to_vec()
-    }
-}
-
-widget! {
-    /// Filter-list view widget
-    ///
-    /// This widget is a wrapper around [`ListView`] which applies a filter to the
-    /// data list.
-    ///
-    /// Why is a data-filter a widget and not a pure-data item, you ask? The answer
-    /// is that a filter-list must be updated when the filter or the data changes,
-    /// and, since filtering a list is not especially cheap, the filtering must be
-    /// cached and updated when required, not every time the list view asks for more
-    /// data. Although it is possible to do this with a data-view, that requires
-    /// machinery for recursive-updates on data-structures and/or a mechanism to
-    /// test whether the underlying list-data changed. Implementing as a widget
-    /// avoids this.
-    // TODO: impl Clone
-    #[derive(Debug)]
-    #[widget{
-        layout = single;
-    }]
-    pub struct FilterListView<
-        D: Directional,
-        T: ListData + UpdHandler<T::Key, V::Msg> + 'static,
-        F: Filter<T::Item> + SingleData,
-        V: Driver<T::Item> = driver::Default,
-    > {
-        #[widget_core]
-        core: CoreData,
-        #[widget]
-        list: ListView<D, FilteredList<T, F>, V>,
-    }
-
-    impl Self where D: Default, V: Default {
-        /// Construct a new instance
-        ///
-        /// This constructor is available where the direction is determined by the
-        /// type: for `D: Directional + Default`. In other cases, use
-        /// [`FilterListView::new_with_direction`].
-        pub fn new(data: T, filter: F) -> Self {
-            Self::new_with_dir_driver(D::default(), <V as Default>::default(), data, filter)
-        }
-    }
-    impl Self where V: Default {
-        /// Construct a new instance with explicit direction
-        pub fn new_with_direction(direction: D, data: T, filter: F) -> Self {
-            Self::new_with_dir_driver(direction, <V as Default>::default(), data, filter)
-        }
-    }
-    impl Self where D: Default {
-        /// Construct a new instance with explicit view
-        pub fn new_with_driver(view: V, data: T, filter: F) -> Self {
-            Self::new_with_dir_driver(D::default(), view, data, filter)
-        }
-    }
-    impl<
-            T: ListData + UpdHandler<T::Key, V::Msg>,
-            F: Filter<T::Item> + SingleData,
-            V: Driver<T::Item> + Default,
-        > FilterListView<Direction, T, F, V>
-    {
-        /// Set the direction of contents
-        pub fn set_direction(&mut self, direction: Direction) -> TkAction {
-            self.list.set_direction(direction)
-        }
-    }
-    impl Self {
-        /// Construct a new instance with explicit direction and view
-        pub fn new_with_dir_driver(direction: D, view: V, data: T, filter: F) -> Self {
-            let data = FilteredList::new(data, filter);
-            FilterListView {
-                core: Default::default(),
-                list: ListView::new_with_dir_driver(direction, view, data),
-            }
-        }
-
-        /// Access the stored data (pre-filter)
-        pub fn unfiltered_data(&self) -> &T {
-            &self.list.data().data
-        }
-
-        /// Mutably access the stored data (pre-filter)
-        ///
-        /// It may be necessary to use [`FilterListView::update_view`] to update the view of this data.
-        pub fn unfiltered_data_mut(&mut self) -> &mut T {
-            &mut self.list.data_mut().data
-        }
-
-        /// Access the stored data (post-filter)
-        pub fn data(&self) -> &T {
-            &self.list.data().data
-        }
-
-        /// Mutably access the stored data (post-filter)
-        ///
-        /// It may be necessary to use [`FilterListView::update_view`] to update the view of this data.
-        pub fn data_mut(&mut self) -> &mut T {
-            &mut self.list.data_mut().data
-        }
-
-        /// Check whether a key has data (post-filter)
-        pub fn contains_key(&self, key: &T::Key) -> bool {
-            self.data().contains_key(key)
-        }
-
-        /// Get a copy of the shared value at `key` (post-filter)
-        pub fn get_value(&self, key: &T::Key) -> Option<T::Item> {
-            self.data().get_cloned(key)
-        }
-
-        /// Set shared data (post-filter)
-        ///
-        /// This method updates the shared data, if supported (see
-        /// [`ListData::update`]). Other widgets sharing this data are notified
-        /// of the update, if data is changed.
-        pub fn set_value(&self, mgr: &mut EventMgr, key: &T::Key, data: T::Item) {
-            if let Some(handle) = self.data().update(key, data) {
-                mgr.trigger_update(handle, 0);
-            }
-        }
-
-        /// Update shared data (post-filter)
-        ///
-        /// This is purely a convenience method over [`FilterListView::set_value`].
-        /// It does nothing if no value is found at `key`.
-        /// It notifies other widgets of updates to the shared data.
-        pub fn update_value<G: Fn(T::Item) -> T::Item>(&self, mgr: &mut EventMgr, key: &T::Key, f: G) {
-            if let Some(item) = self.get_value(key) {
-                self.set_value(mgr, key, f(item));
-            }
-        }
-
-        /// Get the current selection mode
-        pub fn selection_mode(&self) -> SelectionMode {
-            self.list.selection_mode()
-        }
-        /// Set the current selection mode
-        pub fn set_selection_mode(&mut self, mode: SelectionMode) -> TkAction {
-            self.list.set_selection_mode(mode)
-        }
-        /// Set the selection mode (inline)
-        #[must_use]
-        pub fn with_selection_mode(mut self, mode: SelectionMode) -> Self {
-            let _ = self.set_selection_mode(mode);
-            self
-        }
-
-        /// Read the list of selected entries
-        ///
-        /// With mode [`SelectionMode::Single`] this may contain zero or one entry;
-        /// use `selected_iter().next()` to extract only the first (optional) entry.
-        pub fn selected_iter(&'_ self) -> impl Iterator<Item = &'_ T::Key> + '_ {
-            self.list.selected_iter()
-        }
-
-        /// Check whether an entry is selected
-        pub fn is_selected(&self, key: &T::Key) -> bool {
-            self.list.is_selected(key)
-        }
-
-        /// Clear all selected items
-        ///
-        /// Does not send [`ChildMsg`] responses.
-        pub fn clear_selected(&mut self) -> TkAction {
-            self.list.clear_selected()
-        }
-
-        /// Directly select an item
-        ///
-        /// Returns `TkAction::REDRAW` if newly selected, `TkAction::empty()` if
-        /// already selected. Fails if selection mode does not permit selection
-        /// or if the key is invalid.
-        ///
-        /// Does not send [`ChildMsg`] responses.
-        pub fn select(&mut self, key: T::Key) -> Result<TkAction, SelectionError> {
-            self.list.select(key)
-        }
-
-        /// Directly deselect an item
-        ///
-        /// Returns `TkAction::REDRAW` if deselected, `TkAction::empty()` if not
-        /// previously selected or if the key is invalid.
-        ///
-        /// Does not send [`ChildMsg`] responses.
-        pub fn deselect(&mut self, key: &T::Key) -> TkAction {
-            self.list.deselect(key)
-        }
-
-        /// Manually trigger an update to handle changed data or filter
-        pub fn update_view(&mut self, _: &mut EventMgr) {
-            self.list.data().version();
-        }
-
-        /// Get the direction of contents
-        pub fn direction(&self) -> Direction {
-            self.list.direction()
-        }
-
-        /// Set the preferred number of items visible (inline)
-        ///
-        /// This affects the (ideal) size request and whether children are sized
-        /// according to their ideal or minimum size but not the minimum size.
-        #[must_use]
-        pub fn with_num_visible(mut self, number: i32) -> Self {
-            self.list = self.list.with_num_visible(number);
-            self
-        }
-    }
-
-    // TODO: support derive(Scrollable)?
-    impl Scrollable for Self {
-        #[inline]
-        fn scroll_axes(&self, size: Size) -> (bool, bool) {
-            self.list.scroll_axes(size)
-        }
-
-        #[inline]
-        fn max_scroll_offset(&self) -> Offset {
-            self.list.max_scroll_offset()
-        }
-
-        #[inline]
-        fn scroll_offset(&self) -> Offset {
-            self.list.scroll_offset()
-        }
-
-        #[inline]
-        fn set_scroll_offset(&mut self, mgr: &mut EventMgr, offset: Offset) -> Offset {
-            self.list.set_scroll_offset(mgr, offset)
-        }
-    }
-
-    impl WidgetConfig for Self {
-        fn configure(&mut self, mgr: &mut SetRectMgr) {
-            // We must refresh the filtered list when the underlying list changes
-            if let Some(handle) = self.list.data().data.update_handle() {
-                mgr.update_on_handle(handle, self.id());
-            }
-            // As well as when the filter changes
-            if let Some(handle) = self.list.data().update_handle() {
-                mgr.update_on_handle(handle, self.id());
-            }
-        }
-    }
-
-    impl Handler for Self {
-        type Msg = ChildMsg<T::Key, <V::Widget as Handler>::Msg>;
-
-        fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {
-            match event {
-                Event::HandleUpdate { .. } => {
-                    self.update_view(mgr);
-                    Response::Update
-                }
-                _ => Response::Unused,
-            }
-        }
     }
 }

--- a/crates/kas-widgets/src/view/filter_list.rs
+++ b/crates/kas-widgets/src/view/filter_list.rs
@@ -50,9 +50,7 @@ impl<T: ListData, F: Filter<T::Item> + SingleData> FilteredList<T, F> {
     fn new(data: T, filter: F) -> Self {
         let len = data.len();
         let view = RefCell::new(Vec::with_capacity(len));
-        let s = FilteredList { data, filter, view };
-        let _ = s.refresh();
-        s
+        FilteredList { data, filter, view }
     }
 
     /// Refresh the view

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -13,11 +13,10 @@ use kas::event::components::ScrollComponent;
 use kas::event::{ChildMsg, Command, CursorIcon};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
-use kas::updatable::{ListData, UpdatableHandler};
+use kas::updatable::{ListData, Updatable};
 use linear_map::set::LinearSet;
 use log::{debug, trace};
 use std::time::Instant;
-use UpdatableHandler as UpdHandler;
 
 #[derive(Clone, Debug, Default)]
 struct WidgetData<K, W> {
@@ -31,7 +30,7 @@ widget! {
     /// This widget supports a view over a list of shared data items.
     ///
     /// The shared data type `T` must support [`ListData`] and
-    /// [`UpdatableHandler`], the latter with key type `T::Key` and message type
+    /// [`Updatable`], the latter with key type `T::Key` and message type
     /// matching the widget's message. One may use [`kas::updatable::SharedRc`]
     /// or a custom shared data type.
     ///
@@ -44,7 +43,7 @@ widget! {
     #[derive(Clone, Debug)]
     pub struct ListView<
         D: Directional,
-        T: ListData + UpdHandler<T::Key, V::Msg> + 'static,
+        T: ListData + Updatable<T::Key, V::Msg> + 'static,
         V: Driver<T::Item> = driver::Default,
     > {
         #[widget_core]
@@ -94,7 +93,7 @@ widget! {
             Self::new_with_dir_driver(D::default(), view, data)
         }
     }
-    impl<T: ListData + UpdHandler<T::Key, V::Msg>, V: Driver<T::Item>> ListView<Direction, T, V> {
+    impl<T: ListData + Updatable<T::Key, V::Msg>, V: Driver<T::Item>> ListView<Direction, T, V> {
         /// Set the direction of contents
         pub fn set_direction(&mut self, direction: Direction) -> TkAction {
             self.direction = direction;

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -428,7 +428,7 @@ widget! {
 
     impl WidgetConfig for Self {
         fn configure(&mut self, mgr: &mut SetRectMgr) {
-            if let Some(handle) = self.data.update_handle() {
+            for handle in self.data.update_handles().into_iter() {
                 mgr.update_on_handle(handle, self.id());
             }
             mgr.register_nav_fallback(self.id());

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -53,6 +53,7 @@ widget! {
         frame_size: Size,
         view: V,
         data: T,
+        data_ver: u64,
         widgets: Vec<WidgetData<T::Key, V::Widget>>,
         /// The number of widgets in use (cur_len ≤ widgets.len())
         cur_len: u32,
@@ -109,6 +110,7 @@ widget! {
                 frame_size: Default::default(),
                 view,
                 data,
+                data_ver: 0,
                 widgets: Default::default(),
                 cur_len: 0,
                 direction,
@@ -611,9 +613,14 @@ widget! {
         fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {
             match event {
                 Event::HandleUpdate { .. } => {
-                    // TODO(opt): use the update payload to indicate which widgets need updating?
-                    self.update_view(mgr);
-                    return Response::Update;
+                    let data_ver = self.data.version();
+                    if data_ver > self.data_ver {
+                        // TODO(opt): use the update payload to indicate which widgets need updating?
+                        self.update_view(mgr);
+                        self.data_ver = data_ver;
+                        return Response::Update;
+                    }
+                    return Response::Used;
                 }
                 Event::PressMove { coord, .. } => {
                     if let PressPhase::Start(start_coord) = self.press_phase {

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -449,6 +449,7 @@ widget! {
 
             // If data is already available, create some widgets and ensure
             // that the ideal size meets all expectations of these children.
+            self.data_ver = self.data.version();
             if self.widgets.len() == 0 && self.data.len() > 0 {
                 let items = self.data.iter_vec(self.ideal_visible.cast());
                 debug!("allocating widgets (reserve = {})", items.len());

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -420,6 +420,7 @@ widget! {
 
             // If data is already available, create some widgets and ensure
             // that the ideal size meets all expectations of these children.
+            self.data_ver = self.data.version();
             if self.widgets.len() == 0 && !self.data.is_empty() {
                 let cols = self.data.col_iter_vec(self.ideal_len.cols.cast());
                 let rows = self.data.row_iter_vec(self.ideal_len.rows.cast());

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -13,11 +13,10 @@ use kas::event::components::ScrollComponent;
 use kas::event::{ChildMsg, Command, CursorIcon};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
-use kas::updatable::{MatrixData, UpdatableHandler};
+use kas::updatable::{MatrixData, Updatable};
 use linear_map::set::LinearSet;
 use log::{debug, trace};
 use std::time::Instant;
-use UpdatableHandler as UpdHandler;
 
 #[derive(Clone, Copy, Debug, Default)]
 struct Dim {
@@ -37,7 +36,7 @@ widget! {
     /// This widget supports a view over a matrix of shared data items.
     ///
     /// The shared data type `T` must support [`MatrixData`] and
-    /// [`UpdatableHandler`], the latter with key type `T::Key` and message type
+    /// [`Updatable`], the latter with key type `T::Key` and message type
     /// matching the widget's message. One may use [`kas::updatable::SharedRc`]
     /// or a custom shared data type.
     ///
@@ -49,7 +48,7 @@ widget! {
     /// scrolling. You may wish to wrap this widget with [`ScrollBars`].
     #[derive(Clone, Debug)]
     pub struct MatrixView<
-        T: MatrixData + UpdHandler<T::Key, V::Msg> + 'static,
+        T: MatrixData + Updatable<T::Key, V::Msg> + 'static,
         V: Driver<T::Item> = driver::Default,
     > {
         #[widget_core]

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -58,6 +58,7 @@ widget! {
         frame_size: Size,
         view: V,
         data: T,
+        data_ver: u64,
         widgets: Vec<WidgetData<T::Key, V::Widget>>,
         align_hints: AlignHints,
         ideal_len: Dim,
@@ -91,6 +92,7 @@ widget! {
                 frame_size: Default::default(),
                 view,
                 data,
+                data_ver: 0,
                 widgets: Default::default(),
                 align_hints: Default::default(),
                 ideal_len: Dim { rows: 3, cols: 5 },
@@ -612,8 +614,13 @@ widget! {
         fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {
             match event {
                 Event::HandleUpdate { .. } => {
-                    self.update_view(mgr);
-                    return Response::Update;
+                    let data_ver = self.data.version();
+                    if data_ver > self.data_ver {
+                        self.update_view(mgr);
+                        self.data_ver = data_ver;
+                        return Response::Update;
+                    }
+                    return Response::Used;
                 }
                 Event::PressMove { coord, .. } => {
                     if let PressPhase::Start(start_coord) = self.press_phase {

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -401,7 +401,7 @@ widget! {
 
     impl WidgetConfig for Self {
         fn configure(&mut self, mgr: &mut SetRectMgr) {
-            if let Some(handle) = self.data.update_handle() {
+            for handle in self.data.update_handles().into_iter() {
                 mgr.update_on_handle(handle, self.id());
             }
             mgr.register_nav_fallback(self.id());

--- a/crates/kas-widgets/src/view/mod.rs
+++ b/crates/kas-widgets/src/view/mod.rs
@@ -80,7 +80,7 @@ mod single_view;
 pub mod driver;
 
 pub use driver::Driver;
-pub use filter_list::FilterListView;
+pub use filter_list::FilteredList;
 pub use list_view::ListView;
 pub use matrix_view::MatrixView;
 pub use single_view::SingleView;

--- a/crates/kas-widgets/src/view/mod.rs
+++ b/crates/kas-widgets/src/view/mod.rs
@@ -19,8 +19,8 @@
 //! For simpler cases it is not always necessary to implement your own shared
 //! data type, for example `SharedRc<i32>` implements [`SingleData`] and
 //! `&'static [&'static str]` implements [`ListData`]. The [`SharedRc`] type
-//! provides an `update` method and the [`UpdateHandle`] required to synchronise
-//! views; `&[T]` does not (data is constant).
+//! provides an `update` method and the [`UpdateHandle`] and version counter
+//! required to synchronise views; `&[T]` does not (data is constant).
 //!
 //! # View widgets and drivers
 //!

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -36,6 +36,7 @@ widget! {
         core: CoreData,
         view: V,
         data: T,
+        data_ver: u64,
         #[widget]
         child: V::Widget,
     }
@@ -64,6 +65,7 @@ widget! {
                 core: Default::default(),
                 view,
                 data,
+                data_ver: 0,
                 child,
             }
         }
@@ -116,9 +118,15 @@ widget! {
         fn handle(&mut self, mgr: &mut EventMgr, event: Event) -> Response<Self::Msg> {
             match event {
                 Event::HandleUpdate { .. } => {
-                    let value = self.data.get_cloned();
-                    *mgr |= self.view.set(&mut self.child, value);
-                    Response::Update
+                    let data_ver = self.data.version();
+                    if data_ver > self.data_ver {
+                        let value = self.data.get_cloned();
+                        *mgr |= self.view.set(&mut self.child, value);
+                        self.data_ver = data_ver;
+                        Response::Update
+                    } else {
+                        Response::Used
+                    }
                 }
                 _ => Response::Unused,
             }

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -7,8 +7,7 @@
 
 use super::{driver, Driver};
 use kas::prelude::*;
-use kas::updatable::{SingleData, UpdatableHandler};
-use UpdatableHandler as UpdHandler;
+use kas::updatable::{SingleData, Updatable};
 
 widget! {
     /// Single view widget
@@ -16,7 +15,7 @@ widget! {
     /// This widget supports a view over a shared data item.
     ///
     /// The shared data type `T` must support [`SingleData`] and
-    /// [`UpdatableHandler`], the latter with key type `()` and message type
+    /// [`Updatable`], the latter with key type `()` and message type
     /// matching the widget's message. One may use [`kas::updatable::SharedRc`]
     /// or a custom shared data type.
     ///
@@ -29,7 +28,7 @@ widget! {
         layout = single;
     }]
     pub struct SingleView<
-        T: SingleData + UpdHandler<(), V::Msg> + 'static,
+        T: SingleData + Updatable<(), V::Msg> + 'static,
         V: Driver<T::Item> = driver::Default,
     > {
         #[widget_core]

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -60,12 +60,13 @@ widget! {
         /// Construct a new instance with explicit view
         pub fn new_with_driver(view: V, data: T) -> Self {
             let mut child = view.make();
+            let data_ver = data.version();
             let _ = view.set(&mut child, data.get_cloned());
             SingleView {
                 core: Default::default(),
                 view,
                 data,
-                data_ver: 0,
+                data_ver,
                 child,
             }
         }

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -108,7 +108,7 @@ widget! {
 
     impl WidgetConfig for Self {
         fn configure(&mut self, mgr: &mut SetRectMgr) {
-            if let Some(handle) = self.data.update_handle() {
+            for handle in self.data.update_handles().into_iter() {
                 mgr.update_on_handle(handle, self.id());
             }
         }

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -85,12 +85,7 @@ impl MyData {
         (is_active, text)
     }
 }
-impl Updatable for MyData {
-    fn update_handles(&self) -> Vec<UpdateHandle> {
-        vec![self.handle]
-    }
-}
-impl UpdatableHandler<usize, EntryMsg> for MyData {
+impl Updatable<usize, EntryMsg> for MyData {
     fn handle(&self, key: &usize, msg: &EntryMsg) -> Option<UpdateHandle> {
         match msg {
             EntryMsg::Select => {
@@ -108,6 +103,9 @@ impl ListData for MyData {
     type Key = usize;
     type Item = (usize, bool, String);
 
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![self.handle]
+    }
     fn version(&self) -> u64 {
         self.ver
     }

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -48,7 +48,7 @@ struct MyData {
 impl MyData {
     fn new(len: usize) -> Self {
         MyData {
-            ver: 0,
+            ver: 1,
             len,
             data: Default::default(),
             handle: UpdateHandle::new(),

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -39,6 +39,7 @@ enum EntryMsg {
 
 #[derive(Debug)]
 struct MyData {
+    ver: u64,
     len: usize,
     // (active index, map of strings)
     data: RefCell<(usize, HashMap<usize, String>)>,
@@ -47,12 +48,14 @@ struct MyData {
 impl MyData {
     fn new(len: usize) -> Self {
         MyData {
+            ver: 0,
             len,
             data: Default::default(),
             handle: UpdateHandle::new(),
         }
     }
     fn set_len(&mut self, len: usize) -> (Option<String>, UpdateHandle) {
+        self.ver += 1;
         self.len = len;
         let mut new_text = None;
         let mut data = self.data.borrow_mut();
@@ -70,6 +73,7 @@ impl MyData {
     // Note: in general this method should update the data source and return
     // self.handle, but for our uses this is sufficient.
     fn set_active(&mut self, active: usize) -> String {
+        self.ver += 1;
         self.data.borrow_mut().0 = active;
         self.get(active).1
     }
@@ -105,7 +109,7 @@ impl ListData for MyData {
     type Item = (usize, bool, String);
 
     fn version(&self) -> u64 {
-        0
+        self.ver
     }
 
     fn len(&self) -> usize {

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -86,8 +86,8 @@ impl MyData {
     }
 }
 impl Updatable for MyData {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        Some(self.handle)
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![self.handle]
     }
 }
 impl UpdatableHandler<usize, EntryMsg> for MyData {

--- a/examples/filter-list.rs
+++ b/examples/filter-list.rs
@@ -9,7 +9,7 @@ use kas::dir::Down;
 use kas::event::ChildMsg;
 use kas::prelude::*;
 use kas::updatable::filter::ContainsCaseInsensitive;
-use kas::widgets::view::{driver, FilterListView, SelectionMode, SingleView};
+use kas::widgets::view::{self, driver, SelectionMode, SingleView};
 use kas::widgets::{EditBox, Label, RadioBox, RadioBoxGroup, ScrollBars, Window};
 
 const MONTHS: &[&str] = &[
@@ -48,36 +48,31 @@ fn main() -> kas::shell::Result<()> {
     println!("filter-list: {} entries", data.len());
     let filter = ContainsCaseInsensitive::new("");
     let filter_driver = driver::Widget::<EditBox>::default();
+    type FilteredList = view::FilteredList<&'static [&'static str], ContainsCaseInsensitive>;
+    type ListView = view::ListView<Down, FilteredList, driver::DefaultNav>;
+    let filtered = FilteredList::new(data, filter.clone());
 
-    let window = Window::new(
-        "Filter-list",
-        make_widget! {
-            #[widget{
-                layout = list(down): *;
-            }]
-            #[handler(msg = VoidMsg)]
-            struct {
-                #[widget(use_msg = set_selection_mode)] _ = selection_mode,
-                #[widget] filter = SingleView::new_with_driver(filter_driver, filter.clone()),
-                #[widget(use_msg = select)] list:
-                    ScrollBars<FilterListView<
-                        Down,
-                        &'static [&'static str],
-                        ContainsCaseInsensitive,
-                        driver::DefaultNav,
-                    >> =
-                    ScrollBars::new(FilterListView::new(data, filter)),
+    let widget = make_widget! {
+        #[widget{
+            layout = list(down): *;
+        }]
+        #[handler(msg = VoidMsg)]
+        struct {
+            #[widget(use_msg = set_selection_mode)] _ = selection_mode,
+            #[widget] filter = SingleView::new_with_driver(filter_driver, filter),
+            #[widget(use_msg = select)] list: ScrollBars<ListView> =
+                ScrollBars::new(ListView::new(filtered)),
+        }
+        impl Self {
+            fn set_selection_mode(&mut self, mgr: &mut EventMgr, mode: SelectionMode) {
+                *mgr |= self.list.set_selection_mode(mode);
             }
-            impl Self {
-                fn set_selection_mode(&mut self, mgr: &mut EventMgr, mode: SelectionMode) {
-                    *mgr |= self.list.set_selection_mode(mode);
-                }
-                fn select(&mut self, _: &mut EventMgr, msg: ChildMsg<usize, VoidMsg>) {
-                    println!("Selection message: {:?}", msg);
-                }
+            fn select(&mut self, _: &mut EventMgr, msg: ChildMsg<usize, VoidMsg>) {
+                println!("Selection message: {:?}", msg);
             }
-        },
-    );
+        }
+    };
+    let window = Window::new("Filter-list", widget);
 
     let theme = kas::theme::ShadedTheme::new();
     kas::shell::Toolkit::new(theme)?.with(window)?.run()

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -70,7 +70,7 @@ impl MatrixData for TableData {
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
-    let table = MatrixView::new(TableData(0, 12))
+    let table = MatrixView::new(TableData(1, 12))
         .with_num_visible(12, 12)
         .with_selection_mode(SelectionMode::Single);
     let table = ScrollBars::new(table);

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -1,18 +1,13 @@
 //! Do you know your times tables?
 
 use kas::prelude::*;
-use kas::updatable::{MatrixData, Updatable, UpdatableHandler};
+use kas::updatable::{MatrixData, Updatable};
 use kas::widgets::view::{driver::DefaultNav, MatrixView, SelectionMode};
 use kas::widgets::{EditBox, ScrollBars, StrLabel, Window};
 
 #[derive(Debug)]
 struct TableData(u64, usize);
-impl Updatable for TableData {
-    fn update_handles(&self) -> Vec<UpdateHandle> {
-        vec![]
-    }
-}
-impl UpdatableHandler<(usize, usize), VoidMsg> for TableData {
+impl Updatable<(usize, usize), VoidMsg> for TableData {
     fn handle(&self, _: &(usize, usize), _: &VoidMsg) -> Option<UpdateHandle> {
         None
     }
@@ -23,6 +18,9 @@ impl MatrixData for TableData {
     type Key = (usize, usize);
     type Item = usize;
 
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![]
+    }
     fn version(&self) -> u64 {
         self.0
     }

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -8,8 +8,8 @@ use kas::widgets::{EditBox, ScrollBars, StrLabel, Window};
 #[derive(Debug)]
 struct TableData(u64, usize);
 impl Updatable for TableData {
-    fn update_handle(&self) -> Option<UpdateHandle> {
-        None
+    fn update_handles(&self) -> Vec<UpdateHandle> {
+        vec![]
     }
 }
 impl UpdatableHandler<(usize, usize), VoidMsg> for TableData {


### PR DESCRIPTION
Alternative to #288: give shared data a version counter *and* `UpdateHandle`(s).

Compared to #288:

- each shared-data trait has an `fn update_handles(&self) -> Vec<UpdateHandle>` method (rarely called hence the heap allocation is unimportant)
- shared-data view widgets must register for and handle `UpdateHandle`s, but don't need to check data version on draw
- we don't need to redraw everything simply because shared data changes
- shared-data implementations are a little bit more complex due to having an `UpdateHandle` and a version counter

Overall this is only slightly more complex and avoids "redraw the world on any shared data change", so is preferable.

Another option is to tweak the code in this PR by replacing `fn version` with `fn refresh` and remove data version counters:

- drop data version counters
- most shared data types do nothing in `refresh`; derived ones like `FilteredList` rebuild their view

This is a little bit simpler at the cost of potentially redundant expensive `refresh` operations (e.g. if multiple view widgets share the same `FilteredList`; admittedly this seems unlikely). But since the reduction in complexity is small this won't be done now (but does remain an option in the future).