### PR TITLE
Trait revision, part 2: remove configure_recurse, core_data[_mut]

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -117,7 +117,7 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// The default implementation simply uses [`WidgetId::next_key_after`].
     /// Widgets may choose to assign children custom keys by overriding this
-    /// method and [`Widget::configure_recurse`].
+    /// method and [`Widget::make_child_id`].
     #[inline]
     fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
         id.next_key_after(self.id_ref())
@@ -267,34 +267,6 @@ pub trait Widget: Layout {
     fn pre_configure(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
         let _ = mgr;
         self.core_data_mut().id = id;
-    }
-
-    /// Configure widget and children
-    ///
-    /// This method:
-    ///
-    /// 1.  Assigns `id` to self
-    /// 2.  Constructs an identifier for and call `configure_recurse` on each child
-    /// 3.  Calls [`Self::configure`]
-    ///
-    /// Normally the default implementation is used. A custom implementation
-    /// may be used to influence configuration of children, for example by
-    /// calling [`EventState::new_accel_layer`] or by constructing children's
-    /// [`WidgetId`] values in a non-standard manner (in this case ensure that
-    /// [`WidgetChildren::find_child_index`] has a correct implementation).
-    ///
-    /// To directly configure a child, call [`SetRectMgr::configure`] instead.
-    fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-        self.pre_configure(mgr, id);
-
-        for index in 0..self.num_children() {
-            let id = self.make_child_id(index);
-            if let Some(widget) = self.get_child_mut(index) {
-                widget.configure_recurse(mgr, id);
-            }
-        }
-
-        self.configure(mgr);
     }
 
     /// Configure widget
@@ -493,7 +465,7 @@ pub trait WidgetExt: WidgetChildren {
     ///
     /// Note that the default-constructed [`WidgetId`] is *invalid*: any
     /// operations on this value will cause a panic. Valid identifiers are
-    /// assigned by [`Widget::configure_recurse`].
+    /// assigned by [`Widget::pre_configure`].
     #[inline]
     fn id(&self) -> WidgetId {
         self.core_data().id.clone()
@@ -503,7 +475,7 @@ pub trait WidgetExt: WidgetChildren {
     ///
     /// Note that the default-constructed [`WidgetId`] is *invalid*: any
     /// operations on this value will cause a panic. Valid identifiers are
-    /// assigned by [`Widget::configure_recurse`].
+    /// assigned by [`Widget::pre_configure`].
     #[inline]
     fn id_ref(&self) -> &WidgetId {
         &self.core_data().id

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -13,7 +13,7 @@ use crate::geom::{Coord, Offset, Rect};
 use crate::layout::{self, AlignHints, AxisInfo, SetRectMgr, SizeRules};
 use crate::theme::{DrawMgr, SizeMgr};
 use crate::util::IdentifyWidget;
-use crate::{CoreData, WidgetId};
+use crate::WidgetId;
 use kas_macros::autoimpl;
 
 #[allow(unused)]
@@ -55,13 +55,6 @@ pub trait WidgetCore: Any + fmt::Debug {
 
     /// Get self as type `Any` (mutable)
     fn as_any_mut(&mut self) -> &mut dyn Any;
-
-    /// Get mutable access to the [`CoreData`] providing property storage.
-    ///
-    /// This should not normally be needed by user code.
-    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-    #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    fn core_data_mut(&mut self) -> &mut CoreData;
 
     /// Get the widget's identifier
     ///
@@ -211,14 +204,11 @@ pub trait Layout: WidgetChildren {
     /// itself within the excess space, according to the `align` hints provided.
     ///
     /// This method may be implemented through [`Self::layout`] or directly.
-    /// The default implementation assigns `self.core_data_mut().rect = rect`
+    /// The default implementation assigns `self.core.rect = rect`
     /// and applies the layout described by [`Self::layout`].
     ///
     /// [`Stretch`]: crate::layout::Stretch
-    fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
-        self.core_data_mut().rect = rect;
-        self.layout().set_rect(mgr, rect, align);
-    }
+    fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints);
 
     /// Draw a widget and its children
     ///
@@ -274,10 +264,7 @@ pub trait Widget: Layout {
     /// [`EventState::new_accel_layer`].
     ///
     /// Default impl: assign `id` to self
-    fn pre_configure(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-        let _ = mgr;
-        self.core_data_mut().id = id;
-    }
+    fn pre_configure(&mut self, mgr: &mut SetRectMgr, id: WidgetId);
 
     /// Configure widget
     ///

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -188,23 +188,26 @@ pub trait Layout: WidgetChildren {
 
     /// Set size and position
     ///
-    /// This is the final step to layout solving. It may be influenced by
-    /// [`Self::size_rules`], but it is not guaranteed that `size_rules` is
-    /// called first. After calling `set_rect`, the widget must be ready for
-    /// calls to [`Self::draw`] and event handling.
+    /// This is the final step to layout solving. It is expected that [`Self::size_rules`] is called
+    /// for each axis before this method; if this does not happen then layout may be incorrect.
+    /// Note that `size_rules` may not be called again before the next call to `set_rect`.
+    /// After `set_rect` is called, the widget must be ready for drawing and event handling.
     ///
     /// The size of the assigned `rect` is normally at least the minimum size
     /// requested by [`Self::size_rules`], but this is not guaranteed. In case
     /// this minimum is not met, it is permissible for the widget to draw
     /// outside of its assigned `rect` and to not function as normal.
     ///
-    /// The assigned `rect` may be larger than the widget's size requirements.
+    /// The assigned `rect` may be larger than the widget's size requirements,
+    /// regardless of the [`Stretch`] policy used.
     /// It is up to the widget to either stretch to occupy this space or align
     /// itself within the excess space, according to the `align` hints provided.
     ///
     /// This method may be implemented through [`Self::layout`] or directly.
     /// The default implementation assigns `self.core_data_mut().rect = rect`
     /// and applies the layout described by [`Self::layout`].
+    ///
+    /// [`Stretch`]: crate::layout::Stretch
     fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
         self.core_data_mut().rect = rect;
         self.layout().set_rect(mgr, rect, align);

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -256,6 +256,19 @@ pub trait Widget: Layout {
         self.id_ref().make_child(index)
     }
 
+    /// Pre-configuration
+    ///
+    /// This method is called before children are configured to assign a
+    /// [`WidgetId`]. Usually it does nothing else, but a custom implementation
+    /// may be used to affect child configuration, e.g. via
+    /// [`EventState::new_accel_layer`].
+    ///
+    /// Default impl: assign `id` to self
+    fn pre_configure(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
+        let _ = mgr;
+        self.core_data_mut().id = id;
+    }
+
     /// Configure widget and children
     ///
     /// This method:
@@ -272,7 +285,7 @@ pub trait Widget: Layout {
     ///
     /// To directly configure a child, call [`SetRectMgr::configure`] instead.
     fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-        self.core_data_mut().id = id;
+        self.pre_configure(mgr, id);
 
         for index in 0..self.num_children() {
             let id = self.make_child_id(index);

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -248,6 +248,14 @@ pub trait Layout: WidgetChildren {
 /// [`derive(Widget)`]: https://docs.rs/kas/latest/kas/macros/index.html#the-derivewidget-macro
 #[autoimpl(for<T: trait + ?Sized> Box<T>)]
 pub trait Widget: Layout {
+    /// Make an identifier for a child
+    ///
+    /// Default impl: `self.id_ref().make_child(index)`
+    #[inline]
+    fn make_child_id(&mut self, index: usize) -> WidgetId {
+        self.id_ref().make_child(index)
+    }
+
     /// Configure widget and children
     ///
     /// This method:
@@ -267,7 +275,7 @@ pub trait Widget: Layout {
         self.core_data_mut().id = id;
 
         for index in 0..self.num_children() {
-            let id = self.id_ref().make_child(index);
+            let id = self.make_child_id(index);
             if let Some(widget) = self.get_child_mut(index) {
                 widget.configure_recurse(mgr, id);
             }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -67,7 +67,7 @@ impl EventState {
     /// This should be called by the toolkit on the widget tree when the window
     /// is created (before or after resizing).
     ///
-    /// This method calls [`Widget::configure_recurse`] in order to assign
+    /// This method calls [`SetRectMgr::configure`] in order to assign
     /// [`WidgetId`] identifiers and call widgets' [`Widget::configure`]
     /// method. Additionally, it updates the [`EventState`] to account for
     /// renamed and removed widgets.

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -275,6 +275,8 @@ impl Size {
     }
 
     /// Construct, using the same value on all axes
+    ///
+    /// In debug mode, this asserts that components are non-negative.
     #[inline]
     pub fn splat(n: i32) -> Self {
         debug_assert!(n >= 0, "Size::splat({}): negative value", n);
@@ -323,6 +325,9 @@ impl std::ops::AddAssign for Size {
     }
 }
 
+/// Subtract a `Size` from a `Size`
+///
+/// In debug mode this asserts that the result is non-negative.
 impl std::ops::Sub for Size {
     type Output = Self;
 
@@ -335,6 +340,9 @@ impl std::ops::Sub for Size {
         Self(self.0 - rhs.0, self.1 - rhs.1)
     }
 }
+/// Subtract a `Size` from a `Size`
+///
+/// In debug mode this asserts that the result is non-negative.
 impl std::ops::SubAssign for Size {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
@@ -347,6 +355,9 @@ impl std::ops::SubAssign for Size {
     }
 }
 
+/// Multiply a `Size` by an integer
+///
+/// In debug mode this asserts that the result is non-negative.
 impl std::ops::Mul<i32> for Size {
     type Output = Self;
 
@@ -356,6 +367,9 @@ impl std::ops::Mul<i32> for Size {
         Size(self.0 * x, self.1 * x)
     }
 }
+/// Divide a `Size` by an integer
+///
+/// In debug mode this asserts that the result is non-negative.
 impl std::ops::Div<i32> for Size {
     type Output = Self;
 
@@ -366,6 +380,9 @@ impl std::ops::Div<i32> for Size {
     }
 }
 
+/// Convert an [`Offset`] into a [`Coord`]
+///
+/// In debug mode this asserts that the result is non-negative.
 impl Conv<Offset> for Coord {
     #[inline]
     fn try_conv(v: Offset) -> Result<Self> {
@@ -374,6 +391,9 @@ impl Conv<Offset> for Coord {
     }
 }
 
+/// Convert an [`Offset`] into a [`Size`]
+///
+/// In debug mode this asserts that the result is non-negative.
 impl Conv<Offset> for Size {
     #[inline]
     fn try_conv(v: Offset) -> Result<Self> {
@@ -413,7 +433,6 @@ impl Conv<Size> for (u32, u32) {
 impl Conv<Size> for kas_text::Vec2 {
     #[inline]
     fn try_conv(size: Size) -> Result<Self> {
-        debug_assert!(size.0 >= 0 && size.1 >= 0);
         Ok(Vec2::try_conv(size)?.into())
     }
 }
@@ -575,6 +594,8 @@ impl Rect {
     }
 
     /// Expand self in all directions by the given `n`
+    ///
+    /// In debug mode this asserts that `n` is non-negative.
     #[inline]
     #[must_use = "method does not modify self but returns a new value"]
     pub fn expand(&self, n: i32) -> Rect {

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -58,38 +58,29 @@ impl Quad {
     }
 
     /// Shrink self in all directions by the given `value`
-    ///
-    /// In debug mode, this asserts `a.le(b)` after shrinking.
     #[inline]
     #[must_use = "method does not modify self but returns a new value"]
     pub fn shrink(&self, value: f32) -> Quad {
         let a = self.a + value;
         let b = self.b - value;
-        debug_assert!(a.le(b));
         Quad { a, b }
     }
 
     /// Grow self in all directions by the given `value`
-    ///
-    /// In debug mode, this asserts `a.le(b)` after shrinking.
     #[inline]
     #[must_use = "method does not modify self but returns a new value"]
     pub fn grow(&self, value: f32) -> Quad {
         let a = self.a - value;
         let b = self.b + value;
-        debug_assert!(a.le(b));
         Quad { a, b }
     }
 
     /// Shrink self in all directions by the given `value`
-    ///
-    /// In debug mode, this asserts `a.le(b)` after shrinking.
     #[inline]
     #[must_use = "method does not modify self but returns a new value"]
     pub fn shrink_vec(&self, value: Vec2) -> Quad {
         let a = self.a + value;
         let b = self.b - value;
-        debug_assert!(a.le(b));
         Quad { a, b }
     }
 

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -195,9 +195,16 @@ impl<'a> SetRectMgr<'a> {
     /// the parent's id via [`WidgetId::make_child`].
     #[inline]
     pub fn configure(&mut self, id: WidgetId, widget: &mut dyn Widget) {
-        // Yes, this method is just a shim! We reserve the option to add other code here in the
-        // future, hence do not advise calling `configure_recurse` directly.
-        widget.configure_recurse(self, id);
+        widget.pre_configure(self, id);
+
+        for index in 0..widget.num_children() {
+            let id = widget.make_child_id(index);
+            if let Some(widget) = widget.get_child_mut(index) {
+                self.configure(id, widget);
+            }
+        }
+
+        widget.configure(self);
     }
 
     /// Update a text object, setting font properties and wrap size

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -12,7 +12,7 @@ use super::{Align, AlignHints, AxisInfo, SizeRules};
 use super::{RowStorage, RowTemp, RulesSetter, RulesSolver};
 use crate::dir::{Direction, Directional};
 use crate::geom::{Coord, Rect};
-use crate::{Widget, WidgetExt};
+use crate::Widget;
 
 /// A [`RulesSolver`] for rows (and, without loss of generality, for columns).
 ///

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -134,17 +134,16 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// traits only if not implemented explicitly within the
 /// defining [`impl_scope!`].
 ///
-/// Using the `derive` argument activates a special "thin wrapper" mode.
-/// In this case, layout may optionally be defined explicitly. Non-layout
-/// properties are not supported.
-///
-/// When not using `derive`, layout must be defined, either via the `layout`
-/// argument or by implementing [`Layout`]. All other properties are optional.
+/// This macro may inject methods into existing [`Layout`] / [`Widget`] implementations.
+/// This is used both to provide default implementations which could not be
+/// written on the trait and to implement properties like `key_nav`.
+/// (In the case of multiple implementations of the same trait, as used for
+/// specialization, only the first implementation of each trait is extended.)
 ///
 /// ## Syntax
 ///
 /// > _WidgetAttr_ :\
-/// > &nbsp;&nbsp; `#` `[` _WidgetAttrArgs_? `]`
+/// > &nbsp;&nbsp; `#` `[` `widget` _WidgetAttrArgs_? `]`
 /// >
 /// > _WidgetAttrArgs_ :\
 /// > &nbsp;&nbsp; `{` (_WidgetAttrArg_ `;`) * `}`
@@ -170,9 +169,23 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// -   `#[widget]`: marks the field as a [`Widget`] to be configured, enumerated by
 ///     [`WidgetChildren`] and included by glob layouts
 ///
-/// ## Layout
+/// ## Derive
 ///
-/// Widget layout must be described somehow
+/// It is possible to derive from a field which is itself a widget, e.g.:
+/// ```ignore
+/// impl_scope! {
+///     #[autoimpl(Deref, DerefMut using self.0)]
+///     #[derive(Clone, Debug, Default)]
+///     #[widget{ derive = self.0; }]
+///     pub struct ScrollBarRegion<W: Widget>(ScrollBars<ScrollRegion<W>>);
+/// }
+/// ```
+///
+/// This is a special mode where most features of `#[widget]` are not
+/// available. A few may still be used: `key_nav`, `hover_highlight`,
+/// `cursor_icon`. Additionally, it is currently permitted to implement
+/// [`WidgetChildren`], [`Layout`] and [`Widget`] traits manually (this option
+/// may be removed in the future if not deemed useful).
 ///
 /// [`Widget`]: https://docs.rs/kas/0.11/kas/trait.Widget.html
 /// [`WidgetCore`]: https://docs.rs/kas/0.11/kas/trait.WidgetCore.html

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -188,8 +188,8 @@ pub fn widget(mut attr: WidgetArgs, scope: &mut Scope) -> Result<()> {
         }
     });
 
-    if impl_widget_children {
-        if let Some(inner) = opt_derive {
+    if let Some(inner) = opt_derive {
+        if impl_widget_children {
             scope.generated.push(quote! {
                 impl #impl_generics ::kas::WidgetChildren
                     for #name #ty_generics #where_clause
@@ -212,120 +212,45 @@ pub fn widget(mut attr: WidgetArgs, scope: &mut Scope) -> Result<()> {
                     }
                 }
             });
-        } else {
-            let count = children.len();
+        }
 
-            let mut get_rules = quote! {};
-            let mut get_mut_rules = quote! {};
-            for (i, child) in children.iter().enumerate() {
-                let ident = &child.ident;
-                get_rules.append_all(quote! { #i => Some(&self.#ident), });
-                get_mut_rules.append_all(quote! { #i => Some(&mut self.#ident), });
-            }
-
+        if layout_impl.is_none() {
             scope.generated.push(quote! {
-                impl #impl_generics ::kas::WidgetChildren
-                    for #name #ty_generics #where_clause
+                impl #impl_generics ::kas::Layout
+                        for #name #ty_generics #where_clause
                 {
-                    fn num_children(&self) -> usize {
-                        #count
+                    #[inline]
+                    fn layout(&mut self) -> ::kas::layout::Layout<'_> {
+                        self.#inner.layout()
                     }
-                    fn get_child(&self, _index: usize) -> Option<&dyn ::kas::Widget> {
-                        match _index {
-                            #get_rules
-                            _ => None
-                        }
+                    #[inline]
+                    fn size_rules(&mut self,
+                        size_mgr: ::kas::theme::SizeMgr,
+                        axis: ::kas::layout::AxisInfo,
+                    ) -> ::kas::layout::SizeRules {
+                        self.#inner.size_rules(size_mgr, axis)
                     }
-                    fn get_child_mut(&mut self, _index: usize) -> Option<&mut dyn ::kas::Widget> {
-                        match _index {
-                            #get_mut_rules
-                            _ => None
-                        }
+                    #[inline]
+                    fn set_rect(
+                        &mut self,
+                        mgr: &mut ::kas::layout::SetRectMgr,
+                        rect: ::kas::geom::Rect,
+                        align: ::kas::layout::AlignHints,
+                    ) {
+                        self.#inner.set_rect(mgr, rect, align);
+                    }
+                    #[inline]
+                    fn draw(
+                        &mut self,
+                        draw: ::kas::theme::DrawMgr,
+                    ) {
+                        self.#inner.draw(draw);
                     }
                 }
             });
         }
-    }
 
-    let layout = match attr.layout.take() {
-        Some(layout) => {
-            let layout = layout.generate(children.iter().map(|c| &c.ident))?;
-            Some(quote! {
-                fn layout<'a>(&'a mut self) -> ::kas::layout::Layout<'a> {
-                    use ::kas::{WidgetCore, layout};
-                    let mut _chain = &mut (#access_core_data_mut).layout;
-                    #layout
-                }
-            })
-        }
-        None => None,
-    };
-
-    if let Some(index) = layout_impl {
-        let layout_impl = &mut scope.impls[index];
-        if let Some(item) = layout {
-            layout_impl.items.push(parse2(item)?);
-        }
-    } else if let Some(inner) = opt_derive {
-        let layout = layout.unwrap_or_else(|| {
-            quote! {
-                #[inline]
-                fn layout(&mut self) -> ::kas::layout::Layout<'_> {
-                    self.#inner.layout()
-                }
-            }
-        });
-        scope.generated.push(quote! {
-            impl #impl_generics ::kas::Layout
-                    for #name #ty_generics #where_clause
-            {
-                #layout
-                #[inline]
-                fn size_rules(&mut self,
-                    size_mgr: ::kas::theme::SizeMgr,
-                    axis: ::kas::layout::AxisInfo,
-                ) -> ::kas::layout::SizeRules {
-                    self.#inner.size_rules(size_mgr, axis)
-                }
-                #[inline]
-                fn set_rect(
-                    &mut self,
-                    mgr: &mut ::kas::layout::SetRectMgr,
-                    rect: ::kas::geom::Rect,
-                    align: ::kas::layout::AlignHints,
-                ) {
-                    self.#inner.set_rect(mgr, rect, align);
-                }
-                #[inline]
-                fn draw(
-                    &mut self,
-                    draw: ::kas::theme::DrawMgr,
-                ) {
-                    self.#inner.draw(draw);
-                }
-            }
-        });
-    } else if let Some(layout) = layout {
-        scope.generated.push(quote! {
-            impl #impl_generics ::kas::Layout for #name #ty_generics #where_clause {
-                #layout
-            }
-        });
-    }
-
-    if let Some(index) = widget_impl {
-        let widget_impl = &mut scope.impls[index];
-        if let Some(item) = attr.key_nav {
-            widget_impl.items.push(parse2(item)?);
-        }
-        if let Some(item) = attr.hover_highlight {
-            widget_impl.items.push(parse2(item)?);
-        }
-        if let Some(item) = attr.cursor_icon {
-            widget_impl.items.push(parse2(item)?);
-        }
-    } else {
-        let methods = if let Some(inner) = opt_derive {
+        if widget_impl.is_none() {
             let key_nav = attr.key_nav.unwrap_or_else(|| {
                 quote! {
                     #[inline]
@@ -350,97 +275,171 @@ pub fn widget(mut attr: WidgetArgs, scope: &mut Scope) -> Result<()> {
                     }
                 }
             });
-            quote! {
-                #[inline]
-                fn make_child_id(&mut self, index: usize) -> ::kas::WidgetId {
-                    self.#inner.make_child_id(index)
-                }
-                #[inline]
-                fn pre_configure(
-                    &mut self,
-                    mgr: &mut ::kas::layout::SetRectMgr,
-                    id: ::kas::WidgetId,
-                ) {
-                    self.#inner.pre_configure(mgr, id)
-                }
-                #[inline]
-                fn configure(&mut self, mgr: &mut ::kas::layout::SetRectMgr) {
-                    self.#inner.configure(mgr);
-                }
-                #key_nav
-                #hover_highlight
-                #cursor_icon
+            scope.generated.push(quote! {
+                impl #impl_generics ::kas::Widget
+                        for #name #ty_generics #where_clause
+                {
+                    #[inline]
+                    fn make_child_id(&mut self, index: usize) -> ::kas::WidgetId {
+                        self.#inner.make_child_id(index)
+                    }
+                    #[inline]
+                    fn pre_configure(
+                        &mut self,
+                        mgr: &mut ::kas::layout::SetRectMgr,
+                        id: ::kas::WidgetId,
+                    ) {
+                        self.#inner.pre_configure(mgr, id)
+                    }
+                    #[inline]
+                    fn configure(&mut self, mgr: &mut ::kas::layout::SetRectMgr) {
+                        self.#inner.configure(mgr);
+                    }
+                    #key_nav
+                    #hover_highlight
+                    #cursor_icon
 
-                #[inline]
-                fn translation(&self) -> ::kas::geom::Offset {
-                    self.#inner.translation()
-                }
-                #[inline]
-                fn spatial_nav(
-                    &mut self,
-                    mgr: &mut ::kas::layout::SetRectMgr,
-                    reverse: bool,
-                    from: Option<usize>,
-                ) -> Option<usize> {
-                    self.#inner.spatial_nav(mgr, reverse, from)
-                }
-                #[inline]
-                fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
-                    self.#inner.find_id(coord)
-                }
+                    #[inline]
+                    fn translation(&self) -> ::kas::geom::Offset {
+                        self.#inner.translation()
+                    }
+                    #[inline]
+                    fn spatial_nav(
+                        &mut self,
+                        mgr: &mut ::kas::layout::SetRectMgr,
+                        reverse: bool,
+                        from: Option<usize>,
+                    ) -> Option<usize> {
+                        self.#inner.spatial_nav(mgr, reverse, from)
+                    }
+                    #[inline]
+                    fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
+                        self.#inner.find_id(coord)
+                    }
 
-                #[inline]
-                fn handle_event(
-                    &mut self,
-                    mgr: &mut ::kas::event::EventMgr,
-                    event: ::kas::event::Event,
-                ) -> ::kas::event::Response {
-                    self.#inner.handle_event(mgr, event)
+                    #[inline]
+                    fn handle_event(
+                        &mut self,
+                        mgr: &mut ::kas::event::EventMgr,
+                        event: ::kas::event::Event,
+                    ) -> ::kas::event::Response {
+                        self.#inner.handle_event(mgr, event)
+                    }
+                    #[inline]
+                    fn handle_unused(
+                        &mut self,
+                        mgr: &mut ::kas::event::EventMgr,
+                        index: usize,
+                        event: ::kas::event::Event,
+                    ) -> ::kas::event::Response {
+                        self.#inner.handle_unused(mgr, index, event)
+                    }
+                    #[inline]
+                    fn handle_message(
+                        &mut self,
+                        mgr: &mut ::kas::event::EventMgr,
+                        index: usize,
+                    ) {
+                        self.#inner.handle_message(mgr, index);
+                    }
+                    #[inline]
+                    fn handle_scroll(
+                        &mut self,
+                        mgr: &mut ::kas::event::EventMgr,
+                        scroll: ::kas::event::Scroll,
+                    ) {
+                        self.#inner.handle_scroll(mgr, scroll);
+                    }
                 }
-                #[inline]
-                fn handle_unused(
-                    &mut self,
-                    mgr: &mut ::kas::event::EventMgr,
-                    index: usize,
-                    event: ::kas::event::Event,
-                ) -> ::kas::event::Response {
-                    self.#inner.handle_unused(mgr, index, event)
+            });
+        }
+
+        return Ok(());
+    }
+
+    if impl_widget_children {
+        let count = children.len();
+
+        let mut get_rules = quote! {};
+        let mut get_mut_rules = quote! {};
+        for (i, child) in children.iter().enumerate() {
+            let ident = &child.ident;
+            get_rules.append_all(quote! { #i => Some(&self.#ident), });
+            get_mut_rules.append_all(quote! { #i => Some(&mut self.#ident), });
+        }
+
+        scope.generated.push(quote! {
+            impl #impl_generics ::kas::WidgetChildren
+                for #name #ty_generics #where_clause
+            {
+                fn num_children(&self) -> usize {
+                    #count
                 }
-                #[inline]
-                fn handle_message(
-                    &mut self,
-                    mgr: &mut ::kas::event::EventMgr,
-                    index: usize,
-                ) {
-                    self.#inner.handle_message(mgr, index);
+                fn get_child(&self, _index: usize) -> Option<&dyn ::kas::Widget> {
+                    match _index {
+                        #get_rules
+                        _ => None
+                    }
                 }
-                #[inline]
-                fn handle_scroll(
-                    &mut self,
-                    mgr: &mut ::kas::event::EventMgr,
-                    scroll: ::kas::event::Scroll,
-                ) {
-                    self.#inner.handle_scroll(mgr, scroll);
+                fn get_child_mut(&mut self, _index: usize) -> Option<&mut dyn ::kas::Widget> {
+                    match _index {
+                        #get_mut_rules
+                        _ => None
+                    }
                 }
             }
-        } else {
-            let mut toks = TokenStream::new();
-            if let Some(item) = attr.key_nav {
-                toks.append_all(item);
+        });
+    }
+
+    let layout = match attr.layout.take() {
+        Some(layout) => {
+            let layout = layout.generate(children.iter().map(|c| &c.ident))?;
+            Some(quote! {
+                fn layout<'a>(&'a mut self) -> ::kas::layout::Layout<'a> {
+                    use ::kas::{WidgetCore, layout};
+                    let mut _chain = &mut (#access_core_data_mut).layout;
+                    #layout
+                }
+            })
+        }
+        None => None,
+    };
+
+    if let Some(index) = layout_impl {
+        let layout_impl = &mut scope.impls[index];
+        if let Some(item) = layout {
+            layout_impl.items.push(parse2(item)?);
+        }
+    } else if let Some(layout) = layout {
+        scope.generated.push(quote! {
+            impl #impl_generics ::kas::Layout for #name #ty_generics #where_clause {
+                #layout
             }
-            if let Some(item) = attr.hover_highlight {
-                toks.append_all(item);
-            }
-            if let Some(item) = attr.cursor_icon {
-                toks.append_all(item);
-            }
-            toks
-        };
+        });
+    }
+
+    if let Some(index) = widget_impl {
+        let widget_impl = &mut scope.impls[index];
+        if let Some(item) = attr.key_nav {
+            widget_impl.items.push(parse2(item)?);
+        }
+        if let Some(item) = attr.hover_highlight {
+            widget_impl.items.push(parse2(item)?);
+        }
+        if let Some(item) = attr.cursor_icon {
+            widget_impl.items.push(parse2(item)?);
+        }
+    } else {
+        let key_nav = attr.key_nav;
+        let hover_highlight = attr.hover_highlight;
+        let cursor_icon = attr.cursor_icon;
         scope.generated.push(quote! {
             impl #impl_generics ::kas::Widget
                     for #name #ty_generics #where_clause
             {
-                #methods
+                #key_nav
+                #hover_highlight
+                #cursor_icon
             }
         });
     }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -343,14 +343,6 @@ pub fn widget(mut attr: WidgetArgs, scope: &mut Scope) -> Result<()> {
                     self.#inner.pre_configure(mgr, id)
                 }
                 #[inline]
-                fn configure_recurse(
-                    &mut self,
-                    mgr: &mut ::kas::layout::SetRectMgr,
-                    id: ::kas::WidgetId,
-                ) {
-                    self.#inner.configure_recurse(mgr, id);
-                }
-                #[inline]
                 fn configure(&mut self, mgr: &mut ::kas::layout::SetRectMgr) {
                     self.#inner.configure(mgr);
                 }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -110,7 +110,9 @@ pub fn widget(mut attr: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 || *path == parse_quote! { kas::Layout }
                 || *path == parse_quote! { Layout }
             {
-                layout_impl = Some(index);
+                if layout_impl.is_none() {
+                    layout_impl = Some(index);
+                }
             } else if *path == parse_quote! { ::kas::Widget }
                 || *path == parse_quote! { kas::Widget }
                 || *path == parse_quote! { Widget }
@@ -121,7 +123,9 @@ pub fn widget(mut attr: WidgetArgs, scope: &mut Scope) -> Result<()> {
                         "impl conflicts with use of #[widget(derive=FIELD)]"
                     );
                 }
-                widget_impl = Some(index);
+                if widget_impl.is_none() {
+                    widget_impl = Some(index);
+                }
             }
         }
     }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -335,6 +335,14 @@ pub fn widget(mut attr: WidgetArgs, scope: &mut Scope) -> Result<()> {
                     self.#inner.make_child_id(index)
                 }
                 #[inline]
+                fn pre_configure(
+                    &mut self,
+                    mgr: &mut ::kas::layout::SetRectMgr,
+                    id: ::kas::WidgetId,
+                ) {
+                    self.#inner.pre_configure(mgr, id)
+                }
+                #[inline]
                 fn configure_recurse(
                     &mut self,
                     mgr: &mut ::kas::layout::SetRectMgr,

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -331,6 +331,10 @@ pub fn widget(mut attr: WidgetArgs, scope: &mut Scope) -> Result<()> {
             });
             quote! {
                 #[inline]
+                fn make_child_id(&mut self, index: usize) -> ::kas::WidgetId {
+                    self.#inner.make_child_id(index)
+                }
+                #[inline]
                 fn configure_recurse(
                     &mut self,
                     mgr: &mut ::kas::layout::SetRectMgr,

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -261,6 +261,12 @@ where
         state: InputState,
     ) -> Quad {
         let inner = outer.shrink(self.w.dims.button_frame as f32);
+        #[cfg(debug_assertions)]
+        {
+            if !inner.a.lt(inner.b) {
+                log::warn!("frame too small: {outer:?}");
+            }
+        }
 
         if !(state.disabled() || state.depress()) {
             let (mut a, mut b) = (self.w.dims.shadow_a, self.w.dims.shadow_b);

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -203,6 +203,12 @@ where
     fn draw_edit_box(&mut self, outer: Rect, bg_col: Rgba, nav_focus: bool) -> Quad {
         let outer = Quad::conv(outer);
         let inner = outer.shrink(self.w.dims.frame as f32);
+        #[cfg(debug_assertions)]
+        {
+            if !inner.a.lt(inner.b) {
+                log::warn!("frame too small: {outer:?}");
+            }
+        }
 
         let outer_col = self.cols.background;
         let inner_col = if nav_focus {

--- a/crates/kas-widgets/src/adapter/label.rs
+++ b/crates/kas-widgets/src/adapter/label.rs
@@ -125,10 +125,7 @@ impl_scope! {
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
-            if !self.rect().contains(coord) {
-                return None;
-            }
-            Some(self.inner.id())
+            self.rect().contains(coord).then(|| self.inner.id())
         }
     }
 

--- a/crates/kas-widgets/src/checkbox.rs
+++ b/crates/kas-widgets/src/checkbox.rs
@@ -28,15 +28,14 @@ impl_scope! {
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
             let size = size_mgr.checkbox();
-            self.core.rect.size = size;
             let margins = size_mgr.outer_margins();
             SizeRules::extract_fixed(axis, size, margins)
         }
 
-        fn set_rect(&mut self, _: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
             let rect = align
                 .complete(Align::Center, Align::Center)
-                .aligned_rect(self.rect().size, rect);
+                .aligned_rect(mgr.size_mgr().checkbox(), rect);
             self.core.rect = rect;
         }
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -59,14 +59,9 @@ impl_scope! {
     }
 
     impl Widget for Self {
-        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-            self.core_data_mut().id = id;
+        fn pre_configure(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
+            self.core.id = id;
             mgr.new_accel_layer(self.id(), true);
-
-            let id = self.id_ref().make_child(widget_index![self.popup]);
-            self.popup.configure_recurse(mgr, id);
-
-            self.configure(mgr);
         }
 
         fn key_nav(&self) -> bool {

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -105,12 +105,33 @@ impl_scope! {
     }
 
     impl Widget for Self {
+        fn make_child_id(&mut self, index: usize) -> WidgetId {
+            if let Some(child) = self.widgets.get(index) {
+                // Use the widget's existing identifier, if any
+                if child.id_ref().is_valid() {
+                    if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
+                        self.id_map.insert(key, index);
+                        return child.id();
+                    }
+                }
+            }
+
+            loop {
+                let key = self.next;
+                self.next += 1;
+                if let Entry::Vacant(entry) = self.id_map.entry(key) {
+                    entry.insert(index);
+                    return self.id_ref().make_child(key);
+                }
+            }
+        }
+
         fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
             self.core_data_mut().id = id;
             self.id_map.clear();
 
             for index in 0..self.widgets.len() {
-                let id = self.make_next_id(index);
+                let id = self.make_child_id(index);
                 self.widgets[index].configure_recurse(mgr, id);
             }
 
@@ -165,28 +186,6 @@ impl_scope! {
     }
 
     impl Self {
-        // Assumption: index is a valid entry of self.widgets
-        fn make_next_id(&mut self, index: usize) -> WidgetId {
-            if let Some(child) = self.widgets.get(index) {
-                // Use the widget's existing identifier, if any
-                if child.id_ref().is_valid() {
-                    if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
-                        self.id_map.insert(key, index);
-                        return child.id();
-                    }
-                }
-            }
-
-            loop {
-                let key = self.next;
-                self.next += 1;
-                if let Entry::Vacant(entry) = self.id_map.entry(key) {
-                    entry.insert(index);
-                    return self.id_ref().make_child(key);
-                }
-            }
-        }
-
         /// Construct a new instance with explicit direction
         #[inline]
         pub fn new_with_direction(direction: D, widgets: Vec<W>) -> Self {
@@ -269,7 +268,7 @@ impl_scope! {
         pub fn push(&mut self, mgr: &mut SetRectMgr, widget: W) -> usize {
             let index = self.widgets.len();
             self.widgets.push(widget);
-            let id = self.make_next_id(index);
+            let id = self.make_child_id(index);
             mgr.configure(id, &mut self.widgets[index]);
             *mgr |= TkAction::RESIZE;
             index
@@ -304,7 +303,7 @@ impl_scope! {
                 }
             }
             self.widgets.insert(index, widget);
-            let id = self.make_next_id(index);
+            let id = self.make_child_id(index);
             mgr.configure(id, &mut self.widgets[index]);
             *mgr |= TkAction::RESIZE;
         }
@@ -346,7 +345,7 @@ impl_scope! {
                 }
             }
 
-            let id = self.make_next_id(index);
+            let id = self.make_child_id(index);
             mgr.configure(id, &mut self.widgets[index]);
 
             *mgr |= TkAction::RESIZE;
@@ -361,7 +360,7 @@ impl_scope! {
             let old_len = self.widgets.len();
             self.widgets.extend(iter);
             for index in old_len..self.widgets.len() {
-                let id = self.make_next_id(index);
+                let id = self.make_child_id(index);
                 mgr.configure(id, &mut self.widgets[index]);
             }
 
@@ -392,7 +391,7 @@ impl_scope! {
             if len > old_len {
                 self.widgets.reserve(len - old_len);
                 for index in old_len..len {
-                    let id = self.make_next_id(index);
+                    let id = self.make_child_id(index);
                     let mut widget = f(index);
                     mgr.configure(id, &mut widget);
                     self.widgets.push(widget);

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -126,16 +126,9 @@ impl_scope! {
             }
         }
 
-        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-            self.core_data_mut().id = id;
+        fn pre_configure(&mut self, _: &mut SetRectMgr, id: WidgetId) {
+            self.core.id = id;
             self.id_map.clear();
-
-            for index in 0..self.widgets.len() {
-                let id = self.make_child_id(index);
-                self.widgets[index].configure_recurse(mgr, id);
-            }
-
-            self.configure(mgr);
         }
 
         fn spatial_nav(

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -61,10 +61,16 @@ pub trait Menu: Widget {
     /// Note further: if this returns `Some(_)`, then spacing for menu item frames is added
     /// "magically" by the caller. The implementor should draw a frame as follows:
     /// ```
+    /// # use kas::geom::Rect;
+    /// # use kas::theme::{DrawMgr, FrameStyle};
+    /// # struct S;
+    /// # impl S {
+    /// # fn rect(&self) -> Rect { Rect::ZERO }
     /// fn draw(&mut self, mut draw: DrawMgr) {
     ///     draw.frame(self.rect(), FrameStyle::MenuEntry, Default::default());
     ///     // draw children here
     /// }
+    /// # }
     /// ```
     // TODO: adding frame spacing like this is quite hacky. Find a better approach?
     fn sub_items(&mut self) -> Option<SubItems> {

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -52,15 +52,21 @@ pub struct SubItems<'a> {
 pub trait Menu: Widget {
     /// Access row items for aligned layout
     ///
-    /// If this is implemented, the row will be sized and layout through direct
-    /// access to these sub-components. [`Layout::size_rules`] will not be
-    /// invoked on `self`. [`Layout::set_rect`] will be, but should not set the
-    /// position of these items. [`Layout::draw`] should draw all components,
-    /// including a frame with style [`kas::theme::FrameStyle::MenuEntry`] on
-    /// self.
+    /// If this returns sub-items, then these items are aligned in the menu view. This involves
+    /// (1) calling `Self::size_rules` and `Self::set_rect` like usual, and (2) running an external
+    /// layout solver on these items (which also calls `size_rules` and `set_rect` on each item).
+    /// This is redundant, but ensures the expectations on [`Layout::size_rules`] and
+    /// [`Layout::set_rect`] are met.
     ///
-    /// Return value is `None` or `Some((label, opt_label2, opt_submenu, opt_icon, opt_toggle))`.
-    /// `opt_label2` is used to show shortcut labels. `opt_submenu` is a sub-menu indicator.
+    /// Note further: if this returns `Some(_)`, then spacing for menu item frames is added
+    /// "magically" by the caller. The implementor should draw a frame as follows:
+    /// ```
+    /// fn draw(&mut self, mut draw: DrawMgr) {
+    ///     draw.frame(self.rect(), FrameStyle::MenuEntry, Default::default());
+    ///     // draw children here
+    /// }
+    /// ```
+    // TODO: adding frame spacing like this is quite hacky. Find a better approach?
     fn sub_items(&mut self) -> Option<SubItems> {
         None
     }

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -143,10 +143,7 @@ impl_scope! {
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
-            if !self.rect().contains(coord) {
-                return None;
-            }
-            Some(self.checkbox.id())
+            self.rect().contains(coord).then(|| self.checkbox.id())
         }
     }
 

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -88,7 +88,7 @@ impl_scope! {
         }
 
         fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
-            self.core_data_mut().rect = rect;
+            self.core.rect = rect;
             let dim = (self.direction, self.widgets.len());
             let mut setter = RowSetter::<D, Vec<i32>, _>::new(rect, dim, align, &mut self.layout_store);
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -138,15 +138,10 @@ impl_scope! {
     }
 
     impl Widget for Self {
-        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-            self.core_data_mut().id = id;
+        fn pre_configure(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
+            self.core.id = id;
             mgr.add_accel_keys(self.id_ref(), self.label.keys());
             mgr.new_accel_layer(self.id(), true);
-
-            let id = self.id_ref().make_child(widget_index![self.list]);
-            self.list.configure_recurse(mgr, id);
-
-            self.configure(mgr);
         }
 
         fn key_nav(&self) -> bool {

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -74,15 +74,14 @@ impl_scope! {
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
             let size = size_mgr.radiobox();
-            self.core.rect.size = size;
             let margins = size_mgr.outer_margins();
             SizeRules::extract_fixed(axis, size, margins)
         }
 
-        fn set_rect(&mut self, _: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
             let rect = align
                 .complete(Align::Center, Align::Center)
-                .aligned_rect(self.rect().size, rect);
+                .aligned_rect(mgr.size_mgr().radiobox(), rect);
             self.core.rect = rect;
         }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -228,21 +228,9 @@ impl_scope! {
             self.make_next_id(is_handle, child_index / 2)
         }
 
-        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-            self.core_data_mut().id = id;
+        fn pre_configure(&mut self, _: &mut SetRectMgr, id: WidgetId) {
+            self.core.id = id;
             self.id_map.clear();
-
-            // It does not matter what order we choose widget/child ids:
-            for index in 0..self.widgets.len() {
-                let id = self.make_next_id(false, index);
-                self.widgets[index].configure_recurse(mgr, id);
-            }
-            for index in 0..self.handles.len() {
-                let id = self.make_next_id(true, index);
-                self.handles[index].configure_recurse(mgr, id);
-            }
-
-            self.configure(mgr);
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -223,6 +223,11 @@ impl_scope! {
     }
 
     impl Widget for Self {
+        fn make_child_id(&mut self, child_index: usize) -> WidgetId {
+            let is_handle = (child_index & 1) != 0;
+            self.make_next_id(is_handle, child_index / 2)
+        }
+
         fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
             self.core_data_mut().id = id;
             self.id_map.clear();

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -47,30 +47,6 @@ impl_scope! {
         id_map: HashMap<usize, usize>, // map key of WidgetId to index
     }
 
-    impl Self {
-        // Assumption: index is a valid entry of self.widgets
-        fn make_next_id(&mut self, index: usize) -> WidgetId {
-            if let Some(child) = self.widgets.get(index) {
-                // Use the widget's existing identifier, if any
-                if child.id_ref().is_valid() {
-                    if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
-                        self.id_map.insert(key, index);
-                        return child.id();
-                    }
-                }
-            }
-
-            loop {
-                let key = self.next;
-                self.next += 1;
-                if let Entry::Vacant(entry) = self.id_map.entry(key) {
-                    entry.insert(index);
-                    return self.id_ref().make_child(key);
-                }
-            }
-        }
-    }
-
     impl WidgetChildren for Self {
         #[inline]
         fn num_children(&self) -> usize {
@@ -119,12 +95,33 @@ impl_scope! {
     }
 
     impl Widget for Self {
+        fn make_child_id(&mut self, index: usize) -> WidgetId {
+            if let Some(child) = self.widgets.get(index) {
+                // Use the widget's existing identifier, if any
+                if child.id_ref().is_valid() {
+                    if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
+                        self.id_map.insert(key, index);
+                        return child.id();
+                    }
+                }
+            }
+
+            loop {
+                let key = self.next;
+                self.next += 1;
+                if let Entry::Vacant(entry) = self.id_map.entry(key) {
+                    entry.insert(index);
+                    return self.id_ref().make_child(key);
+                }
+            }
+        }
+
         fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
             self.core_data_mut().id = id;
             self.id_map.clear();
 
             for index in 0..self.widgets.len() {
-                let id = self.make_next_id(index);
+                let id = self.make_child_id(index);
                 self.widgets[index].configure_recurse(mgr, id);
             }
 
@@ -271,7 +268,7 @@ impl<W: Widget> Stack<W> {
     pub fn push(&mut self, mgr: &mut SetRectMgr, widget: W) -> usize {
         let index = self.widgets.len();
         self.widgets.push(widget);
-        let id = self.make_next_id(index);
+        let id = self.make_child_id(index);
         mgr.configure(id, &mut self.widgets[index]);
         if index == self.active {
             *mgr |= TkAction::RESIZE;
@@ -324,7 +321,7 @@ impl<W: Widget> Stack<W> {
             }
         }
         self.widgets.insert(index, widget);
-        let id = self.make_next_id(index);
+        let id = self.make_child_id(index);
         mgr.configure(id, &mut self.widgets[index]);
     }
 
@@ -380,7 +377,7 @@ impl<W: Widget> Stack<W> {
             }
         }
 
-        let id = self.make_next_id(index);
+        let id = self.make_child_id(index);
         mgr.configure(id, &mut self.widgets[index]);
 
         if self.active < index {
@@ -404,7 +401,7 @@ impl<W: Widget> Stack<W> {
         let old_len = self.widgets.len();
         self.widgets.extend(iter);
         for index in old_len..self.widgets.len() {
-            let id = self.make_next_id(index);
+            let id = self.make_child_id(index);
             mgr.configure(id, &mut self.widgets[index]);
         }
 
@@ -438,7 +435,7 @@ impl<W: Widget> Stack<W> {
         if len > old_len {
             self.widgets.reserve(len - old_len);
             for index in old_len..len {
-                let id = self.make_next_id(index);
+                let id = self.make_child_id(index);
                 let mut widget = f(index);
                 mgr.configure(id, &mut widget);
                 self.widgets.push(widget);

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -116,16 +116,9 @@ impl_scope! {
             }
         }
 
-        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-            self.core_data_mut().id = id;
+        fn pre_configure(&mut self, _: &mut SetRectMgr, id: WidgetId) {
+            self.core.id = id;
             self.id_map.clear();
-
-            for index in 0..self.widgets.len() {
-                let id = self.make_child_id(index);
-                self.widgets[index].configure_recurse(mgr, id);
-            }
-
-            self.configure(mgr);
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {

--- a/crates/kas-widgets/src/view/list_view.rs
+++ b/crates/kas-widgets/src/view/list_view.rs
@@ -521,9 +521,7 @@ impl_scope! {
     }
 
     impl Widget for Self {
-        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-            self.core_data_mut().id = id;
-
+        fn configure(&mut self, mgr: &mut SetRectMgr) {
             // If data is available but not loaded yet, make some widgets for
             // use by size_rules (this allows better sizing). Configure the new
             // widgets (this allows resource loading which may affect size.)
@@ -545,10 +543,6 @@ impl_scope! {
                 }
             }
 
-            self.configure(mgr);
-        }
-
-        fn configure(&mut self, mgr: &mut SetRectMgr) {
             self.data.update_on_handles(mgr.ev_state(), self.id_ref());
             mgr.register_nav_fallback(self.id());
         }

--- a/crates/kas-widgets/src/view/matrix_view.rs
+++ b/crates/kas-widgets/src/view/matrix_view.rs
@@ -503,9 +503,7 @@ impl_scope! {
     }
 
     impl Widget for Self {
-        fn configure_recurse(&mut self, mgr: &mut SetRectMgr, id: WidgetId) {
-            self.core_data_mut().id = id;
-
+        fn configure(&mut self, mgr: &mut SetRectMgr) {
             // If data is available but not loaded yet, make some widgets for
             // use by size_rules (this allows better sizing). Configure the new
             // widgets (this allows resource loading which may affect size.)
@@ -531,10 +529,6 @@ impl_scope! {
                 }
             }
 
-            self.configure(mgr);
-        }
-
-        fn configure(&mut self, mgr: &mut SetRectMgr) {
             self.data.update_on_handles(mgr.ev_state(), self.id_ref());
             mgr.register_nav_fallback(self.id());
         }

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -12,7 +12,7 @@ use kas::event::{Event, EventMgr, Response};
 use kas::layout::SetRectMgr;
 use kas::macros::make_widget;
 use kas::widgets::{Frame, Label, TextButton, Window};
-use kas::{Widget, WidgetExt};
+use kas::{Widget, WidgetCore, WidgetExt};
 
 #[derive(Clone, Debug)]
 struct MsgReset;


### PR DESCRIPTION
Replace `Widget::configure_recurse` with `make_child_id`, `pre_configure`. More user-friendly: it's not required to replace `configure_recurse` impl when changing only one part of its behaviour.

Remove `WidgetCore::core_data` and `core_data_mut` methods: widgets still have a `core` field, but its type is no longer fixed. An unorthodox tactic was used to achieve this: the "default implementations" of `pre_configure` and `set_rect` are now generated by the `#[widget]` macro. This should "just work", but one issue was discovered: (unstable) specialization allows multiple implementations of traits (such as `Widget`), only the most general of which is required to be complete. We use the simplest "fix" possible: only write default implementations into the *first* implementation of the `Widget` (or `Layout`) trait.

Require `size_rules` to be called before `set_rect`. This requirement was removed in #305, but not really: resulting layout could be quite broken. We clarify that `size_rules` *should* be called first for each axis, and failure to do so may result in broken layout, but calling `set_rect` again without `size_rules` is permitted. We fix `RadioBoxBare` and `CheckBoxBare` in the case `set_rect` assigns too-small a `rect` and is then called again with a large enough `rect`.