### PR TITLE
Fix initial window size on Wayland; visual improvements

### DIFF
--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -147,7 +147,6 @@ type AccelLayer = (bool, HashMap<VirtualKeyCode, WidgetId>);
 pub struct EventState {
     config: WindowConfig,
     disabled: Vec<WidgetId>,
-    scale_factor: f32,
     configure_active: bool,
     configure_count: usize,
     window_has_focus: bool,

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -597,6 +597,11 @@ impl<'a> EventMgr<'a> {
     }
 
     /// Access a [`SizeMgr`]
+    ///
+    /// Warning: sizes are calculated using the window's current scale factor.
+    /// This may change, even without user action, since some platforms
+    /// always initialize windows with scale factor 1.
+    /// See also notes on [`WidgetConfig::configure`].
     pub fn size_mgr<F: FnMut(SizeMgr) -> T, T>(&mut self, mut f: F) -> T {
         let mut result = None;
         self.shell.size_and_draw_shared(&mut |size_handle, _| {

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -146,12 +146,6 @@ impl EventState {
         Vec2::conv(dist).sum_square() >= thresh * thresh
     }
 
-    /// Access the screen's scale factor
-    #[inline]
-    pub fn scale_factor(&self) -> f32 {
-        self.scale_factor
-    }
-
     /// Set/unset a widget as disabled
     ///
     /// Disabled status applies to all descendants.

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -33,7 +33,6 @@ impl EventState {
         EventState {
             config: WindowConfig::new(config, scale_factor),
             disabled: vec![],
-            scale_factor,
             configure_active: false,
             configure_count: 0,
             window_has_focus: false,
@@ -64,7 +63,6 @@ impl EventState {
 
     /// Update scale factor
     pub fn set_scale_factor(&mut self, scale_factor: f32) {
-        self.scale_factor = scale_factor;
         self.config.set_scale_factor(scale_factor);
     }
 

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -613,7 +613,7 @@ impl std::ops::SubAssign<Offset> for Rect {
 mod winit_impls {
     use super::{Coord, Size};
     use crate::cast::{Cast, CastApprox, Conv, ConvApprox};
-    use winit::dpi::{PhysicalPosition, PhysicalSize};
+    use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 
     impl<X: CastApprox<i32>> ConvApprox<PhysicalPosition<X>> for Coord {
         #[inline]
@@ -629,11 +629,25 @@ mod winit_impls {
         }
     }
 
-    impl From<Size> for winit::dpi::Size {
+    impl Size {
+        /// Convert to a "physical" [`winit::dpi::Size`]
+        ///
+        /// This implies that the [`Size`] was calculated using the correct
+        /// scale factor. Before the window has been constructed (when the
+        /// scale factor is supposedly unknown) this should not be used.
         #[inline]
-        fn from(size: Size) -> Self {
-            let (w, h): (u32, u32) = size.cast();
+        pub fn as_physical(self) -> winit::dpi::Size {
+            let (w, h): (u32, u32) = self.cast();
             winit::dpi::Size::Physical(PhysicalSize::new(w, h))
+        }
+
+        /// Convert to a "logical" [`winit::dpi::Size`]
+        ///
+        /// This implies that the [`Size`] was calculated using `scale_factor = 1`.
+        #[inline]
+        pub fn as_logical(self) -> winit::dpi::Size {
+            let (w, h) = (self.0 as f64, self.1 as f64);
+            winit::dpi::Size::Logical(LogicalSize::new(w, h))
         }
     }
 }

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -8,6 +8,7 @@
 //! For drawing operations, all dimensions use the `f32` type.
 
 use crate::cast::*;
+use crate::dir::Directional;
 use crate::geom::{Coord, Offset, Rect, Size};
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
@@ -312,6 +313,18 @@ macro_rules! impl_vec2 {
             #[inline]
             pub fn sum_square(self) -> $f {
                 self.0 * self.0 + self.1 * self.1
+            }
+
+            /// Extract one component, based on a direction
+            ///
+            /// This merely extracts the horizontal or vertical component.
+            /// It never negates it, even if the axis is reversed.
+            #[inline]
+            pub fn extract<D: Directional>(self, dir: D) -> $f {
+                match dir.is_vertical() {
+                    false => self.0,
+                    true => self.1,
+                }
             }
         }
 

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -169,6 +169,11 @@ impl<'a> SetRectMgr<'a> {
     }
 
     /// Access a [`SizeMgr`]
+    ///
+    /// Warning: sizes are calculated using the window's current scale factor.
+    /// This may change, even without user action, since some platforms
+    /// always initialize windows with scale factor 1.
+    /// See also notes on [`WidgetConfig::configure`].
     pub fn size_mgr(&self) -> SizeMgr<'a> {
         SizeMgr::new(self.sh)
     }

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -204,11 +204,14 @@ impl<'a> Layout<'a> {
         self.size_rules_(mgr, axis)
     }
     fn size_rules_(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-        let frame = |mgr: SizeMgr, child: &mut Layout, storage: &mut FrameStorage, style| {
+        let frame = |mgr: SizeMgr, child: &mut Layout, storage: &mut FrameStorage, mut style| {
             let frame_rules = mgr.frame(style, axis.is_vertical());
             let child_rules = child.size_rules_(mgr, axis);
+            if axis.is_horizontal() && style == FrameStyle::MenuEntry {
+                style = FrameStyle::InnerMargin;
+            }
             let (rules, offset, size) = match style {
-                FrameStyle::InnerMargin | FrameStyle::MenuEntry | FrameStyle::EditBox => {
+                FrameStyle::InnerMargin | FrameStyle::EditBox => {
                     frame_rules.surround_with_margin(child_rules)
                 }
                 FrameStyle::NavFocus => frame_rules.surround_as_margin(child_rules),

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -37,7 +37,7 @@ pub struct Parameters {
     pub menu_frame: f32,
     /// Button frame size (non-flat outer region)
     pub button_frame: f32,
-    /// Checkbox inner size in Points
+    /// CheckBox inner size in Points
     pub checkbox_inner: f32,
     /// Scrollbar minimum handle size
     pub scrollbar_size: Vec2,
@@ -172,22 +172,18 @@ impl<D: 'static> SizeHandle for Window<D> {
     }
 
     fn frame(&self, style: FrameStyle, _is_vert: bool) -> FrameRules {
+        let inner = self.dims.inner_margin.into();
         match style {
             FrameStyle::InnerMargin => FrameRules::new_sym(0, 0, 0),
             FrameStyle::Frame => FrameRules::new_sym(self.dims.frame, 0, 0),
             FrameStyle::Popup => FrameRules::new_sym(self.dims.popup_frame, 0, 0),
-            FrameStyle::MenuEntry => FrameRules::new_sym(self.dims.menu_frame, 0, 0),
+            FrameStyle::MenuEntry => FrameRules::new_sym(self.dims.menu_frame, inner, 0),
             FrameStyle::NavFocus => FrameRules::new_sym(self.dims.inner_margin.into(), 0, 0),
             FrameStyle::Button => {
-                let inner = self.dims.inner_margin.into();
                 let outer = self.dims.outer_margin;
                 FrameRules::new_sym(self.dims.frame, inner, outer)
             }
-            FrameStyle::EditBox => {
-                let inner = self.dims.inner_margin.into();
-                let outer = 0;
-                FrameRules::new_sym(self.dims.frame, inner, outer)
-            }
+            FrameStyle::EditBox => FrameRules::new_sym(self.dims.frame, inner, 0),
         }
     }
 

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -559,7 +559,19 @@ where
             let v = inner.size() * (anim_fade / 2.0);
             let inner = Quad::from_coords(inner.a + v, inner.b - v);
             let col = self.cols.check_mark_state(state);
-            self.draw.rect(inner, col);
+            let f = self.w.dims.frame as f32 * 0.5;
+            if inner.size().min_comp() >= 2.0 * f {
+                let inner = inner.shrink(f);
+                let size = inner.size();
+                let vstep = size.1 * 0.125;
+                let a = Vec2(inner.a.0, inner.b.1 - 3.0 * vstep);
+                let b = Vec2(inner.a.0 + size.0 * 0.25, inner.b.1 - vstep);
+                let c = Vec2(inner.b.0, inner.a.1 + vstep);
+                self.draw.rounded_line(a, b, f, col);
+                self.draw.rounded_line(b, c, f, col);
+            } else {
+                self.draw.rect(inner, col);
+            }
         }
     }
 

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -105,7 +105,7 @@ impl FlatTheme {
 }
 
 const DIMS: dim::Parameters = dim::Parameters {
-    outer_margin: 8.0,
+    outer_margin: 7.0,
     inner_margin: 1.2,
     text_margin: (3.4, 2.0),
     frame_size: 2.4,
@@ -113,7 +113,7 @@ const DIMS: dim::Parameters = dim::Parameters {
     menu_frame: 2.4,
     // NOTE: visual thickness is (button_frame * scale_factor).round() * (1 - BG_SHRINK_FACTOR)
     button_frame: 2.4,
-    checkbox_inner: 9.0,
+    checkbox_inner: 7.0,
     scrollbar_size: Vec2::splat(8.0),
     slider_size: Vec2(16.0, 16.0),
     progress_bar: Vec2::splat(8.0),
@@ -555,7 +555,7 @@ where
         let inner = self.button_frame(outer, col_frame, col_bg, state);
 
         if anim_fade < 1.0 {
-            let inner = inner.shrink((2 * self.w.dims.inner_margin) as f32);
+            let inner = inner.shrink(self.w.dims.inner_margin as f32);
             let v = inner.size() * (anim_fade / 2.0);
             let inner = Quad::from_coords(inner.a + v, inner.b - v);
             let col = self.cols.check_mark_state(state);
@@ -593,7 +593,7 @@ where
         self.draw.circle(outer, r, col);
 
         if anim_fade < 1.0 {
-            let r = self.w.dims.button_frame + 2 * self.w.dims.inner_margin as i32;
+            let r = self.w.dims.button_frame + self.w.dims.inner_margin as i32;
             let inner = outer.shrink(r as f32);
             let v = inner.size() * (anim_fade / 2.0);
             let inner = Quad::from_coords(inner.a + v, inner.b - v);
@@ -651,10 +651,9 @@ where
             }
         };
 
-        let dist = outer.size().min_comp() / 2.0;
-        let inner = first.shrink(dist);
+        let inner = first.shrink(first.size().min_comp() / 2.0);
         self.draw.rounded_frame(first, inner, 0.0, self.cols.accent);
-        let inner = second.shrink(dist);
+        let inner = second.shrink(second.size().min_comp() / 2.0);
         self.draw
             .rounded_frame(second, inner, 1.0 / 3.0, self.cols.frame);
 

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -199,26 +199,21 @@ where
 
     /// Draw an edit box with optional navigation highlight.
     /// Return the inner rect.
-    ///
-    /// - `outer`: define position via outer rect
-    /// - `bg_col`: colour of background
-    /// - `nav_col`: colour of navigation highlight, if visible
-    fn draw_edit_box(&mut self, outer: Rect, bg_col: Rgba, nav_col: Option<Rgba>) -> Quad {
-        let mut outer = Quad::conv(outer);
-        let mut inner = outer.shrink(self.w.dims.frame as f32);
+    fn draw_edit_box(&mut self, outer: Rect, bg_col: Rgba, nav_focus: bool) -> Quad {
+        let outer = Quad::conv(outer);
+        let inner = outer.shrink(self.w.dims.frame as f32);
 
-        let col = self.cols.background;
+        let outer_col = self.cols.background;
+        let inner_col = if nav_focus {
+            self.cols.accent_soft
+        } else {
+            outer_col
+        };
         self.draw
-            .shaded_square_frame(outer, inner, (-0.6, 0.0), col, col);
-
-        if let Some(col) = nav_col {
-            outer = inner;
-            inner = outer.shrink(self.w.dims.inner_margin as f32);
-            self.draw.frame(outer, inner, col);
-        }
+            .shaded_square_frame(outer, inner, (-0.6, 0.0), outer_col, inner_col);
 
         self.draw.rect(inner, bg_col);
-        inner
+        inner.shrink(self.w.dims.inner_margin as f32)
     }
 
     /// Draw a handle (for slider, scrollbar)
@@ -324,7 +319,7 @@ where
             FrameStyle::EditBox => {
                 let state = InputState::new_except_depress(self.ev, id);
                 let bg_col = self.cols.from_edit_bg(bg, state);
-                self.draw_edit_box(rect, bg_col, self.cols.nav_region(state));
+                self.draw_edit_box(rect, bg_col, state.nav_focus());
             }
             style => self.as_flat().frame(id, rect, style, bg),
         }
@@ -378,9 +373,8 @@ where
         let anim_fade = self.w.anim.fade_bool_1m(self.draw.draw, id, checked);
 
         let bg_col = self.cols.from_edit_bg(Default::default(), state);
-        let nav_col = self.cols.nav_region(state).or(Some(bg_col));
 
-        let inner = self.draw_edit_box(rect, bg_col, nav_col);
+        let inner = self.draw_edit_box(rect, bg_col, state.nav_focus());
 
         if anim_fade < 1.0 {
             let v = inner.size() * (anim_fade / 2.0);
@@ -395,9 +389,8 @@ where
         let anim_fade = self.w.anim.fade_bool_1m(self.draw.draw, id, checked);
 
         let bg_col = self.cols.from_edit_bg(Default::default(), state);
-        let nav_col = self.cols.nav_region(state).or(Some(bg_col));
 
-        let inner = self.draw_edit_box(rect, bg_col, nav_col);
+        let inner = self.draw_edit_box(rect, bg_col, state.nav_focus());
 
         if anim_fade < 1.0 {
             let v = inner.size() * (anim_fade / 2.0);

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -62,7 +62,7 @@ impl ShadedTheme {
 }
 
 const DIMS: dim::Parameters = dim::Parameters {
-    outer_margin: 6.0,
+    outer_margin: 5.0,
     inner_margin: 1.2,
     text_margin: (3.4, 2.0),
     frame_size: 5.0,

--- a/crates/kas-wgpu/src/shared.rs
+++ b/crates/kas-wgpu/src/shared.rs
@@ -31,8 +31,7 @@ pub struct SharedState<C: CustomPipe, T> {
     pub theme: T,
     pub config: Rc<RefCell<kas::event::Config>>,
     pub pending: Vec<PendingAction>,
-    /// Newly created windows need to know the scale_factor *before* they are
-    /// created. This is used to estimate ideal window size.
+    /// Estimated scale factor (from last window constructed or available screens)
     pub scale_factor: f64,
     pub frame_dur: Duration,
     window_id: u32,

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -53,7 +53,19 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
     ) -> Result<Self, OsError> {
         let time = Instant::now();
 
-        let scale_factor = shared.scale_factor as f32;
+        // Wayland only supports windows constructed via logical size
+        let use_logical_size = if cfg!(unix) {
+            use winit::platform::unix::EventLoopWindowTargetExtUnix;
+            elwt.is_wayland()
+        } else {
+            false
+        };
+        let scale_factor = if use_logical_size {
+            1.0
+        } else {
+            shared.scale_factor as f32
+        };
+
         let mut theme_window = shared.theme.new_window(scale_factor);
 
         let mut ev_state = EventState::new(shared.config.clone(), scale_factor);
@@ -61,14 +73,24 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         ev_state.full_configure(&mut tkw, &mut *widget);
 
         let size_mgr = SizeMgr::new(theme_window.size_handle());
-        let solve_cache = SolveCache::find_constraints(widget.as_widget_mut(), size_mgr);
+        let mut solve_cache = SolveCache::find_constraints(widget.as_widget_mut(), size_mgr);
+
         // Opening a zero-size window causes a crash, so force at least 1x1:
         let ideal = solve_cache.ideal(true).max(Size(1, 1));
+        let ideal = match use_logical_size {
+            false => ideal.as_physical(),
+            true => ideal.as_logical(),
+        };
 
         let mut builder = WindowBuilder::new().with_inner_size(ideal);
         let restrict_dimensions = widget.restrict_dimensions();
         if restrict_dimensions.0 {
-            builder = builder.with_min_inner_size(solve_cache.min(true));
+            let min = solve_cache.min(true);
+            let min = match use_logical_size {
+                false => min.as_physical(),
+                true => min.as_logical(),
+            };
+            builder = builder.with_min_inner_size(min);
         }
         if restrict_dimensions.1 {
             builder = builder.with_max_inner_size(ideal);
@@ -83,7 +105,18 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         let scale_factor = window.scale_factor();
         shared.scale_factor = scale_factor;
         let size: Size = window.inner_size().cast();
-        info!("Constucted new window with size {:?}", size);
+        info!(
+            "Constucted new window with physical size {:?}, scale factor {}",
+            size, scale_factor
+        );
+
+        // Now that we have a scale factor, we may need to resize:
+        if use_logical_size && scale_factor != 1.0 {
+            let scale_factor = scale_factor as f32;
+            ev_state.set_scale_factor(scale_factor);
+            shared.theme.update_window(&mut theme_window, scale_factor);
+            solve_cache.invalidate_rule_cache();
+        }
 
         let mut draw = shared.draw.draw.new_window();
         shared.draw.draw.resize(&mut draw, size);
@@ -301,12 +334,12 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
         let restrict_dimensions = self.widget.restrict_dimensions();
         if restrict_dimensions.0 {
-            self.window
-                .set_min_inner_size(Some(self.solve_cache.min(true)));
+            let min = self.solve_cache.min(true).as_physical();
+            self.window.set_min_inner_size(Some(min));
         };
         if restrict_dimensions.1 {
-            self.window
-                .set_max_inner_size(Some(self.solve_cache.ideal(true)));
+            let ideal = self.solve_cache.ideal(true).as_physical();
+            self.window.set_max_inner_size(Some(ideal));
         };
 
         self.window.request_redraw();

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -54,12 +54,20 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         let time = Instant::now();
 
         // Wayland only supports windows constructed via logical size
-        let use_logical_size = if cfg!(unix) {
+        #[allow(unused_assignments, unused_mut)]
+        let mut use_logical_size = false;
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        {
             use winit::platform::unix::EventLoopWindowTargetExtUnix;
-            elwt.is_wayland()
-        } else {
-            false
-        };
+            use_logical_size = elwt.is_wayland();
+        }
+
         let scale_factor = if use_logical_size {
             1.0
         } else {

--- a/crates/kas-widgets/src/checkbox.rs
+++ b/crates/kas-widgets/src/checkbox.rs
@@ -216,7 +216,7 @@ widget! {
     impl Self {
         /// Construct a checkbox with a given `label` and event handler `f`
         ///
-        /// Checkbox labels are optional; if no label is desired, use an empty
+        /// CheckBox labels are optional; if no label is desired, use an empty
         /// string.
         ///
         /// On toggle (through user input events or [`Event::Activate`]) the

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -12,7 +12,7 @@ use kas::geom::Vec2;
 use kas::layout::{self, FrameStorage};
 use kas::prelude::*;
 use kas::text::SelectionHelper;
-use kas::theme::{Background, FrameStyle, TextClass};
+use kas::theme::{Background, FrameStyle, IdRect, TextClass};
 use std::fmt::Debug;
 use std::ops::Range;
 use unicode_segmentation::{GraphemeCursor, UnicodeSegmentation};
@@ -193,7 +193,7 @@ widget! {
             } else {
                 Background::Default
             };
-            draw.frame(&*self, FrameStyle::EditBox, bg);
+            draw.frame(IdRect(self.inner.id_ref(), self.rect()), FrameStyle::EditBox, bg);
             self.inner.draw(draw.re());
         }
     }


### PR DESCRIPTION
Wayland windows now have size calculated using scale-factor 1, then rescaled if necessary (required since Wayland only accepts logical coordinates; i.e. client has no control over scaled size). X11 and other platforms continue to use the guessed scale factor (at least on X11 this is the best option).

Add some documentation regarding configuration and scale factor.

Visual improvements:

- Revise margins, especially vertical margin in menus
- Use a check mark in `FlatTheme`
- Fix `EditBox` focus indicator; new effect in `ShadedTheme`