### PR TITLE
Revise TextClass; remove DrawHandle::text_accel

### DIFF
--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -487,7 +487,7 @@ mod test {
         let id = WidgetId::ROOT;
         let feature = IdCoord(&id, Coord::ZERO);
         let text = crate::text::Text::new_single("sample");
-        let class = TextClass::Label;
+        let class = TextClass::Label(false);
         draw.text_selected(feature, &text, .., class)
     }
 }

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -15,7 +15,7 @@ use crate::event::EventState;
 use crate::geom::{Coord, Offset, Rect};
 use crate::layout::SetRectMgr;
 use crate::macros::autoimpl;
-use crate::text::{AccelString, Text, TextApi, TextDisplay};
+use crate::text::{TextApi, TextDisplay};
 use crate::{TkAction, WidgetId};
 
 /// Optional background colour
@@ -191,20 +191,6 @@ impl<'a> DrawMgr<'a> {
     ) {
         let f = feature.into();
         self.h.text_effects(f.0, f.1, text, class);
-    }
-
-    /// Draw an `AccelString` text
-    ///
-    /// [`SizeMgr::text_bound`] should be called prior to this method to
-    /// select a font, font size and wrap options (based on the [`TextClass`]).
-    pub fn text_accel<'b>(
-        &mut self,
-        feature: impl Into<IdCoord<'b>>,
-        text: &Text<AccelString>,
-        class: TextClass,
-    ) {
-        let f = feature.into();
-        self.h.text_accel(f.0, f.1, text, class);
     }
 
     /// Draw some text using the standard font, with a subset selected
@@ -393,14 +379,6 @@ pub trait DrawHandle {
     /// [`SizeMgr::text_bound`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
     fn text_effects(&mut self, id: &WidgetId, pos: Coord, text: &dyn TextApi, class: TextClass);
-
-    /// Draw an `AccelString` text
-    ///
-    /// The `text` is drawn within the rect from `pos` to `text.env().bounds`.
-    ///
-    /// [`SizeMgr::text_bound`] should be called prior to this method to
-    /// select a font, font size and wrap options (based on the [`TextClass`]).
-    fn text_accel(&mut self, id: &WidgetId, pos: Coord, text: &Text<AccelString>, class: TextClass);
 
     /// Method used to implement [`Self::text_selected`]
     fn text_selected_range(

--- a/crates/kas-core/src/theme/style.rs
+++ b/crates/kas-core/src/theme/style.rs
@@ -12,30 +12,51 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextClass {
     /// Label text is drawn over the background colour
-    Label,
-    /// Scrollable label (same as label except that min height is limited)
+    ///
+    /// This takes one parameter: `multi_line`. Text is wrapped only if true.
+    Label(bool),
+    /// Scrollable label
+    ///
+    /// This is similar to `Label(true)`, but may occupy less vertical space.
+    /// Usually it also implies that the text is both scrollable and selectable,
+    /// but these are characteristics of the widget, not the text object.
     LabelScroll,
+    /// Label with accelerator keys
+    ///
+    /// This takes one parameter: `multi_line`. Text is wrapped only if true.
+    ///
+    /// This is identical to `Label` except that effects are only drawn if
+    /// accelerator-key mode is activated (usually the `Alt` key).
+    AccelLabel(bool),
     /// Button text is drawn over a button
+    ///
+    /// Same as `AccelLabel(false)`, though theme may differentiate.
     Button,
-    /// Class of text drawn in a single-line edit box
-    Edit,
-    /// Class of text drawn in a multi-line edit box
-    EditMulti,
     /// Menu label (single line, does not stretch)
+    ///
+    /// Similar to `AccelLabel(false)`, but with horizontal stretching disabled.
     MenuLabel,
+    /// Editable text, usually encapsulated in some type of box
+    ///
+    /// This takes one parameter: `multi_line`. Text is wrapped only if true.
+    Edit(bool),
 }
 
 impl TextClass {
-    /// True if text should be automatically line-wrapped
-    pub fn line_wrap(self) -> bool {
-        self == TextClass::Label || self == TextClass::EditMulti
+    /// True if text is single-line only
+    #[inline]
+    pub fn single_line(self) -> bool {
+        !self.multi_line()
     }
-}
 
-/// Default class: Label
-impl Default for TextClass {
-    fn default() -> Self {
-        TextClass::Label
+    /// True if text is multi-line and should automatically line-wrap
+    #[inline]
+    pub fn multi_line(self) -> bool {
+        use TextClass::*;
+        matches!(
+            self,
+            Label(true) | LabelScroll | AccelLabel(true) | Edit(true)
+        )
     }
 }
 

--- a/crates/kas-core/src/theme/style.rs
+++ b/crates/kas-core/src/theme/style.rs
@@ -58,6 +58,14 @@ impl TextClass {
             Label(true) | LabelScroll | AccelLabel(true) | Edit(true)
         )
     }
+
+    /// True if text effects should only be shown dependant on accelerator-key
+    /// mode being active
+    #[inline]
+    pub fn is_accel(self) -> bool {
+        use TextClass::*;
+        matches!(self, AccelLabel(_) | Button | MenuLabel)
+    }
 }
 
 /// Style of a frame

--- a/crates/kas-theme/src/config.rs
+++ b/crates/kas-theme/src/config.rs
@@ -275,8 +275,8 @@ mod defaults {
         let mut selector = FontSelector::new();
         selector.set_families(vec!["serif".into()]);
         let list = [
-            (TextClass::Edit, selector.clone()),
-            (TextClass::EditMulti, selector),
+            (TextClass::Edit(false), selector.clone()),
+            (TextClass::Edit(true), selector),
         ];
         list.iter().cloned().collect()
     }

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -18,8 +18,7 @@ use kas::dir::{Direction, Directional};
 use kas::draw::{color::Rgba, *};
 use kas::event::EventState;
 use kas::geom::*;
-use kas::text::format::FormattableText;
-use kas::text::{fonts, AccelString, Effect, Text, TextApi, TextDisplay};
+use kas::text::{fonts, Effect, TextApi, TextDisplay};
 use kas::theme::{self, SizeHandle, ThemeControl};
 use kas::theme::{Background, FrameStyle, TextClass};
 use kas::{TkAction, WidgetId};
@@ -446,28 +445,18 @@ where
         self.draw.text(pos.cast(), text, col);
     }
 
-    fn text_effects(&mut self, id: &WidgetId, pos: Coord, text: &dyn TextApi, _: TextClass) {
-        let col = if self.ev.is_disabled(id) {
-            self.cols.text_disabled
-        } else {
-            self.cols.text
-        };
-        self.draw
-            .text_col_effects(pos.cast(), text.display(), col, text.effect_tokens());
-    }
-
-    fn text_accel(&mut self, id: &WidgetId, pos: Coord, text: &Text<AccelString>, _: TextClass) {
+    fn text_effects(&mut self, id: &WidgetId, pos: Coord, text: &dyn TextApi, class: TextClass) {
         let pos = Vec2::conv(pos);
         let col = if self.ev.is_disabled(id) {
             self.cols.text_disabled
         } else {
             self.cols.text
         };
-        if self.ev.show_accel_labels() {
-            let effects = text.text().effect_tokens();
-            self.draw.text_col_effects(pos, text.as_ref(), col, effects);
+        if class.is_accel() && !self.ev.show_accel_labels() {
+            self.draw.text(pos, text.display(), col);
         } else {
-            self.draw.text(pos, text.as_ref(), col);
+            self.draw
+                .text_col_effects(pos, text.display(), col, text.effect_tokens());
         }
     }
 

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -15,7 +15,7 @@ use kas::dir::{Direction, Directional};
 use kas::draw::{color::Rgba, *};
 use kas::event::EventState;
 use kas::geom::*;
-use kas::text::{AccelString, Text, TextApi, TextDisplay};
+use kas::text::{TextApi, TextDisplay};
 use kas::theme::{self, Background, SizeHandle, ThemeControl};
 use kas::theme::{FrameStyle, TextClass};
 use kas::{TkAction, WidgetId};
@@ -348,16 +348,6 @@ where
 
     fn text_effects(&mut self, id: &WidgetId, pos: Coord, text: &dyn TextApi, class: TextClass) {
         self.as_flat().text_effects(id, pos, text, class);
-    }
-
-    fn text_accel(
-        &mut self,
-        id: &WidgetId,
-        pos: Coord,
-        text: &Text<AccelString>,
-        class: TextClass,
-    ) {
-        self.as_flat().text_accel(id, pos, text, class);
     }
 
     fn text_selected_range(

--- a/crates/kas-widgets/src/adapter/label.rs
+++ b/crates/kas-widgets/src/adapter/label.rs
@@ -25,6 +25,7 @@ widget! {
         dir: D,
         #[widget]
         inner: W,
+        wrap: bool,
         layout_store: layout::FixedRowStorage<2>,
         label_store: layout::TextStorage,
         label: Text<AccelString>,
@@ -46,6 +47,7 @@ widget! {
                 core: Default::default(),
                 dir: direction,
                 inner,
+                wrap: true,
                 layout_store: Default::default(),
                 label_store: Default::default(),
                 label: Text::new_multi(label.into()),
@@ -62,6 +64,27 @@ widget! {
         #[inline]
         pub fn deconstruct(self) -> (W, Text<AccelString>) {
             (self.inner, self.label)
+        }
+
+        /// Get whether line-wrapping is enabled
+        #[inline]
+        pub fn wrap(&self) -> bool {
+            self.wrap
+        }
+
+        /// Enable/disable line wrapping
+        ///
+        /// By default this is enabled.
+        #[inline]
+        pub fn set_wrap(&mut self, wrap: bool) {
+            self.wrap = wrap;
+        }
+
+        /// Enable/disable line wrapping (inline)
+        #[inline]
+        pub fn with_wrap(mut self, wrap: bool) -> Self {
+            self.wrap = wrap;
+            self
         }
 
         /// Set text in an existing `Label`
@@ -88,7 +111,7 @@ widget! {
         fn layout(&mut self) -> layout::Layout<'_> {
             let arr = [
                 layout::Layout::single(&mut self.inner),
-                layout::Layout::text(&mut self.label_store, &mut self.label, TextClass::Label),
+                layout::Layout::text(&mut self.label_store, &mut self.label, TextClass::Label(self.wrap)),
             ];
             layout::Layout::list(arr.into_iter(), self.dir, &mut self.layout_store)
         }

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -379,11 +379,7 @@ widget! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            let class = if self.multi_line {
-                TextClass::EditMulti
-            } else {
-                TextClass::Edit
-            };
+            let class = TextClass::Edit(self.multi_line);
             size_mgr.text_bound(&mut self.text, class, axis)
         }
 
@@ -412,11 +408,7 @@ widget! {
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
-            let class = if self.multi_line {
-                TextClass::EditMulti
-            } else {
-                TextClass::Edit
-            };
+            let class = TextClass::Edit(self.multi_line);
             draw.with_clip_region(self.rect(), self.view_offset, |mut draw| {
                 if self.selection.is_empty() {
                     draw.text(&*self, self.text.as_ref(), class);

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -62,10 +62,11 @@ widget! {
     }
 }
 
+// NOTE: the only effect of this specialization is to change the TextClass.
 #[cfg(feature = "min_spec")]
 impl Layout for AccelLabel {
     fn draw(&mut self, mut draw: DrawMgr) {
-        draw.text_accel(&*self, &self.label, TextClass::AccelLabel(self.wrap));
+        draw.text_effects(&*self, &self.label, TextClass::AccelLabel(self.wrap));
     }
 }
 

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -18,13 +18,14 @@ widget! {
     pub struct Label<T: FormattableText + 'static> {
         #[widget_core]
         core: CoreData,
+        wrap: bool,
         label: Text<T>,
     }
 
     impl Layout for Self {
         #[inline]
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            size_mgr.text_bound(&mut self.label, TextClass::Label, axis)
+            size_mgr.text_bound(&mut self.label, TextClass::Label(self.wrap), axis)
         }
 
         fn set_rect(&mut self, _: &mut SetRectMgr, rect: Rect, align: AlignHints) {
@@ -37,11 +38,11 @@ widget! {
 
         #[cfg(feature = "min_spec")]
         default fn draw(&mut self, mut draw: DrawMgr) {
-            draw.text_effects(&*self, &self.label, TextClass::Label);
+            draw.text_effects(&*self, &self.label, TextClass::Label(self.wrap));
         }
         #[cfg(not(feature = "min_spec"))]
         fn draw(&mut self, mut draw: DrawMgr) {
-            draw.text_effects(&*self, &self.label, TextClass::Label);
+            draw.text_effects(&*self, &self.label, TextClass::Label(self.wrap));
         }
     }
 
@@ -64,7 +65,7 @@ widget! {
 #[cfg(feature = "min_spec")]
 impl Layout for AccelLabel {
     fn draw(&mut self, mut draw: DrawMgr) {
-        draw.text_accel(&*self, &self.label, TextClass::Label);
+        draw.text_accel(&*self, &self.label, TextClass::AccelLabel(self.wrap));
     }
 }
 
@@ -72,13 +73,13 @@ impl Layout for AccelLabel {
 #[cfg(feature = "min_spec")]
 impl<'a> Layout for Label<&'a str> {
     fn draw(&mut self, mut draw: DrawMgr) {
-        draw.text(&*self, self.label.as_ref(), TextClass::Label);
+        draw.text(&*self, self.label.as_ref(), TextClass::Label(self.wrap));
     }
 }
 #[cfg(feature = "min_spec")]
 impl Layout for StringLabel {
     fn draw(&mut self, mut draw: DrawMgr) {
-        draw.text(&*self, self.label.as_ref(), TextClass::Label);
+        draw.text(&*self, self.label.as_ref(), TextClass::Label(self.wrap));
     }
 }
 
@@ -108,8 +109,30 @@ impl<T: FormattableText + 'static> Label<T> {
     pub fn new(label: T) -> Self {
         Label {
             core: Default::default(),
+            wrap: true,
             label: Text::new_multi(label),
         }
+    }
+
+    /// Get whether line-wrapping is enabled
+    #[inline]
+    pub fn wrap(&self) -> bool {
+        self.wrap
+    }
+
+    /// Enable/disable line wrapping
+    ///
+    /// By default this is enabled.
+    #[inline]
+    pub fn set_wrap(&mut self, wrap: bool) {
+        self.wrap = wrap;
+    }
+
+    /// Enable/disable line wrapping (inline)
+    #[inline]
+    pub fn with_wrap(mut self, wrap: bool) -> Self {
+        self.wrap = wrap;
+        self
     }
 
     /// Set text in an existing `Label`

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -41,7 +41,7 @@ widget! {
 
         fn draw(&mut self, mut draw: DrawMgr) {
             draw.frame(&*self, FrameStyle::MenuEntry, Default::default());
-            draw.text_accel(
+            draw.text_effects(
                 kas::theme::IdCoord(self.id_ref(), self.layout_label.pos),
                 &self.label,
                 TextClass::MenuLabel,

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -144,7 +144,7 @@ widget! {
 
         fn draw(&mut self, mut draw: DrawMgr) {
             draw.frame(&*self, FrameStyle::MenuEntry, Default::default());
-            draw.text_accel(
+            draw.text_effects(
                 kas::theme::IdCoord(self.id_ref(), self.label_store.pos),
                 &self.label,
                 TextClass::MenuLabel,

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -96,7 +96,7 @@ widget! {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
             let mut rules = self.inner.size_rules(size_mgr.re(), axis);
             self.min_child_size.set_component(axis, rules.min_size());
-            let line_height = size_mgr.line_height(TextClass::Label);
+            let line_height = size_mgr.line_height(TextClass::Label(false));
             self.scroll.set_scroll_rate(3.0 * f32::conv(line_height));
             rules.reduce_min_to(line_height);
 


### PR DESCRIPTION
- Simplify the theme's API slightly
- Fix accelerator-key underlines always being visible in the calculator
- Allow disabling line-wrapping for labels
- Fix not showing accelerator underlines without `Alt` for `AccelLabel` on stable Rust