### PR TITLE
Fix use of autoimpl for dyn Trait

### DIFF
--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -332,9 +332,8 @@ impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 #[autoimpl(for<H: trait + ?Sized> Box<H>)]
 #[cfg_attr(feature = "stack_dst", autoimpl(
-    for<'a, S: Default + Copy + AsRef<[usize]> + AsMut<[usize]>>
-    stack_dst::ValueA<dyn DrawHandle + 'a, S>
-    using dyn DrawHandle
+    for<H: trait + ?Sized, S: Default + Copy + AsRef<[usize]> + AsMut<[usize]>>
+    stack_dst::ValueA<H, S>
 ))]
 pub trait DrawHandle {
     /// Access components: [`SizeHandle`], [`DrawShared`], [`EventState`]

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -140,8 +140,7 @@ mod widget_index;
 /// Implement `MyTrait` for `&T`, `&mut T` and `Box<dyn MyTrait>`:
 /// ```
 /// # use kas_macros::autoimpl;
-/// #[autoimpl(for<'a, T: trait + ?Sized> &'a T, &'a mut T)]
-/// #[autoimpl(for<> Box<dyn MyTrait> using dyn MyTrait)]
+/// #[autoimpl(for<'a, T: trait + ?Sized> &'a T, &'a mut T, Box<T>)]
 /// trait MyTrait {
 ///     fn f(&self) -> String;
 /// }

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -145,12 +145,12 @@ mod widget_index;
 ///     fn f(&self) -> String;
 /// }
 /// ```
-/// Note that so long as a parameter bound like `T: trait` exists, the
-/// definitive type may be deduced (e.g. `<T as MyTrait>`). In the second
-/// case, we must specify the definitive type directly: `using dyn MyTrait`.
+/// Note that the first parameter bound like `T: trait` is used as the
+/// definitive type (required). For example, here, `f` is implemented with the
+/// body `<T as MyTrait>::f(self)`.
 ///
-/// Note also that parameters of trait re-implementations must start with `for`,
-/// hence the empty `for<>`.
+/// Note further: if the trait uses generic parameters itself, these must be
+/// introduced explicitly in the `for<..>` parameter list.
 
 #[proc_macro_attribute]
 #[proc_macro_error]

--- a/crates/kas-macros/tests/autoimpl.rs
+++ b/crates/kas-macros/tests/autoimpl.rs
@@ -72,18 +72,45 @@ impl Z for () {
 
 #[test]
 fn z() {
-    fn impls_z(_: impl Z) {}
+    fn impls_z(mut z: impl Z<B = i32>) {
+        z.f();
+        z.g(1, &2);
+    }
 
     impls_z(());
     impls_z(&mut ());
     impls_z(Box::new(()));
 }
 
-#[autoimpl(for<'a, V, T> &'a T, &'a mut T where T: trait + ?Sized)]
-#[autoimpl(for<V> Box<dyn G<V>> using dyn G<V>)]
+#[autoimpl(for<'a, V, T> &'a T, &'a mut T, Box<T> where T: trait + ?Sized)]
 trait G<V>
 where
     V: Debug,
 {
     fn g(&self) -> V;
+}
+
+#[test]
+fn g() {
+    struct S;
+    impl G<i32> for S {
+        fn g(&self) -> i32 {
+            123
+        }
+    }
+
+    fn impls_g(g: impl G<i32>) {
+        assert_eq!(g.g(), 123);
+    }
+
+    impls_g(S);
+    impls_g(&S);
+    impls_g(&&S);
+    impls_g(&mut S);
+    impls_g(&&mut S);
+    impls_g(&S as &dyn G<i32>);
+    impls_g(Box::new(S));
+    impls_g(&mut &Box::new(S));
+    impls_g(Box::new(S) as Box<dyn G<i32>>);
+    impls_g(&mut (Box::new(S) as Box<dyn G<i32>>));
 }


### PR DESCRIPTION
Fixes #293 (reminder to self: compile-only tests are not a substitute for running tests).

Support for an explicit definitive type is removed completely. *Potentially* it could be useful in some contexts, e.g.:
```rust
#[autoimpl(for<'a> &'a mut (), Box<()> using <() as Z>)]
trait Z {
    // ...
}

impl Z for () {
    // ...
}
```
... *however* (1) `<() as Z>` does not parse as a type (`::` expected) and (2) the reason we can't deduce the definitive type here is because the re-implementation is for a specific target type, which is less useful in general. Thus, I choose to remove `using PartialType` syntax instead of supporting this case.