### PR TITLE
New Component trait; make Layout::size_rules optional; better layout for menus

### DIFF
--- a/crates/kas-core/src/component.rs
+++ b/crates/kas-core/src/component.rs
@@ -14,7 +14,7 @@ use kas_macros::{autoimpl, impl_scope};
 
 /// Components are not true widgets, but support layout solving
 ///
-/// TODO: since this is a sub-set of widget functionality, should [`Widget`]
+/// TODO: since this is a sub-set of widget functionality, should [`crate::Widget`]
 /// extend `Component`? (Significant trait revision would be required.)
 pub trait Component {
     /// Get size rules for the given axis
@@ -26,7 +26,7 @@ pub trait Component {
     /// True if the layout direction is up/left (reverse reading direction)
     ///
     /// TODO: replace with spatial_nav?
-    fn is_reversed(&mut self) -> bool {
+    fn is_reversed(&self) -> bool {
         false
     }
 

--- a/crates/kas-core/src/component.rs
+++ b/crates/kas-core/src/component.rs
@@ -1,0 +1,142 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Widget components
+
+use crate::geom::{Coord, Rect, Size};
+use crate::layout::{Align, AlignHints, AxisInfo, SetRectMgr, SizeRules};
+use crate::text::{format, AccelString, Text, TextApi};
+use crate::theme::{DrawMgr, IdCoord, SizeMgr, TextClass};
+use crate::{TkAction, WidgetId};
+use kas_macros::{autoimpl, impl_scope};
+
+/// Components are not true widgets, but support layout solving
+///
+/// TODO: since this is a sub-set of widget functionality, should [`Widget`]
+/// extend `Component`? (Significant trait revision would be required.)
+pub trait Component {
+    /// Get size rules for the given axis
+    fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules;
+
+    /// Apply a given `rect` to self
+    fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints);
+
+    /// True if the layout direction is up/left (reverse reading direction)
+    ///
+    /// TODO: replace with spatial_nav?
+    fn is_reversed(&mut self) -> bool {
+        false
+    }
+
+    /// Translate a coordinate to a [`WidgetId`]
+    fn find_id(&mut self, coord: Coord) -> Option<WidgetId>;
+
+    /// Draw the component and its children
+    fn draw(&mut self, draw: DrawMgr, id: &WidgetId);
+}
+
+impl_scope! {
+    /// A label component
+    #[impl_default(where T: trait)]
+    #[autoimpl(Clone, Debug where T: trait)]
+    pub struct Label<T: format::FormattableText> {
+        text: Text<T>,
+        class: TextClass = TextClass::Label(false),
+        pos: Coord,
+    }
+
+    impl Self {
+        /// Construct
+        #[inline]
+        pub fn new(label: T, class: TextClass) -> Self {
+            Label {
+                text: Text::new_single(label),
+                class,
+                pos: Default::default(),
+            }
+        }
+
+        /// Get text
+        pub fn as_str(&self) -> &str {
+            self.text.as_str()
+        }
+
+        /// Set the text and prepare
+        ///
+        /// Update text and trigger a resize if necessary.
+        ///
+        /// The `avail` parameter is used to determine when a resize is required. If
+        /// this parameter is a little bit wrong then resizes may sometimes happen
+        /// unnecessarily or may not happen when text is slightly too big (e.g.
+        /// spills into the margin area); this behaviour is probably acceptable.
+        /// Passing `Size::ZERO` will always resize (unless text is empty).
+        /// Passing `Size::MAX` should never resize.
+        pub fn set_text_and_prepare(&mut self, s: T, avail: Size) -> TkAction {
+            self.text.set_text(s);
+            crate::text::util::prepare_if_needed(&mut self.text, avail)
+        }
+
+        /// Set the text from a string and prepare
+        ///
+        /// Update text and trigger a resize if necessary.
+        ///
+        /// The `avail` parameter is used to determine when a resize is required. If
+        /// this parameter is a little bit wrong then resizes may sometimes happen
+        /// unnecessarily or may not happen when text is slightly too big (e.g.
+        /// spills into the margin area); this behaviour is probably acceptable.
+        pub fn set_string_and_prepare(&mut self, s: String, avail: Size) -> TkAction
+        where
+            T: format::EditableText,
+        {
+            use crate::text::EditableTextApi;
+            self.text.set_string(s);
+            crate::text::util::prepare_if_needed(&mut self.text, avail)
+        }
+
+        /// Get class
+        pub fn class(&self) -> TextClass {
+            self.class
+        }
+
+        /// Set class
+        ///
+        /// This may influence layout.
+        pub fn set_class(&mut self, class: TextClass) -> TkAction {
+            self.class = class;
+            TkAction::RESIZE
+        }
+    }
+
+    impl Label<AccelString> {
+        /// Get the accelerator keys
+        pub fn keys(&self) -> &[crate::event::VirtualKeyCode] {
+            self.text.text().keys()
+        }
+    }
+
+    impl Component for Self {
+        fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            mgr.text_bound(&mut self.text, self.class, axis)
+        }
+
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+            self.pos = rect.pos;
+            let halign = match self.class {
+                TextClass::Button => Align::Center,
+                _ => Align::Default,
+            };
+            let align = align.unwrap_or(halign, Align::Center);
+            mgr.text_set_size(&mut self.text, self.class, rect.size, align);
+        }
+
+        fn find_id(&mut self, _: Coord) -> Option<WidgetId> {
+            None
+        }
+
+        fn draw(&mut self, mut draw: DrawMgr, id: &WidgetId) {
+            draw.text_effects(IdCoord(id, self.pos), &self.text, self.class);
+        }
+    }
+}

--- a/crates/kas-core/src/component.rs
+++ b/crates/kas-core/src/component.rs
@@ -145,8 +145,8 @@ impl_scope! {
     /// A mark
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub struct Mark {
-        style: MarkStyle,
-        rect: Rect,
+        pub style: MarkStyle,
+        pub rect: Rect,
     }
     impl Self {
         /// Construct

--- a/crates/kas-core/src/component.rs
+++ b/crates/kas-core/src/component.rs
@@ -8,7 +8,7 @@
 use crate::geom::{Coord, Rect, Size};
 use crate::layout::{Align, AlignHints, AxisInfo, SetRectMgr, SizeRules};
 use crate::text::{format, AccelString, Text, TextApi};
-use crate::theme::{DrawMgr, IdCoord, SizeMgr, TextClass};
+use crate::theme::{DrawMgr, IdCoord, IdRect, MarkStyle, SizeMgr, TextClass};
 use crate::{TkAction, WidgetId};
 use kas_macros::{autoimpl, impl_scope};
 
@@ -137,6 +137,39 @@ impl_scope! {
 
         fn draw(&mut self, mut draw: DrawMgr, id: &WidgetId) {
             draw.text_effects(IdCoord(id, self.pos), &self.text, self.class);
+        }
+    }
+}
+
+impl_scope! {
+    /// A mark
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct Mark {
+        style: MarkStyle,
+        rect: Rect,
+    }
+    impl Self {
+        /// Construct
+        pub fn new(style: MarkStyle) -> Self {
+            let rect = Rect::ZERO;
+            Mark { style, rect }
+        }
+    }
+    impl Component for Self {
+        fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            mgr.mark(self.style, axis)
+        }
+
+        fn set_rect(&mut self, _: &mut SetRectMgr, rect: Rect, _: AlignHints) {
+            self.rect = rect;
+        }
+
+        fn find_id(&mut self, _: Coord) -> Option<WidgetId> {
+            None
+        }
+
+        fn draw(&mut self, mut draw: DrawMgr, id: &WidgetId) {
+            draw.mark(IdRect(id, self.rect), self.style);
         }
     }
 }

--- a/crates/kas-core/src/layout/grid_solver.rs
+++ b/crates/kas-core/src/layout/grid_solver.rs
@@ -12,8 +12,9 @@ use super::{GridStorage, RowTemp, RulesSetter, RulesSolver};
 use crate::cast::{Cast, Conv};
 use crate::geom::{Coord, Offset, Rect, Size};
 
+/// Bound on [`GridSolver`] type parameters
 pub trait DefaultWithLen {
-    // Construct with default elements of given length; panic on failure
+    /// Construct with default elements of given length; panic on failure
     fn default_with_len(len: usize) -> Self;
 }
 impl<T: Copy + Default, const N: usize> DefaultWithLen for [T; N] {

--- a/crates/kas-core/src/layout/grid_solver.rs
+++ b/crates/kas-core/src/layout/grid_solver.rs
@@ -105,11 +105,11 @@ impl<CSR: DefaultWithLen, RSR: DefaultWithLen, S: GridStorage> GridSolver<CSR, R
     fn prepare(&mut self, storage: &mut S) {
         if self.axis.has_fixed {
             if self.axis.is_vertical() {
-                let (widths, rules, total) = storage.widths_rules_total();
-                SizeRules::solve_seq_total(widths, rules, total, self.axis.other_axis);
+                let (widths, rules) = storage.widths_and_rules();
+                SizeRules::solve_seq(widths, rules, self.axis.other_axis);
             } else {
-                let (heights, rules, total) = storage.heights_rules_total();
-                SizeRules::solve_seq_total(heights, rules, total, self.axis.other_axis);
+                let (heights, rules) = storage.heights_and_rules();
+                SizeRules::solve_seq(heights, rules, self.axis.other_axis);
             }
         }
 
@@ -243,18 +243,14 @@ where
                 rules.distribute_span_over(&mut widths[begin..end]);
             }
 
-            widths.iter().sum()
+            SizeRules::sum(widths)
         }
 
-        let rules;
         if self.axis.is_horizontal() {
-            rules = calculate(storage.width_rules(), self.col_spans.as_mut());
-            storage.set_width_total(rules);
+            calculate(storage.width_rules(), self.col_spans.as_mut())
         } else {
-            rules = calculate(storage.height_rules(), self.row_spans.as_mut());
-            storage.set_height_total(rules);
+            calculate(storage.height_rules(), self.row_spans.as_mut())
         }
-        rules
     }
 }
 
@@ -286,7 +282,8 @@ impl<CT: RowTemp, RT: RowTemp, S: GridStorage> GridSetter<CT, RT, S> {
 
         if cols > 0 {
             let align = align.horiz.unwrap_or(Align::Default);
-            let (widths, rules, total) = storage.widths_rules_total();
+            let (widths, rules) = storage.widths_and_rules();
+            let total = SizeRules::sum(rules);
             let max_size = total.max_size();
             let mut target = rect.size.0;
 
@@ -312,7 +309,8 @@ impl<CT: RowTemp, RT: RowTemp, S: GridStorage> GridSetter<CT, RT, S> {
 
         if rows > 0 {
             let align = align.vert.unwrap_or(Align::Default);
-            let (heights, rules, total) = storage.heights_rules_total();
+            let (heights, rules) = storage.heights_and_rules();
+            let total = SizeRules::sum(rules);
             let max_size = total.max_size();
             let mut target = rect.size.1;
 

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -48,7 +48,9 @@ mod visitor;
 use crate::dir::{Direction, Directional};
 use crate::draw::DrawShared;
 use crate::event::EventState;
-use crate::theme::{SizeHandle, SizeMgr};
+use crate::geom::{Size, Vec2};
+use crate::text::TextApi;
+use crate::theme::{SizeHandle, SizeMgr, TextClass};
 use crate::{TkAction, WidgetConfig, WidgetId};
 use std::ops::{Deref, DerefMut};
 
@@ -196,6 +198,20 @@ impl<'a> SetRectMgr<'a> {
         // Yes, this method is just a shim! We reserve the option to add other code here in the
         // future, hence do not advise calling `configure_recurse` directly.
         widget.configure_recurse(self, id);
+    }
+
+    /// Update a text object, setting font properties and wrap size
+    ///
+    /// Returns required size.
+    #[inline]
+    pub fn text_set_size(
+        &self,
+        text: &mut dyn TextApi,
+        class: TextClass,
+        size: Size,
+        align: (Align, Align),
+    ) -> Vec2 {
+        self.sh.text_set_size(text, class, size, align)
     }
 }
 

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -62,7 +62,7 @@ pub use size_rules::SizeRules;
 pub use size_types::*;
 pub use sizer::{solve_size_rules, RulesSetter, RulesSolver, SolveCache};
 pub use storage::*;
-pub use visitor::{FrameStorage, Layout, StorageChain, TextStorage};
+pub use visitor::{FrameStorage, Layout, StorageChain};
 
 /// Information on which axis is being resized
 ///

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -42,8 +42,8 @@ impl<S: RowStorage> RowSolver<S> {
         let axis_is_vertical = axis.is_vertical() ^ dir.is_vertical();
 
         if axis.has_fixed && axis_is_vertical {
-            let (widths, rules, total) = storage.widths_rules_total();
-            SizeRules::solve_seq_total(widths, rules, total, axis.other_axis);
+            let (widths, rules) = storage.widths_and_rules();
+            SizeRules::solve_seq(widths, rules, axis.other_axis);
         }
 
         RowSolver {
@@ -90,13 +90,8 @@ impl<S: RowStorage> RulesSolver for RowSolver<S> {
         }
     }
 
-    fn finish(self, storage: &mut Self::Storage) -> SizeRules {
-        let rules = self.rules.unwrap_or(SizeRules::EMPTY);
-        if !self.axis_is_vertical {
-            storage.set_total(rules);
-        }
-
-        rules
+    fn finish(self, _: &mut Self::Storage) -> SizeRules {
+        self.rules.unwrap_or(SizeRules::EMPTY)
     }
 }
 
@@ -136,7 +131,8 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
         if len > 0 {
             let is_horiz = direction.is_horizontal();
             let mut width = if is_horiz { rect.size.0 } else { rect.size.1 };
-            let (widths, rules, total) = storage.widths_rules_total();
+            let (widths, rules) = storage.widths_and_rules();
+            let total = SizeRules::sum(rules);
             let max_size = total.max_size();
             let align = if is_horiz { align.horiz } else { align.vert };
             let align = align.unwrap_or(Align::Default);
@@ -225,7 +221,7 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
     pub fn solve_range(&mut self, storage: &mut S, range: Range<usize>, width: i32) {
         assert!(range.end <= self.offsets.as_mut().len());
 
-        let (widths, rules, _) = storage.widths_rules_total();
+        let (widths, rules) = storage.widths_and_rules();
         SizeRules::solve_seq(&mut widths[range.clone()], &rules[range], width);
     }
 }

--- a/crates/kas-core/src/layout/size_types.rs
+++ b/crates/kas-core/src/layout/size_types.rs
@@ -274,8 +274,6 @@ impl SpriteDisplay {
     }
 
     /// Generates `size_rules` based on size
-    ///
-    /// Set [`Self::size`] before calling this.
     pub fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo, raw_size: Size) -> SizeRules {
         let margins = self.margins.select(mgr.re()).extract(axis);
         let scale_factor = mgr.scale_factor();

--- a/crates/kas-core/src/layout/sizer.rs
+++ b/crates/kas-core/src/layout/sizer.rs
@@ -62,16 +62,13 @@ pub trait RulesSetter {
 
 /// Solve size rules for a widget
 ///
-/// It is required that a widget's `size_rules` method is called, for each axis,
-/// before `set_rect`. This method may be used to call `size_rules` in case the
-/// parent's own `size_rules` method may not.
+/// Automatic layout solving requires that a widget's `size_rules` method is
+/// called for each axis before `set_rect`. This method simply calls
+/// `size_rules` on each axis.
 ///
-/// Note: it is not necessary to solve size rules again before calling
-/// `set_rect` a second time, although if the widget's content changes then it
-/// is recommended.
-///
-/// Note: it is not necessary to ever call `size_rules` *or* `set_rect` if the
-/// widget is never drawn and never receives events.
+/// If `size_rules` is not called, internal layout may be poor (depending on the
+/// widget). If widget content changes, it is recommended to call
+/// `solve_size_rules` and `set_rect` again.
 ///
 /// Parameters `x_size` and `y_size` should be passed where this dimension is
 /// fixed and are used e.g. for text wrapping.
@@ -196,8 +193,8 @@ impl SolveCache {
             width -= self.margins.sum_horiz();
         }
 
-        // We call size_rules not because we want the result, but because our
-        // spec requires that we do so before calling set_rect.
+        // We call size_rules not because we want the result, but to allow
+        // internal layout solving.
         if self.refresh_rules || width != self.last_width {
             if self.refresh_rules {
                 let w = widget.size_rules(mgr.size_mgr(), AxisInfo::new(false, None));

--- a/crates/kas-core/src/layout/storage.rs
+++ b/crates/kas-core/src/layout/storage.rs
@@ -32,22 +32,35 @@ impl Storage for () {
 
 /// Requirements of row solver storage type
 ///
-/// Details are hidden (for internal use only).
+/// Usually this is set by a [`crate::layout::RowSolver`] from
+/// [`crate::Layout::size_rules`], then used by [`crate::Layout::set_rect`] to
+/// divide the assigned rect between children.
+///
+/// It may be useful to access this directly if not solving size rules normally;
+/// specifically this allows a different size solver to replace `size_rules` and
+/// influence `set_rect`.
+///
+/// Note: some implementations allocate when [`Self::set_dim`] is first called.
+/// It is expected that this method is called before other methods.
 pub trait RowStorage: sealed::Sealed + Clone {
-    #[doc(hidden)]
+    /// Set dimension: number of columns or rows
     fn set_dim(&mut self, cols: usize);
 
-    #[doc(hidden)]
+    /// Access [`SizeRules`] for each column/row
     fn rules(&mut self) -> &mut [SizeRules] {
         self.widths_and_rules().1
     }
 
-    #[doc(hidden)]
+    /// Access widths for each column/row
+    ///
+    /// Widths are calculated from rules when `set_rect` is called. Assigning
+    /// to widths before `set_rect` is called only has any effect when the available
+    /// size exceeds the minimum required (see [`SizeRules::solve_seq`]).
     fn widths(&mut self) -> &mut [i32] {
         self.widths_and_rules().0
     }
 
-    #[doc(hidden)]
+    /// Access widths and rules simultaneously
     fn widths_and_rules(&mut self) -> (&mut [i32], &mut [SizeRules]);
 }
 
@@ -136,32 +149,52 @@ where
 
 /// Requirements of grid solver storage type
 ///
-/// Details are hidden (for internal use only).
+/// Usually this is set by a [`crate::layout::GridSolver`] from
+/// [`crate::Layout::size_rules`], then used by [`crate::Layout::set_rect`] to
+/// divide the assigned rect between children.
+///
+/// It may be useful to access this directly if not solving size rules normally;
+/// specifically this allows a different size solver to replace `size_rules` and
+/// influence `set_rect`.
+///
+/// Note: some implementations allocate when [`Self::set_dims`] is first called.
+/// It is expected that this method is called before other methods.
 pub trait GridStorage: sealed::Sealed + Clone {
-    #[doc(hidden)]
+    /// Set dimension: number of columns and rows
     fn set_dims(&mut self, cols: usize, rows: usize);
 
-    #[doc(hidden)]
+    /// Access [`SizeRules`] for each column
     fn width_rules(&mut self) -> &mut [SizeRules] {
         self.widths_and_rules().1
     }
-    #[doc(hidden)]
+
+    /// Access [`SizeRules`] for each row
     fn height_rules(&mut self) -> &mut [SizeRules] {
         self.heights_and_rules().1
     }
 
-    #[doc(hidden)]
+    /// Access widths for each column
+    ///
+    /// Widths are calculated from rules when `set_rect` is called. Assigning
+    /// to widths before `set_rect` is called only has any effect when the available
+    /// size exceeds the minimum required (see [`SizeRules::solve_seq`]).
     fn widths(&mut self) -> &mut [i32] {
         self.widths_and_rules().0
     }
-    #[doc(hidden)]
+
+    /// Access heights for each row
+    ///
+    /// Heights are calculated from rules when `set_rect` is called. Assigning
+    /// to heights before `set_rect` is called only has any effect when the available
+    /// size exceeds the minimum required (see [`SizeRules::solve_seq`]).
     fn heights(&mut self) -> &mut [i32] {
         self.heights_and_rules().0
     }
 
-    #[doc(hidden)]
+    /// Access column widths and rules simultaneously
     fn widths_and_rules(&mut self) -> (&mut [i32], &mut [SizeRules]);
-    #[doc(hidden)]
+
+    /// Access row heights and rules simultaneously
     fn heights_and_rules(&mut self) -> (&mut [i32], &mut [SizeRules]);
 }
 

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -344,7 +344,7 @@ where
         }
     }
 
-    fn is_reversed(&mut self) -> bool {
+    fn is_reversed(&self) -> bool {
         self.direction.is_reversed()
     }
 
@@ -386,7 +386,7 @@ impl<'a, W: WidgetConfig, D: Directional> Component for Slice<'a, W, D> {
         }
     }
 
-    fn is_reversed(&mut self) -> bool {
+    fn is_reversed(&self) -> bool {
         self.direction.is_reversed()
     }
 
@@ -429,7 +429,7 @@ where
         }
     }
 
-    fn is_reversed(&mut self) -> bool {
+    fn is_reversed(&self) -> bool {
         // TODO: replace is_reversed with direct implementation of spatial_nav
         false
     }

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -191,7 +191,7 @@ impl<'a> Layout<'a> {
     }
     fn size_rules_(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
         let frame = |mgr: SizeMgr, child: &mut Layout, storage: &mut FrameStorage, mut style| {
-            let frame_rules = mgr.frame(style, axis.is_vertical());
+            let frame_rules = mgr.frame(style, axis);
             let child_rules = child.size_rules_(mgr, axis);
             if axis.is_horizontal() && style == FrameStyle::MenuEntry {
                 style = FrameStyle::InnerMargin;

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -11,10 +11,9 @@
 use super::{AlignHints, AxisInfo, RulesSetter, RulesSolver, SetRectMgr, SizeRules, Storage};
 use super::{DynRowStorage, RowPositionSolver, RowSetter, RowSolver, RowStorage};
 use super::{GridChildInfo, GridDimensions, GridSetter, GridSolver, GridStorage};
-use crate::cast::Cast;
 use crate::draw::color::Rgb;
 use crate::geom::{Coord, Offset, Rect, Size};
-use crate::text::{Align, TextApi, TextApiExt};
+use crate::text::{Align, TextApi};
 use crate::theme::{Background, DrawMgr, FrameStyle, IdCoord, IdRect, SizeMgr, TextClass};
 use crate::WidgetId;
 use crate::{dir::Directional, WidgetConfig};
@@ -491,16 +490,14 @@ impl<'a> Visitor for Text<'a> {
         mgr.text_bound(self.text, self.class, axis)
     }
 
-    fn set_rect(&mut self, _mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+    fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+        self.data.pos = rect.pos;
         let halign = match self.class {
             TextClass::Button => Align::Center,
             _ => Align::Default,
         };
-        self.data.pos = rect.pos;
-        self.text.update_env(|env| {
-            env.set_bounds(rect.size.cast());
-            env.set_align(align.unwrap_or(halign, Align::Center));
-        });
+        let align = align.unwrap_or(halign, Align::Center);
+        mgr.text_set_size(self.text, self.class, rect.size, align);
     }
 
     fn is_reversed(&mut self) -> bool {

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -54,21 +54,6 @@ impl StorageChain {
     }
 }
 
-/// Implementation helper for layout of children
-trait Visitor {
-    /// Get size rules for the given axis
-    fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules;
-
-    /// Apply a given `rect` to self
-    fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints);
-
-    fn is_reversed(&mut self) -> bool;
-
-    fn find_id(&mut self, coord: Coord) -> Option<WidgetId>;
-
-    fn draw(&mut self, draw: DrawMgr, id: &WidgetId);
-}
-
 /// A layout visitor
 ///
 /// This constitutes a "visitor" which iterates over each child widget. Layout
@@ -83,6 +68,8 @@ enum LayoutType<'a> {
     None,
     /// A component
     Component(&'a mut dyn Component),
+    /// A boxed component
+    BoxComponent(Box<dyn Component + 'a>),
     /// A single child widget
     Single(&'a mut dyn WidgetConfig),
     /// A single child widget with alignment
@@ -93,8 +80,6 @@ enum LayoutType<'a> {
     Frame(Box<Layout<'a>>, &'a mut FrameStorage, FrameStyle),
     /// Button frame around content
     Button(Box<Layout<'a>>, &'a mut FrameStorage, Option<Rgb>),
-    /// An embedded layout
-    Visitor(Box<dyn Visitor + 'a>),
 }
 
 impl<'a> Default for Layout<'a> {
@@ -158,7 +143,7 @@ impl<'a> Layout<'a> {
         D: Directional,
         S: RowStorage,
     {
-        let layout = LayoutType::Visitor(Box::new(List {
+        let layout = LayoutType::BoxComponent(Box::new(List {
             data,
             direction,
             children: list,
@@ -177,7 +162,7 @@ impl<'a> Layout<'a> {
         W: WidgetConfig,
         D: Directional,
     {
-        let layout = LayoutType::Visitor(Box::new(Slice {
+        let layout = LayoutType::BoxComponent(Box::new(Slice {
             data,
             direction,
             children: slice,
@@ -191,7 +176,7 @@ impl<'a> Layout<'a> {
         I: Iterator<Item = (GridChildInfo, Layout<'a>)> + 'a,
         S: GridStorage,
     {
-        let layout = LayoutType::Visitor(Box::new(Grid {
+        let layout = LayoutType::BoxComponent(Box::new(Grid {
             data,
             dim,
             children: iter,
@@ -225,12 +210,12 @@ impl<'a> Layout<'a> {
         match &mut self.layout {
             LayoutType::None => SizeRules::EMPTY,
             LayoutType::Component(component) => component.size_rules(mgr, axis),
+            LayoutType::BoxComponent(component) => component.size_rules(mgr, axis),
             LayoutType::Single(child) => child.size_rules(mgr, axis),
             LayoutType::AlignSingle(child, _) => child.size_rules(mgr, axis),
             LayoutType::AlignLayout(layout, _) => layout.size_rules_(mgr, axis),
             LayoutType::Frame(child, storage, style) => frame(mgr, child, storage, *style),
             LayoutType::Button(child, storage, _) => frame(mgr, child, storage, FrameStyle::Button),
-            LayoutType::Visitor(visitor) => visitor.size_rules(mgr, axis),
         }
     }
 
@@ -243,6 +228,7 @@ impl<'a> Layout<'a> {
         match &mut self.layout {
             LayoutType::None => (),
             LayoutType::Component(component) => component.set_rect(mgr, rect, align),
+            LayoutType::BoxComponent(layout) => layout.set_rect(mgr, rect, align),
             LayoutType::Single(child) => child.set_rect(mgr, rect, align),
             LayoutType::AlignSingle(child, hints) => {
                 let align = hints.combine(align);
@@ -258,7 +244,6 @@ impl<'a> Layout<'a> {
                 rect.size -= storage.size;
                 child.set_rect_(mgr, rect, align);
             }
-            LayoutType::Visitor(layout) => layout.set_rect(mgr, rect, align),
         }
     }
 
@@ -273,11 +258,11 @@ impl<'a> Layout<'a> {
         match &mut self.layout {
             LayoutType::None => false,
             LayoutType::Component(component) => component.is_reversed(),
+            LayoutType::BoxComponent(layout) => layout.is_reversed(),
             LayoutType::Single(_) | LayoutType::AlignSingle(_, _) => false,
             LayoutType::AlignLayout(layout, _) => layout.is_reversed_(),
             LayoutType::Frame(layout, _, _) => layout.is_reversed_(),
             LayoutType::Button(layout, _, _) => layout.is_reversed_(),
-            LayoutType::Visitor(layout) => layout.is_reversed(),
         }
     }
 
@@ -293,12 +278,12 @@ impl<'a> Layout<'a> {
         match &mut self.layout {
             LayoutType::None => None,
             LayoutType::Component(component) => component.find_id(coord),
+            LayoutType::BoxComponent(layout) => layout.find_id(coord),
             LayoutType::Single(child) | LayoutType::AlignSingle(child, _) => child.find_id(coord),
             LayoutType::AlignLayout(layout, _) => layout.find_id_(coord),
             LayoutType::Frame(child, _, _) => child.find_id_(coord),
             // Buttons steal clicks, hence Button never returns ID of content
             LayoutType::Button(_, _, _) => None,
-            LayoutType::Visitor(layout) => layout.find_id(coord),
         }
     }
 
@@ -311,6 +296,7 @@ impl<'a> Layout<'a> {
         match &mut self.layout {
             LayoutType::None => (),
             LayoutType::Component(component) => component.draw(draw, id),
+            LayoutType::BoxComponent(layout) => layout.draw(draw, id),
             LayoutType::Single(child) | LayoutType::AlignSingle(child, _) => child.draw(draw.re()),
             LayoutType::AlignLayout(layout, _) => layout.draw_(draw, id),
             LayoutType::Frame(child, storage, style) => {
@@ -325,7 +311,6 @@ impl<'a> Layout<'a> {
                 draw.frame(IdRect(id, storage.rect), FrameStyle::Button, bg);
                 child.draw_(draw, id);
             }
-            LayoutType::Visitor(layout) => layout.draw(draw, id),
         }
     }
 }
@@ -337,7 +322,7 @@ struct List<'a, S, D, I> {
     children: I,
 }
 
-impl<'a, S: RowStorage, D: Directional, I> Visitor for List<'a, S, D, I>
+impl<'a, S: RowStorage, D: Directional, I> Component for List<'a, S, D, I>
 where
     I: ExactSizeIterator<Item = Layout<'a>>,
 {
@@ -382,7 +367,7 @@ struct Slice<'a, W: WidgetConfig, D: Directional> {
     children: &'a mut [W],
 }
 
-impl<'a, W: WidgetConfig, D: Directional> Visitor for Slice<'a, W, D> {
+impl<'a, W: WidgetConfig, D: Directional> Component for Slice<'a, W, D> {
     fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
         let dim = (self.direction, self.children.len());
         let mut solver = RowSolver::new(axis, dim, self.data);
@@ -425,7 +410,7 @@ struct Grid<'a, S, I> {
     children: I,
 }
 
-impl<'a, S: GridStorage, I> Visitor for Grid<'a, S, I>
+impl<'a, S: GridStorage, I> Component for Grid<'a, S, I>
 where
     I: Iterator<Item = (GridChildInfo, Layout<'a>)>,
 {

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -24,6 +24,7 @@ mod toolkit;
 
 // public implementations:
 pub mod class;
+pub mod component;
 #[cfg(feature = "config")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "config")))]
 pub mod config;

--- a/crates/kas-core/src/text.rs
+++ b/crates/kas-core/src/text.rs
@@ -34,6 +34,8 @@ pub mod util {
     /// this parameter is a little bit wrong then resizes may sometimes happen
     /// unnecessarily or may not happen when text is slightly too big (e.g.
     /// spills into the margin area); this behaviour is probably acceptable.
+    /// Passing `Size::ZERO` will always resize (unless text is empty).
+    /// Passing `Size::MAX` should never resize.
     pub fn set_text_and_prepare<T: format::FormattableText>(
         text: &mut Text<T>,
         s: T,
@@ -67,7 +69,10 @@ pub mod util {
     ///
     /// Note: an alternative approach would be to delay text preparation by
     /// adding TkAction::PREPARE and a new method, perhaps in Layout.
-    fn prepare_if_needed<T: format::FormattableText>(text: &mut Text<T>, avail: Size) -> TkAction {
+    pub(crate) fn prepare_if_needed<T: format::FormattableText>(
+        text: &mut Text<T>,
+        avail: Size,
+    ) -> TkAction {
         if fonts::fonts().num_faces() == 0 {
             // Fonts not loaded yet: cannot prepare and can assume it will happen later anyway.
             return TkAction::empty();

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -8,7 +8,7 @@
 use std::convert::AsRef;
 use std::ops::{Bound, Range, RangeBounds};
 
-use super::{FrameStyle, IdCoord, IdRect, SizeHandle, SizeMgr, TextClass};
+use super::{FrameStyle, IdCoord, IdRect, MarkStyle, SizeHandle, SizeMgr, TextClass};
 use crate::dir::Direction;
 use crate::draw::{color::Rgb, Draw, DrawShared, ImageId, PassType};
 use crate::event::EventState;
@@ -254,6 +254,12 @@ impl<'a> DrawMgr<'a> {
         self.h.radiobox(f.0, f.1, checked);
     }
 
+    /// Draw UI element: mark
+    pub fn mark<'b>(&mut self, feature: impl Into<IdRect<'b>>, style: MarkStyle) {
+        let f = feature.into();
+        self.h.mark(f.0, f.1, style);
+    }
+
     /// Draw UI element: scrollbar
     ///
     /// -   `id2`: [`WidgetId`] of the handle
@@ -416,6 +422,9 @@ pub trait DrawHandle {
     ///
     /// This is similar in appearance to a checkbox.
     fn radiobox(&mut self, id: &WidgetId, rect: Rect, checked: bool);
+
+    /// Draw UI element: mark
+    fn mark(&mut self, id: &WidgetId, rect: Rect, style: MarkStyle);
 
     /// Draw UI element: scrollbar
     ///

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -7,7 +7,8 @@
 
 use std::ops::Deref;
 
-use super::{FrameStyle, TextClass};
+use super::{FrameStyle, MarkStyle, TextClass};
+use crate::dir::Directional;
 use crate::geom::{Size, Vec2};
 use crate::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use crate::macros::autoimpl;
@@ -88,8 +89,8 @@ impl<'a> SizeMgr<'a> {
     }
 
     /// Size of a frame around another element
-    pub fn frame(&self, style: FrameStyle, is_vert: bool) -> FrameRules {
-        self.0.frame(style, is_vert)
+    pub fn frame(&self, style: FrameStyle, dir: impl Directional) -> FrameRules {
+        self.0.frame(style, dir.is_vertical())
     }
 
     /// Size of a separator frame between items
@@ -156,6 +157,11 @@ impl<'a> SizeMgr<'a> {
     /// Size of the element drawn by [`DrawMgr::radiobox`].
     pub fn radiobox(&self) -> Size {
         self.0.radiobox()
+    }
+
+    /// A simple mark
+    pub fn mark(&self, style: MarkStyle, dir: impl Directional) -> SizeRules {
+        self.0.mark(style, dir.is_vertical())
     }
 
     /// Dimensions for a scrollbar
@@ -266,6 +272,9 @@ pub trait SizeHandle {
 
     /// Size of the element drawn by [`DrawMgr::radiobox`].
     fn radiobox(&self) -> Size;
+
+    /// A simple mark
+    fn mark(&self, style: MarkStyle, is_vert: bool) -> SizeRules;
 
     /// Dimensions for a scrollbar
     ///

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -144,11 +144,6 @@ impl<'a> SizeMgr<'a> {
         self.0.text_bound(text, class, axis)
     }
 
-    /// Width of an edit marker
-    pub fn text_cursor_width(&self) -> f32 {
-        self.0.text_cursor_width()
-    }
-
     /// Size of the element drawn by [`DrawMgr::checkbox`].
     pub fn checkbox(&self) -> Size {
         self.0.checkbox()
@@ -263,9 +258,6 @@ pub trait SizeHandle {
         size: Size,
         align: (Align, Align),
     ) -> Vec2;
-
-    /// Width of an edit marker
-    fn text_cursor_width(&self) -> f32;
 
     /// Size of the element drawn by [`DrawMgr::checkbox`].
     fn checkbox(&self) -> Size;

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -7,13 +7,13 @@
 
 use std::ops::Deref;
 
-#[allow(unused)]
-use super::DrawMgr;
 use super::{FrameStyle, TextClass};
-use crate::geom::Size;
+use crate::geom::{Size, Vec2};
 use crate::layout::{AxisInfo, FrameRules, Margins, SizeRules};
 use crate::macros::autoimpl;
-use crate::text::TextApi;
+use crate::text::{Align, TextApi};
+#[allow(unused)]
+use crate::{layout::SetRectMgr, theme::DrawMgr};
 
 // for doc use
 #[allow(unused)]
@@ -125,19 +125,15 @@ impl<'a> SizeMgr<'a> {
         self.0.line_height(class)
     }
 
-    /// Update a [`crate::text::Text`] and get a size bound
+    /// Update a text object, setting font properties and getting a size bound
     ///
-    /// First, this method updates the text's [`Environment`]: `bounds`, `dpp`
-    /// and `pt_size` are set. Second, the text is prepared (which is necessary
-    /// to calculate size requirements). Finally, this converts the requirements
-    /// to a [`SizeRules`] value and returns it.
+    /// This method updates the text's [`Environment`] and uses the result to
+    /// calculate size requirements.
     ///
-    /// Usually this method is used in [`Layout::size_rules`], then
-    /// [`TextApiExt::update_env`] is used in [`Layout::set_rect`].
+    /// It is necessary to update the environment *again* once the target `rect`
+    /// is known: use [`SetRectMgr::text_set_size`] to do this.
     ///
     /// [`Environment`]: crate::text::Environment
-    /// [`Layout::set_rect`]: crate::Layout::set_rect
-    /// [`Layout::size_rules`]: crate::Layout::size_rules
     pub fn text_bound(
         &self,
         text: &mut dyn TextApi,
@@ -240,20 +236,27 @@ pub trait SizeHandle {
     /// The height of a line of text
     fn line_height(&self, class: TextClass) -> i32;
 
-    /// Update a [`crate::text::Text`] and get a size bound
+    /// Update a text object, setting font properties and getting a size bound
     ///
-    /// First, this method updates the text's [`Environment`]: `bounds`, `dpp`
-    /// and `pt_size` are set. Second, the text is prepared (which is necessary
-    /// to calculate size requirements). Finally, this converts the requirements
-    /// to a [`SizeRules`] value and returns it.
+    /// This method updates the text's [`Environment`] and uses the result to
+    /// calculate size requirements.
     ///
-    /// Usually this method is used in [`Layout::size_rules`], then
-    /// [`TextApiExt::update_env`] is used in [`Layout::set_rect`].
+    /// It is necessary to update the environment *again* once the target `rect`
+    /// is known: use [`Self::text_set_size`] to do this.
     ///
     /// [`Environment`]: crate::text::Environment
-    /// [`Layout::set_rect`]: crate::Layout::set_rect
-    /// [`Layout::size_rules`]: crate::Layout::size_rules
     fn text_bound(&self, text: &mut dyn TextApi, class: TextClass, axis: AxisInfo) -> SizeRules;
+
+    /// Update a text object, setting font properties and wrap size
+    ///
+    /// Returns required size.
+    fn text_set_size(
+        &self,
+        text: &mut dyn TextApi,
+        class: TextClass,
+        size: Size,
+        align: (Align, Align),
+    ) -> Vec2;
 
     /// Width of an edit marker
     fn text_cursor_width(&self) -> f32;

--- a/crates/kas-core/src/theme/style.rs
+++ b/crates/kas-core/src/theme/style.rs
@@ -5,6 +5,8 @@
 
 //! Theme style components
 
+use crate::dir::Direction;
+
 /// Class of text drawn
 ///
 /// Themes choose font, font size, colour, and alignment based on this.
@@ -87,4 +89,11 @@ pub enum FrameStyle {
     Button,
     /// Box used to contain editable text
     EditBox,
+}
+
+/// Style of marks
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum MarkStyle {
+    /// An arrowhead/angle-bracket/triangle pointing in the given direction
+    Point(Direction),
 }

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -15,7 +15,7 @@ use kas::cast::traits::*;
 use kas::geom::{Size, Vec2};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::text::{fonts::FontId, Align, TextApi, TextApiExt};
-use kas::theme::{FrameStyle, SizeHandle, TextClass};
+use kas::theme::{FrameStyle, MarkStyle, SizeHandle, TextClass};
 
 /// Parameterisation of [`Dimensions`]
 ///
@@ -68,6 +68,7 @@ pub struct Dimensions {
     pub menu_frame: i32,
     pub button_frame: i32,
     pub checkbox: i32,
+    pub mark: i32,
     pub scrollbar: Size,
     pub slider: Size,
     pub progress_bar: Size,
@@ -94,6 +95,8 @@ impl Dimensions {
         let popup_frame = (params.popup_frame_size * scale_factor).cast_nearest();
         let menu_frame = (params.menu_frame * scale_factor).cast_nearest();
 
+        let mark = i32::conv_nearest(params.checkbox_inner * dpp);
+
         let shadow_size = params.shadow_size * scale_factor;
         let shadow_offset = shadow_size * params.shadow_rel_offset;
 
@@ -111,8 +114,8 @@ impl Dimensions {
             popup_frame,
             menu_frame,
             button_frame: (params.button_frame * scale_factor).cast_nearest(),
-            checkbox: i32::conv_nearest(params.checkbox_inner * dpp)
-                + 2 * (i32::from(inner_margin) + frame),
+            checkbox: mark + 2 * (i32::from(inner_margin) + frame),
+            mark,
             scrollbar: Size::conv_nearest(params.scrollbar_size * scale_factor),
             slider: Size::conv_nearest(params.slider_size * scale_factor),
             progress_bar: Size::conv_nearest(params.progress_bar * scale_factor),
@@ -314,6 +317,15 @@ impl<D: 'static> SizeHandle for Window<D> {
     #[inline]
     fn radiobox(&self) -> Size {
         self.checkbox()
+    }
+
+    fn mark(&self, style: MarkStyle, _is_vert: bool) -> SizeRules {
+        match style {
+            MarkStyle::Point(_) => {
+                let m = self.dims.outer_margin;
+                SizeRules::fixed(self.dims.mark, (m, m))
+            }
+        }
     }
 
     fn scrollbar(&self) -> (Size, i32) {

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -208,41 +208,50 @@ impl<D: 'static> SizeHandle for Window<D> {
     }
 
     fn text_bound(&self, text: &mut dyn TextApi, class: TextClass, axis: AxisInfo) -> SizeRules {
-        // Note: for horizontal axis of Edit* classes, input text does not affect size rules.
-        // We must set env at least once, but do for vertical axis anyway.
-        let mut required = None;
-        if !axis.is_horizontal() || !matches!(class, TextClass::Edit(_)) {
-            required = Some(text.update_env(|env| {
-                if let Some(font_id) = self.fonts.get(&class).cloned() {
-                    env.set_font_id(font_id);
-                }
-                env.set_dpp(self.dims.dpp);
-                env.set_pt_size(self.dims.pt_size);
-
-                let mut bounds = kas::text::Vec2::INFINITY;
-                if let Some(size) = axis.size_other_if_fixed(false) {
-                    bounds.1 = size.cast();
-                } else if let Some(size) = axis.size_other_if_fixed(true) {
-                    bounds.0 = size.cast();
-                }
-                env.set_bounds(bounds);
-                env.set_align((Align::TL, Align::TL)); // force top-left alignment for sizing
-                env.set_wrap(class.multi_line());
-            }));
-        }
-
         let margin = match axis.is_horizontal() {
             true => self.dims.text_margin.0,
             false => self.dims.text_margin.1,
         };
         let margins = (margin, margin);
+
+        // Note: for horizontal axis of Edit* classes, input text does not affect size rules.
+        // We must set env at least once, but do for vertical axis anyway.
+        if axis.is_horizontal() {
+            if let TextClass::Edit(multi) = class {
+                let min = self.dims.min_line_length;
+                let (min, ideal) = match multi {
+                    false => (min, 2 * min),
+                    true => (min, 3 * min),
+                };
+                return SizeRules::new(min, ideal, margins, Stretch::Low);
+            }
+        }
+
+        let required = text.update_env(|env| {
+            if let Some(font_id) = self.fonts.get(&class).cloned() {
+                env.set_font_id(font_id);
+            }
+            env.set_dpp(self.dims.dpp);
+            env.set_pt_size(self.dims.pt_size);
+
+            let mut bounds = kas::text::Vec2::INFINITY;
+            if let Some(size) = axis.size_other_if_fixed(false) {
+                bounds.1 = size.cast();
+            } else if let Some(size) = axis.size_other_if_fixed(true) {
+                bounds.0 = size.cast();
+            }
+            env.set_bounds(bounds);
+            env.set_align((Align::TL, Align::TL)); // force top-left alignment for sizing
+            env.set_wrap(class.multi_line());
+        });
+
         if axis.is_horizontal() {
             let min = self.dims.min_line_length;
             let (min, ideal) = match class {
                 TextClass::Edit(false) => (min, 2 * min),
                 TextClass::Edit(true) => (min, 3 * min),
                 _ => {
-                    let bound = i32::conv_ceil(required.unwrap().0);
+                    let bound = i32::conv_ceil(required.0);
                     (bound.min(min), bound.min(3 * min))
                 }
             };
@@ -256,7 +265,7 @@ impl<D: 'static> SizeHandle for Window<D> {
             };
             SizeRules::new(min, ideal, margins, stretch)
         } else {
-            let bound = i32::conv_ceil(required.unwrap().1);
+            let bound = i32::conv_ceil(required.1);
             let min = match class {
                 _ if class.single_line() => self.dims.line_height,
                 TextClass::Label(true) => bound,

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -17,7 +17,7 @@ use kas::event::EventState;
 use kas::geom::*;
 use kas::text::{TextApi, TextDisplay};
 use kas::theme::{self, Background, SizeHandle, ThemeControl};
-use kas::theme::{FrameStyle, TextClass};
+use kas::theme::{FrameStyle, MarkStyle, TextClass};
 use kas::{TkAction, WidgetId};
 
 /// A theme using simple shading to give apparent depth to elements
@@ -398,6 +398,10 @@ where
             let col = self.cols.check_mark_state(state);
             self.draw.shaded_circle(inner, (0.0, 1.0), col);
         }
+    }
+
+    fn mark(&mut self, id: &WidgetId, rect: Rect, style: MarkStyle) {
+        self.as_flat().mark(id, rect, style);
     }
 
     fn scrollbar(&mut self, id: &WidgetId, id2: &WidgetId, rect: Rect, h_rect: Rect, _: Direction) {

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -70,6 +70,7 @@ const DIMS: dim::Parameters = dim::Parameters {
     menu_frame: 2.4,
     button_frame: 5.0,
     checkbox_inner: 9.0,
+    mark: 9.0,
     scrollbar_size: Vec2::splat(8.0),
     slider_size: Vec2(12.0, 25.0),
     progress_bar: Vec2::splat(12.0),

--- a/crates/kas-widgets/src/adapter/label.rs
+++ b/crates/kas-widgets/src/adapter/label.rs
@@ -66,6 +66,15 @@ impl_scope! {
             (self.inner, self.label)
         }
 
+        /// Access layout storage
+        ///
+        /// The number of columns/rows is fixed at two: the `inner` widget, and
+        /// the `label` (in this order, regardless of direction).
+        #[inline]
+        pub fn layout_storage(&mut self) -> &mut impl layout::RowStorage {
+            &mut self.layout_store
+        }
+
         /// Get whether line-wrapping is enabled
         #[inline]
         pub fn wrap(&self) -> bool {

--- a/crates/kas-widgets/src/adapter/label.rs
+++ b/crates/kas-widgets/src/adapter/label.rs
@@ -5,7 +5,7 @@
 
 //! Wrapper adding a label
 
-use kas::text::util::set_text_and_prepare;
+use kas::component::Label;
 use kas::theme::TextClass;
 use kas::{event, layout, prelude::*};
 
@@ -27,8 +27,7 @@ impl_scope! {
         inner: W,
         wrap: bool,
         layout_store: layout::FixedRowStorage<2>,
-        label_store: layout::TextStorage,
-        label: Text<AccelString>,
+        label: Label<AccelString>,
     }
 
     impl Self where D: Default {
@@ -43,14 +42,14 @@ impl_scope! {
         /// Construct from `direction`, `inner` widget and `label`
         #[inline]
         pub fn new_with_direction<T: Into<AccelString>>(direction: D, inner: W, label: T) -> Self {
+            let wrap = true;
             WithLabel {
                 core: Default::default(),
                 dir: direction,
                 inner,
-                wrap: true,
+                wrap,
                 layout_store: Default::default(),
-                label_store: Default::default(),
-                label: Text::new_multi(label.into()),
+                label: Label::new(label.into(), TextClass::Label(wrap)),
             }
         }
 
@@ -60,10 +59,10 @@ impl_scope! {
             self.dir.as_direction()
         }
 
-        /// Deconstruct into `(inner, label)`
+        /// Take inner
         #[inline]
-        pub fn deconstruct(self) -> (W, Text<AccelString>) {
-            (self.inner, self.label)
+        pub fn take_inner(self) -> W {
+            self.inner
         }
 
         /// Access layout storage
@@ -101,12 +100,12 @@ impl_scope! {
         /// Note: this must not be called before fonts have been initialised
         /// (usually done by the theme when the main loop starts).
         pub fn set_text<T: Into<AccelString>>(&mut self, text: T) -> TkAction {
-            set_text_and_prepare(&mut self.label, text.into(), self.core.rect.size)
+            self.label.set_text_and_prepare(text.into(), self.core.rect.size)
         }
 
         /// Get the accelerator keys
         pub fn keys(&self) -> &[event::VirtualKeyCode] {
-            self.label.text().keys()
+            self.label.keys()
         }
     }
 
@@ -120,7 +119,7 @@ impl_scope! {
         fn layout(&mut self) -> layout::Layout<'_> {
             let arr = [
                 layout::Layout::single(&mut self.inner),
-                layout::Layout::text(&mut self.label_store, &mut self.label, TextClass::Label(self.wrap)),
+                layout::Layout::component(&mut self.label),
             ];
             layout::Layout::list(arr.into_iter(), self.dir, &mut self.layout_store)
         }
@@ -142,10 +141,10 @@ impl_scope! {
     impl SetAccel for Self {
         fn set_accel_string(&mut self, string: AccelString) -> TkAction {
             let mut action = TkAction::empty();
-            if self.label.text().keys() != string.keys() {
+            if self.label.keys() != string.keys() {
                 action |= TkAction::RECONFIGURE;
             }
-            action | set_text_and_prepare(&mut self.label, string, self.core.rect.size)
+            action | self.label.set_text_and_prepare(string, self.core.rect.size)
         }
     }
 }

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -5,7 +5,8 @@
 
 //! Message Map widget
 
-use crate::{Menu, MenuLabel};
+use crate::Menu;
+use kas::component::Component;
 use kas::prelude::*;
 use std::rc::Rc;
 
@@ -70,7 +71,10 @@ impl_scope! {
 
     impl<W: Menu, M: 'static> Menu for MapResponse<W, M> {
         fn menu_sub_items(&mut self) -> Option<(
-            &mut MenuLabel,
+            &mut dyn Component,
+            Option<&mut dyn Component>,
+            Option<&mut dyn Component>,
+            Option<&mut dyn Component>,
             Option<&mut dyn WidgetConfig>,
         )> {
             self.inner.menu_sub_items()

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -5,7 +5,7 @@
 
 //! Message Map widget
 
-use crate::Menu;
+use crate::{Menu, MenuLabel};
 use kas::prelude::*;
 use std::rc::Rc;
 
@@ -69,6 +69,12 @@ impl_scope! {
     }
 
     impl<W: Menu, M: 'static> Menu for MapResponse<W, M> {
+        fn menu_sub_items(&mut self) -> Option<(
+            &mut MenuLabel,
+            Option<&mut dyn WidgetConfig>,
+        )> {
+            self.inner.menu_sub_items()
+        }
         fn menu_is_open(&self) -> bool {
             self.inner.menu_is_open()
         }

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -5,8 +5,7 @@
 
 //! Message Map widget
 
-use crate::Menu;
-use kas::component::Component;
+use crate::menu;
 use kas::prelude::*;
 use std::rc::Rc;
 
@@ -69,15 +68,9 @@ impl_scope! {
         }
     }
 
-    impl<W: Menu, M: 'static> Menu for MapResponse<W, M> {
-        fn menu_sub_items(&mut self) -> Option<(
-            &mut dyn Component,
-            Option<&mut dyn Component>,
-            Option<&mut dyn Component>,
-            Option<&mut dyn Component>,
-            Option<&mut dyn WidgetConfig>,
-        )> {
-            self.inner.menu_sub_items()
+    impl<W: menu::Menu, M: 'static> menu::Menu for MapResponse<W, M> {
+        fn sub_items(&mut self) -> Option<menu::SubItems> {
+            self.inner.sub_items()
         }
         fn menu_is_open(&self) -> bool {
             self.inner.menu_is_open()

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -330,7 +330,9 @@ impl<M: 'static> ComboBox<M> {
     ///
     /// Panics if `index` is out of bounds.
     pub fn replace<T: Into<AccelString>>(&mut self, mgr: &mut SetRectMgr, index: usize, label: T) {
-        *mgr |= self.popup.inner[index].set_accel(label);
+        self.popup
+            .inner
+            .replace(mgr, index, MenuEntry::new(label, ()));
     }
 }
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -6,6 +6,7 @@
 //! Combobox
 
 use super::{IndexedColumn, MenuEntry, PopupFrame};
+use kas::component::Label;
 use kas::event::{self, Command};
 use kas::layout;
 use kas::prelude::*;
@@ -26,9 +27,8 @@ impl_scope! {
     pub struct ComboBox<M: 'static> {
         #[widget_core]
         core: CoreData,
-        label: Text<String>,
+        label: Label<String>,
         layout_frame: layout::FrameStorage,
-        layout_text: layout::TextStorage,
         #[widget]
         popup: ComboPopup,
         active: usize,
@@ -39,7 +39,7 @@ impl_scope! {
 
     impl kas::Layout for Self {
         fn layout(&mut self) -> layout::Layout<'_> {
-            let inner = layout::Layout::text(&mut self.layout_text, &mut self.label, TextClass::Button);
+            let inner = layout::Layout::component(&mut self.label);
             layout::Layout::button(&mut self.layout_frame, inner, None)
         }
 
@@ -211,12 +211,11 @@ impl ComboBox<VoidMsg> {
     #[inline]
     pub fn new(entries: Vec<MenuEntry<()>>, active: usize) -> Self {
         let label = entries.get(active).map(|entry| entry.get_string());
-        let label = Text::new_single(label.unwrap_or("".to_string()));
+        let label = Label::new(label.unwrap_or("".to_string()), TextClass::Button);
         ComboBox {
             core: Default::default(),
             label,
             layout_frame: Default::default(),
-            layout_text: Default::default(),
             popup: ComboPopup {
                 core: Default::default(),
                 inner: PopupFrame::new(IndexedColumn::new(entries)),
@@ -243,7 +242,6 @@ impl ComboBox<VoidMsg> {
             core: self.core,
             label: self.label,
             layout_frame: self.layout_frame,
-            layout_text: self.layout_text,
             popup: self.popup,
             active: self.active,
             opening: self.opening,
@@ -274,7 +272,7 @@ impl<M: 'static> ComboBox<M> {
                 "".to_string()
             };
             let avail = self.core.rect.size.clamped_sub(self.layout_frame.size);
-            kas::text::util::set_text_and_prepare(&mut self.label, string, avail)
+            self.label.set_text_and_prepare(string, avail)
         } else {
             TkAction::empty()
         }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -5,7 +5,7 @@
 
 //! Combobox
 
-use super::{IndexedColumn, MenuEntry, PopupFrame};
+use super::{menu::MenuEntry, IndexedColumn, PopupFrame};
 use kas::component::{Label, Mark};
 use kas::event::{self, Command};
 use kas::layout;

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -6,11 +6,11 @@
 //! Combobox
 
 use super::{IndexedColumn, MenuEntry, PopupFrame};
-use kas::component::Label;
+use kas::component::{Label, Mark};
 use kas::event::{self, Command};
 use kas::layout;
 use kas::prelude::*;
-use kas::theme::TextClass;
+use kas::theme::{MarkStyle, TextClass};
 use kas::WindowId;
 use std::rc::Rc;
 
@@ -28,6 +28,8 @@ impl_scope! {
         #[widget_core]
         core: CoreData,
         label: Label<String>,
+        mark: Mark,
+        layout_list: layout::FixedRowStorage<2>,
         layout_frame: layout::FrameStorage,
         #[widget]
         popup: ComboPopup,
@@ -39,8 +41,12 @@ impl_scope! {
 
     impl kas::Layout for Self {
         fn layout(&mut self) -> layout::Layout<'_> {
-            let inner = layout::Layout::component(&mut self.label);
-            layout::Layout::button(&mut self.layout_frame, inner, None)
+            let list = [
+                layout::Layout::component(&mut self.label),
+                layout::Layout::component(&mut self.mark),
+            ];
+            let list = layout::Layout::list(list.into_iter(), Direction::Right, &mut self.layout_list);
+            layout::Layout::button(&mut self.layout_frame, list, None)
         }
 
         fn spatial_nav(&mut self, _: &mut SetRectMgr, _: bool, _: Option<usize>) -> Option<usize> {
@@ -215,6 +221,8 @@ impl ComboBox<VoidMsg> {
         ComboBox {
             core: Default::default(),
             label,
+            mark: Mark::new(MarkStyle::Point(Direction::Down)),
+            layout_list: Default::default(),
             layout_frame: Default::default(),
             popup: ComboPopup {
                 core: Default::default(),
@@ -241,6 +249,8 @@ impl ComboBox<VoidMsg> {
         ComboBox {
             core: self.core,
             label: self.label,
+            mark: self.mark,
+            layout_list: self.layout_list,
             layout_frame: self.layout_frame,
             popup: self.popup,
             active: self.active,

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -383,22 +383,17 @@ impl_scope! {
             size_mgr.text_bound(&mut self.text, class, axis)
         }
 
-        fn set_rect(&mut self, _: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
             let valign = if self.multi_line {
                 Align::Default
             } else {
                 Align::Center
             };
+            let class = TextClass::Edit(self.multi_line);
 
             self.core.rect = rect;
-            let size = rect.size;
-            self.required = self
-                .text
-                .update_env(|env| {
-                    env.set_align(align.unwrap_or(Align::Default, valign));
-                    env.set_bounds(size.cast());
-                })
-                .into();
+            let align = align.unwrap_or(Align::Default, valign);
+            self.required = mgr.text_set_size(&mut self.text, class, rect.size, align);
             self.set_view_offset_from_edit_pos();
         }
 

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -116,6 +116,22 @@ impl<W: Widget> Grid<W> {
         grid
     }
 
+    /// Get grid dimensions
+    ///
+    /// The numbers of rows, columns and spans is determined automatically.
+    #[inline]
+    pub fn dimensions(&self) -> GridDimensions {
+        self.dim
+    }
+
+    /// Access layout storage
+    ///
+    /// Use [`Self::dimensions`] to get expected dimensions.
+    #[inline]
+    pub fn layout_storage(&mut self) -> &mut impl layout::GridStorage {
+        &mut self.data
+    }
+
     fn calc_dim(&mut self) {
         let mut dim = GridDimensions::default();
         for child in &self.widgets {

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -70,12 +70,10 @@ impl_scope! {
             size_mgr.text_bound(&mut self.label, TextClass::Label(self.wrap), axis)
         }
 
-        fn set_rect(&mut self, _: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
-            self.label.update_env(|env| {
-                env.set_bounds(rect.size.cast());
-                env.set_align(align.unwrap_or(Align::Default, Align::Center));
-            });
+            let align = align.unwrap_or(Align::Default, Align::Center);
+            mgr.text_set_size(&mut self.label, TextClass::Label(self.wrap), rect.size, align);
         }
 
         #[cfg(feature = "min_spec")]

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -21,9 +21,7 @@
 //!
 //! ## Menus
 //!
-//! -   [`ComboBox`]: a simple pop-up selector
-//! -   [`MenuBar`], [`SubMenu`]: menu parent widgets
-//! -   [`MenuEntry`], [`MenuToggle`], [`Separator`]: menu entries
+//! See the [`menu`] module.
 //!
 //! ## Controls
 //!
@@ -73,7 +71,7 @@ mod label;
 mod list;
 #[macro_use]
 mod macros;
-mod menu;
+pub mod menu;
 mod nav_frame;
 mod progress;
 mod radiobox;
@@ -101,7 +99,6 @@ pub use frame::{Frame, PopupFrame};
 pub use grid::{BoxGrid, Grid};
 pub use label::{AccelLabel, Label, StrLabel, StringLabel};
 pub use list::*;
-pub use menu::*;
 pub use nav_frame::NavFrame;
 pub use progress::ProgressBar;
 pub use radiobox::{RadioBox, RadioBoxBare, RadioBoxGroup};

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -345,6 +345,14 @@ impl_scope! {
             self.direction.as_direction()
         }
 
+        /// Access layout storage
+        ///
+        /// The number of columns/rows is [`Self.len`].
+        #[inline]
+        pub fn layout_storage(&mut self) -> &mut impl layout::RowStorage {
+            &mut self.layout_store
+        }
+
         /// True if there are no child widgets
         pub fn is_empty(&self) -> bool {
             self.widgets.is_empty()

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -7,6 +7,7 @@
 
 use crate::adapter::AdaptWidget;
 use crate::Separator;
+use kas::component::Component;
 use kas::dir::Right;
 use kas::prelude::*;
 use std::fmt::Debug;
@@ -18,9 +19,6 @@ mod submenu;
 pub use menu_entry::{MenuEntry, MenuToggle};
 pub use menubar::{MenuBar, MenuBuilder};
 pub use submenu::SubMenu;
-
-/// Menu label component
-pub type MenuLabel = kas::component::Label<AccelString>;
 
 /// Trait governing menus, sub-menus and menu-entries
 #[autoimpl(for<T: trait + ?Sized> Box<T>)]
@@ -34,8 +32,17 @@ pub trait Menu: Widget {
     /// including a frame with style [`kas::theme::FrameStyle::MenuEntry`] on
     /// self.
     ///
-    /// Return value is `None` or `Some((label, opt_toggle))`.
-    fn menu_sub_items(&mut self) -> Option<(&mut MenuLabel, Option<&mut dyn WidgetConfig>)> {
+    /// Return value is `None` or `Some((label, opt_label2, opt_submenu, opt_icon, opt_toggle))`.
+    /// `opt_label2` is used to show shortcut labels. `opt_submenu` is a sub-menu indicator.
+    fn menu_sub_items(
+        &mut self,
+    ) -> Option<(
+        &mut dyn Component,
+        Option<&mut dyn Component>,
+        Option<&mut dyn Component>,
+        Option<&mut dyn Component>,
+        Option<&mut dyn WidgetConfig>,
+    )> {
         None
     }
 

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -3,7 +3,19 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! Menus
+//! Menu widgets
+//!
+//! The following serve as menu roots:
+//!
+//! -   [`crate::ComboBox`]
+//! -   [`MenuBar`]
+//!
+//! Any implementation of the [`Menu`] trait may be used as a menu item:
+//!
+//! -   [`SubMenu`]
+//! -   [`MenuEntry`]
+//! -   [`MenuToggle`]
+//! -   [`Separator`]
 
 use crate::adapter::AdaptWidget;
 use crate::Separator;
@@ -20,6 +32,22 @@ pub use menu_entry::{MenuEntry, MenuToggle};
 pub use menubar::{MenuBar, MenuBuilder};
 pub use submenu::SubMenu;
 
+/// Return value of [`Menu::sub_items`]
+#[derive(Default)]
+pub struct SubItems<'a> {
+    /// Primary label
+    pub label: Option<&'a mut dyn Component>,
+    /// Secondary label, often used to show shortcut key
+    pub label2: Option<&'a mut dyn Component>,
+    /// Sub-menu indicator
+    pub submenu: Option<&'a mut dyn Component>,
+    /// Icon
+    pub icon: Option<&'a mut dyn Component>,
+    /// Toggle mark
+    // TODO: should be a component?
+    pub toggle: Option<&'a mut dyn WidgetConfig>,
+}
+
 /// Trait governing menus, sub-menus and menu-entries
 #[autoimpl(for<T: trait + ?Sized> Box<T>)]
 pub trait Menu: Widget {
@@ -34,15 +62,7 @@ pub trait Menu: Widget {
     ///
     /// Return value is `None` or `Some((label, opt_label2, opt_submenu, opt_icon, opt_toggle))`.
     /// `opt_label2` is used to show shortcut labels. `opt_submenu` is a sub-menu indicator.
-    fn menu_sub_items(
-        &mut self,
-    ) -> Option<(
-        &mut dyn Component,
-        Option<&mut dyn Component>,
-        Option<&mut dyn Component>,
-        Option<&mut dyn Component>,
-        Option<&mut dyn WidgetConfig>,
-    )> {
+    fn sub_items(&mut self) -> Option<SubItems> {
         None
     }
 

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -19,6 +19,9 @@ pub use menu_entry::{MenuEntry, MenuToggle};
 pub use menubar::{MenuBar, MenuBuilder};
 pub use submenu::SubMenu;
 
+/// Menu label component
+pub type MenuLabel = kas::component::Label<AccelString>;
+
 /// Trait governing menus, sub-menus and menu-entries
 #[autoimpl(for<T: trait + ?Sized> Box<T>)]
 pub trait Menu: Widget {

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -25,7 +25,21 @@ pub type MenuLabel = kas::component::Label<AccelString>;
 /// Trait governing menus, sub-menus and menu-entries
 #[autoimpl(for<T: trait + ?Sized> Box<T>)]
 pub trait Menu: Widget {
-    /// Report whether one's own menu is open
+    /// Access row items for aligned layout
+    ///
+    /// If this is implemented, the row will be sized and layout through direct
+    /// access to these sub-components. [`Layout::size_rules`] will not be
+    /// invoked on `self`. [`Layout::set_rect`] will be, but should not set the
+    /// position of these items. [`Layout::draw`] should draw all components,
+    /// including a frame with style [`kas::theme::FrameStyle::MenuEntry`] on
+    /// self.
+    ///
+    /// Return value is `None` or `Some((label, opt_toggle))`.
+    fn menu_sub_items(&mut self) -> Option<(&mut MenuLabel, Option<&mut dyn WidgetConfig>)> {
+        None
+    }
+
+    /// Report whether a submenu (if any) is open
     ///
     /// By default, this is `false`.
     fn menu_is_open(&self) -> bool {

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -143,9 +143,8 @@ impl_scope! {
             Some(self.checkbox.id())
         }
 
-        fn draw(&mut self, mut draw: DrawMgr) {
-            draw.frame(&*self, FrameStyle::MenuEntry, Default::default());
-            let id = self.id();
+        fn draw(&mut self, draw: DrawMgr) {
+            let id = self.checkbox.id();
             self.layout().draw(draw, &id);
         }
     }

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -95,7 +95,14 @@ impl_scope! {
         }
     }
 
-    impl Menu for Self {}
+    impl Menu for Self {
+        fn menu_sub_items(&mut self) -> Option<(
+            &mut MenuLabel,
+            Option<&mut dyn WidgetConfig>,
+        )> {
+            Some((&mut self.label, None))
+        }
+    }
 }
 
 impl_scope! {
@@ -147,7 +154,14 @@ impl_scope! {
         type Msg = M;
     }
 
-    impl Menu for Self {}
+    impl Menu for Self {
+        fn menu_sub_items(&mut self) -> Option<(
+            &mut MenuLabel,
+            Option<&mut dyn WidgetConfig>,
+        )> {
+            Some((&mut self.label, Some(&mut self.checkbox)))
+        }
+    }
 
     impl MenuToggle<VoidMsg> {
         /// Construct a toggleable menu entry with a given `label`

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -8,7 +8,7 @@
 use super::{Menu, MenuLabel};
 use crate::CheckBoxBare;
 use kas::component::Component;
-use kas::theme::{FrameStyle, TextClass};
+use kas::theme::{FrameStyle, IdRect, TextClass};
 use kas::{layout, prelude::*};
 use std::fmt::Debug;
 
@@ -20,7 +20,6 @@ impl_scope! {
         #[widget_core]
         core: kas::CoreData,
         label: MenuLabel,
-        layout_frame: layout::FrameStorage,
         msg: M,
     }
 
@@ -36,8 +35,7 @@ impl_scope! {
 
     impl Layout for Self {
         fn layout(&mut self) -> layout::Layout<'_> {
-            let inner = layout::Layout::component(&mut self.label);
-            layout::Layout::frame(&mut self.layout_frame, inner, FrameStyle::MenuEntry)
+            layout::Layout::component(&mut self.label)
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
@@ -56,7 +54,6 @@ impl_scope! {
             MenuEntry {
                 core: Default::default(),
                 label: MenuLabel::new(label.into(), TextClass::MenuLabel),
-                layout_frame: Default::default(),
                 msg,
             }
         }
@@ -79,7 +76,7 @@ impl_scope! {
             if self.label.keys() != string.keys() {
                 action |= TkAction::RECONFIGURE;
             }
-            let avail = self.core.rect.size.clamped_sub(self.layout_frame.size);
+            let avail = self.core.rect.size;
             action | self.label.set_text_and_prepare(string, avail)
         }
     }
@@ -118,7 +115,6 @@ impl_scope! {
         checkbox: CheckBoxBare<M>,
         label: MenuLabel,
         layout_list: layout::DynRowStorage,
-        layout_frame: layout::FrameStorage,
     }
 
     impl WidgetConfig for Self {
@@ -133,8 +129,7 @@ impl_scope! {
                 layout::Layout::single(&mut self.checkbox),
                 layout::Layout::component(&mut self.label),
             ];
-            let inner = layout::Layout::list(list.into_iter(), Direction::Right, &mut self.layout_list);
-            layout::Layout::frame(&mut self.layout_frame, inner, FrameStyle::MenuEntry)
+            layout::Layout::list(list.into_iter(), Direction::Right, &mut self.layout_list)
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
@@ -144,8 +139,9 @@ impl_scope! {
             Some(self.checkbox.id())
         }
 
-        fn draw(&mut self, draw: DrawMgr) {
+        fn draw(&mut self, mut draw: DrawMgr) {
             let id = self.checkbox.id();
+            draw.frame(IdRect(&id, self.rect()), FrameStyle::MenuEntry, Default::default());
             self.layout().draw(draw, &id);
         }
     }
@@ -172,7 +168,6 @@ impl_scope! {
                 checkbox: CheckBoxBare::new(),
                 label: MenuLabel::new(label.into(), TextClass::MenuLabel),
                 layout_list: Default::default(),
-                layout_frame: Default::default(),
             }
         }
 
@@ -192,7 +187,6 @@ impl_scope! {
                 checkbox: self.checkbox.on_toggle(f),
                 label: self.label,
                 layout_list: self.layout_list,
-                layout_frame: self.layout_frame,
             }
         }
     }

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -5,9 +5,9 @@
 
 //! Menu Entries
 
-use super::{Menu, MenuLabel};
+use super::Menu;
 use crate::CheckBoxBare;
-use kas::component::Component;
+use kas::component::{Component, Label};
 use kas::theme::{FrameStyle, IdRect, TextClass};
 use kas::{layout, prelude::*};
 use std::fmt::Debug;
@@ -19,7 +19,7 @@ impl_scope! {
     pub struct MenuEntry<M: Clone + Debug + 'static> {
         #[widget_core]
         core: kas::CoreData,
-        label: MenuLabel,
+        label: Label<AccelString>,
         msg: M,
     }
 
@@ -53,7 +53,7 @@ impl_scope! {
         pub fn new<S: Into<AccelString>>(label: S, msg: M) -> Self {
             MenuEntry {
                 core: Default::default(),
-                label: MenuLabel::new(label.into(), TextClass::MenuLabel),
+                label: Label::new(label.into(), TextClass::MenuLabel),
                 msg,
             }
         }
@@ -94,10 +94,13 @@ impl_scope! {
 
     impl Menu for Self {
         fn menu_sub_items(&mut self) -> Option<(
-            &mut MenuLabel,
+            &mut dyn Component,
+            Option<&mut dyn Component>,
+            Option<&mut dyn Component>,
+            Option<&mut dyn Component>,
             Option<&mut dyn WidgetConfig>,
         )> {
-            Some((&mut self.label, None))
+            Some((&mut self.label, None, None, None, None))
         }
     }
 }
@@ -113,7 +116,7 @@ impl_scope! {
         core: CoreData,
         #[widget]
         checkbox: CheckBoxBare<M>,
-        label: MenuLabel,
+        label: Label<AccelString>,
         layout_list: layout::DynRowStorage,
     }
 
@@ -152,10 +155,13 @@ impl_scope! {
 
     impl Menu for Self {
         fn menu_sub_items(&mut self) -> Option<(
-            &mut MenuLabel,
+            &mut dyn Component,
+            Option<&mut dyn Component>,
+            Option<&mut dyn Component>,
+            Option<&mut dyn Component>,
             Option<&mut dyn WidgetConfig>,
         )> {
-            Some((&mut self.label, Some(&mut self.checkbox)))
+            Some((&mut self.label, None, None, None, Some(&mut self.checkbox)))
         }
     }
 
@@ -166,7 +172,7 @@ impl_scope! {
             MenuToggle {
                 core: Default::default(),
                 checkbox: CheckBoxBare::new(),
-                label: MenuLabel::new(label.into(), TextClass::MenuLabel),
+                label: Label::new(label.into(), TextClass::MenuLabel),
                 layout_list: Default::default(),
             }
         }

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -5,7 +5,7 @@
 
 //! Menu Entries
 
-use super::Menu;
+use super::{Menu, SubItems};
 use crate::CheckBoxBare;
 use kas::component::{Component, Label};
 use kas::theme::{FrameStyle, IdRect, TextClass};
@@ -93,14 +93,11 @@ impl_scope! {
     }
 
     impl Menu for Self {
-        fn menu_sub_items(&mut self) -> Option<(
-            &mut dyn Component,
-            Option<&mut dyn Component>,
-            Option<&mut dyn Component>,
-            Option<&mut dyn Component>,
-            Option<&mut dyn WidgetConfig>,
-        )> {
-            Some((&mut self.label, None, None, None, None))
+        fn sub_items(&mut self) -> Option<SubItems> {
+            Some(SubItems {
+                label: Some(&mut self.label),
+                ..Default::default()
+            })
         }
     }
 }
@@ -154,14 +151,12 @@ impl_scope! {
     }
 
     impl Menu for Self {
-        fn menu_sub_items(&mut self) -> Option<(
-            &mut dyn Component,
-            Option<&mut dyn Component>,
-            Option<&mut dyn Component>,
-            Option<&mut dyn Component>,
-            Option<&mut dyn WidgetConfig>,
-        )> {
-            Some((&mut self.label, None, None, None, Some(&mut self.checkbox)))
+        fn sub_items(&mut self) -> Option<SubItems> {
+            Some(SubItems {
+                label: Some(&mut self.label),
+                toggle: Some(&mut self.checkbox),
+                ..Default::default()
+            })
         }
     }
 

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -81,7 +81,7 @@ impl_scope! {
         fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
             let dim = (self.direction, self.widgets.len());
             let mut solver = RowSolver::new(axis, dim, &mut self.layout_store);
-            let frame_rules = mgr.frame(FrameStyle::MenuEntry, axis.is_vertical());
+            let frame_rules = mgr.frame(FrameStyle::MenuEntry, axis);
             for (n, child) in self.widgets.iter_mut().enumerate() {
                 solver.for_child(&mut self.layout_store, n, |axis| {
                     let rules = child.size_rules(mgr.re(), axis);

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -6,9 +6,10 @@
 //! Menubar
 
 use super::{Menu, SubMenu, SubMenuBuilder};
-use crate::IndexedList;
 use kas::event::{self, Command};
+use kas::layout::{self, RowSetter, RowSolver, RulesSetter, RulesSolver};
 use kas::prelude::*;
+use kas::theme::FrameStyle;
 
 impl_scope! {
     /// A menu-bar
@@ -16,14 +17,13 @@ impl_scope! {
     /// This widget houses a sequence of menu buttons, allowing input actions across
     /// menus.
     #[autoimpl(Debug where D: trait)]
-    #[widget{
-        layout = single;
-    }]
+    #[widget]
     pub struct MenuBar<M: 'static, D: Directional = kas::dir::Right> {
         #[widget_core]
         core: CoreData,
-        #[widget]
-        pub bar: IndexedList<D, SubMenu<M, D::Flipped>>,
+        direction: D,
+        widgets: Vec<SubMenu<M, D::Flipped>>,
+        layout_store: layout::DynRowStorage,
         delayed_open: Option<WidgetId>,
     }
 
@@ -46,13 +46,59 @@ impl_scope! {
             }
             MenuBar {
                 core: Default::default(),
-                bar: IndexedList::new_with_direction(direction, menus),
+                direction,
+                widgets: menus,
+                layout_store: Default::default(),
                 delayed_open: None,
             }
         }
 
         pub fn builder() -> MenuBuilder<M, D> {
             MenuBuilder { menus: vec![] }
+        }
+    }
+
+    impl WidgetChildren for Self {
+        #[inline]
+        fn num_children(&self) -> usize {
+            self.widgets.len()
+        }
+        #[inline]
+        fn get_child(&self, index: usize) -> Option<&dyn WidgetConfig> {
+            self.widgets.get(index).map(|w| w.as_widget())
+        }
+        #[inline]
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn WidgetConfig> {
+            self.widgets.get_mut(index).map(|w| w.as_widget_mut())
+        }
+    }
+
+    impl Layout for Self {
+        fn layout(&mut self) -> layout::Layout<'_> {
+            layout::Layout::slice(&mut self.widgets, self.direction, &mut self.layout_store)
+        }
+
+        fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            let dim = (self.direction, self.widgets.len());
+            let mut solver = RowSolver::new(axis, dim, &mut self.layout_store);
+            let frame_rules = mgr.frame(FrameStyle::MenuEntry, axis.is_vertical());
+            for (n, child) in self.widgets.iter_mut().enumerate() {
+                solver.for_child(&mut self.layout_store, n, |axis| {
+                    let rules = child.size_rules(mgr.re(), axis);
+                    frame_rules.surround_as_margin(rules).0
+                });
+            }
+            solver.finish(&mut self.layout_store)
+        }
+
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+            self.core_data_mut().rect = rect;
+            let dim = (self.direction, self.widgets.len());
+            let mut setter = RowSetter::<D, Vec<i32>, _>::new(rect, dim, align, &mut self.layout_store);
+
+            for (n, child) in self.widgets.iter_mut().enumerate() {
+                child.set_rect(mgr, setter.child_rect(&mut self.layout_store, n), AlignHints::CENTER);
+            }
         }
     }
 
@@ -76,7 +122,7 @@ impl_scope! {
                 } => {
                     if start_id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
                         if source.is_primary() {
-                            let any_menu_open = self.bar.iter().any(|w| w.menu_is_open());
+                            let any_menu_open = self.widgets.iter().any(|w| w.menu_is_open());
                             let press_in_the_bar = self.rect().contains(coord);
 
                             if !press_in_the_bar || !any_menu_open {
@@ -85,7 +131,7 @@ impl_scope! {
                             mgr.set_grab_depress(source, start_id.clone());
                             if press_in_the_bar {
                                 if self
-                                    .bar
+                                    .widgets
                                     .iter()
                                     .any(|w| w.eq_id(&start_id) && !w.menu_is_open())
                                 {
@@ -116,7 +162,7 @@ impl_scope! {
                         None => return Response::Used,
                     };
 
-                    if self.bar.is_strict_ancestor_of(&id) {
+                    if self.is_strict_ancestor_of(&id) {
                         // We instantly open a sub-menu on motion over the bar,
                         // but delay when over a sub-menu (most intuitive?)
                         if self.rect().contains(coord) {
@@ -152,17 +198,17 @@ impl_scope! {
                     // Arrow keys can switch to the next / previous menu
                     // as well as to the first / last item of an open menu.
                     use Command::{Left, Up};
-                    let is_vert = self.bar.direction().is_vertical();
-                    let reverse = self.bar.direction().is_reversed() ^ matches!(cmd, Left | Up);
+                    let is_vert = self.direction.is_vertical();
+                    let reverse = self.direction.is_reversed() ^ matches!(cmd, Left | Up);
                     match cmd.as_direction().map(|d| d.is_vertical()) {
                         Some(v) if v == is_vert => {
-                            for i in 0..self.bar.len() {
-                                if self.bar[i].menu_is_open() {
+                            for i in 0..self.widgets.len() {
+                                if self.widgets[i].menu_is_open() {
                                     let mut j = isize::conv(i);
                                     j = if reverse { j - 1 } else { j + 1 };
-                                    j = j.rem_euclid(self.bar.len().cast());
-                                    self.bar[i].set_menu_path(mgr, None, true);
-                                    let w = &mut self.bar[usize::conv(j)];
+                                    j = j.rem_euclid(self.widgets.len().cast());
+                                    self.widgets[i].set_menu_path(mgr, None, true);
+                                    let w = &mut self.widgets[usize::conv(j)];
                                     w.set_menu_path(mgr, Some(&w.id()), true);
                                     break;
                                 }
@@ -184,21 +230,26 @@ impl_scope! {
     impl event::SendEvent for Self {
         fn send(&mut self, mgr: &mut EventMgr, id: WidgetId, event: Event) -> Response<Self::Msg> {
             if self.eq_id(&id) {
-                self.handle(mgr, event)
-            } else {
-                match self.bar.send(mgr, id.clone(), event.clone()) {
-                    Response::Unused => self.handle(mgr, event),
-                    r => r.try_into().unwrap_or_else(|(_, msg)| {
-                        log::trace!(
-                            "Received by {} from {}: {:?}",
-                            self.id(),
-                            id,
-                            kas::util::TryFormat(&msg)
-                        );
-                        Response::Msg(msg)
-                    }),
+                return self.handle(mgr, event);
+            } else if let Some(index) = id.next_key_after(self.id_ref()) {
+                if let Some(widget) = self.widgets.get_mut(index) {
+                    return match widget.send(mgr, id.clone(), event.clone()) {
+                        Response::Unused => self.handle(mgr, event),
+                        r => r.try_into().unwrap_or_else(|msg| {
+                            log::trace!(
+                                "Received by {} from {}: {:?}",
+                                self.id(),
+                                id,
+                                kas::util::TryFormat(&msg)
+                            );
+                            Response::Msg(msg)
+                        }),
+                    };
                 }
             }
+
+            debug_assert!(false, "SendEvent::send: bad WidgetId");
+            Response::Unused
         }
     }
 
@@ -206,8 +257,8 @@ impl_scope! {
         fn set_menu_path(&mut self, mgr: &mut EventMgr, target: Option<&WidgetId>, set_focus: bool) {
             log::trace!("{}::set_menu_path: target={:?}, set_focus={}", self.identify(), target, set_focus);
             self.delayed_open = None;
-            for i in 0..self.bar.len() {
-                self.bar[i].set_menu_path(mgr, target, set_focus);
+            for i in 0..self.widgets.len() {
+                self.widgets[i].set_menu_path(mgr, target, set_focus);
             }
         }
     }

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -202,7 +202,7 @@ impl_scope! {
         }
     }
 
-    impl Menu for Self {
+    impl Self {
         fn set_menu_path(&mut self, mgr: &mut EventMgr, target: Option<&WidgetId>, set_focus: bool) {
             log::trace!("{}::set_menu_path: target={:?}, set_focus={}", self.identify(), target, set_focus);
             self.delayed_open = None;

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -322,8 +322,8 @@ impl_scope! {
             let frame_rules = mgr.size_mgr().frame(FrameStyle::MenuEntry, is_vert);
             let (_, frame_offset, frame_size) = frame_rules.surround_no_margin(SizeRules::EMPTY);
             let subtract_frame = |mut rect: Rect| {
-                rect.pos = rect.pos + Offset::splat(frame_offset);
-                rect.size = rect.size - Size::splat(frame_size);
+                rect.pos += Offset::splat(frame_offset);
+                rect.size -= Size::splat(frame_size);
                 rect
             };
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -153,7 +153,9 @@ impl_scope! {
         fn draw(&mut self, mut draw: DrawMgr) {
             draw.frame(&*self, FrameStyle::MenuEntry, Default::default());
             self.label.draw(draw.re(), &self.core.id);
-            self.mark.draw(draw, &self.core.id);
+            if self.mark.rect.size != Size::ZERO {
+                self.mark.draw(draw, &self.core.id);
+            }
         }
     }
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -6,12 +6,13 @@
 //! Sub-menu
 
 use super::{BoxedMenu, Menu, MenuLabel};
-use crate::{Column, PopupFrame};
+use crate::PopupFrame;
 use kas::component::Component;
 use kas::event::{self, Command};
+use kas::layout::{self, RulesSetter, RulesSolver};
 use kas::prelude::*;
 use kas::theme::{FrameStyle, TextClass};
-use kas::{layout, WindowId};
+use kas::WindowId;
 
 impl_scope! {
     /// A sub-menu
@@ -25,7 +26,7 @@ impl_scope! {
         label: MenuLabel,
         layout_frame: layout::FrameStorage,
         #[widget]
-        pub list: PopupFrame<Column<BoxedMenu<M>>>,
+        list: PopupFrame<MenuView<BoxedMenu<M>>>,
         popup_id: Option<WindowId>,
     }
 
@@ -68,7 +69,7 @@ impl_scope! {
                 key_nav: true,
                 label: MenuLabel::new(label.into(), TextClass::MenuLabel),
                 layout_frame: Default::default(),
-                list: PopupFrame::new(Column::new(list)),
+                list: PopupFrame::new(MenuView::new(list)),
                 popup_id: None,
             }
         }
@@ -94,9 +95,8 @@ impl_scope! {
         fn handle_dir_key(&mut self, mgr: &mut EventMgr, cmd: Command) -> Response<M> {
             if self.menu_is_open() {
                 if let Some(dir) = cmd.as_direction() {
-                    if dir.is_vertical() == self.list.direction().is_vertical() {
-                        let rev = dir.is_reversed() ^ self.list.direction().is_reversed();
-                        mgr.next_nav_focus(self, rev, true);
+                    if dir.is_vertical() {
+                        mgr.next_nav_focus(self, false, true);
                         Response::Used
                     } else if dir == self.direction.as_direction().reversed() {
                         self.close_menu(mgr, true);
@@ -200,6 +200,14 @@ impl_scope! {
     }
 
     impl Menu for Self {
+        fn menu_sub_items(&mut self) -> Option<(
+            &mut MenuLabel,
+            Option<&mut dyn WidgetConfig>,
+        )> {
+            // Issue: widget is used both by MenuBar and other SubMenus
+            Some((&mut self.label, None))
+        }
+
         fn menu_is_open(&self) -> bool {
             self.popup_id.is_some()
         }
@@ -229,15 +237,190 @@ impl_scope! {
             self.label.as_str()
         }
     }
+}
 
-    impl SetAccel for Self {
-        fn set_accel_string(&mut self, string: AccelString) -> TkAction {
-            let mut action = TkAction::empty();
-            if self.label.keys() != string.keys() {
-                action |= TkAction::RECONFIGURE;
+const MENU_VIEW_COLS: u32 = 2;
+const fn menu_view_row_info(row: u32) -> layout::GridChildInfo {
+    layout::GridChildInfo {
+        col: 0,
+        col_end: MENU_VIEW_COLS,
+        row,
+        row_end: row + 1,
+    }
+}
+
+impl_scope! {
+    /// A menu view
+    #[autoimpl(Debug)]
+    #[widget {
+        msg=<W as Handler>::Msg;
+    }]
+    struct MenuView<W: Menu> {
+        #[widget_core]
+        core: CoreData,
+        dim: layout::GridDimensions,
+        store: layout::DynGridStorage, //NOTE(opt): number of columns is fixed
+        list: Vec<W>,
+    }
+
+    impl kas::WidgetChildren for Self {
+        #[inline]
+        fn num_children(&self) -> usize {
+            self.list.len()
+        }
+        #[inline]
+        fn get_child(&self, index: usize) -> Option<&dyn WidgetConfig> {
+            self.list.get(index).map(|w| w.as_widget())
+        }
+        #[inline]
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn WidgetConfig> {
+            self.list.get_mut(index).map(|w| w.as_widget_mut())
+        }
+    }
+
+    impl kas::Layout for Self {
+        fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            self.dim = layout::GridDimensions {
+                cols: MENU_VIEW_COLS,
+                col_spans: self.list.iter_mut().filter_map(|w| w.menu_sub_items().is_none().then(|| ())).count().cast(),
+                rows: self.list.len().cast(),
+                row_spans: 0,
+            };
+
+            let store = &mut self.store;
+            let mut solver = layout::GridSolver::<Vec<_>, Vec<_>, _>::new(axis, self.dim, store);
+
+            let frame_rules = mgr.frame(FrameStyle::MenuEntry, axis.is_vertical());
+            let is_horiz = axis.is_horizontal();
+            let with_frame_rules = |rules| if is_horiz {
+                frame_rules.surround_with_margin(rules).0
+            } else {
+                frame_rules.surround_no_margin(rules).0
+            };
+
+            for (row, child) in self.list.iter_mut().enumerate() {
+                let row = u32::conv(row);
+                if let Some((label, opt_toggle)) = child.menu_sub_items() {
+                    if let Some(w) = opt_toggle {
+                        let info = layout::GridChildInfo::new(0, row);
+                        solver.for_child(store, info, |axis| with_frame_rules(w.size_rules(mgr.re(), axis)));
+                    }
+                    let info = layout::GridChildInfo::new(1, row);
+                    solver.for_child(store, info, |axis| with_frame_rules(label.size_rules(mgr.re(), axis)));
+                } else {
+                    let info = menu_view_row_info(row);
+                    solver.for_child(store, info, |axis| child.size_rules(mgr.re(), axis));
+                }
             }
-            let avail = self.core.rect.size.clamped_sub(self.layout_frame.size);
-            action | self.label.set_text_and_prepare(string, avail)
+            solver.finish(store)
+        }
+
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+            self.core.rect = rect;
+            let store = &mut self.store;
+            let mut setter = layout::GridSetter::<Vec<_>, Vec<_>, _>::new(rect, self.dim, align, store);
+
+            // Assumption: frame inner margin is at least as large as content margins
+            let is_vert = false; // assumption: horiz and vert are the same
+            let frame_rules = mgr.size_mgr().frame(FrameStyle::MenuEntry, is_vert);
+            let (_, frame_offset, frame_size) = frame_rules.surround_no_margin(SizeRules::EMPTY);
+            let subtract_frame = |mut rect: Rect| {
+                rect.pos = rect.pos + Offset::splat(frame_offset);
+                rect.size = rect.size - Size::splat(frame_size);
+                rect
+            };
+
+            for (row, child) in self.list.iter_mut().enumerate() {
+                let row = u32::conv(row);
+                let child_rect = setter.child_rect(store, menu_view_row_info(row));
+
+                if let Some((label, opt_toggle)) = child.menu_sub_items() {
+                    if let Some(w) = opt_toggle {
+                        let info = layout::GridChildInfo::new(0, row);
+                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)), align);
+                    }
+                    let info = layout::GridChildInfo::new(1, row);
+                    label.set_rect(mgr, subtract_frame(setter.child_rect(store, info)), align);
+
+                    child.core_data_mut().rect = child_rect;
+                } else {
+                    child.set_rect(mgr, rect, align);
+                }
+            }
+        }
+
+        fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
+            if !self.rect().contains(coord) {
+                return None;
+            }
+
+            for child in self.list.iter_mut() {
+                if let Some(id) = child.find_id(coord) {
+                    return Some(id);
+                }
+            }
+            Some(self.id())
+        }
+
+        fn draw(&mut self, mut draw: DrawMgr) {
+            for child in self.list.iter_mut() {
+                child.draw(draw.re());
+            }
+        }
+    }
+
+    impl event::SendEvent for Self {
+        fn send(&mut self, mgr: &mut EventMgr, id: WidgetId, event: Event) -> Response<Self::Msg> {
+            if let Some(index) = self.find_child_index(&id) {
+                if let Some(child) = self.list.get_mut(index) {
+                    let r = child.send(mgr, id.clone(), event);
+                    return match Response::try_from(r) {
+                        Ok(r) => r,
+                        Err(msg) => {
+                            log::trace!(
+                                "Received by {} from {}: {:?}",
+                                self.id(),
+                                id,
+                                kas::util::TryFormat(&msg)
+                            );
+                            Response::Msg(msg)
+                        }
+                    };
+                }
+            }
+
+            Response::Unused
+        }
+    }
+
+    impl Self {
+        /// Construct from a list of menu items
+        pub fn new(list: Vec<W>) -> Self {
+            MenuView {
+                core: Default::default(),
+                dim: Default::default(),
+                store: Default::default(),
+                list,
+            }
+        }
+
+        /// Number of menu items
+        pub fn len(&self) -> usize {
+            self.list.len()
+        }
+    }
+
+    impl std::ops::Index<usize> for Self {
+        type Output = W;
+
+        fn index(&self, index: usize) -> &Self::Output {
+            &self.list[index]
+        }
+    }
+
+    impl std::ops::IndexMut<usize> for Self {
+        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+            &mut self.list[index]
         }
     }
 }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -24,7 +24,6 @@ impl_scope! {
         direction: D,
         pub(crate) key_nav: bool,
         label: MenuLabel,
-        layout_frame: layout::FrameStorage,
         #[widget]
         list: PopupFrame<MenuView<BoxedMenu<M>>>,
         popup_id: Option<WindowId>,
@@ -68,7 +67,6 @@ impl_scope! {
                 direction,
                 key_nav: true,
                 label: MenuLabel::new(label.into(), TextClass::MenuLabel),
-                layout_frame: Default::default(),
                 list: PopupFrame::new(MenuView::new(list)),
                 popup_id: None,
             }
@@ -140,8 +138,7 @@ impl_scope! {
 
     impl kas::Layout for Self {
         fn layout(&mut self) -> layout::Layout<'_> {
-            let label = layout::Layout::component(&mut self.label);
-            layout::Layout::frame(&mut self.layout_frame, label, FrameStyle::MenuEntry)
+            layout::Layout::component(&mut self.label)
         }
 
         fn spatial_nav(&mut self, _: &mut SetRectMgr, _: bool, _: Option<usize>) -> Option<usize> {
@@ -293,7 +290,7 @@ impl_scope! {
             let frame_rules = mgr.frame(FrameStyle::MenuEntry, axis.is_vertical());
             let is_horiz = axis.is_horizontal();
             let with_frame_rules = |rules| if is_horiz {
-                frame_rules.surround_with_margin(rules).0
+                frame_rules.surround_as_margin(rules).0
             } else {
                 frame_rules.surround_no_margin(rules).0
             };
@@ -344,7 +341,7 @@ impl_scope! {
 
                     child.core_data_mut().rect = child_rect;
                 } else {
-                    child.set_rect(mgr, rect, align);
+                    child.set_rect(mgr, child_rect, align);
                 }
             }
         }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -35,16 +35,10 @@ impl_scope! {
             size_mgr.text_bound(&mut self.text, TextClass::LabelScroll, axis)
         }
 
-        fn set_rect(&mut self, _: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
-            let size = rect.size;
-            self.required = self
-                .text
-                .update_env(|env| {
-                    env.set_align(align.unwrap_or(Align::Default, Align::Default));
-                    env.set_bounds(size.cast());
-                })
-                .into();
+            let align = align.unwrap_or(Align::Default, Align::Default);
+            self.required = mgr.text_set_size(&mut self.text, TextClass::LabelScroll, rect.size, align);
             self.set_view_offset_from_edit_pos();
         }
 

--- a/crates/kas-widgets/src/scrollbar.rs
+++ b/crates/kas-widgets/src/scrollbar.rs
@@ -210,7 +210,6 @@ impl_scope! {
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
             let (size, min_len) = size_mgr.scrollbar();
-            self.min_handle_len = size.0;
             let margins = (0, 0);
             if self.direction.is_vertical() == axis.is_vertical() {
                 SizeRules::new(min_len, min_len, margins, Stretch::High)
@@ -228,6 +227,7 @@ impl_scope! {
                 .aligned_rect(ideal_size, rect);
             self.core.rect = rect;
             self.handle.set_rect(mgr, rect, align);
+            self.min_handle_len = (mgr.size_mgr().scrollbar().0).0;
             let _ = self.update_handle();
         }
 

--- a/crates/kas-widgets/src/separator.rs
+++ b/crates/kas-widgets/src/separator.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Debug;
 
-use crate::Menu;
+use crate::menu::Menu;
 use kas::prelude::*;
 
 impl_scope! {

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -161,9 +161,6 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            // Assumption: if size_rules is called, then set_rect will be too.
-            self.size_solved = true;
-
             if self.widgets.is_empty() {
                 return SizeRules::EMPTY;
             }
@@ -195,6 +192,7 @@ impl_scope! {
 
         fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
+            self.size_solved = true;
             if self.widgets.is_empty() {
                 return;
             }

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -40,7 +40,7 @@ impl_scope! {
         core: CoreData,
         align_hints: AlignHints,
         widgets: Vec<W>,
-        sized_range: Range<usize>,
+        sized_range: Range<usize>, // range of pages for which size rules are solved
         active: usize,
         size_limit: usize,
         next: usize,

--- a/crates/kas-widgets/src/view/driver.rs
+++ b/crates/kas-widgets/src/view/driver.rs
@@ -43,8 +43,7 @@ pub trait Driver<T>: Debug + 'static {
     /// Set the viewed data
     ///
     /// The widget may expect `configure` to be called at least once before data
-    /// is set and to have `size_rules` and `set_rect` called after each time
-    /// data is set.
+    /// is set and to have `set_rect` called after each time data is set.
     fn set(&self, widget: &mut Self::Widget, data: T) -> TkAction;
     /// Get data from the view
     ///

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -130,7 +130,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Quit,
     }
 
-    let menubar = MenuBar::<Menu>::builder()
+    let menubar = menu::MenuBar::<Menu>::builder()
         .menu("&App", |menu| {
             menu.entry("&Quit", Menu::Quit);
         })


### PR DESCRIPTION
Previously it was required to call `Layout::size_rules` for each axis before calling `Layout::set_rect`; not doing so could cause a panic (text entries). This requirement is removed. (It is also planned to avoid a panic if `Layout::draw` is called without `Layout::set_rect`, but this requires changes to KAS-text.)

Added: `kas_core::component` module with `Component` trait. This is replaces the internal `Visitor` trait. Two public implementations currently exist:

- `Label`: a text object with position
- `Mark`: a new graphical item, currently only supporting "angle" style arrow marks

Added internal `MenuView` type used for a grid layout of menu items (thus aligning menu labels etc.). This makes use of the loosened layout rules.

Sub-menus and `ComboBox` now have a marker.
![submenu-marker](https://user-images.githubusercontent.com/134893/163561407-be530adf-302f-4d9f-9d5c-90c3a4ae01fe.png)
