### PR TITLE
make_widget → impl_singleton

### DIFF
--- a/crates/kas-macros/README.md
+++ b/crates/kas-macros/README.md
@@ -12,10 +12,7 @@ Stable vs nightly
 -----------------
 
 Note that proc macros may emit error messages on stable rust, but currently can
-only emit warnings with nightly `rustc`. Warning lints may be emitted by:
-
--   the `#[widget]` attribute macro
--   `make_widget!`, which uses `#[widget]`
+only emit warnings with nightly `rustc`.
 
 
 Copyright and Licence

--- a/crates/kas-macros/src/args.rs
+++ b/crates/kas-macros/src/args.rs
@@ -4,7 +4,6 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 use crate::make_layout;
-use impl_tools_lib::parse_attr_group;
 use proc_macro2::TokenStream;
 use proc_macro_error::{abort, emit_error};
 use quote::quote_spanned;
@@ -290,7 +289,6 @@ pub struct WidgetField {
 
 #[derive(Debug)]
 pub struct MakeWidget {
-    pub attr_widget: WidgetArgs,
     pub attrs: Vec<Attribute>,
 
     pub token: Token![struct],
@@ -304,26 +302,7 @@ pub struct MakeWidget {
 
 impl Parse for MakeWidget {
     fn parse(input: ParseStream) -> Result<Self> {
-        let mut attrs = input.call(Attribute::parse_outer)?;
-        let mut index = None;
-        for (i, attr) in attrs.iter().enumerate() {
-            if attr.path == parse_quote! { widget } {
-                if index.is_none() {
-                    index = Some(i);
-                } else {
-                    emit_error!(attr.span(), "multiple #[widget(..)] attributes on type");
-                }
-            }
-        }
-
-        let attr_widget;
-        if let Some(i) = index {
-            let attr = attrs.remove(i);
-            let (_, tokens) = parse_attr_group(attr.tokens)?;
-            attr_widget = syn::parse2(tokens)?;
-        } else {
-            attr_widget = Default::default();
-        }
+        let attrs = input.call(Attribute::parse_outer)?;
 
         let token = input.parse::<Token![struct]>()?;
 
@@ -342,7 +321,6 @@ impl Parse for MakeWidget {
         }
 
         Ok(MakeWidget {
-            attr_widget,
             attrs,
 
             token,

--- a/crates/kas-macros/src/args.rs
+++ b/crates/kas-macros/src/args.rs
@@ -285,7 +285,7 @@ pub struct WidgetField {
     pub ident: Option<Ident>,
     pub colon_token: Option<Colon>,
     pub ty: ChildType,
-    pub value: Expr,
+    pub value: Option<Expr>,
 }
 
 #[derive(Debug)]
@@ -435,8 +435,15 @@ impl Parse for WidgetField {
             ChildType::Generic(None)
         };
 
-        let _: Eq = input.parse()?;
-        let value: Expr = input.parse()?;
+        let mut value = None;
+        if let Ok(_) = input.parse::<Eq>() {
+            value = Some(input.parse()?);
+        } else if !matches!(&ty, ChildType::Fixed(_)) {
+            return Err(Error::new(
+                input.span(),
+                "require either a fixed type or a value assignment",
+            ));
+        }
 
         Ok(WidgetField {
             attrs,

--- a/crates/kas-macros/src/args.rs
+++ b/crates/kas-macros/src/args.rs
@@ -278,7 +278,7 @@ pub enum ChildType {
 }
 
 #[derive(Debug)]
-pub struct WidgetField {
+pub struct SingletonField {
     pub attrs: Vec<Attribute>,
     pub vis: Visibility,
     pub ident: Option<Ident>,
@@ -288,19 +288,19 @@ pub struct WidgetField {
 }
 
 #[derive(Debug)]
-pub struct MakeWidget {
+pub struct ImplSingleton {
     pub attrs: Vec<Attribute>,
 
     pub token: Token![struct],
     pub generics: Generics,
 
     pub brace_token: Brace,
-    pub fields: Punctuated<WidgetField, Comma>,
+    pub fields: Punctuated<SingletonField, Comma>,
 
     pub impls: Vec<ItemImpl>,
 }
 
-impl Parse for MakeWidget {
+impl Parse for ImplSingleton {
     fn parse(input: ParseStream) -> Result<Self> {
         let attrs = input.call(Attribute::parse_outer)?;
 
@@ -313,14 +313,14 @@ impl Parse for MakeWidget {
 
         let content;
         let brace_token = braced!(content in input);
-        let fields = content.parse_terminated(WidgetField::parse)?;
+        let fields = content.parse_terminated(SingletonField::parse)?;
 
         let mut impls = Vec::new();
         while !input.is_empty() {
             impls.push(parse_impl(None, input)?);
         }
 
-        Ok(MakeWidget {
+        Ok(ImplSingleton {
             attrs,
 
             token,
@@ -334,7 +334,7 @@ impl Parse for MakeWidget {
     }
 }
 
-impl Parse for WidgetField {
+impl Parse for SingletonField {
     fn parse(input: ParseStream) -> Result<Self> {
         let attrs = input.call(Attribute::parse_outer)?;
         let vis = input.parse()?;
@@ -423,7 +423,7 @@ impl Parse for WidgetField {
             ));
         }
 
-        Ok(WidgetField {
+        Ok(SingletonField {
             attrs,
             vis,
             ident,

--- a/crates/kas-macros/src/impl_singleton.rs
+++ b/crates/kas-macros/src/impl_singleton.rs
@@ -3,7 +3,7 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-use crate::args::{ChildType, MakeWidget};
+use crate::args::{ChildType, ImplSingleton};
 use impl_tools_lib::{
     fields::{Field, Fields, FieldsNamed},
     Scope, ScopeItem,
@@ -18,7 +18,7 @@ use syn::token::Comma;
 use syn::{visit_mut, ConstParam, GenericParam, Lifetime, LifetimeDef, TypeParam};
 use syn::{Ident, Result, Type, TypePath, Visibility};
 
-pub(crate) fn make_widget(mut args: MakeWidget) -> Result<TokenStream> {
+pub(crate) fn impl_singleton(mut args: ImplSingleton) -> Result<TokenStream> {
     // Used to make fresh identifiers for generic types
     let mut name_buf = String::with_capacity(32);
     let mut make_ident = move |args: std::fmt::Arguments, span| -> Ident {

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::let_and_return)]
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::needless_late_init)]
+#![allow(clippy::redundant_pattern_matching)]
 
 extern crate proc_macro;
 

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -361,12 +361,10 @@ pub fn widget(_: TokenStream, item: TokenStream) -> TokenStream {
 /// fn main() {
 ///     let world = "world";
 ///     let says_hello_world = impl_singleton! {
-///         struct {
-///             name: impl fmt::Display = world,
-///         }
+///         struct(impl fmt::Display = world);
 ///         impl fmt::Display for Self {
 ///             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-///                 write!(f, "hello {}", self.name)
+///                 write!(f, "hello {}", self.0)
 ///             }
 ///         }
 ///     };
@@ -374,21 +372,29 @@ pub fn widget(_: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// That is, this macro creates an anonymous struct type (currently only
-/// standard structs are supported), which may have trait implementations, then
-/// creates an instance of that struct.
+/// That is, this macro creates an anonymous struct type (must be a struct),
+/// which may have trait implementations, then creates an instance of that
+/// struct.
 ///
-/// Struct fields may appear as follows:
+/// Struct fields may have a fixed type or may be generic. Syntax is as follows:
 ///
-/// -   `ident: ty = value`
-/// -   `ident: ty` — uses `Default` to construct value
-/// -   `_: ty = value` — field name may be anonymous
-/// -   `ident = value` — uses a type parameter instead of a defined type
-/// -   `ident: impl Trait = value` — uses a type parameter with trait bound(s)
-/// -   `ident: for<'a, T> std::borrow::Cow<'a, T> = value` — use explicit generic parameters
+/// -   **regular struct:** `ident: ty = value`
+/// -   **regular struct:** `ident: ty` — uses `Default` to construct value
+/// -   **regular struct:** `ident = value` — type is generic without bounds
+/// -   **tuple struct:** `ty = value`
+/// -   **tuple struct:** `ty`
+/// -   **tuple struct:** `_ = value`
+///
+/// The `ident` may be `_` (anonymous field).
+///
+/// The `ty` expression may be replaced with one of the following:
+///
+/// -   `impl Trait` (or `impl A + B + C`) — type is generic with given bounds
+/// -   `for<'a, T> std::borrow::Cow<'a, T>` — a generic with locally declared
+///     type parameters (note: parameter names are made unique)
 ///
 /// As a special rule, any field using the `#[widget]` attribute and without a
-/// fixed type is bound by the `::kas::Widget` trait.
+/// fixed type has the `::kas::Widget` trait bound applied.
 ///
 /// Refer to [examples](https://github.com/search?q=impl_singleton+repo%3Akas-gui%2Fkas+path%3Aexamples&type=Code) for usage.
 #[proc_macro_error]

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -357,7 +357,7 @@ pub fn widget(_: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// -   `#[derive(Debug)]` is added automatically
 /// -   a `core: widget_core!()` field is added automatically
-/// -   all fields must have an initializer, e.g. `ident: ty = value,`
+/// -   fields may have an initializer, e.g. `ident: ty = value,` (otherwise they must implement `Default`)
 /// -   the type of fields is optional: `ident = value,` works (but see note above)
 /// -   the name of fields is optional: `_: ty = value,` and `_ = value,` are valid
 /// -   instead of a type, a type bound may be used: `ident: impl Trait = value,`

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -355,7 +355,6 @@ pub fn widget(_: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Syntax is similar to using [`widget`](macro@widget) within [`impl_scope!`], except that:
 ///
-/// -   `#[derive(Debug)]` is added automatically
 /// -   fields may have an initializer, e.g. `ident: ty = value,` (otherwise they must implement `Default`)
 /// -   the type of fields is optional: `ident = value,` works (but see note above)
 /// -   the name of fields is optional: `_: ty = value,` and `_ = value,` are valid

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -112,6 +112,8 @@ pub fn autoimpl(attr: TokenStream, item: TokenStream) -> TokenStream {
     toks
 }
 
+const IMPL_SCOPE_RULES: [&'static dyn ScopeAttr; 2] = [&AttrImplDefault, &widget::AttrImplWidget];
+
 /// Implementation scope
 ///
 /// See [`impl_tools::impl_scope`](https://docs.rs/impl-tools/0.3/impl_tools/macro.impl_scope.html)
@@ -120,8 +122,12 @@ pub fn autoimpl(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn impl_scope(input: TokenStream) -> TokenStream {
     let mut scope = parse_macro_input!(input as Scope);
-    let rules: [&'static dyn ScopeAttr; 2] = [&AttrImplDefault, &widget::AttrImplWidget];
-    scope.apply_attrs(|path| rules.iter().cloned().find(|rule| rule.path().matches(path)));
+    scope.apply_attrs(|path| {
+        IMPL_SCOPE_RULES
+            .iter()
+            .cloned()
+            .find(|rule| rule.path().matches(path))
+    });
     scope.expand().into()
 }
 

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -356,7 +356,6 @@ pub fn widget(_: TokenStream, item: TokenStream) -> TokenStream {
 /// Syntax is similar to using [`widget`](macro@widget) within [`impl_scope!`], except that:
 ///
 /// -   `#[derive(Debug)]` is added automatically
-/// -   a `core: widget_core!()` field is added automatically
 /// -   fields may have an initializer, e.g. `ident: ty = value,` (otherwise they must implement `Default`)
 /// -   the type of fields is optional: `ident = value,` works (but see note above)
 /// -   the name of fields is optional: `_: ty = value,` and `_ = value,` are valid

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -188,7 +188,7 @@ impl GridDimensions {
 struct NameGenerator(usize);
 impl NameGenerator {
     fn next(&mut self) -> StorIdent {
-        let name = format!("stor{}", self.0);
+        let name = format!("_stor{}", self.0);
         self.0 += 1;
         StorIdent::Generated(name, Span::call_site())
     }

--- a/crates/kas-macros/src/make_widget.rs
+++ b/crates/kas-macros/src/make_widget.rs
@@ -94,8 +94,11 @@ pub(crate) fn make_widget(mut args: MakeWidget) -> Result<TokenStream> {
             }
         };
 
-        let value = &field.value;
-        field_val_toks.append_all(quote! { #ident: #value, });
+        if let Some(ref value) = field.value {
+            field_val_toks.append_all(quote! { #ident: #value, });
+        } else {
+            field_val_toks.append_all(quote! { #ident: Default::default(), });
+        }
 
         fields.push_value(Field {
             attrs: field.attrs,

--- a/crates/kas-macros/src/make_widget.rs
+++ b/crates/kas-macros/src/make_widget.rs
@@ -101,8 +101,6 @@ pub(crate) fn make_widget(mut args: MakeWidget) -> Result<TokenStream> {
         args.generics.where_clause = None;
     }
 
-    args.attrs.insert(0, parse_quote! { #[derive(Debug)] });
-
     let mut scope = Scope {
         attrs: args.attrs,
         vis: Visibility::Inherited,

--- a/crates/kas-macros/src/make_widget.rs
+++ b/crates/kas-macros/src/make_widget.rs
@@ -25,24 +25,8 @@ pub(crate) fn make_widget(mut args: MakeWidget) -> Result<TokenStream> {
         Ident::new(&name_buf, Span::call_site())
     };
 
-    let core_ident: Ident = parse_quote! { core };
-
-    // fields of anonymous struct:
     let mut fields = Punctuated::<Field, Comma>::new();
-    fields.push_value(Field {
-        attrs: vec![],
-        vis: Visibility::Inherited,
-        ident: Some(core_ident),
-        colon_token: Default::default(),
-        ty: parse_quote! { widget_core!() },
-        assign: None,
-    });
-    fields.push_punct(Default::default());
-
-    // initialisers for these fields:
-    let mut field_val_toks = quote! {
-        core: Default::default(),
-    };
+    let mut field_val_toks = quote! {};
 
     if args.generics.where_clause.is_none() {
         args.generics.where_clause = Some(WhereClause {

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -206,7 +206,10 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
             }
         };
     } else {
-        return Err(Error::new(fields.span(), "no field of type widget_core!()"));
+        return Err(Error::new(
+            scope.ident.span(),
+            "when applying #[widget]: no field of type widget_core!()",
+        ));
     }
 
     scope.generated.push(quote! {

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -52,9 +52,7 @@ fn main() -> kas::shell::Result<()> {
             };
         }]
         #[derive(Debug, Default)]
-        struct Buttons {
-            core: widget_core!(),
-        }
+        struct Buttons(widget_core!());
     };
 
     impl_scope! {

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -26,7 +26,7 @@ enum Key {
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
-    let buttons = make_widget! {
+    impl_scope! {
         // Buttons get keyboard bindings through the "&" item (e.g. "&1"
         // binds both main and numpad 1 key) and via `with_keys`.
         #[widget{
@@ -51,20 +51,24 @@ fn main() -> kas::shell::Result<()> {
                 2, 4: TextButton::new_msg("&.", Key::Char('.'));
             };
         }]
-        struct {}
-        impl kas::Widget for Self {
+        #[derive(Debug, Default)]
+        struct Buttons {
+            core: widget_core!(),
         }
     };
-    let content = make_widget! {
+
+    impl_scope! {
+        #[impl_default]
         #[widget{
             layout = column: [
                 self.display,
-                self.buttons,
+                Buttons::default(),
             ];
         }]
-        struct {
-            #[widget] display: impl HasString = EditBox::new("0").with_editable(false).multi_line(true),
-            #[widget] buttons = buttons,
+        #[derive(Debug)]
+        struct CalcUI {
+            core: widget_core!(),
+            #[widget] display: EditBox = EditBox::new("0").with_editable(false).multi_line(true),
             calc: Calculator = Calculator::new(),
         }
         impl Widget for Self {
@@ -80,8 +84,9 @@ fn main() -> kas::shell::Result<()> {
                 }
             }
         }
-    };
-    let window = Window::new("Calculator", content);
+    }
+
+    let window = Window::new("Calculator", CalcUI::default());
 
     let theme = kas::theme::ShadedTheme::new().with_font_size(16.0);
     kas::shell::Toolkit::new(theme)?.with(window)?.run()

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -5,7 +5,6 @@
 
 //! Counter example (simple button)
 
-use kas::macros::make_widget;
 use kas::prelude::*;
 use kas::widgets::{Label, TextButton, Window};
 
@@ -15,7 +14,7 @@ fn main() -> kas::shell::Result<()> {
     #[derive(Clone, Debug)]
     struct Increment(i32);
 
-    let counter = make_widget! {
+    impl_scope! {
         #[widget{
             layout = column: [
                 align(center): self.display,
@@ -25,10 +24,21 @@ fn main() -> kas::shell::Result<()> {
                 ],
             ];
         }]
-        struct {
+        #[derive(Debug)]
+        struct Counter {
+            core: widget_core!(),
             #[widget]
-            display: Label<String> = Label::from("0"),
-            count: i32 = 0,
+            display: Label<String>,
+            count: i32,
+        }
+        impl Self {
+            fn new(count: i32) -> Self {
+                Counter {
+                    core: Default::default(),
+                    display: Label::from(count.to_string()),
+                    count,
+                }
+            }
         }
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
@@ -40,7 +50,7 @@ fn main() -> kas::shell::Result<()> {
         }
     };
 
-    let window = Window::new("Counter", counter);
+    let window = Window::new("Counter", Counter::new(0));
 
     let theme = kas::theme::ShadedTheme::new().with_font_size(24.0);
     kas::shell::Toolkit::new(theme)?.with(window)?.run()

--- a/examples/custom-theme.rs
+++ b/examples/custom-theme.rs
@@ -112,33 +112,35 @@ fn main() -> kas::shell::Result<()> {
 
     let theme = CustomTheme::default();
 
-    let window = Window::new(
-        "Theme demo",
-        make_widget! {
-            #[widget{
-            layout = grid: {
-                1, 1: "Custom theme demo\nChoose your colour!";
-                0, 1: TextButton::new_msg("&White", Item::White);
-                1, 2: TextButton::new_msg("&Red", Item::Red);
-                2, 1: TextButton::new_msg("&Yellow", Item::Yellow);
-                1, 0: TextButton::new_msg("&Green", Item::Green);
-            };
-            }]
-            struct {}
-            impl Widget for Self {
-                fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
-                    if let Some(item) = mgr.try_pop_msg::<Item>() {
-                        match item {
-                            Item::White => BACKGROUND.with(|b| b.set(Rgba::WHITE)),
-                            Item::Red => BACKGROUND.with(|b| b.set(Rgba::rgb(0.9, 0.2, 0.2))),
-                            Item::Green => BACKGROUND.with(|b| b.set(Rgba::rgb(0.2, 0.9, 0.2))),
-                            Item::Yellow => BACKGROUND.with(|b| b.set(Rgba::rgb(0.9, 0.9, 0.2))),
-                        }
+    impl_scope! {
+        #[widget{
+        layout = grid: {
+            1, 1: "Custom theme demo\nChoose your colour!";
+            0, 1: TextButton::new_msg("&White", Item::White);
+            1, 2: TextButton::new_msg("&Red", Item::Red);
+            2, 1: TextButton::new_msg("&Yellow", Item::Yellow);
+            1, 0: TextButton::new_msg("&Green", Item::Green);
+        };
+        }]
+        #[derive(Debug, Default)]
+        struct Demo {
+            core: widget_core!(),
+        }
+        impl Widget for Self {
+            fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+                if let Some(item) = mgr.try_pop_msg::<Item>() {
+                    match item {
+                        Item::White => BACKGROUND.with(|b| b.set(Rgba::WHITE)),
+                        Item::Red => BACKGROUND.with(|b| b.set(Rgba::rgb(0.9, 0.2, 0.2))),
+                        Item::Green => BACKGROUND.with(|b| b.set(Rgba::rgb(0.2, 0.9, 0.2))),
+                        Item::Yellow => BACKGROUND.with(|b| b.set(Rgba::rgb(0.9, 0.9, 0.2))),
                     }
                 }
             }
-        },
-    );
+        }
+    }
+
+    let window = Window::new("Theme demo", Demo::default());
 
     kas::shell::Toolkit::new(theme)?.with(window)?.run()
 }

--- a/examples/custom-theme.rs
+++ b/examples/custom-theme.rs
@@ -123,9 +123,7 @@ fn main() -> kas::shell::Result<()> {
         };
         }]
         #[derive(Debug, Default)]
-        struct Demo {
-            core: widget_core!(),
-        }
+        struct Demo(widget_core!());
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
                 if let Some(item) = mgr.try_pop_msg::<Item>() {

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -217,6 +217,7 @@ fn main() -> kas::shell::Result<()> {
             ];
         }]
         struct {
+            core: widget_core!(),
             #[widget] edit: impl HasString = EditBox::new("3")
                 .on_afl(|text, mgr| match text.parse::<usize>() {
                     Ok(n) => mgr.push_msg(n),
@@ -268,6 +269,7 @@ fn main() -> kas::shell::Result<()> {
                 ];
             }]
             struct {
+                core: widget_core!(),
                 #[widget] controls = controls,
                 #[widget] display: StringLabel = Label::from("Entry #1"),
                 #[widget] list: ScrollBars<MyList> =

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -216,6 +216,7 @@ fn main() -> kas::shell::Result<()> {
                 TextButton::new_msg("↓↑", Control::Dir),
             ];
         }]
+        #[derive(Debug)]
         struct {
             core: widget_core!(),
             #[widget] edit: impl HasString = EditBox::new("3")
@@ -268,6 +269,7 @@ fn main() -> kas::shell::Result<()> {
                     self.list,
                 ];
             }]
+            #[derive(Debug)]
             struct {
                 core: widget_core!(),
                 #[widget] controls = controls,

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -205,7 +205,7 @@ impl Driver<(usize, bool, String)> for MyDriver {
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
-    let controls = make_widget! {
+    let controls = impl_singleton! {
         #[widget{
             layout = row: [
                 "Number of rows:",
@@ -258,7 +258,7 @@ fn main() -> kas::shell::Result<()> {
 
     let window = Window::new(
         "Dynamic widget demo",
-        make_widget! {
+        impl_singleton! {
             #[widget{
                 layout = column: [
                     "Demonstration of dynamic widget creation / deletion",

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -111,6 +111,7 @@ fn main() -> kas::shell::Result<()> {
                 TextButton::new_msg("↓↑", Control::Dir),
             ];
         }]
+        #[derive(Debug)]
         struct {
             core: widget_core!(),
             #[widget] edit: impl HasString = EditBox::new("3")
@@ -163,6 +164,7 @@ fn main() -> kas::shell::Result<()> {
                     self.list,
                 ];
             }]
+            #[derive(Debug)]
             struct {
                 core: widget_core!(),
                 #[widget] controls = controls,

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -100,7 +100,7 @@ impl ListEntry {
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
-    let controls = make_widget! {
+    let controls = impl_singleton! {
         #[widget{
             layout = row: [
                 "Number of rows:",
@@ -153,7 +153,7 @@ fn main() -> kas::shell::Result<()> {
 
     let window = Window::new(
         "Dynamic widget demo",
-        make_widget! {
+        impl_singleton! {
             #[widget{
                 layout = column: [
                     "Demonstration of dynamic widget creation / deletion",

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -112,6 +112,7 @@ fn main() -> kas::shell::Result<()> {
             ];
         }]
         struct {
+            core: widget_core!(),
             #[widget] edit: impl HasString = EditBox::new("3")
                 .on_afl(|text, mgr| match text.parse::<usize>() {
                     Ok(n) => mgr.push_msg(n),
@@ -163,6 +164,7 @@ fn main() -> kas::shell::Result<()> {
                 ];
             }]
             struct {
+                core: widget_core!(),
                 #[widget] controls = controls,
                 #[widget] display: StringLabel = Label::from("Entry #1"),
                 #[widget] list: ScrollBarRegion<List<Direction, ListEntry>> =

--- a/examples/filter-list.rs
+++ b/examples/filter-list.rs
@@ -47,6 +47,7 @@ fn main() -> kas::shell::Result<()> {
             ];
         }]
         struct {
+            core: widget_core!(),
             #[widget] r0 = RadioBox::new_msg("none", r.clone(), SelectionMode::None).with_state(true),
             #[widget] r1 = RadioBox::new_msg("single", r.clone(), SelectionMode::Single),
             #[widget] r2 = RadioBox::new_msg("multiple", r, SelectionMode::Multiple),

--- a/examples/filter-list.rs
+++ b/examples/filter-list.rs
@@ -38,7 +38,7 @@ fn main() -> kas::shell::Result<()> {
     type ListView = view::ListView<Down, FilteredList, driver::DefaultNav>;
     let filtered = FilteredList::new(data, filter.clone());
 
-    let widget = make_widget! {
+    let widget = impl_singleton! {
         #[widget{
             layout = column: [
                 row: ["Selection:", self.r0, self.r1, self.r2],

--- a/examples/filter-list.rs
+++ b/examples/filter-list.rs
@@ -46,6 +46,7 @@ fn main() -> kas::shell::Result<()> {
                 self.list,
             ];
         }]
+        #[derive(Debug)]
         struct {
             core: widget_core!(),
             #[widget] r0 = RadioBox::new_msg("none", r.clone(), SelectionMode::None).with_state(true),

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -179,6 +179,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ];
         }]
         struct {
+            core: widget_core!(),
             #[widget] label: StringLabel = Label::from("Use button to edit →"),
             future: Option<Future<Option<String>>>,
         }
@@ -243,6 +244,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ];
         }]
         struct {
+            core: widget_core!(),
             #[widget] sl = ScrollLabel::new(text),
             #[widget] eb = EditBox::new("edit me").with_guard(Guard),
             #[widget] tb = TextButton::new_msg("&Press me", Item::Button),
@@ -303,6 +305,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ];
             }]
             struct {
+                core: widget_core!(),
                 #[widget] menubar = menubar,
                 #[widget] img_gallery = img_gallery,
                 #[widget] gallery:

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -171,7 +171,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[derive(Clone, Debug)]
     struct MsgEdit;
 
-    let popup_edit_box = make_widget! {
+    let popup_edit_box = impl_singleton! {
         #[widget{
             layout = row: [
                 self.label,
@@ -226,7 +226,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 טקסט לדוגמא במספר שפות.";
 
     let radio = RadioBoxGroup::default();
-    let widgets = make_widget! {
+    let widgets = impl_singleton! {
         #[widget{
             layout = aligned_column: [
                 row: ["ScrollLabel", self.sl],
@@ -298,7 +298,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let window = Window::new(
         "Widget Gallery",
-        make_widget! {
+        impl_singleton! {
             #[widget{
                 layout = column: [
                     self.menubar,

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -180,7 +180,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }]
         struct {
             #[widget] label: StringLabel = Label::from("Use button to edit →"),
-            future: Option<Future<Option<String>>> = None,
+            future: Option<Future<Option<String>>>,
         }
         impl Widget for Self {
             fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -178,6 +178,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 TextButton::new_msg("&Edit", MsgEdit),
             ];
         }]
+        #[derive(Debug)]
         struct {
             core: widget_core!(),
             #[widget] label: StringLabel = Label::from("Use button to edit →"),
@@ -243,6 +244,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 row: ["Child window", self.pu],
             ];
         }]
+        #[derive(Debug)]
         struct {
             core: widget_core!(),
             #[widget] sl = ScrollLabel::new(text),
@@ -304,6 +306,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     self.gallery,
                 ];
             }]
+            #[derive(Debug)]
             struct {
                 core: widget_core!(),
                 #[widget] menubar = menubar,

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -29,7 +29,7 @@ fn main() -> kas::shell::Result<()> {
             }]
             struct {
                 #[widget] edit = EditBox::new("A small\nsample\nof text").multi_line(true),
-                #[widget] check = CheckBoxBare::new(),
+                #[widget] check: CheckBoxBare,
             }
         },
     );

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -5,7 +5,7 @@
 
 //! Demonstration of widget and text layouts
 
-use kas::macros::make_widget;
+use kas::macros::impl_singleton;
 use kas::widgets::{CheckBoxBare, EditBox, Label, ScrollLabel, Window};
 
 const LIPSUM: &'static str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nunc mi, consequat eget urna ut, auctor luctus mi. Sed molestie mi est. Sed non ligula ante. Curabitur ac molestie ante, nec sodales eros. In non arcu at turpis euismod bibendum ut tincidunt eros. Suspendisse blandit maximus nisi, viverra hendrerit elit efficitur et. Morbi ut facilisis eros. Vivamus dignissim, sapien sed mattis consectetur, libero leo imperdiet turpis, ac pulvinar libero purus eu lorem. Etiam quis sollicitudin urna. Integer vitae erat vel neque gravida blandit ac non quam.";
@@ -14,7 +14,7 @@ const CRASIT: &'static str = "Cras sit amet justo ipsum. Aliquam in nunc posuere
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
-    let demo = make_widget! {
+    let demo = impl_singleton! {
         #[widget{
             layout = grid: {
                 1, 0: "Layout demo";

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -14,26 +14,25 @@ const CRASIT: &'static str = "Cras sit amet justo ipsum. Aliquam in nunc posuere
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
-    let window = Window::new(
-        "Layout demo",
-        make_widget! {
-            #[widget{
-                layout = grid: {
-                    1, 0: "Layout demo";
-                    2, 0: self.check;
-                    0..3, 1: Label::new(LIPSUM);
-                    0, 2: align(center): "abc אבג def";
-                    1..3, 2..4: align(stretch): ScrollLabel::new(CRASIT);
-                    0, 3: self.edit;
-                };
-            }]
-            struct {
-                core: widget_core!(),
-                #[widget] edit = EditBox::new("A small\nsample\nof text").multi_line(true),
-                #[widget] check: CheckBoxBare,
-            }
-        },
-    );
+    let demo = make_widget! {
+        #[widget{
+            layout = grid: {
+                1, 0: "Layout demo";
+                2, 0: self.check;
+                0..3, 1: Label::new(LIPSUM);
+                0, 2: align(center): "abc אבג def";
+                1..3, 2..4: align(stretch): ScrollLabel::new(CRASIT);
+                0, 3: self.edit;
+            };
+        }]
+        #[derive(Debug)]
+        struct {
+            core: widget_core!(),
+            #[widget] edit = EditBox::new("A small\nsample\nof text").multi_line(true),
+            #[widget] check: CheckBoxBare,
+        }
+    };
+    let window = Window::new("Layout demo", demo);
 
     let theme = kas::theme::FlatTheme::new();
     kas::shell::Toolkit::new(theme)?.with(window)?.run()

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -28,6 +28,7 @@ fn main() -> kas::shell::Result<()> {
                 };
             }]
             struct {
+                core: widget_core!(),
                 #[widget] edit = EditBox::new("A small\nsample\nof text").multi_line(true),
                 #[widget] check: CheckBoxBare,
             }

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -60,6 +60,7 @@ It also supports lists:
                 layout = row: [self.editor, self.label];
             }]
             struct {
+                core: widget_core!(),
                 #[widget] editor: EditBox<Guard> =
                     EditBox::new(doc).multi_line(true).with_guard(Guard),
                 #[widget] label: ScrollBarRegion<Label<Markdown>> =

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -7,7 +7,7 @@
 
 use kas::class::HasStr;
 use kas::event::EventMgr;
-use kas::macros::make_widget;
+use kas::macros::impl_singleton;
 use kas::text::format::Markdown;
 use kas::widgets::{EditBox, EditField, EditGuard, Label, ScrollBarRegion, Window};
 use kas::Widget;
@@ -55,7 +55,7 @@ It also supports lists:
 
     let window = Window::new(
         "Markdown parser",
-        make_widget! {
+        impl_singleton! {
             #[widget{
                 layout = row: [self.editor, self.label];
             }]

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -59,6 +59,7 @@ It also supports lists:
             #[widget{
                 layout = row: [self.editor, self.label];
             }]
+            #[derive(Debug)]
             struct {
                 core: widget_core!(),
                 #[widget] editor: EditBox<Guard> =

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -6,7 +6,7 @@
 //! Counter example (simple button)
 
 use kas::event::EventMgr;
-use kas::macros::make_widget;
+use kas::macros::impl_singleton;
 use kas::widgets::{EditField, RowSplitter, TextButton, Window};
 use kas::Widget;
 
@@ -24,7 +24,7 @@ fn main() -> kas::shell::Result<()> {
 
     let window = Window::new(
         "Slitter panes",
-        make_widget! {
+        impl_singleton! {
             // TODO: use vertical splitter
             #[widget{
                 layout = column: [

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -35,6 +35,7 @@ fn main() -> kas::shell::Result<()> {
                     self.panes,
                 ];
             }]
+            #[derive(Debug)]
             struct {
                 core: widget_core!(),
                 #[widget] panes: RowSplitter<EditField> = panes,

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -36,6 +36,7 @@ fn main() -> kas::shell::Result<()> {
                 ];
             }]
             struct {
+                core: widget_core!(),
                 #[widget] panes: RowSplitter<EditField> = panes,
             }
             impl Widget for Self {

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -32,6 +32,7 @@ fn make_window() -> Box<dyn kas::Window> {
             ];
         }]
         struct {
+            core: widget_core!(),
             #[widget] display: impl HasString = Frame::new(Label::new("0.000".to_string())),
             saved: Duration,
             start: Option<Instant>,

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -33,8 +33,8 @@ fn make_window() -> Box<dyn kas::Window> {
         }]
         struct {
             #[widget] display: impl HasString = Frame::new(Label::new("0.000".to_string())),
-            saved: Duration = Duration::default(),
-            start: Option<Instant> = None,
+            saved: Duration,
+            start: Option<Instant>,
         }
         impl Widget for Self {
             fn configure(&mut self, mgr: &mut SetRectMgr) {

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use kas::class::HasString;
 use kas::event::{Event, EventMgr, Response};
 use kas::layout::SetRectMgr;
-use kas::macros::make_widget;
+use kas::macros::impl_singleton;
 use kas::widgets::{Frame, Label, TextButton, Window};
 use kas::{Widget, WidgetCore, WidgetExt};
 
@@ -23,7 +23,7 @@ struct MsgStart;
 // There's no reason for this, but it demonstrates usage of Toolkit::add_boxed
 fn make_window() -> Box<dyn kas::Window> {
     // Construct a row widget, with state and children
-    let stopwatch = make_widget! {
+    let stopwatch = impl_singleton! {
         #[widget{
             layout = row: [
                 self.display,

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -31,6 +31,7 @@ fn make_window() -> Box<dyn kas::Window> {
                 TextButton::new_msg("&start / &stop", MsgStart),
             ];
         }]
+        #[derive(Debug)]
         struct {
             core: widget_core!(),
             #[widget] display: impl HasString = Frame::new(Label::new("0.000".to_string())),

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -32,6 +32,7 @@ fn main() -> kas::shell::Result<()> {
                 ];
             }]
             struct {
+                core: widget_core!(),
                 // SingleView embeds a shared value, here default-constructed to 0
                 #[widget] counter: SingleView<SharedRc<i32>>,
             }

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -31,6 +31,7 @@ fn main() -> kas::shell::Result<()> {
                     ],
                 ];
             }]
+            #[derive(Debug)]
             struct {
                 core: widget_core!(),
                 // SingleView embeds a shared value, here default-constructed to 0

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -6,7 +6,7 @@
 //! A counter synchronised between multiple windows
 
 use kas::event::EventMgr;
-use kas::macros::make_widget;
+use kas::macros::impl_singleton;
 use kas::updatable::SharedRc;
 use kas::widgets::view::SingleView;
 use kas::widgets::{TextButton, Window};
@@ -20,7 +20,7 @@ fn main() -> kas::shell::Result<()> {
 
     let window = Window::new(
         "Counter",
-        make_widget! {
+        impl_singleton! {
             #[derive(Clone)]
             #[widget{
                 layout = column: [

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -33,7 +33,7 @@ fn main() -> kas::shell::Result<()> {
             }]
             struct {
                 // SingleView embeds a shared value, here default-constructed to 0
-                #[widget] counter: SingleView<SharedRc<i32>> = Default::default(),
+                #[widget] counter: SingleView<SharedRc<i32>>,
             }
             impl Widget for Self {
                 fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -64,7 +64,7 @@ fn main() -> kas::shell::Result<()> {
         .with_selection_mode(SelectionMode::Single);
     let table = ScrollBars::new(table);
 
-    let layout = make_widget! {
+    let layout = impl_singleton! {
         #[widget{
             layout = column: [
                 row: ["From 1 to", self.max],

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -72,6 +72,7 @@ fn main() -> kas::shell::Result<()> {
             ];
         }]
         struct {
+            core: widget_core!(),
             #[widget] max: impl HasString = EditBox::new("12")
                 .on_afl(|text, mgr| match text.parse::<usize>() {
                     Ok(n) => mgr.push_msg(n),

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -71,6 +71,7 @@ fn main() -> kas::shell::Result<()> {
                 align(right): self.table,
             ];
         }]
+        #[derive(Debug)]
         struct {
             core: widget_core!(),
             #[widget] max: impl HasString = EditBox::new("12")


### PR DESCRIPTION
What was `make_widget` is made more generic, no longer being special to widgets (aside from a rule for `#[widget]` fields which adds the `Widget` trait bound):

- do not add `widget_core!()` field or derive `Debug` automatically
- construct values using `Default::default()` if omitted
- make locally-declared type parameter names unique
- rename to `impl_singleton`
- support unit and tuple structs