### PR TITLE
Restore configure_recurse; use local reconfigure for dynamic parents

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -247,9 +247,14 @@ pub trait WidgetConfig: Layout {
 /// This trait is part of the [`Widget`] family. It may be derived by
 /// the [`crate::macros::widget`] macro, but is not by default.
 ///
-/// Implementations of this trait should *either* define [`Self::layout`]
-/// (optionally with other methods as required) *or* define at least
-/// [`Self::size_rules`] and [`Self::draw`].
+/// There are two methods of implementing this trait:
+///
+/// -   Implement [`Self::layout`]. This alone suffices in many cases; other
+///     methods may be overridden if necessary.
+/// -   Ignore [`Self::layout`] and implement [`Self::size_rules`] (to give the
+///     widget size) and [`Self::draw`] (to make it show something). Other
+///     methods may be required (e.g. [`Self::set_rect`] to position child
+///     elements).
 ///
 /// Layout solving happens in two steps:
 ///
@@ -269,8 +274,9 @@ pub trait Layout: WidgetChildren {
     ///
     /// The default implementation is for an empty layout (zero size required,
     /// no child elements, no graphics).
+    #[inline]
     fn layout(&mut self) -> layout::Layout<'_> {
-        Default::default() // TODO: remove default impl
+        Default::default()
     }
 
     /// Get size rules for the given axis

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -110,26 +110,14 @@ pub trait WidgetChildren: WidgetCore {
     /// This method may be removed in the future.
     fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn WidgetConfig>;
 
-    /// Get the [`WidgetId`] for this child
-    ///
-    /// Note: the result should be generated relative to `self.id`.
-    /// Most widgets may use the default implementation.
-    ///
-    /// This must return `Some(..)` when `index` is valid; in other cases the
-    /// result does not matter.
-    ///
-    /// If a custom implementation is used, then [`Self::find_child_index`]
-    /// must be implemented to do the inverse of `make_child_id`, and
-    /// probably a custom implementation of [`Layout::spatial_nav`] is needed.
-    #[inline]
-    fn make_child_id(&self, index: usize) -> Option<WidgetId> {
-        Some(self.id_ref().make_child(index))
-    }
-
     /// Find the child which is an ancestor of this `id`, if any
     ///
     /// If `Some(index)` is returned, this is *probably* but not guaranteed
     /// to be a valid child index.
+    ///
+    /// The default implementation simply uses [`WidgetId::next_key_after`].
+    /// Widgets may choose to assign children custom keys by overriding this
+    /// method and [`WidgetChildren::configure_recurse`].
     #[inline]
     fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
         id.next_key_after(self.id_ref())
@@ -180,7 +168,8 @@ pub trait WidgetConfig: Layout {
     /// Normally the default implementation is used. A custom implementation
     /// may be used to influence configuration of children, for example by
     /// calling [`EventState::new_accel_layer`] or by constructing children's
-    /// [`WidgetId`] values in a non-standard manner.
+    /// [`WidgetId`] values in a non-standard manner (in this case ensure that
+    /// [`WidgetChildren::find_child_index`] has a correct implementation).
     ///
     /// To directly configure a child, call [`SetRectMgr::configure`] instead.
     fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -147,8 +147,6 @@ type AccelLayer = (bool, HashMap<VirtualKeyCode, WidgetId>);
 pub struct EventState {
     config: WindowConfig,
     disabled: Vec<WidgetId>,
-    configure_active: bool,
-    configure_count: usize,
     window_has_focus: bool,
     modifiers: ModifiersState,
     /// char focus is on same widget as sel_focus; otherwise its value is ignored

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -198,7 +198,9 @@ impl<'a> SetRectMgr<'a> {
     /// the parent's id via [`WidgetId::make_child`].
     #[inline]
     pub fn configure(&mut self, id: WidgetId, widget: &mut dyn WidgetConfig) {
-        EventState::configure(self, id, widget);
+        // Yes, this method is just a shim! We reserve the option to add other code here in the
+        // future, hence do not advise calling `configure_recurse` directly.
+        widget.configure_recurse(self, id);
     }
 }
 

--- a/crates/kas-core/src/toolkit.rs
+++ b/crates/kas-core/src/toolkit.rs
@@ -71,7 +71,7 @@ bitflags! {
         */
         /// Reset size of all widgets without recalculating requirements
         const SET_SIZE = 1 << 8;
-        /// Resize all widgets
+        /// Resize all widgets in the window
         const RESIZE = 1 << 9;
         /// Update theme memory
         const THEME_UPDATE = 1 << 10;

--- a/crates/kas-core/src/toolkit.rs
+++ b/crates/kas-core/src/toolkit.rs
@@ -46,8 +46,9 @@ bitflags! {
     /// assignments are supported by both `TkAction` and [`event::EventMgr`].
     ///
     /// Users receiving a value of this type from a widget update method should
-    /// generally call `*mgr |= action;` during event handling. Prior to
-    /// starting the event loop (`toolkit.run()`), these values can be ignored.
+    /// usually handle with `*mgr |= action;`. Before the event loop starts
+    /// (`toolkit.run()`) or if the widget in question is not part of a UI these
+    /// values can be ignored.
     #[must_use]
     #[derive(Default)]
     pub struct TkAction: u32 {

--- a/crates/kas-core/src/updatable/data_traits.rs
+++ b/crates/kas-core/src/updatable/data_traits.rs
@@ -105,6 +105,11 @@ pub trait ListData: Debug {
     /// increase the version number (allowing change detection).
     fn version(&self) -> u64;
 
+    /// No data is available
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Number of data items available
     ///
     /// Note: users may assume this is `O(1)`.

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -293,54 +293,46 @@ impl<M: 'static> ComboBox<M> {
     }
 
     /// Remove all choices
-    ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    pub fn clear(&mut self) -> TkAction {
+    pub fn clear(&mut self) {
         self.popup.inner.clear()
     }
 
     /// Add a choice to the combobox, in last position
     ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    pub fn push<T: Into<AccelString>>(&mut self, label: T) -> TkAction {
+    /// Returns the index of the new choice
+    //
+    // TODO(opt): these methods cause full-window resize. They don't need to
+    // resize at all if the menu is closed!
+    pub fn push<T: Into<AccelString>>(&mut self, mgr: &mut SetRectMgr, label: T) -> usize {
         let column = &mut self.popup.inner;
-        column.push(MenuEntry::new(label, ()))
-        // TODO: localised reconfigure
+        column.push(mgr, MenuEntry::new(label, ()))
     }
 
     /// Pops the last choice from the combobox
-    ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    pub fn pop(&mut self) -> (Option<()>, TkAction) {
-        let r = self.popup.inner.pop();
-        (r.0.map(|_| ()), r.1)
+    pub fn pop(&mut self, mgr: &mut SetRectMgr) -> Option<()> {
+        self.popup.inner.pop(mgr).map(|_| ())
     }
 
     /// Add a choice at position `index`
     ///
     /// Panics if `index > len`.
-    ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    pub fn insert<T: Into<AccelString>>(&mut self, index: usize, label: T) -> TkAction {
+    pub fn insert<T: Into<AccelString>>(&mut self, mgr: &mut SetRectMgr, index: usize, label: T) {
         let column = &mut self.popup.inner;
-        column.insert(index, MenuEntry::new(label, ()))
-        // TODO: localised reconfigure
+        column.insert(mgr, index, MenuEntry::new(label, ()));
     }
 
     /// Removes the choice at position `index`
     ///
     /// Panics if `index` is out of bounds.
-    ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    pub fn remove(&mut self, index: usize) -> TkAction {
-        self.popup.inner.remove(index).1
+    pub fn remove(&mut self, mgr: &mut SetRectMgr, index: usize) {
+        self.popup.inner.remove(mgr, index);
     }
 
     /// Replace the choice at `index`
     ///
     /// Panics if `index` is out of bounds.
-    pub fn replace<T: Into<AccelString>>(&mut self, index: usize, label: T) -> TkAction {
-        self.popup.inner[index].set_accel(label)
+    pub fn replace<T: Into<AccelString>>(&mut self, mgr: &mut SetRectMgr, index: usize, label: T) {
+        *mgr |= self.popup.inner[index].set_accel(label);
     }
 }
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -190,15 +190,18 @@ impl ComboBox<VoidMsg> {
     /// types, and the chosen `active` entry. For example:
     /// ```
     /// # use kas_widgets::ComboBox;
-    /// let combobox = ComboBox::new(&["zero", "one", "two"], 0);
+    /// let combobox = ComboBox::new_from_iter(&["zero", "one", "two"], 0);
     /// ```
     #[inline]
-    pub fn new<T: Into<AccelString>, I: IntoIterator<Item = T>>(iter: I, active: usize) -> Self {
+    pub fn new_from_iter<T: Into<AccelString>, I: IntoIterator<Item = T>>(
+        iter: I,
+        active: usize,
+    ) -> Self {
         let entries = iter
             .into_iter()
             .map(|label| MenuEntry::new(label, ()))
             .collect();
-        Self::new_entries(entries, active)
+        Self::new(entries, active)
     }
 
     /// Construct a combobox with the given menu entries
@@ -206,7 +209,7 @@ impl ComboBox<VoidMsg> {
     /// A combobox presents a menu with a fixed set of choices when clicked,
     /// with the `active` choice selected (0-based index).
     #[inline]
-    pub fn new_entries(entries: Vec<MenuEntry<()>>, active: usize) -> Self {
+    pub fn new(entries: Vec<MenuEntry<()>>, active: usize) -> Self {
         let label = entries.get(active).map(|entry| entry.get_string());
         let label = Text::new_single(label.unwrap_or("".to_string()));
         ComboBox {

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -139,10 +139,15 @@ impl<W: Widget> Grid<W> {
     }
 
     /// Edit an existing grid via a builder
+    ///
+    /// This may be used to edit children before window construction. It may
+    /// also be used from a running UI, but in this case a full reconfigure
+    /// of the window's widgets is required (triggered by the the return
+    /// value, [`TkAction::RECONFIGURE`]).
     pub fn edit<F: FnOnce(GridBuilder<W>)>(&mut self, f: F) -> TkAction {
         f(GridBuilder(&mut self.widgets));
         self.calc_dim();
-        TkAction::RECONFIGURE // just assume this is requried
+        TkAction::RECONFIGURE
     }
 
     /// True if there are no child widgets

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -259,6 +259,18 @@ widget! {
             }
         }
 
+        /// Edit the list of children directly
+        ///
+        /// This may be used to edit children before window construction. It may
+        /// also be used from a running UI, but in this case a full reconfigure
+        /// of the window's widgets is required (triggered by the the return
+        /// value, [`TkAction::RECONFIGURE`]).
+        #[inline]
+        pub fn edit<F: FnOnce(&mut Vec<W>)>(&mut self, f: F) -> TkAction {
+            f(&mut self.widgets);
+            TkAction::RECONFIGURE
+        }
+
         /// Get the direction of contents
         pub fn direction(&self) -> Direction {
             self.direction.as_direction()

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -7,6 +7,7 @@
 
 use kas::dir::{Down, Right};
 use kas::{event, layout, prelude::*};
+use std::collections::HashMap;
 use std::ops::{Index, IndexMut};
 
 /// Support for optionally-indexed messages
@@ -174,9 +175,12 @@ widget! {
     > {
         #[widget_core]
         core: CoreData,
+        layout_store: layout::DynRowStorage,
         widgets: Vec<W>,
-        data: layout::DynRowStorage,
         direction: D,
+        size_solved: bool,
+        next: usize,
+        id_map: HashMap<usize, usize>, // map key of WidgetId to index
         _pd: std::marker::PhantomData<M>,
     }
 
@@ -193,11 +197,42 @@ widget! {
         fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn WidgetConfig> {
             self.widgets.get_mut(index).map(|w| w.as_widget_mut())
         }
+
+        fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
+            id.next_key_after(self.id_ref()).and_then(|k| self.id_map.get(&k).cloned())
+        }
+    }
+
+    impl WidgetConfig for Self {
+        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
+            self.core_data_mut().id = id;
+            self.id_map.clear();
+
+            for index in 0..self.widgets.len() {
+                let id = self.make_next_id(index);
+                self.widgets[index].configure_recurse(mgr, id);
+            }
+
+            self.configure(mgr);
+        }
     }
 
     impl Layout for Self {
         fn layout(&mut self) -> layout::Layout<'_> {
-            make_layout!(self.core; slice(self.direction): self.widgets)
+            if self.size_solved {
+                layout::Layout::slice(&mut self.widgets, self.direction, &mut self.layout_store)
+            } else {
+                // Draw without sizing all elements may cause a panic, so don't.
+                Default::default()
+            }
+        }
+
+        fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            // Assumption: if size_rules is called, then set_rect will be too.
+            self.size_solved = true;
+
+            layout::Layout::slice(&mut self.widgets, self.direction, &mut self.layout_store)
+                .size_rules(size_mgr, axis)
         }
     }
 
@@ -247,14 +282,39 @@ widget! {
     }
 
     impl Self {
+        // Assumption: index is a valid entry of self.widgets
+        fn make_next_id(&mut self, index: usize) -> WidgetId {
+            if let Some(child) = self.widgets.get(index) {
+                // Use the widget's existing identifier, if any
+                if child.id_ref().is_valid() {
+                    if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
+                        self.id_map.insert(key, index);
+                        return child.id();
+                    }
+                }
+            }
+
+            loop {
+                let key = self.next;
+                self.next += 1;
+                if !self.id_map.contains_key(&key) {
+                    self.id_map.insert(key, index);
+                    return self.id_ref().make_child(key);
+                }
+            }
+        }
+
         /// Construct a new instance with explicit direction
         #[inline]
         pub fn new_with_direction(direction: D, widgets: Vec<W>) -> Self {
             GenericList {
                 core: Default::default(),
+                layout_store: Default::default(),
                 widgets,
-                data: Default::default(),
                 direction,
+                size_solved: false,
+                next: 0,
+                id_map: Default::default(),
                 _pd: Default::default(),
             }
         }
@@ -286,129 +346,155 @@ widget! {
             self.widgets.len()
         }
 
-        /// Returns the number of elements the vector can hold without reallocating.
-        pub fn capacity(&self) -> usize {
-            self.widgets.capacity()
-        }
-
-        /// Reserves capacity for at least `additional` more elements to be inserted
-        /// into the list. See documentation of [`Vec::reserve`].
-        pub fn reserve(&mut self, additional: usize) {
-            self.widgets.reserve(additional);
-        }
-
         /// Remove all child widgets
-        ///
-        /// Triggers a [reconfigure action](EventState::send_action) if any widget is
-        /// removed.
-        pub fn clear(&mut self) -> TkAction {
-            let action = match self.widgets.is_empty() {
-                true => TkAction::empty(),
-                false => TkAction::RECONFIGURE,
-            };
+        pub fn clear(&mut self) {
             self.widgets.clear();
-            action
+            self.size_solved = false;
         }
 
         /// Append a child widget
         ///
-        /// Triggers a [reconfigure action](EventState::send_action).
-        pub fn push(&mut self, widget: W) -> TkAction {
+        /// The new child is configured immediately. [`TkAction::RESIZE`] is
+        /// triggered.
+        ///
+        /// Returns the new element's index.
+        pub fn push(&mut self, mgr: &mut SetRectMgr, widget: W) -> usize {
+            let index = self.widgets.len();
             self.widgets.push(widget);
-            TkAction::RECONFIGURE
+            let id = self.make_next_id(index);
+            mgr.configure(id, &mut self.widgets[index]);
+            self.size_solved = false;
+            *mgr |= TkAction::RESIZE;
+            index
         }
 
-        /// Remove the last child widget
+        /// Remove the last child widget (if any) and return
         ///
-        /// Returns `None` if there are no children. Otherwise, this
-        /// triggers a reconfigure before the next draw operation.
-        ///
-        /// Triggers a [reconfigure action](EventState::send_action) if any widget is
-        /// removed.
-        pub fn pop(&mut self) -> (Option<W>, TkAction) {
-            let action = match self.widgets.is_empty() {
-                true => TkAction::empty(),
-                false => TkAction::RECONFIGURE,
-            };
-            (self.widgets.pop(), action)
+        /// Triggers [`TkAction::RESIZE`].
+        pub fn pop(&mut self, mgr: &mut SetRectMgr) -> Option<W> {
+            let result = self.widgets.pop();
+            if let Some(w) = result.as_ref() {
+                *mgr |= TkAction::RESIZE;
+
+                if w.id_ref().is_valid() {
+                    if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
+                        self.id_map.remove(&key);
+                    }
+                }
+            }
+            result
         }
 
         /// Inserts a child widget position `index`
         ///
         /// Panics if `index > len`.
         ///
-        /// Triggers a [reconfigure action](EventState::send_action).
-        pub fn insert(&mut self, index: usize, widget: W) -> TkAction {
+        /// The new child is configured immediately. Triggers [`TkAction::RESIZE`].
+        pub fn insert(&mut self, mgr: &mut SetRectMgr, index: usize, widget: W) {
+            for v in self.id_map.values_mut() {
+                if *v >= index {
+                    *v += 1;
+                }
+            }
             self.widgets.insert(index, widget);
-            TkAction::RECONFIGURE
+            let id = self.make_next_id(index);
+            mgr.configure(id, &mut self.widgets[index]);
+            self.size_solved = false;
+            *mgr |= TkAction::RESIZE;
         }
 
         /// Removes the child widget at position `index`
         ///
         /// Panics if `index` is out of bounds.
         ///
-        /// Triggers a [reconfigure action](EventState::send_action).
-        pub fn remove(&mut self, index: usize) -> (W, TkAction) {
-            let r = self.widgets.remove(index);
-            (r, TkAction::RECONFIGURE)
+        /// Triggers [`TkAction::RESIZE`].
+        pub fn remove(&mut self, mgr: &mut SetRectMgr, index: usize) -> W {
+            let w = self.widgets.remove(index);
+            if w.id_ref().is_valid() {
+                if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
+                    self.id_map.remove(&key);
+                }
+            }
+
+            *mgr |= TkAction::RESIZE;
+
+            for v in self.id_map.values_mut() {
+                if *v > index {
+                    *v -= 1;
+                }
+            }
+            w
         }
 
         /// Replace the child at `index`
         ///
         /// Panics if `index` is out of bounds.
         ///
-        /// Triggers a [reconfigure action](EventState::send_action).
-        // TODO: in theory it is possible to avoid a reconfigure where both widgets
-        // have no children and have compatible size. Is this a good idea and can
-        // we somehow test "has compatible size"?
-        pub fn replace(&mut self, index: usize, mut widget: W) -> (W, TkAction) {
-            std::mem::swap(&mut widget, &mut self.widgets[index]);
-            (widget, TkAction::RECONFIGURE)
+        /// The new child is configured immediately. Triggers [`TkAction::RESIZE`].
+        pub fn replace(&mut self, mgr: &mut SetRectMgr, index: usize, mut w: W) -> W {
+            std::mem::swap(&mut w, &mut self.widgets[index]);
+
+            if w.id_ref().is_valid() {
+                if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
+                    self.id_map.remove(&key);
+                }
+            }
+
+            let id = self.make_next_id(index);
+            mgr.configure(id, &mut self.widgets[index]);
+
+            self.size_solved = false;
+            *mgr |= TkAction::RESIZE;
+
+            w
         }
 
         /// Append child widgets from an iterator
         ///
-        /// Triggers a [reconfigure action](EventState::send_action) if any widgets
-        /// are added.
-        pub fn extend<T: IntoIterator<Item = W>>(&mut self, iter: T) -> TkAction {
-            let len = self.widgets.len();
+        /// New children are configured immediately. Triggers [`TkAction::RESIZE`].
+        pub fn extend<T: IntoIterator<Item = W>>(&mut self, mgr: &mut SetRectMgr, iter: T) {
+            let old_len = self.widgets.len();
             self.widgets.extend(iter);
-            match len == self.widgets.len() {
-                true => TkAction::empty(),
-                false => TkAction::RECONFIGURE,
+            for index in old_len..self.widgets.len() {
+                let id = self.make_next_id(index);
+                mgr.configure(id, &mut self.widgets[index]);
             }
+
+            self.size_solved = false;
+            *mgr |= TkAction::RESIZE;
         }
 
         /// Resize, using the given closure to construct new widgets
         ///
-        /// Triggers a [reconfigure action](EventState::send_action).
-        pub fn resize_with<F: Fn(usize) -> W>(&mut self, len: usize, f: F) -> TkAction {
-            let l0 = self.widgets.len();
-            if l0 == len {
-                return TkAction::empty();
-            } else if l0 > len {
-                self.widgets.truncate(len);
-            } else {
-                self.widgets.reserve(len);
-                for i in l0..len {
-                    self.widgets.push(f(i));
+        /// New children are configured immediately. Triggers [`TkAction::RESIZE`].
+        pub fn resize_with<F: Fn(usize) -> W>(&mut self, mgr: &mut SetRectMgr, len: usize, f: F) {
+            let old_len = self.widgets.len();
+
+            if len < old_len {
+                *mgr |= TkAction::RESIZE;
+                loop {
+                    let w = self.widgets.pop().unwrap();
+                    if w.id_ref().is_valid() {
+                        if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
+                            self.id_map.remove(&key);
+                        }
+                    }
+                    if len == self.widgets.len() {
+                        return;
+                    }
                 }
             }
-            TkAction::RECONFIGURE
-        }
 
-        /// Retain only widgets satisfying predicate `f`
-        ///
-        /// See documentation of [`Vec::retain`].
-        ///
-        /// Triggers a [reconfigure action](EventState::send_action) if any widgets
-        /// are removed.
-        pub fn retain<F: FnMut(&W) -> bool>(&mut self, f: F) -> TkAction {
-            let len = self.widgets.len();
-            self.widgets.retain(f);
-            match len == self.widgets.len() {
-                true => TkAction::empty(),
-                false => TkAction::RECONFIGURE,
+            if len > old_len {
+                self.widgets.reserve(len - old_len);
+                for index in old_len..len {
+                    let id = self.make_next_id(index);
+                    let mut widget = f(index);
+                    mgr.configure(id, &mut widget);
+                    self.widgets.push(widget);
+                }
+                self.size_solved = false;
+                *mgr |= TkAction::RESIZE;
             }
         }
 

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -7,7 +7,7 @@
 
 use kas::dir::{Down, Right};
 use kas::{event, layout, prelude::*};
-use std::collections::HashMap;
+use std::collections::hash_map::{Entry, HashMap};
 use std::ops::{Index, IndexMut};
 
 /// Support for optionally-indexed messages
@@ -297,8 +297,8 @@ widget! {
             loop {
                 let key = self.next;
                 self.next += 1;
-                if !self.id_map.contains_key(&key) {
-                    self.id_map.insert(key, index);
+                if let Entry::Vacant(entry) = self.id_map.entry(key) {
+                    entry.insert(index);
                     return self.id_ref().make_child(key);
                 }
             }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -120,10 +120,15 @@ widget! {
     }
 
     impl WidgetConfig for Self {
-        fn pre_configure(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
+        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
             self.core_data_mut().id = id;
             mgr.add_accel_keys(self.id_ref(), self.label.text().keys());
             mgr.new_accel_layer(self.id(), true);
+
+            let id = self.id_ref().make_child(widget_index![self.list]);
+            self.list.configure_recurse(mgr, id);
+
+            self.configure(mgr);
         }
 
         fn key_nav(&self) -> bool {

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -277,6 +277,20 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         }
     }
 
+    /// Edit the list of children directly
+    ///
+    /// This may be used to edit children before window construction. It may
+    /// also be used from a running UI, but in this case a full reconfigure
+    /// of the window's widgets is required (triggered by the the return
+    /// value, [`TkAction::RECONFIGURE`]).
+    #[inline]
+    pub fn edit<F: FnOnce(&mut Vec<W>)>(&mut self, f: F) -> TkAction {
+        f(&mut self.widgets);
+        let len = self.widgets.len().saturating_sub(1);
+        self.handles.resize_with(len, DragHandle::new);
+        TkAction::RECONFIGURE
+    }
+
     fn adjust_size(&mut self, mgr: &mut SetRectMgr, n: usize) {
         assert!(n < self.handles.len());
         assert_eq!(self.widgets.len(), self.handles.len() + 1);

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -6,7 +6,7 @@
 //! A row or column with sizes adjustable via dividing handles
 
 use log::warn;
-use std::collections::HashMap;
+use std::collections::hash_map::{Entry, HashMap};
 use std::ops::{Index, IndexMut};
 
 use super::DragHandle;
@@ -105,8 +105,8 @@ widget! {
             loop {
                 let key = self.next;
                 self.next += 1;
-                if !self.id_map.contains_key(&key) {
-                    self.id_map.insert(key, child_index);
+                if let Entry::Vacant(entry) = self.id_map.entry(key) {
+                    entry.insert(index);
                     return self.id_ref().make_child(key);
                 }
             }

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -6,7 +6,7 @@
 //! A stack
 
 use kas::{event, prelude::*};
-use std::collections::HashMap;
+use std::collections::hash_map::{Entry, HashMap};
 use std::fmt::Debug;
 use std::ops::{Index, IndexMut, Range};
 
@@ -63,8 +63,8 @@ widget! {
             loop {
                 let key = self.next;
                 self.next += 1;
-                if !self.id_map.contains_key(&key) {
-                    self.id_map.insert(key, index);
+                if let Entry::Vacant(entry) = self.id_map.entry(key) {
+                    entry.insert(index);
                     return self.id_ref().make_child(key);
                 }
             }

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -5,10 +5,10 @@
 
 //! A stack
 
-use std::fmt::Debug;
-use std::ops::{Index, IndexMut};
-
 use kas::{event, prelude::*};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::ops::{Index, IndexMut, Range};
 
 /// A stack of boxed widgets
 ///
@@ -23,21 +23,52 @@ pub type RefStack<'a, M> = Stack<&'a mut dyn Widget<Msg = M>>;
 widget! {
     /// A stack of widgets
     ///
-    /// A stack consists a set of child widgets, all of equal size.
-    /// Only a single member is visible at a time.
+    /// A stack consists a set of child widgets, "pages", all of equal size.
+    /// Only a single page is visible at a time. The page is "turned" by calling
+    /// [`Self::set_active`].
     ///
-    /// This may only be parametrised with a single widget type; [`BoxStack`] is
-    /// a parametrisation allowing run-time polymorphism of child widgets.
+    /// This may only be parametrised with a single widget type, thus usually
+    /// it will be necessary to box children (this is what [`BoxStack`] is).
     ///
-    /// Configuring and resizing elements is O(n) in the number of children.
-    /// Drawing and event handling is O(1).
+    /// Configuring is `O(n)` in the number of pages `n`. Resizing may be `O(n)`
+    /// or may be limited: see [`Self::set_size_limit`]. Drawing is `O(1)`, and
+    /// so is event handling in the expected case.
     #[derive(Clone, Default, Debug)]
     #[handler(msg=<W as event::Handler>::Msg)]
     pub struct Stack<W: Widget> {
         #[widget_core]
         core: CoreData,
+        align_hints: AlignHints,
         widgets: Vec<W>,
+        sized_range: Range<usize>,
         active: usize,
+        size_limit: usize,
+        next: usize,
+        id_map: HashMap<usize, usize>, // map key of WidgetId to index
+    }
+
+    impl Self {
+        // Assumption: index is a valid entry of self.widgets
+        fn make_next_id(&mut self, index: usize) -> WidgetId {
+            if let Some(child) = self.widgets.get(index) {
+                // Use the widget's existing identifier, if any
+                if child.id_ref().is_valid() {
+                    if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
+                        self.id_map.insert(key, index);
+                        return child.id();
+                    }
+                }
+            }
+
+            loop {
+                let key = self.next;
+                self.next += 1;
+                if !self.id_map.contains_key(&key) {
+                    self.id_map.insert(key, index);
+                    return self.id_ref().make_child(key);
+                }
+            }
+        }
     }
 
     impl WidgetChildren for Self {
@@ -53,33 +84,57 @@ widget! {
         fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn WidgetConfig> {
             self.widgets.get_mut(index).map(|w| w.as_widget_mut())
         }
+
+        fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
+            id.next_key_after(self.id_ref()).and_then(|k| self.id_map.get(&k).cloned())
+        }
+    }
+
+    impl WidgetConfig for Self {
+        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
+            self.core_data_mut().id = id;
+            self.id_map.clear();
+
+            for index in 0..self.widgets.len() {
+                let id = self.make_next_id(index);
+                self.widgets[index].configure_recurse(mgr, id);
+            }
+
+            self.configure(mgr);
+        }
     }
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
             let mut rules = SizeRules::EMPTY;
-            for child in &mut self.widgets {
-                rules = rules.max(child.size_rules(size_mgr.re(), axis));
+            let end = self.active.saturating_add(self.size_limit).min(self.widgets.len());
+            let start = end.saturating_sub(self.size_limit);
+            self.sized_range = start..end;
+            debug_assert!(self.sized_range.contains(&self.active));
+            for index in start..end {
+                rules = rules.max(self.widgets[index].size_rules(size_mgr.re(), axis));
             }
             rules
         }
 
         fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
-            for child in &mut self.widgets {
+            self.align_hints = align;
+            if let Some(child) = self.widgets.get_mut(self.active) {
                 child.set_rect(mgr, rect, align);
             }
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
-            if self.active < self.widgets.len() {
+            // Latter condition is implied, but compiler doesn't know this:
+            if self.sized_range.contains(&self.active) && self.active < self.widgets.len() {
                 return self.widgets[self.active].find_id(coord);
             }
             None
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
-            if self.active < self.widgets.len() {
+            if self.sized_range.contains(&self.active) && self.active < self.widgets.len() {
                 self.widgets[self.active].draw(draw.re());
             }
         }
@@ -91,7 +146,7 @@ widget! {
                 if let Some(child) = self.widgets.get_mut(index) {
                     return match child.send(mgr, id, event) {
                         Response::Focus(rect) => {
-                            *mgr |= self.set_active(index);
+                            mgr.set_rect_mgr(|mgr| self.set_active(mgr, index));
                             Response::Focus(rect)
                         }
                         r => r,
@@ -122,18 +177,23 @@ impl<W: Widget> Stack<W> {
     /// Construct a new instance
     ///
     /// If `active < widgets.len()`, then `widgets[active]` will initially be
-    /// visible; otherwise, no widget will be visible.
+    /// shown; otherwise, no page will be visible or receive press events.
     pub fn new(widgets: Vec<W>, active: usize) -> Self {
         Stack {
             core: Default::default(),
+            align_hints: Default::default(),
             widgets,
+            sized_range: 0..0,
             active,
+            size_limit: usize::MAX,
+            next: 0,
+            id_map: Default::default(),
         }
     }
 
     /// Edit the list of children directly
     ///
-    /// This may be used to edit children before window construction. It may
+    /// This may be used to edit pages before window construction. It may
     /// also be used from a running UI, but in this case a full reconfigure
     /// of the window's widgets is required (triggered by the the return
     /// value, [`TkAction::RECONFIGURE`]).
@@ -143,26 +203,57 @@ impl<W: Widget> Stack<W> {
         TkAction::RECONFIGURE
     }
 
+    /// Limit the number of pages considered by [`Layout::size_rules`]
+    ///
+    /// By default, this is `usize::MAX`: all pages affect the result. If
+    /// this is set to 1 then only the active page will affect the result. If
+    /// this is `n > 1`, then `min(n, num_pages)` pages (including active)
+    /// will be used. (If this is set to 0 it is silently replaced with 1.)
+    ///
+    /// Using a limit lower than the number of pages has two effects:
+    /// (1) resizing is faster and (2) calling [`Self::set_active`] may cause a
+    /// full-window resize.
+    pub fn set_size_limit(&mut self, limit: usize) {
+        self.size_limit = limit.max(1);
+    }
+
     /// Get the index of the active widget
     pub fn active_index(&self) -> usize {
         self.active
     }
 
-    /// Change the active widget via index
+    /// Set the active page
     ///
-    /// It is not required that `active < self.len()`; if not, no widget will be
-    /// drawn or respond to events, but the stack will still size as required by
-    /// child widgets.
-    pub fn set_active(&mut self, active: usize) -> TkAction {
-        if self.active == active {
-            TkAction::empty()
+    /// Behaviour depends on whether [`SizeRules`] were already solved for
+    /// `index` (see [`Self::set_size_limit`] and note that methods like
+    /// [`Self::push`] do not solve rules for new pages). Case:
+    ///
+    /// -   `index >= num_pages`: no page displayed
+    /// -   `index == active` and `SizeRules` were solved: nothing happens
+    /// -   `SizeRules` were solved: set layout ([`Layout::set_rect`]) and
+    ///     update mouse-cursor target ([`TkAction::REGION_MOVED`])
+    /// -   Otherwise: resize the whole window ([`TkAction::RESIZE`])
+    pub fn set_active(&mut self, mgr: &mut SetRectMgr, index: usize) {
+        let old_index = self.active;
+        self.active = index;
+        if index >= self.widgets.len() {
+            if old_index < self.widgets.len() {
+                *mgr |= TkAction::REGION_MOVED;
+            }
+            return;
+        }
+
+        if self.sized_range.contains(&index) {
+            if old_index != index {
+                self.widgets[index].set_rect(mgr, self.core.rect, self.align_hints);
+                *mgr |= TkAction::REGION_MOVED;
+            }
         } else {
-            self.active = active;
-            TkAction::REGION_MOVED
+            *mgr |= TkAction::RESIZE;
         }
     }
 
-    /// Get a direct reference to the active widget, if any
+    /// Get a direct reference to the active child widget, if any
     pub fn active(&self) -> Option<&W> {
         if self.active < self.widgets.len() {
             Some(&self.widgets[self.active])
@@ -171,148 +262,209 @@ impl<W: Widget> Stack<W> {
         }
     }
 
-    /// Get a direct mutable reference to the active widget, if any
-    pub fn active_mut(&mut self) -> Option<&mut W> {
-        if self.active < self.widgets.len() {
-            Some(&mut self.widgets[self.active])
-        } else {
-            None
-        }
-    }
-
-    /// True if there are no child widgets
+    /// True if there are no pages
     pub fn is_empty(&self) -> bool {
         self.widgets.is_empty()
     }
 
-    /// Returns the number of child widgets
+    /// Returns the number of pages
     pub fn len(&self) -> usize {
         self.widgets.len()
     }
 
-    /// Returns the number of elements the vector can hold without reallocating.
-    pub fn capacity(&self) -> usize {
-        self.widgets.capacity()
-    }
-
-    /// Reserves capacity for at least `additional` more elements to be inserted
-    /// into the list. See documentation of [`Vec::reserve`].
-    pub fn reserve(&mut self, additional: usize) {
-        self.widgets.reserve(additional);
-    }
-
-    /// Remove all child widgets
+    /// Remove all pages
     ///
-    /// Triggers a [reconfigure action](EventState::send_action) if any widget is
-    /// removed.
-    pub fn clear(&mut self) -> TkAction {
-        let action = match self.widgets.is_empty() {
-            true => TkAction::empty(),
-            false => TkAction::RECONFIGURE,
-        };
+    /// This does not change the active page index.
+    pub fn clear(&mut self) {
         self.widgets.clear();
-        action
+        self.sized_range = 0..0;
     }
 
-    /// Append a child widget
+    /// Append a page
     ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    pub fn push(&mut self, widget: W) -> TkAction {
+    /// The new page is configured immediately. If it becomes the active page
+    /// and then [`TkAction::RESIZE`] will be triggered.
+    ///
+    /// Returns the new page's index.
+    pub fn push(&mut self, mgr: &mut SetRectMgr, widget: W) -> usize {
+        let index = self.widgets.len();
         self.widgets.push(widget);
-        TkAction::RECONFIGURE
+        let id = self.make_next_id(index);
+        mgr.configure(id, &mut self.widgets[index]);
+        if index == self.active {
+            *mgr |= TkAction::RESIZE;
+        }
+        self.sized_range.end = self.sized_range.end.min(index);
+        index
     }
 
-    /// Remove the last child widget
+    /// Remove the last child widget (if any) and return
     ///
-    /// Returns `None` if there are no children. Otherwise, this
-    /// triggers a reconfigure before the next draw operation.
-    ///
-    /// Triggers a [reconfigure action](EventState::send_action) if any widget is
-    /// removed.
-    pub fn pop(&mut self) -> (Option<W>, TkAction) {
-        let action = match self.widgets.is_empty() {
-            true => TkAction::empty(),
-            false => TkAction::RECONFIGURE,
-        };
-        (self.widgets.pop(), action)
+    /// If this page was active then the previous page becomes active.
+    pub fn pop(&mut self, mgr: &mut SetRectMgr) -> Option<W> {
+        let result = self.widgets.pop();
+        if let Some(w) = result.as_ref() {
+            if self.active > 0 && self.active == self.widgets.len() {
+                self.active -= 1;
+                if self.sized_range.contains(&self.active) {
+                    self.widgets[self.active].set_rect(mgr, self.core.rect, self.align_hints);
+                } else {
+                    *mgr |= TkAction::RESIZE;
+                }
+            }
+
+            if w.id_ref().is_valid() {
+                if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
+                    self.id_map.remove(&key);
+                }
+            }
+        }
+        result
     }
 
     /// Inserts a child widget position `index`
     ///
     /// Panics if `index > len`.
     ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    pub fn insert(&mut self, index: usize, widget: W) -> TkAction {
+    /// The new child is configured immediately. The active page does not
+    /// change.
+    pub fn insert(&mut self, mgr: &mut SetRectMgr, index: usize, widget: W) {
+        if self.active < index {
+            self.sized_range.end = self.sized_range.end.min(index);
+        } else {
+            self.sized_range.start = (self.sized_range.start + 1).max(index + 1);
+            self.sized_range.end += 1;
+            self.active = self.active.saturating_add(1);
+        }
+        for v in self.id_map.values_mut() {
+            if *v >= index {
+                *v += 1;
+            }
+        }
         self.widgets.insert(index, widget);
-        TkAction::RECONFIGURE
+        let id = self.make_next_id(index);
+        mgr.configure(id, &mut self.widgets[index]);
     }
 
     /// Removes the child widget at position `index`
     ///
     /// Panics if `index` is out of bounds.
     ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    pub fn remove(&mut self, index: usize) -> (W, TkAction) {
-        let r = self.widgets.remove(index);
-        (r, TkAction::RECONFIGURE)
+    /// If the active page is removed then the previous page (if any) becomes
+    /// active.
+    pub fn remove(&mut self, mgr: &mut SetRectMgr, index: usize) -> W {
+        let w = self.widgets.remove(index);
+        if w.id_ref().is_valid() {
+            if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
+                self.id_map.remove(&key);
+            }
+        }
+
+        if self.active == index {
+            self.active = self.active.saturating_sub(1);
+            if self.sized_range.contains(&self.active) {
+                self.widgets[self.active].set_rect(mgr, self.core.rect, self.align_hints);
+            } else {
+                *mgr |= TkAction::RESIZE;
+            }
+        }
+        if index < self.sized_range.end {
+            self.sized_range.end -= 1;
+            if index < self.sized_range.start {
+                self.sized_range.start -= 1;
+            }
+        }
+
+        for v in self.id_map.values_mut() {
+            if *v > index {
+                *v -= 1;
+            }
+        }
+        w
     }
 
     /// Replace the child at `index`
     ///
     /// Panics if `index` is out of bounds.
     ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    // TODO: in theory it is possible to avoid a reconfigure where both widgets
-    // have no children and have compatible size. Is this a good idea and can
-    // we somehow test "has compatible size"?
-    pub fn replace(&mut self, index: usize, mut widget: W) -> (W, TkAction) {
-        std::mem::swap(&mut widget, &mut self.widgets[index]);
-        (widget, TkAction::RECONFIGURE)
+    /// The new child is configured immediately. If it replaces the active page,
+    /// then [`TkAction::RESIZE`] is triggered.
+    pub fn replace(&mut self, mgr: &mut SetRectMgr, index: usize, mut w: W) -> W {
+        std::mem::swap(&mut w, &mut self.widgets[index]);
+
+        if w.id_ref().is_valid() {
+            if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
+                self.id_map.remove(&key);
+            }
+        }
+
+        let id = self.make_next_id(index);
+        mgr.configure(id, &mut self.widgets[index]);
+
+        if self.active < index {
+            self.sized_range.end = self.sized_range.end.min(index);
+        } else {
+            self.sized_range.start = (self.sized_range.start + 1).max(index + 1);
+            self.sized_range.end += 1;
+            if index == self.active {
+                *mgr |= TkAction::RESIZE;
+            }
+        }
+
+        w
     }
 
     /// Append child widgets from an iterator
     ///
-    /// Triggers a [reconfigure action](EventState::send_action) if any widgets
-    /// are added.
-    pub fn extend<T: IntoIterator<Item = W>>(&mut self, iter: T) -> TkAction {
-        let len = self.widgets.len();
+    /// New children are configured immediately. If a new page becomes active,
+    /// then [`TkAction::RESIZE`] is triggered.
+    pub fn extend<T: IntoIterator<Item = W>>(&mut self, mgr: &mut SetRectMgr, iter: T) {
+        let old_len = self.widgets.len();
         self.widgets.extend(iter);
-        match len == self.widgets.len() {
-            true => TkAction::empty(),
-            false => TkAction::RECONFIGURE,
+        for index in old_len..self.widgets.len() {
+            let id = self.make_next_id(index);
+            mgr.configure(id, &mut self.widgets[index]);
+        }
+
+        if (old_len..self.widgets.len()).contains(&self.active) {
+            *mgr |= TkAction::RESIZE;
         }
     }
 
     /// Resize, using the given closure to construct new widgets
     ///
-    /// Triggers a [reconfigure action](EventState::send_action).
-    pub fn resize_with<F: Fn(usize) -> W>(&mut self, len: usize, f: F) -> TkAction {
-        let l0 = self.widgets.len();
-        if l0 == len {
-            return TkAction::empty();
-        } else if l0 > len {
-            self.widgets.truncate(len);
-        } else {
-            self.widgets.reserve(len);
-            for i in l0..len {
-                self.widgets.push(f(i));
+    /// New children are configured immediately. If a new page becomes active,
+    /// then [`TkAction::RESIZE`] is triggered.
+    pub fn resize_with<F: Fn(usize) -> W>(&mut self, mgr: &mut SetRectMgr, len: usize, f: F) {
+        let old_len = self.widgets.len();
+
+        if len < old_len {
+            self.sized_range.end = self.sized_range.end.min(len);
+            loop {
+                let w = self.widgets.pop().unwrap();
+                if w.id_ref().is_valid() {
+                    if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
+                        self.id_map.remove(&key);
+                    }
+                }
+                if len == self.widgets.len() {
+                    return;
+                }
             }
         }
-        TkAction::RECONFIGURE
-    }
 
-    /// Retain only widgets satisfying predicate `f`
-    ///
-    /// See documentation of [`Vec::retain`].
-    ///
-    /// Triggers a [reconfigure action](EventState::send_action) if any widgets
-    /// are removed.
-    pub fn retain<F: FnMut(&W) -> bool>(&mut self, f: F) -> TkAction {
-        let len = self.widgets.len();
-        self.widgets.retain(f);
-        match len == self.widgets.len() {
-            true => TkAction::empty(),
-            false => TkAction::RECONFIGURE,
+        if len > old_len {
+            self.widgets.reserve(len - old_len);
+            for index in old_len..len {
+                let id = self.make_next_id(index);
+                let mut widget = f(index);
+                mgr.configure(id, &mut widget);
+                self.widgets.push(widget);
+            }
+
+            if (old_len..len).contains(&self.active) {
+                *mgr |= TkAction::RESIZE;
+            }
         }
     }
 }

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -131,6 +131,18 @@ impl<W: Widget> Stack<W> {
         }
     }
 
+    /// Edit the list of children directly
+    ///
+    /// This may be used to edit children before window construction. It may
+    /// also be used from a running UI, but in this case a full reconfigure
+    /// of the window's widgets is required (triggered by the the return
+    /// value, [`TkAction::RECONFIGURE`]).
+    #[inline]
+    pub fn edit<F: FnOnce(&mut Vec<W>)>(&mut self, f: F) -> TkAction {
+        f(&mut self.widgets);
+        TkAction::RECONFIGURE
+    }
+
     /// Get the index of the active widget
     pub fn active_index(&self) -> usize {
         self.active

--- a/crates/kas-widgets/src/view/driver.rs
+++ b/crates/kas-widgets/src/view/driver.rs
@@ -41,6 +41,10 @@ pub trait Driver<T>: Debug + 'static {
     /// The controller may later call [`Driver::set`] on the widget then show it.
     fn make(&self) -> Self::Widget;
     /// Set the viewed data
+    ///
+    /// The widget may expect `configure` to be called at least once before data
+    /// is set and to have `size_rules` and `set_rect` called after each time
+    /// data is set.
     fn set(&self, widget: &mut Self::Widget, data: T) -> TkAction;
     /// Get data from the view
     ///

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -431,7 +431,7 @@ widget! {
             if self.widgets.len() == 0 && !self.data.is_empty() {
                 let items = self.data.iter_vec(self.ideal_visible.cast());
                 let len = items.len();
-                debug!("allocating {len} widgets");
+                debug!("allocating {} widgets", len);
                 self.widgets.reserve(len);
                 for key in items.into_iter() {
                     let id = self.data.make_id(self.id_ref(), &key);

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -396,11 +396,6 @@ widget! {
         fn num_children(&self) -> usize {
             self.widgets.len()
         }
-        fn make_child_id(&self, index: usize) -> Option<WidgetId> {
-            self.widgets.get(index)
-                .and_then(|w| w.key.as_ref())
-                .map(|key| self.data.make_id(self.id_ref(), key))
-        }
         #[inline]
         fn get_child(&self, index: usize) -> Option<&dyn WidgetConfig> {
             self.widgets.get(index).map(|w| w.widget.as_widget())
@@ -426,6 +421,33 @@ widget! {
     }
 
     impl WidgetConfig for Self {
+        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
+            self.core_data_mut().id = id;
+
+            // If data is available but not loaded yet, make some widgets for
+            // use by size_rules (this allows better sizing). Configure the new
+            // widgets (this allows resource loading which may affect size.)
+            self.data_ver = self.data.version();
+            if self.widgets.len() == 0 && !self.data.is_empty() {
+                let items = self.data.iter_vec(self.ideal_visible.cast());
+                let len = items.len();
+                debug!("allocating {len} widgets");
+                self.widgets.reserve(len);
+                for key in items.into_iter() {
+                    let id = self.data.make_id(self.id_ref(), &key);
+                    let mut widget = self.view.make();
+                    mgr.configure(id, &mut widget);
+                    if let Some(item) = self.data.get_cloned(&key) {
+                        *mgr |= self.view.set(&mut widget, item);
+                    }
+                    let key = Some(key);
+                    self.widgets.push(WidgetData { key, widget });
+                }
+            }
+
+            self.configure(mgr);
+        }
+
         fn configure(&mut self, mgr: &mut SetRectMgr) {
             for handle in self.data.update_handles().into_iter() {
                 mgr.update_on_handle(handle, self.id());
@@ -446,24 +468,6 @@ widget! {
                 self.child_size_min = rules.min_size();
             }
 
-            // If data is already available, create some widgets and ensure
-            // that the ideal size meets all expectations of these children.
-            self.data_ver = self.data.version();
-            if self.widgets.len() == 0 && self.data.len() > 0 {
-                let items = self.data.iter_vec(self.ideal_visible.cast());
-                debug!("allocating widgets (reserve = {})", items.len());
-                self.widgets.reserve(items.len());
-                for key in items.into_iter() {
-                    if let Some(item) = self.data.get_cloned(&key) {
-                        let mut widget = self.view.make();
-                        // Note: we cannot call configure here, but it needs
-                        // to happen! Therefore we set key=None and do not
-                        // care about order of data within self.widgets.
-                        let _ = self.view.set(&mut widget, item);
-                        self.widgets.push(WidgetData { key: None, widget });
-                    }
-                }
-            }
             if self.widgets.len() > 0 {
                 let other = axis.other().map(|mut size| {
                     // Use same logic as in set_rect to find per-child size:

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -405,7 +405,7 @@ widget! {
                 let cols = self.data.col_iter_vec(self.ideal_len.cols.cast());
                 let rows = self.data.row_iter_vec(self.ideal_len.rows.cast());
                 let len = cols.len() * rows.len();
-                debug!("allocating {len} widgets");
+                debug!("allocating {} widgets", len);
                 self.widgets.reserve(len);
                 for row in rows.iter(){
                     for col in cols.iter() {

--- a/crates/kas-widgets/src/view/single_view.rs
+++ b/crates/kas-widgets/src/view/single_view.rs
@@ -58,9 +58,8 @@ widget! {
     impl Self {
         /// Construct a new instance with explicit view
         pub fn new_with_driver(view: V, data: T) -> Self {
-            let mut child = view.make();
+            let child = view.make();
             let data_ver = data.version();
-            let _ = view.set(&mut child, data.get_cloned());
             SingleView {
                 core: Default::default(),
                 view,
@@ -110,6 +109,9 @@ widget! {
             for handle in self.data.update_handles().into_iter() {
                 mgr.update_on_handle(handle, self.id());
             }
+
+            // We set data now, after child is configured
+            *mgr |= self.view.set(&mut self.child, self.data.get_cloned());
         }
     }
 

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -162,7 +162,10 @@ fn main() -> kas::shell::Result<()> {
                         Control::Set(len) => {
                             let active = self.active;
                             let old_len = self.list.len();
-                            *mgr |= self.list.inner_mut().resize_with(len, |n| ListEntry::new(n, n == active));
+                            mgr.set_rect_mgr(|mgr| {
+                                self.list.inner_mut()
+                                    .resize_with(mgr, len, |n| ListEntry::new(n, n == active))
+                            });
                             if active >= old_len && active < len {
                                 let _ = self.set_radio(mgr, (active, EntryMsg::Select));
                             }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -256,7 +256,7 @@ fn main() -> kas::shell::Result<()> {
                 .with_state(true)
                 .on_select(|_| Some(Item::Radio(2))),
             #[widget] cbbl = Label::new("ComboBox"),
-            #[widget] cbb = ComboBox::new(&["&One", "T&wo", "Th&ree"], 0)
+            #[widget] cbb = ComboBox::new_from_iter(&["&One", "T&wo", "Th&ree"], 0)
                 .on_select(|_, index| Some(Item::Combo((index + 1).cast()))),
             #[widget] sdl = Label::new("Slider"),
             #[widget(map_msg = handle_slider)] sd =

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -28,10 +28,8 @@ fn main() -> kas::shell::Result<()> {
             #[widget] _ = TextButton::new_msg("+", Message::Incr),
         }
     };
-    let mut panes = RowSplitter::<EditField>::default();
-    let _ = panes.resize_with(2, |n| {
-        EditField::new(format!("Pane {}", n + 1)).multi_line(true)
-    });
+    let panes = (0..2).map(|n| EditField::new(format!("Pane {}", n + 1)).multi_line(true));
+    let panes = RowSplitter::<EditField>::new(panes.collect());
 
     let window = Window::new(
         "Slitter panes",
@@ -49,11 +47,14 @@ fn main() -> kas::shell::Result<()> {
                 fn handle_button(&mut self, mgr: &mut EventMgr, msg: Message) {
                     match msg {
                         Message::Decr => {
-                            *mgr |= self.panes.pop().1;
+                            mgr.set_rect_mgr(|mgr| self.panes.pop(mgr));
                         }
                         Message::Incr => {
                             let n = self.panes.len() + 1;
-                            *mgr |= self.panes.push(EditField::new(format!("Pane {}", n)).multi_line(true));
+                            mgr.set_rect_mgr(|mgr| self.panes.push(
+                                mgr,
+                                EditField::new(format!("Pane {}", n)).multi_line(true)
+                            ));
                         }
                     };
                 }


### PR DESCRIPTION
`List`, `Stack`, `ComboBox` and `Splitter` widgets now locally reconfigure new children without changing the `WidgetId` of other children (they use a `HashMap` for `WidgetId` → `child_index` lookup).

The result (using `example/data-list.rs` and a hand-controlled stopwatch):

| | before | after |
|- | -| -|
| from 0 to 100,000 | 17.6s | 17.8s |
| from 100,000 to 100,001 | 13.8s | 0.6s |

Full-window resize is still required after adjusting the number of widgets, but apparently this is clearly much faster than configuring widgets (a little surprising since configuring is mostly just assigning a `WidgetId`).

TODO: `ComboBox` doesn't need to resize the window if the menu is closed, and only needs to resize the menu if open, but it inherits the full-window resize from `List`. (Low impact optimisation so I'll leave it.)