### PR TITLE
Rename Draw/SizeHandle → ThemeDraw/Size; revise SizeMgr; #[extends] macro for ThemeDraw

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ KAS optionally uses several Rust nightly features, but is functional without
 Usage of `unsafe` is allowed, but not preferred. Current use cases:
 
 -   Defining constants requiring `unwrap` (tracker: [`const_option`](https://github.com/rust-lang/rust/issues/58732)). Note that since 1.57, `panic!` in const fns is supported, hence a work-around using `match` is possible.
--   To get around lifetime restrictions on the `draw_handle` and `size_handle`
+-   To get around lifetime restrictions on the theme API's `Theme::draw` and `Window::size`
     methods; this will no longer require `unsafe` once the
     `generic_associated_types` feature is stabilised.
 -   `WidgetId` uses `unsafe` code to support both inline and heap-allocated

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -246,6 +246,11 @@ pub trait Layout {
     /// It is expected that [`Self::set_rect`] is called before this method,
     /// but failure to do so should not cause a fatal error.
     ///
+    /// The `draw` parameter is pre-parameterized with this widget's
+    /// [`WidgetId`], allowing drawn components to react to input state. This
+    /// implies that when calling `draw` on children, the child's `id` must be
+    /// supplied via [`DrawMgr::re_id`] or [`DrawMgr::recurse`].
+    ///
     /// Default implementation:
     ///
     /// -   No default implementation, except,

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -8,7 +8,7 @@
 use super::{color::Rgba, AnimationState};
 #[allow(unused)]
 use super::{DrawRounded, DrawRoundedImpl};
-use super::{DrawSharedImpl, ImageId, PassId, PassType, SharedState};
+use super::{DrawShared, DrawSharedImpl, ImageId, PassId, PassType, SharedState};
 use crate::geom::{Offset, Quad, Rect, Vec2};
 #[allow(unused)]
 use crate::text::TextApi;
@@ -123,6 +123,9 @@ impl<'a, DS: DrawSharedImpl> DrawIface<'a, DS> {
 /// accessing these requires reconstruction of the implementing type via
 /// [`DrawIface::downcast_from`].
 pub trait Draw {
+    /// Access shared draw state
+    fn shared(&mut self) -> &mut dyn DrawShared;
+
     /// Request redraw at the next frame time
     ///
     /// Animations should call this each frame until complete.
@@ -224,6 +227,10 @@ pub trait Draw {
 }
 
 impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
+    fn shared(&mut self) -> &mut dyn DrawShared {
+        self.shared
+    }
+
     fn animate(&mut self) {
         self.draw.animate();
     }

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -11,7 +11,7 @@
 use linear_map::LinearMap;
 use log::{trace, warn};
 use smallvec::SmallVec;
-use std::any::Any;
+use std::any::{type_name, Any};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::ops::{Deref, DerefMut};
@@ -369,7 +369,7 @@ struct Message {
 impl Message {
     fn new<M: Any + Debug>(msg: Box<M>) -> Self {
         #[cfg(debug_assertions)]
-        let fmt = format!("{:?}", &msg);
+        let fmt = format!("{}::{:?}", type_name::<M>(), &msg);
         let any = msg;
         Message {
             #[cfg(debug_assertions)]

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -652,21 +652,20 @@ impl<'a> EventMgr<'a> {
     /// See also notes on [`Widget::configure`].
     pub fn size_mgr<F: FnMut(SizeMgr) -> T, T>(&mut self, mut f: F) -> T {
         let mut result = None;
-        self.shell.size_and_draw_shared(&mut |size_handle, _| {
-            result = Some(f(SizeMgr::new(size_handle)));
+        self.shell.size_and_draw_shared(&mut |size, _| {
+            result = Some(f(SizeMgr::new(size)));
         });
-        result.expect("ShellWindow::size_handle impl failed to call function argument")
+        result.expect("ShellWindow::size_and_draw_shared impl failed to call function argument")
     }
 
     /// Access a [`SetRectMgr`]
     pub fn set_rect_mgr<F: FnMut(&mut SetRectMgr) -> T, T>(&mut self, mut f: F) -> T {
         let mut result = None;
-        self.shell
-            .size_and_draw_shared(&mut |size_handle, draw_shared| {
-                let mut mgr = SetRectMgr::new(size_handle, draw_shared, self.state);
-                result = Some(f(&mut mgr));
-            });
-        result.expect("ShellWindow::size_handle impl failed to call function argument")
+        self.shell.size_and_draw_shared(&mut |size, draw_shared| {
+            let mut mgr = SetRectMgr::new(size, draw_shared, self.state);
+            result = Some(f(&mut mgr));
+        });
+        result.expect("ShellWindow::size_and_draw_shared impl failed to call function argument")
     }
 
     /// Access a [`DrawShared`]
@@ -675,7 +674,7 @@ impl<'a> EventMgr<'a> {
         self.shell.size_and_draw_shared(&mut |_, draw_shared| {
             result = Some(f(draw_shared));
         });
-        result.expect("ShellWindow::draw_shared impl failed to call function argument")
+        result.expect("ShellWindow::size_and_draw_shared impl failed to call function argument")
     }
 
     /// Grab "press" events for `source` (a mouse or finger)

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -78,8 +78,8 @@ impl EventState {
 
         self.new_accel_layer(WidgetId::ROOT, false);
 
-        shell.size_and_draw_shared(&mut |size_handle, draw_shared| {
-            let mut mgr = SetRectMgr::new(size_handle, draw_shared, self);
+        shell.size_and_draw_shared(&mut |size, draw_shared| {
+            let mut mgr = SetRectMgr::new(size, draw_shared, self);
             mgr.configure(WidgetId::ROOT, widget);
         });
 

--- a/crates/kas-core/src/event/manager/set_rect_mgr.rs
+++ b/crates/kas-core/src/event/manager/set_rect_mgr.rs
@@ -8,10 +8,10 @@
 use super::Pending;
 use crate::draw::DrawShared;
 use crate::event::EventState;
-use crate::geom::{Size, Vec2};
-use crate::layout::Align;
+use crate::geom::{Rect, Size, Vec2};
+use crate::layout::{Align, AlignHints};
 use crate::text::TextApi;
-use crate::theme::{SizeMgr, TextClass, ThemeSize};
+use crate::theme::{Feature, SizeMgr, TextClass, ThemeSize};
 use crate::{TkAction, Widget, WidgetExt, WidgetId};
 use std::ops::{Deref, DerefMut};
 
@@ -79,6 +79,15 @@ impl<'a> SetRectMgr<'a> {
         }
 
         widget.configure(self);
+    }
+
+    /// Align a feature's rect
+    ///
+    /// In case the input `rect` is larger than desired on either axis, it is
+    /// reduced in size and offset within the original `rect` as is preferred.
+    #[inline]
+    pub fn align_feature(&self, feature: Feature, rect: Rect, hints: AlignHints) -> Rect {
+        self.sh.align_feature(feature, rect, hints)
     }
 
     /// Update a text object, setting font properties and wrap size

--- a/crates/kas-core/src/event/manager/set_rect_mgr.rs
+++ b/crates/kas-core/src/event/manager/set_rect_mgr.rs
@@ -11,7 +11,7 @@ use crate::event::EventState;
 use crate::geom::{Size, Vec2};
 use crate::layout::Align;
 use crate::text::TextApi;
-use crate::theme::{SizeHandle, SizeMgr, TextClass};
+use crate::theme::{SizeMgr, TextClass, ThemeSize};
 use crate::{TkAction, Widget, WidgetExt, WidgetId};
 use std::ops::{Deref, DerefMut};
 
@@ -26,7 +26,7 @@ use crate::{event::Event, Layout};
 /// `SetRectMgr` supports [`Deref`] and [`DerefMut`] with target [`EventState`].
 #[must_use]
 pub struct SetRectMgr<'a> {
-    sh: &'a dyn SizeHandle,
+    sh: &'a dyn ThemeSize,
     ds: &'a mut dyn DrawShared,
     pub(crate) ev: &'a mut EventState,
 }
@@ -35,7 +35,7 @@ impl<'a> SetRectMgr<'a> {
     /// Construct
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    pub fn new(sh: &'a dyn SizeHandle, ds: &'a mut dyn DrawShared, ev: &'a mut EventState) -> Self {
+    pub fn new(sh: &'a dyn ThemeSize, ds: &'a mut dyn DrawShared, ev: &'a mut EventState) -> Self {
         SetRectMgr { sh, ds, ev }
     }
 

--- a/crates/kas-core/src/layout/size_rules.rs
+++ b/crates/kas-core/src/layout/size_rules.rs
@@ -125,6 +125,12 @@ impl SizeRules {
         }
     }
 
+    /// A fixed size with given (symmetric) `margin`
+    #[inline]
+    pub fn fixed_splat(size: i32, margin: u16) -> Self {
+        Self::fixed(size, (margin, margin))
+    }
+
     /// A fixed size, scaled from virtual pixels
     ///
     /// This is a shortcut to [`SizeRules::fixed`] using virtual-pixel sizes

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -331,6 +331,18 @@ impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
 ///
 /// # Theme extension
 ///
+/// Most themes will not want to implement *everything*, but rather derive
+/// not-explicitly-implemented methods from a base theme. This may be achieved
+/// with the [`kas_macros::extends`] macro:
+/// ```ignore
+/// #[extends(ThemeDraw, base = self.base())]
+/// impl ThemeDraw {
+///     // only implement some methods here
+/// }
+/// ```
+/// Note: [`Self::components`] and [`Self::draw_device`] must be implemented
+/// explicitly since these methods return references.
+///
 /// If Rust had stable specialization + GATs + negative trait bounds we could
 /// allow theme extension without macros as follows.
 /// <details>

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -104,14 +104,14 @@ impl<'a> DrawMgr<'a> {
 
     /// Access a [`SetRectMgr`]
     pub fn set_rect_mgr<F: FnMut(&mut SetRectMgr) -> T, T>(&mut self, mut f: F) -> T {
-        let (sh, ds, ev) = self.h.components();
-        let mut mgr = SetRectMgr::new(sh, ds, ev);
+        let (sh, draw, ev) = self.h.components();
+        let mut mgr = SetRectMgr::new(sh, draw.shared(), ev);
         f(&mut mgr)
     }
 
     /// Access a [`DrawShared`]
     pub fn draw_shared(&mut self) -> &mut dyn DrawShared {
-        self.h.components().1
+        self.h.components().1.shared()
     }
 
     /// Access the low-level draw device
@@ -120,7 +120,7 @@ impl<'a> DrawMgr<'a> {
     /// base trait [`Draw`]. To access further functionality, it is necessary
     /// to downcast with [`crate::draw::DrawIface::downcast_from`].
     pub fn draw_device(&mut self) -> &mut dyn Draw {
-        self.h.draw_device()
+        self.h.components().1
     }
 
     /// Draw to a new pass
@@ -371,15 +371,8 @@ impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
     stack_dst::ValueA<H, S>
 ))]
 pub trait ThemeDraw {
-    /// Access components: [`ThemeSize`], [`DrawShared`], [`EventState`]
-    fn components(&mut self) -> (&dyn ThemeSize, &mut dyn DrawShared, &mut EventState);
-
-    /// Access the low-level draw device
-    ///
-    /// Note: this drawing API is modular, with limited functionality in the
-    /// base trait [`Draw`]. To access further functionality, it is necessary
-    /// to downcast with [`crate::draw::DrawIface::downcast_from`].
-    fn draw_device(&mut self) -> &mut dyn Draw;
+    /// Access components: [`ThemeSize`], [`Draw`], [`EventState`]
+    fn components(&mut self) -> (&dyn ThemeSize, &mut dyn Draw, &mut EventState);
 
     /// Construct a new pass
     fn new_pass<'a>(

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -478,7 +478,7 @@ pub trait ThemeDraw {
 mod test {
     use super::*;
 
-    fn _draw_handle_ext(mut draw: DrawMgr) {
+    fn _draw_ext(mut draw: DrawMgr) {
         // We can't call this method without constructing an actual ThemeDraw.
         // But we don't need to: we just want to test that methods are callable.
 

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -340,8 +340,8 @@ impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
 ///     // only implement some methods here
 /// }
 /// ```
-/// Note: [`Self::components`] and [`Self::draw_device`] must be implemented
-/// explicitly since these methods return references.
+/// Note: [`Self::components`] must be implemented
+/// explicitly since this method returns references.
 ///
 /// If Rust had stable specialization + GATs + negative trait bounds we could
 /// allow theme extension without macros as follows.

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -45,7 +45,7 @@ impl Default for Background {
 /// -   `draw.checkbox(&*self, self.state);` — note `&*self` to convert from to
 ///     `&W` from `&mut W`, since the latter would cause borrow conflicts
 pub struct DrawMgr<'a> {
-    h: &'a mut dyn DrawHandle,
+    h: &'a mut dyn ThemeDraw,
     id: WidgetId,
 }
 
@@ -88,7 +88,7 @@ impl<'a> DrawMgr<'a> {
     /// Construct from a [`DrawMgr`] and [`EventState`]
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    pub fn new(h: &'a mut dyn DrawHandle, id: WidgetId) -> Self {
+    pub fn new(h: &'a mut dyn ThemeDraw, id: WidgetId) -> Self {
         DrawMgr { h, id }
     }
 
@@ -326,7 +326,7 @@ impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
     }
 }
 
-/// A handle to the active theme, used for drawing
+/// Theme drawing implementation
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 #[autoimpl(for<H: trait + ?Sized> Box<H>)]
@@ -334,7 +334,7 @@ impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
     for<H: trait + ?Sized, S: Default + Copy + AsRef<[usize]> + AsMut<[usize]>>
     stack_dst::ValueA<H, S>
 ))]
-pub trait DrawHandle {
+pub trait ThemeDraw {
     /// Access components: [`SizeHandle`], [`DrawShared`], [`EventState`]
     fn components(&mut self) -> (&dyn SizeHandle, &mut dyn DrawShared, &mut EventState);
 
@@ -351,7 +351,7 @@ pub trait DrawHandle {
         rect: Rect,
         offset: Offset,
         class: PassType,
-        f: Box<dyn FnOnce(&mut dyn DrawHandle) + 'a>,
+        f: Box<dyn FnOnce(&mut dyn ThemeDraw) + 'a>,
     );
 
     /// Target area for drawing
@@ -383,7 +383,7 @@ pub trait DrawHandle {
 
     /// Draw text with effects
     ///
-    /// [`DrawHandle::text`] already supports *font* effects: bold,
+    /// [`ThemeDraw::text`] already supports *font* effects: bold,
     /// emphasis, text size. In addition, this method supports underline and
     /// strikethrough effects.
     ///
@@ -479,7 +479,7 @@ mod test {
     use super::*;
 
     fn _draw_handle_ext(mut draw: DrawMgr) {
-        // We can't call this method without constructing an actual DrawHandle.
+        // We can't call this method without constructing an actual ThemeDraw.
         // But we don't need to: we just want to test that methods are callable.
 
         let _scale = draw.size_mgr().scale_factor();

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -346,7 +346,12 @@ impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
 /// If Rust had stable specialization + GATs + negative trait bounds we could
 /// allow theme extension without macros as follows.
 /// <details>
-/// ```
+///
+/// ```ignore
+/// #![feature(generic_associated_types)]
+/// #![feature(specialization)]
+/// # use kas_core::geom::Rect;
+/// # use kas_core::theme::ThemeDraw;
 /// /// Provides a default implementation of each theme method over a base theme
 /// pub trait ThemeDrawExtends: ThemeDraw {
 ///     /// Type of base implementation
@@ -358,7 +363,10 @@ impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
 ///
 /// // Note: we may need negative trait bounds here to avoid conflict with impl for Box<H>
 /// impl<D: ThemeDrawExtends> ThemeDraw for D {
-///     default fn draw_device(&mut self) -> &mut dyn Draw { self.base().draw_device() }
+///     default fn get_clip_rect(&mut self) -> Rect {
+///         self.base().get_clip_rect()
+///     }
+///
 ///     // And so on for other methods...
 /// }
 /// ```

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -5,7 +5,7 @@
 
 //! "Handle" types used by themes
 
-use super::{FrameStyle, MarkStyle, SizeHandle, SizeMgr, TextClass};
+use super::{FrameStyle, MarkStyle, SizeMgr, TextClass, ThemeSize};
 use crate::dir::Direction;
 use crate::draw::{color::Rgb, Draw, DrawShared, ImageId, PassType};
 use crate::event::{EventState, SetRectMgr};
@@ -335,8 +335,8 @@ impl<'a> std::ops::BitOrAssign<TkAction> for DrawMgr<'a> {
     stack_dst::ValueA<H, S>
 ))]
 pub trait ThemeDraw {
-    /// Access components: [`SizeHandle`], [`DrawShared`], [`EventState`]
-    fn components(&mut self) -> (&dyn SizeHandle, &mut dyn DrawShared, &mut EventState);
+    /// Access components: [`ThemeSize`], [`DrawShared`], [`EventState`]
+    fn components(&mut self) -> (&dyn ThemeSize, &mut dyn DrawShared, &mut EventState);
 
     /// Access the low-level draw device
     ///
@@ -362,7 +362,7 @@ pub trait ThemeDraw {
 
     /// Draw a frame inside the given `rect`
     ///
-    /// The frame dimensions are given by [`SizeHandle::frame`].
+    /// The frame dimensions are given by [`ThemeSize::frame`].
     fn frame(&mut self, id: &WidgetId, rect: Rect, style: FrameStyle, bg: Background);
 
     /// Draw a separator in the given `rect`

--- a/crates/kas-core/src/theme/mod.rs
+++ b/crates/kas-core/src/theme/mod.rs
@@ -10,7 +10,7 @@ mod size;
 mod style;
 
 pub use draw::{Background, DrawMgr, ThemeDraw};
-pub use size::{SizeHandle, SizeMgr};
+pub use size::{SizeMgr, ThemeSize};
 pub use style::*;
 
 #[allow(unused)]

--- a/crates/kas-core/src/theme/mod.rs
+++ b/crates/kas-core/src/theme/mod.rs
@@ -9,7 +9,7 @@ mod draw;
 mod size;
 mod style;
 
-pub use draw::{Background, DrawHandle, DrawMgr};
+pub use draw::{Background, DrawMgr, ThemeDraw};
 pub use size::{SizeHandle, SizeMgr};
 pub use style::*;
 

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -28,13 +28,13 @@ use crate::text::TextApiExt;
 ///
 /// Most methods get or calculate the size of some feature. These same features
 /// may be drawn through [`DrawMgr`].
-pub struct SizeMgr<'a>(&'a dyn SizeHandle);
+pub struct SizeMgr<'a>(&'a dyn ThemeSize);
 
 impl<'a> SizeMgr<'a> {
-    /// Construct from a [`SizeHandle`]
+    /// Construct from a [`ThemeSize`]
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    pub fn new(h: &'a dyn SizeHandle) -> Self {
+    pub fn new(h: &'a dyn ThemeSize) -> Self {
         SizeMgr(h)
     }
 
@@ -195,11 +195,11 @@ impl<'a> SizeMgr<'a> {
     }
 }
 
-/// A handle to the active theme, used for sizing
+/// Theme sizing implementation
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 #[autoimpl(for<S: trait + ?Sized, R: Deref<Target = S>> R)]
-pub trait SizeHandle {
+pub trait ThemeSize {
     /// Get the scale (DPI) factor
     fn scale_factor(&self) -> f32;
 

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -7,10 +7,10 @@
 
 use std::ops::Deref;
 
-use super::{FrameStyle, MarkStyle, TextClass};
+use super::{Feature, FrameStyle, TextClass};
 use crate::dir::Directional;
-use crate::geom::{Size, Vec2};
-use crate::layout::{AxisInfo, FrameRules, Margins, SizeRules};
+use crate::geom::{Rect, Size, Vec2};
+use crate::layout::{AlignHints, AxisInfo, FrameRules, Margins, SizeRules};
 use crate::macros::autoimpl;
 use crate::text::{Align, TextApi};
 #[allow(unused)]
@@ -88,16 +88,6 @@ impl<'a> SizeMgr<'a> {
         self.0.pixels_from_em(em)
     }
 
-    /// Size of a frame around another element
-    pub fn frame(&self, style: FrameStyle, dir: impl Directional) -> FrameRules {
-        self.0.frame(style, dir.is_vertical())
-    }
-
-    /// Size of a separator frame between items
-    pub fn separator(&self) -> Size {
-        self.0.separator()
-    }
-
     /// The margin around content within a widget
     ///
     /// Though inner margins are *usually* empty, they are sometimes drawn to,
@@ -119,6 +109,16 @@ impl<'a> SizeMgr<'a> {
     /// labels which do not have a visible hard edge.
     pub fn text_margins(&self) -> Margins {
         self.0.text_margins()
+    }
+
+    /// Size rules for a feature
+    pub fn feature(&self, feature: Feature, axis: impl Directional) -> SizeRules {
+        self.0.feature(feature, axis.is_vertical())
+    }
+
+    /// Size of a frame around another element
+    pub fn frame(&self, style: FrameStyle, axis: impl Directional) -> FrameRules {
+        self.0.frame(style, axis.is_vertical())
     }
 
     /// The height of a line of text
@@ -143,56 +143,6 @@ impl<'a> SizeMgr<'a> {
     ) -> SizeRules {
         self.0.text_bound(text, class, axis)
     }
-
-    /// Size of the element drawn by [`DrawMgr::checkbox`].
-    pub fn checkbox(&self) -> Size {
-        self.0.checkbox()
-    }
-
-    /// Size of the element drawn by [`DrawMgr::radiobox`].
-    pub fn radiobox(&self) -> Size {
-        self.0.radiobox()
-    }
-
-    /// A simple mark
-    pub fn mark(&self, style: MarkStyle, dir: impl Directional) -> SizeRules {
-        self.0.mark(style, dir.is_vertical())
-    }
-
-    /// Dimensions for a scrollbar
-    ///
-    /// Returns:
-    ///
-    /// -   `size`: minimum size of handle in horizontal orientation;
-    ///     `size.1` is also the width of the scrollbar
-    /// -   `min_len`: minimum length for the whole bar
-    ///
-    /// Required bound: `min_len >= size.0`.
-    pub fn scrollbar(&self) -> (Size, i32) {
-        self.0.scrollbar()
-    }
-
-    /// Dimensions for a slider
-    ///
-    /// Returns:
-    ///
-    /// -   `size`: minimum size of handle in horizontal orientation;
-    ///     `size.1` is also the width of the slider
-    /// -   `min_len`: minimum length for the whole bar
-    ///
-    /// Required bound: `min_len >= size.0`.
-    pub fn slider(&self) -> (Size, i32) {
-        self.0.slider()
-    }
-
-    /// Dimensions for a progress bar
-    ///
-    /// Returns the minimum size for a horizontal progress bar. It is assumed
-    /// that the width is adjustable while the height is (preferably) not.
-    /// For a vertical bar, the values are swapped.
-    pub fn progress_bar(&self) -> Size {
-        self.0.progress_bar()
-    }
 }
 
 /// Theme sizing implementation
@@ -211,12 +161,6 @@ pub trait ThemeSize {
     /// (This depends on the font size.)
     fn pixels_from_em(&self, em: f32) -> f32;
 
-    /// Size of a frame around another element
-    fn frame(&self, style: FrameStyle, is_vert: bool) -> FrameRules;
-
-    /// Size of a separator frame between items
-    fn separator(&self) -> Size;
-
     /// The margin around content within a widget
     ///
     /// Though inner margins are *usually* empty, they are sometimes drawn to,
@@ -233,6 +177,18 @@ pub trait ThemeSize {
     /// Similar to [`Self::outer_margins`], but intended for things like text
     /// labels which do not have a visible hard edge.
     fn text_margins(&self) -> Margins;
+
+    /// Size rules for a feature
+    fn feature(&self, feature: Feature, axis_is_vertical: bool) -> SizeRules;
+
+    /// Align a feature's rect
+    ///
+    /// In case the input `rect` is larger than desired on either axis, it is
+    /// reduced in size and offset within the original `rect` as is preferred.
+    fn align_feature(&self, feature: Feature, rect: Rect, hints: AlignHints) -> Rect;
+
+    /// Size of a frame around another element
+    fn frame(&self, style: FrameStyle, axis_is_vertical: bool) -> FrameRules;
 
     /// The height of a line of text
     fn line_height(&self, class: TextClass) -> i32;
@@ -258,42 +214,4 @@ pub trait ThemeSize {
         size: Size,
         align: (Align, Align),
     ) -> Vec2;
-
-    /// Size of the element drawn by [`DrawMgr::checkbox`].
-    fn checkbox(&self) -> Size;
-
-    /// Size of the element drawn by [`DrawMgr::radiobox`].
-    fn radiobox(&self) -> Size;
-
-    /// A simple mark
-    fn mark(&self, style: MarkStyle, is_vert: bool) -> SizeRules;
-
-    /// Dimensions for a scrollbar
-    ///
-    /// Returns:
-    ///
-    /// -   `size`: minimum size of handle in horizontal orientation;
-    ///     `size.1` is also the width of the scrollbar
-    /// -   `min_len`: minimum length for the whole bar
-    ///
-    /// Required bound: `min_len >= size.0`.
-    fn scrollbar(&self) -> (Size, i32);
-
-    /// Dimensions for a slider
-    ///
-    /// Returns:
-    ///
-    /// -   `size`: minimum size of handle in horizontal orientation;
-    ///     `size.1` is also the width of the slider
-    /// -   `min_len`: minimum length for the whole bar
-    ///
-    /// Required bound: `min_len >= size.0`.
-    fn slider(&self) -> (Size, i32);
-
-    /// Dimensions for a progress bar
-    ///
-    /// Returns the minimum size for a horizontal progress bar. It is assumed
-    /// that the width is adjustable while the height is (preferably) not.
-    /// For a vertical bar, the values are swapped.
-    fn progress_bar(&self) -> Size;
 }

--- a/crates/kas-core/src/theme/style.rs
+++ b/crates/kas-core/src/theme/style.rs
@@ -7,6 +7,54 @@
 
 use crate::dir::Direction;
 
+/// Style of marks
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum MarkStyle {
+    /// An arrowhead/angle-bracket/triangle pointing in the given direction
+    Point(Direction),
+}
+
+/// Various features which may be sized and drawn
+///
+/// Includes most types of features excepting text and frames.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum Feature {
+    Separator,
+    Mark(MarkStyle),
+    CheckBox,
+    RadioBox,
+    ScrollBar(Direction),
+    Slider(Direction),
+    ProgressBar(Direction),
+}
+
+impl From<MarkStyle> for Feature {
+    fn from(style: MarkStyle) -> Self {
+        Feature::Mark(style)
+    }
+}
+
+/// Style of a frame
+///
+/// A "frame" is an element surrounding another element.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum FrameStyle {
+    /// An invisible frame which forces all margins to be interior
+    InnerMargin,
+    /// A frame for grouping content
+    Frame,
+    /// A frame around pop-ups
+    Popup,
+    /// Border around a pop-up menu entry
+    MenuEntry,
+    /// Frame used to indicate navigation focus
+    NavFocus,
+    /// Border of a button
+    Button,
+    /// Box used to contain editable text
+    EditBox,
+}
+
 /// Class of text drawn
 ///
 /// Themes choose font, font size, colour, and alignment based on this.
@@ -68,32 +116,4 @@ impl TextClass {
         use TextClass::*;
         matches!(self, AccelLabel(_) | Button | MenuLabel)
     }
-}
-
-/// Style of a frame
-///
-/// A "frame" is an element surrounding another element.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub enum FrameStyle {
-    /// An invisible frame which forces all margins to be interior
-    InnerMargin,
-    /// A frame for grouping content
-    Frame,
-    /// A frame around pop-ups
-    Popup,
-    /// Border around a pop-up menu entry
-    MenuEntry,
-    /// Frame used to indicate navigation focus
-    NavFocus,
-    /// Border of a button
-    Button,
-    /// Box used to contain editable text
-    EditBox,
-}
-
-/// Style of marks
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub enum MarkStyle {
-    /// An arrowhead/angle-bracket/triangle pointing in the given direction
-    Point(Direction),
 }

--- a/crates/kas-core/src/toolkit.rs
+++ b/crates/kas-core/src/toolkit.rs
@@ -143,7 +143,7 @@ pub trait ShellWindow {
     /// Access [`ThemeSize`] and [`DrawShared`] objects
     ///
     /// Implementations should call the given function argument once; not doing
-    /// so is memory-safe but will cause a panic when `size_handle` is called.
+    /// so is memory-safe but will cause panics in `EventMgr` methods.
     /// User-code *must not* depend on `f` being called for memory safety.
     fn size_and_draw_shared(&mut self, f: &mut dyn FnMut(&mut dyn ThemeSize, &mut dyn DrawShared));
 

--- a/crates/kas-core/src/toolkit.rs
+++ b/crates/kas-core/src/toolkit.rs
@@ -15,7 +15,7 @@
 use crate::draw::DrawShared;
 use crate::event;
 use crate::event::UpdateId;
-use crate::theme::{SizeHandle, ThemeControl};
+use crate::theme::{ThemeControl, ThemeSize};
 use std::num::NonZeroU32;
 
 /// Identifier for a window or pop-up
@@ -140,12 +140,12 @@ pub trait ShellWindow {
     /// returned from the closure.
     fn adjust_theme(&mut self, f: &mut dyn FnMut(&mut dyn ThemeControl) -> TkAction);
 
-    /// Access a [`SizeHandle`] and a [`DrawShared`]
+    /// Access [`ThemeSize`] and [`DrawShared`] objects
     ///
     /// Implementations should call the given function argument once; not doing
     /// so is memory-safe but will cause a panic when `size_handle` is called.
     /// User-code *must not* depend on `f` being called for memory safety.
-    fn size_and_draw_shared(&mut self, f: &mut dyn FnMut(&mut dyn SizeHandle, &mut dyn DrawShared));
+    fn size_and_draw_shared(&mut self, f: &mut dyn FnMut(&mut dyn ThemeSize, &mut dyn DrawShared));
 
     /// Set the mouse cursor
     fn set_cursor_icon(&mut self, icon: event::CursorIcon);

--- a/crates/kas-macros/src/extends.rs
+++ b/crates/kas-macros/src/extends.rs
@@ -1,0 +1,162 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Extends macro
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream, Result};
+use syn::{parse_quote, Expr, ImplItem, ImplItemMethod, ItemImpl, Token};
+
+#[allow(non_camel_case_types)]
+mod kw {
+    syn::custom_keyword!(ThemeDraw);
+    syn::custom_keyword!(base);
+}
+
+pub struct Extends {
+    base: Expr,
+}
+
+impl Parse for Extends {
+    fn parse(content: ParseStream) -> Result<Extends> {
+        let _ = content.parse::<kw::ThemeDraw>()?;
+        let _ = content.parse::<Token![,]>()?;
+        let _ = content.parse::<kw::base>()?;
+        let _ = content.parse::<Token![=]>()?;
+
+        Ok(Extends {
+            base: content.parse()?,
+        })
+    }
+}
+
+struct Methods(Vec<ImplItemMethod>);
+impl Parse for Methods {
+    fn parse(input: ParseStream) -> Result<Methods> {
+        let mut vec = Vec::new();
+
+        while !input.is_empty() {
+            vec.push(input.parse()?);
+        }
+
+        Ok(Methods(vec))
+    }
+}
+
+impl Extends {
+    fn methods_theme_draw(self) -> Vec<ImplItemMethod> {
+        let base = self.base;
+        let methods: Methods = parse_quote! {
+            fn new_pass<'_gen_a>(
+                &mut self,
+                rect: ::kas::geom::Rect,
+                offset: ::kas::geom::Offset,
+                class: ::kas::draw::PassType,
+                f: Box<dyn FnOnce(&mut dyn ::kas::theme::ThemeDraw) + '_gen_a>,
+            ) {
+                (#base).new_pass(rect, offset, class, f);
+            }
+
+            fn get_clip_rect(&mut self) -> Rect {
+                (#base).get_clip_rect()
+            }
+
+            fn frame(&mut self, id: &WidgetId, rect: Rect, style: FrameStyle, bg: Background) {
+                (#base).frame(id, rect, style, bg);
+            }
+
+            fn separator(&mut self, rect: Rect) {
+                (#base).separator(rect);
+            }
+
+            fn selection_box(&mut self, rect: Rect) {
+                (#base).selection_box(rect);
+            }
+
+            fn text(&mut self, id: &WidgetId, pos: Coord, text: &TextDisplay, class: TextClass) {
+                (#base).text(id, pos, text, class);
+            }
+
+            fn text_effects(&mut self, id: &WidgetId, pos: Coord, text: &dyn TextApi, class: TextClass) {
+                (#base).text_effects(id, pos, text, class);
+            }
+
+            fn text_selected_range(
+                &mut self,
+                id: &WidgetId,
+                pos: Coord,
+                text: &TextDisplay,
+                range: Range<usize>,
+                class: TextClass,
+            ) {
+                (#base).text_selected_range(id, pos, text, range, class);
+            }
+
+            fn text_cursor(
+                &mut self,
+                id: &WidgetId,
+                pos: Coord,
+                text: &TextDisplay,
+                class: TextClass,
+                byte: usize,
+            ) {
+                (#base).text_cursor(id, pos, text, class, byte);
+            }
+
+            fn checkbox(&mut self, id: &WidgetId, rect: Rect, checked: bool, last_change: Option<Instant>) {
+                (#base).checkbox(id, rect, checked, last_change);
+            }
+
+            fn radiobox(&mut self, id: &WidgetId, rect: Rect, checked: bool, last_change: Option<Instant>) {
+                (#base).radiobox(id, rect, checked, last_change);
+            }
+
+            fn mark(&mut self, id: &WidgetId, rect: Rect, style: MarkStyle) {
+                (#base).mark(id, rect, style);
+            }
+
+            fn scrollbar(
+                &mut self,
+                id: &WidgetId,
+                id2: &WidgetId,
+                rect: Rect,
+                h_rect: Rect,
+                dir: Direction,
+            ) {
+                (#base).scrollbar(id, id2, rect, h_rect, dir);
+            }
+
+            fn slider(&mut self, id: &WidgetId, id2: &WidgetId, rect: Rect, h_rect: Rect, dir: Direction) {
+                (#base).slider(id, id2, rect, h_rect, dir);
+            }
+
+            fn progress_bar(&mut self, id: &WidgetId, rect: Rect, dir: Direction, value: f32) {
+                (#base).progress_bar(id, rect, dir, value);
+            }
+
+            fn image(&mut self, id: ImageId, rect: Rect) {
+                (#base).image(id, rect);
+            }
+        };
+        methods.0
+    }
+
+    pub fn extend(self, item: TokenStream) -> Result<TokenStream> {
+        let mut impl_: ItemImpl = syn::parse2(item)?;
+
+        let mut methods = self.methods_theme_draw();
+        methods.retain(|method| {
+            let name = method.sig.ident.to_string();
+            impl_.items.iter().all(|item| !matches!(item, ImplItem::Method(ImplItemMethod { sig, .. }) if sig.ident == name))
+        });
+
+        impl_
+            .items
+            .extend(methods.into_iter().map(|m| ImplItem::Method(m)));
+
+        Ok(quote! { #impl_ })
+    }
+}

--- a/crates/kas-macros/src/extends.rs
+++ b/crates/kas-macros/src/extends.rs
@@ -155,7 +155,7 @@ impl Extends {
 
         impl_
             .items
-            .extend(methods.into_iter().map(|m| ImplItem::Method(m)));
+            .extend(methods.into_iter().map(ImplItem::Method));
 
         Ok(quote! { #impl_ })
     }

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -3,7 +3,7 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! Common implementation of [`kas::theme::SizeHandle`]
+//! Common implementation of [`kas::theme::ThemeSize`]
 
 use linear_map::LinearMap;
 use std::any::Any;
@@ -16,7 +16,7 @@ use kas::dir::Directional;
 use kas::geom::{Size, Vec2};
 use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::text::{fonts::FontId, Align, TextApi, TextApiExt};
-use kas::theme::{FrameStyle, MarkStyle, SizeHandle, TextClass};
+use kas::theme::{FrameStyle, MarkStyle, TextClass, ThemeSize};
 
 /// Parameterisation of [`Dimensions`]
 ///
@@ -146,7 +146,7 @@ impl<D> Window<D> {
 }
 
 impl<D: 'static> crate::Window for Window<D> {
-    fn size_handle(&self) -> &dyn SizeHandle {
+    fn size_handle(&self) -> &dyn ThemeSize {
         self
     }
 
@@ -155,7 +155,7 @@ impl<D: 'static> crate::Window for Window<D> {
     }
 }
 
-impl<D: 'static> SizeHandle for Window<D> {
+impl<D: 'static> ThemeSize for Window<D> {
     fn scale_factor(&self) -> f32 {
         self.dims.scale_factor
     }

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -13,10 +13,10 @@ use std::rc::Rc;
 use crate::anim::AnimState;
 use kas::cast::traits::*;
 use kas::dir::Directional;
-use kas::geom::{Size, Vec2};
-use kas::layout::{AxisInfo, FrameRules, Margins, SizeRules, Stretch};
+use kas::geom::{Rect, Size, Vec2};
+use kas::layout::{AlignHints, AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::text::{fonts::FontId, Align, TextApi, TextApiExt};
-use kas::theme::{FrameStyle, MarkStyle, TextClass, ThemeSize};
+use kas::theme::{Feature, FrameStyle, MarkStyle, TextClass, ThemeSize};
 
 /// Parameterisation of [`Dimensions`]
 ///
@@ -168,6 +168,85 @@ impl<D: 'static> ThemeSize for Window<D> {
         self.dims.dpp * self.dims.pt_size * em
     }
 
+    fn inner_margin(&self) -> Size {
+        Size::splat(self.dims.inner_margin.into())
+    }
+
+    fn outer_margins(&self) -> Margins {
+        Margins::splat(self.dims.outer_margin)
+    }
+
+    fn text_margins(&self) -> Margins {
+        Margins::hv_splat(self.dims.text_margin)
+    }
+
+    fn feature(&self, feature: Feature, axis_is_vertical: bool) -> SizeRules {
+        let dir_is_vertical;
+        let mut size;
+        let mut ideal_mul = 3;
+
+        match feature {
+            Feature::Separator => {
+                return SizeRules::fixed_splat(self.dims.frame, 0);
+            }
+            Feature::Mark(MarkStyle::Point(dir)) => {
+                let w = match dir.is_vertical() == axis_is_vertical {
+                    true => self.dims.mark / 2 + i32::conv_ceil(self.dims.mark_line),
+                    false => self.dims.mark + i32::conv_ceil(self.dims.mark_line),
+                };
+                return SizeRules::fixed_splat(w, self.dims.outer_margin);
+            }
+            Feature::CheckBox | Feature::RadioBox => {
+                return SizeRules::fixed_splat(self.dims.checkbox, self.dims.outer_margin);
+            }
+            Feature::ScrollBar(dir) => {
+                dir_is_vertical = dir.is_vertical();
+                size = self.dims.scrollbar;
+            }
+            Feature::Slider(dir) => {
+                dir_is_vertical = dir.is_vertical();
+                size = self.dims.slider;
+                ideal_mul = 5;
+            }
+            Feature::ProgressBar(dir) => {
+                dir_is_vertical = dir.is_vertical();
+                size = self.dims.progress_bar;
+            }
+        }
+
+        let mut stretch = Stretch::High;
+        if dir_is_vertical != axis_is_vertical {
+            size = size.transpose();
+            ideal_mul = 1;
+            stretch = Stretch::None;
+        }
+        let m = self.dims.outer_margin;
+        SizeRules::new(size.0, ideal_mul * size.0, (m, m), stretch)
+    }
+
+    fn align_feature(&self, feature: Feature, rect: Rect, hints: AlignHints) -> Rect {
+        let mut ideal_size = rect.size;
+        match feature {
+            Feature::Separator => (), // has no direction so we cannot align
+            Feature::Mark(_) => (),   // aligned when drawn instead
+            Feature::CheckBox | Feature::RadioBox => {
+                ideal_size = Size::splat(self.dims.checkbox);
+            }
+            Feature::ScrollBar(dir) => {
+                ideal_size.set_component(dir.flipped(), self.dims.scrollbar.1);
+            }
+            Feature::Slider(dir) => {
+                ideal_size.set_component(dir.flipped(), self.dims.slider.1);
+            }
+            Feature::ProgressBar(dir) => {
+                ideal_size.set_component(dir.flipped(), self.dims.progress_bar.1);
+            }
+        }
+        hints
+            .complete(Align::Center, Align::Center)
+            .aligned_rect(ideal_size, rect)
+    }
+
     fn frame(&self, style: FrameStyle, _is_vert: bool) -> FrameRules {
         let inner = self.dims.inner_margin.into();
         match style {
@@ -182,22 +261,6 @@ impl<D: 'static> ThemeSize for Window<D> {
             }
             FrameStyle::EditBox => FrameRules::new_sym(self.dims.frame, inner, 0),
         }
-    }
-
-    fn separator(&self) -> Size {
-        Size::splat(self.dims.frame)
-    }
-
-    fn inner_margin(&self) -> Size {
-        Size::splat(self.dims.inner_margin.into())
-    }
-
-    fn outer_margins(&self) -> Margins {
-        Margins::splat(self.dims.outer_margin)
-    }
-
-    fn text_margins(&self) -> Margins {
-        Margins::hv_splat(self.dims.text_margin)
     }
 
     fn line_height(&self, class: TextClass) -> i32 {
@@ -306,41 +369,5 @@ impl<D: 'static> ThemeSize for Window<D> {
             env.set_wrap(class.multi_line());
         })
         .into()
-    }
-
-    fn checkbox(&self) -> Size {
-        Size::splat(self.dims.checkbox)
-    }
-
-    #[inline]
-    fn radiobox(&self) -> Size {
-        self.checkbox()
-    }
-
-    fn mark(&self, style: MarkStyle, is_vert: bool) -> SizeRules {
-        match style {
-            MarkStyle::Point(dir) => {
-                let w = match dir.is_vertical() == is_vert {
-                    true => self.dims.mark / 2 + i32::conv_ceil(self.dims.mark_line),
-                    false => self.dims.mark + i32::conv_ceil(self.dims.mark_line),
-                };
-                let m = self.dims.outer_margin;
-                SizeRules::fixed(w, (m, m))
-            }
-        }
-    }
-
-    fn scrollbar(&self) -> (Size, i32) {
-        let size = self.dims.scrollbar;
-        (size, 3 * size.0)
-    }
-
-    fn slider(&self) -> (Size, i32) {
-        let size = self.dims.slider;
-        (size, 5 * size.0)
-    }
-
-    fn progress_bar(&self) -> Size {
-        self.dims.progress_bar
     }
 }

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -146,7 +146,7 @@ impl<D> Window<D> {
 }
 
 impl<D: 'static> crate::Window for Window<D> {
-    fn size_handle(&self) -> &dyn ThemeSize {
+    fn size(&self) -> &dyn ThemeSize {
         self
     }
 

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -378,7 +378,7 @@ where
         f(&mut handle);
     }
 
-    fn get_clip_rect(&self) -> Rect {
+    fn get_clip_rect(&mut self) -> Rect {
         self.draw.get_clip_rect()
     }
 

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -21,7 +21,7 @@ use kas::event::EventState;
 use kas::geom::*;
 use kas::text::{fonts, Effect, TextApi, TextDisplay};
 use kas::theme::{Background, FrameStyle, MarkStyle, TextClass};
-use kas::theme::{SizeHandle, ThemeControl, ThemeDraw};
+use kas::theme::{ThemeControl, ThemeDraw, ThemeSize};
 use kas::{TkAction, WidgetId};
 
 // Used to ensure a rectangular background is inside a circular corner.
@@ -336,7 +336,7 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS>
 where
     DS::Draw: DrawRoundedImpl,
 {
-    fn components(&mut self) -> (&dyn SizeHandle, &mut dyn DrawShared, &mut EventState) {
+    fn components(&mut self) -> (&dyn ThemeSize, &mut dyn DrawShared, &mut EventState) {
         (self.w, self.draw.shared, self.ev)
     }
 

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -250,7 +250,7 @@ where
             }
         }
 
-        if !self.cols.is_dark && !(state.disabled() || state.depress()) {
+        if !(self.cols.is_dark || state.disabled() || state.depress()) {
             let (mut a, mut b) = (self.w.dims.shadow_a, self.w.dims.shadow_b);
             if state.hover() {
                 a = a * SHADOW_HOVER;
@@ -571,7 +571,7 @@ where
         let outer = Quad::conv(rect);
         let col = self.cols.nav_region(state).unwrap_or(self.cols.frame);
 
-        if !self.cols.is_dark && !(state.disabled() || state.depress()) {
+        if !(self.cols.is_dark || state.disabled() || state.depress()) {
             let (mut a, mut b) = (self.w.dims.shadow_a, self.w.dims.shadow_b);
             let mut mult = 0.65;
             if state.hover() {

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -336,12 +336,8 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS>
 where
     DS::Draw: DrawRoundedImpl,
 {
-    fn components(&mut self) -> (&dyn ThemeSize, &mut dyn DrawShared, &mut EventState) {
-        (self.w, self.draw.shared, self.ev)
-    }
-
-    fn draw_device(&mut self) -> &mut dyn Draw {
-        &mut self.draw
+    fn components(&mut self) -> (&dyn ThemeSize, &mut dyn Draw, &mut EventState) {
+        (self.w, &mut self.draw, self.ev)
     }
 
     fn new_pass<'b>(

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -20,8 +20,8 @@ use kas::draw::{color::Rgba, *};
 use kas::event::EventState;
 use kas::geom::*;
 use kas::text::{fonts, Effect, TextApi, TextDisplay};
-use kas::theme::{self, SizeHandle, ThemeControl};
 use kas::theme::{Background, FrameStyle, MarkStyle, TextClass};
+use kas::theme::{SizeHandle, ThemeControl, ThemeDraw};
 use kas::{TkAction, WidgetId};
 
 // Used to ensure a rectangular background is inside a circular corner.
@@ -332,7 +332,7 @@ where
     }
 }
 
-impl<'a, DS: DrawSharedImpl> theme::DrawHandle for DrawHandle<'a, DS>
+impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS>
 where
     DS::Draw: DrawRoundedImpl,
 {
@@ -349,7 +349,7 @@ where
         inner_rect: Rect,
         offset: Offset,
         class: PassType,
-        f: Box<dyn FnOnce(&mut dyn theme::DrawHandle) + 'b>,
+        f: Box<dyn FnOnce(&mut dyn ThemeDraw) + 'b>,
     ) {
         let mut shadow = Default::default();
         let mut outer_rect = inner_rect;

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -140,9 +140,9 @@ where
     type Window = dim::Window<DS::Draw>;
 
     #[cfg(not(feature = "gat"))]
-    type DrawHandle = DrawHandle<'static, DS>;
+    type Draw = DrawHandle<'static, DS>;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a> = DrawHandle<'a, DS>;
+    type Draw<'a> = DrawHandle<'a, DS>;
 
     fn config(&self) -> std::borrow::Cow<Self::Config> {
         std::borrow::Cow::Borrowed(&self.config)
@@ -179,12 +179,12 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
+    unsafe fn draw(
         &self,
         draw: DrawIface<DS>,
         ev: &mut EventState,
         w: &mut Self::Window,
-    ) -> Self::DrawHandle {
+    ) -> Self::Draw {
         w.anim.update();
 
         unsafe fn extend_lifetime<'b, T: ?Sized>(r: &'b T) -> &'static T {
@@ -205,12 +205,12 @@ where
         }
     }
     #[cfg(feature = "gat")]
-    fn draw_handle<'a>(
+    fn draw<'a>(
         &'a self,
         draw: DrawIface<'a, DS>,
         ev: &'a mut EventState,
         w: &'a mut Self::Window,
-    ) -> Self::DrawHandle<'a> {
+    ) -> Self::Draw<'a> {
         w.anim.update();
 
         DrawHandle {

--- a/crates/kas-theme/src/multi.rs
+++ b/crates/kas-theme/src/multi.rs
@@ -110,9 +110,9 @@ impl<DS: DrawSharedImpl> Theme<DS> for MultiTheme<DS> {
     type Window = StackDst<dyn Window>;
 
     #[cfg(not(feature = "gat"))]
-    type DrawHandle = StackDst<dyn ThemeDraw>;
+    type Draw = StackDst<dyn ThemeDraw>;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a> = StackDst<dyn ThemeDraw + 'a>;
+    type Draw<'a> = StackDst<dyn ThemeDraw + 'a>;
 
     fn config(&self) -> std::borrow::Cow<Self::Config> {
         let boxed_config = self.themes[self.active].config();
@@ -148,7 +148,7 @@ impl<DS: DrawSharedImpl> Theme<DS> for MultiTheme<DS> {
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
+    unsafe fn draw(
         &self,
         draw: DrawIface<DS>,
         ev: &mut EventState,
@@ -157,7 +157,7 @@ impl<DS: DrawSharedImpl> Theme<DS> for MultiTheme<DS> {
         unsafe fn extend_lifetime_mut<'b, T: ?Sized>(r: &'b mut T) -> &'static mut T {
             std::mem::transmute::<&'b mut T, &'static mut T>(r)
         }
-        self.themes[self.active].draw_handle(
+        self.themes[self.active].draw(
             DrawIface {
                 draw: extend_lifetime_mut(draw.draw),
                 shared: extend_lifetime_mut(draw.shared),
@@ -169,13 +169,13 @@ impl<DS: DrawSharedImpl> Theme<DS> for MultiTheme<DS> {
     }
 
     #[cfg(feature = "gat")]
-    fn draw_handle<'a>(
+    fn draw<'a>(
         &'a self,
         draw: DrawIface<'a, DS>,
         ev: &'a mut EventState,
         window: &'a mut Self::Window,
     ) -> StackDst<dyn ThemeDraw + 'a> {
-        self.themes[self.active].draw_handle(draw, ev, window)
+        self.themes[self.active].draw(draw, ev, window)
     }
 
     fn clear_color(&self) -> color::Rgba {

--- a/crates/kas-theme/src/multi.rs
+++ b/crates/kas-theme/src/multi.rs
@@ -12,7 +12,7 @@ use std::marker::Unsize;
 use crate::{Config, StackDst, Theme, ThemeDst, Window};
 use kas::draw::{color, DrawIface, DrawSharedImpl, SharedState};
 use kas::event::EventState;
-use kas::theme::{DrawHandle, ThemeControl};
+use kas::theme::{ThemeControl, ThemeDraw};
 use kas::TkAction;
 
 #[cfg(feature = "unsize")]
@@ -110,9 +110,9 @@ impl<DS: DrawSharedImpl> Theme<DS> for MultiTheme<DS> {
     type Window = StackDst<dyn Window>;
 
     #[cfg(not(feature = "gat"))]
-    type DrawHandle = StackDst<dyn DrawHandle>;
+    type DrawHandle = StackDst<dyn ThemeDraw>;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a> = StackDst<dyn DrawHandle + 'a>;
+    type DrawHandle<'a> = StackDst<dyn ThemeDraw + 'a>;
 
     fn config(&self) -> std::borrow::Cow<Self::Config> {
         let boxed_config = self.themes[self.active].config();
@@ -153,7 +153,7 @@ impl<DS: DrawSharedImpl> Theme<DS> for MultiTheme<DS> {
         draw: DrawIface<DS>,
         ev: &mut EventState,
         window: &mut Self::Window,
-    ) -> StackDst<dyn DrawHandle> {
+    ) -> StackDst<dyn ThemeDraw> {
         unsafe fn extend_lifetime_mut<'b, T: ?Sized>(r: &'b mut T) -> &'static mut T {
             std::mem::transmute::<&'b mut T, &'static mut T>(r)
         }
@@ -174,7 +174,7 @@ impl<DS: DrawSharedImpl> Theme<DS> for MultiTheme<DS> {
         draw: DrawIface<'a, DS>,
         ev: &'a mut EventState,
         window: &'a mut Self::Window,
-    ) -> StackDst<dyn DrawHandle + 'a> {
+    ) -> StackDst<dyn ThemeDraw + 'a> {
         self.themes[self.active].draw_handle(draw, ev, window)
     }
 

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -239,6 +239,7 @@ where
     }
 }
 
+#[kas::macros::extends(ThemeDraw, base=self.as_flat())]
 impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS>
 where
     DS::Draw: DrawRoundedImpl + DrawShadedImpl,
@@ -341,41 +342,6 @@ where
         self.draw.shaded_round_frame(outer, inner, norm, col);
     }
 
-    fn selection_box(&mut self, rect: Rect) {
-        self.as_flat().selection_box(rect);
-    }
-
-    fn text(&mut self, id: &WidgetId, pos: Coord, text: &TextDisplay, class: TextClass) {
-        self.as_flat().text(id, pos, text, class);
-    }
-
-    fn text_effects(&mut self, id: &WidgetId, pos: Coord, text: &dyn TextApi, class: TextClass) {
-        self.as_flat().text_effects(id, pos, text, class);
-    }
-
-    fn text_selected_range(
-        &mut self,
-        id: &WidgetId,
-        pos: Coord,
-        text: &TextDisplay,
-        range: Range<usize>,
-        class: TextClass,
-    ) {
-        self.as_flat()
-            .text_selected_range(id, pos, text, range, class);
-    }
-
-    fn text_cursor(
-        &mut self,
-        id: &WidgetId,
-        pos: Coord,
-        text: &TextDisplay,
-        class: TextClass,
-        byte: usize,
-    ) {
-        self.as_flat().text_cursor(id, pos, text, class, byte);
-    }
-
     fn checkbox(&mut self, id: &WidgetId, rect: Rect, checked: bool, last_change: Option<Instant>) {
         let state = InputState::new_all(self.ev, id);
         let anim_fade = 1.0 - self.w.anim.fade_bool(self.draw.draw, checked, last_change);
@@ -406,10 +372,6 @@ where
             let col = self.cols.check_mark_state(state);
             self.draw.shaded_circle(inner, (0.0, 1.0), col);
         }
-    }
-
-    fn mark(&mut self, id: &WidgetId, rect: Rect, style: MarkStyle) {
-        self.as_flat().mark(id, rect, style);
     }
 
     fn scrollbar(&mut self, id: &WidgetId, id2: &WidgetId, rect: Rect, h_rect: Rect, _: Direction) {
@@ -458,9 +420,5 @@ where
         let inner = outer.shrink(thickness);
         let col = self.cols.accent_soft;
         self.draw.shaded_round_frame(outer, inner, (0.0, 0.6), col);
-    }
-
-    fn image(&mut self, id: ImageId, rect: Rect) {
-        self.as_flat().image(id, rect);
     }
 }

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -244,12 +244,8 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS>
 where
     DS::Draw: DrawRoundedImpl + DrawShadedImpl,
 {
-    fn components(&mut self) -> (&dyn ThemeSize, &mut dyn DrawShared, &mut EventState) {
-        (self.w, self.draw.shared, self.ev)
-    }
-
-    fn draw_device(&mut self) -> &mut dyn Draw {
-        &mut self.draw
+    fn components(&mut self) -> (&dyn ThemeSize, &mut dyn Draw, &mut EventState) {
+        (self.w, &mut self.draw, self.ev)
     }
 
     fn new_pass<'b>(

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -17,7 +17,7 @@ use kas::draw::{color::Rgba, *};
 use kas::event::EventState;
 use kas::geom::*;
 use kas::text::{TextApi, TextDisplay};
-use kas::theme::{Background, SizeHandle, ThemeControl, ThemeDraw};
+use kas::theme::{Background, ThemeControl, ThemeDraw, ThemeSize};
 use kas::theme::{FrameStyle, MarkStyle, TextClass};
 use kas::{TkAction, WidgetId};
 
@@ -243,7 +243,7 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS>
 where
     DS::Draw: DrawRoundedImpl + DrawShadedImpl,
 {
-    fn components(&mut self) -> (&dyn SizeHandle, &mut dyn DrawShared, &mut EventState) {
+    fn components(&mut self) -> (&dyn ThemeSize, &mut dyn DrawShared, &mut EventState) {
         (self.w, self.draw.shared, self.ev)
     }
 

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -94,9 +94,9 @@ where
     type Window = dim::Window<DS::Draw>;
 
     #[cfg(not(feature = "gat"))]
-    type DrawHandle = DrawHandle<'static, DS>;
+    type Draw = DrawHandle<'static, DS>;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a> = DrawHandle<'a, DS>;
+    type Draw<'a> = DrawHandle<'a, DS>;
 
     fn config(&self) -> std::borrow::Cow<Self::Config> {
         <FlatTheme as Theme<DS>>::config(&self.flat)
@@ -120,12 +120,12 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
+    unsafe fn draw(
         &self,
         draw: DrawIface<DS>,
         ev: &mut EventState,
         w: &mut Self::Window,
-    ) -> Self::DrawHandle {
+    ) -> Self::Draw {
         w.anim.update();
 
         unsafe fn extend_lifetime<'b, T: ?Sized>(r: &'b T) -> &'static T {
@@ -146,12 +146,12 @@ where
         }
     }
     #[cfg(feature = "gat")]
-    fn draw_handle<'a>(
+    fn draw<'a>(
         &'a self,
         draw: DrawIface<'a, DS>,
         ev: &'a mut EventState,
         w: &'a mut Self::Window,
-    ) -> Self::DrawHandle<'a> {
+    ) -> Self::Draw<'a> {
         w.anim.update();
 
         DrawHandle {

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -17,7 +17,7 @@ use kas::draw::{color::Rgba, *};
 use kas::event::EventState;
 use kas::geom::*;
 use kas::text::{TextApi, TextDisplay};
-use kas::theme::{self, Background, SizeHandle, ThemeControl};
+use kas::theme::{Background, SizeHandle, ThemeControl, ThemeDraw};
 use kas::theme::{FrameStyle, MarkStyle, TextClass};
 use kas::{TkAction, WidgetId};
 
@@ -239,7 +239,7 @@ where
     }
 }
 
-impl<'a, DS: DrawSharedImpl> theme::DrawHandle for DrawHandle<'a, DS>
+impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS>
 where
     DS::Draw: DrawRoundedImpl + DrawShadedImpl,
 {
@@ -256,7 +256,7 @@ where
         inner_rect: Rect,
         offset: Offset,
         class: PassType,
-        f: Box<dyn FnOnce(&mut dyn theme::DrawHandle) + 'b>,
+        f: Box<dyn FnOnce(&mut dyn ThemeDraw) + 'b>,
     ) {
         let mut shadow = Default::default();
         let mut outer_rect = inner_rect;

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -285,7 +285,7 @@ where
         f(&mut handle);
     }
 
-    fn get_clip_rect(&self) -> Rect {
+    fn get_clip_rect(&mut self) -> Rect {
         self.draw.get_clip_rect()
     }
 

--- a/crates/kas-theme/src/theme_dst.rs
+++ b/crates/kas-theme/src/theme_dst.rs
@@ -12,7 +12,7 @@ use std::ops::{Deref, DerefMut};
 use super::{StackDst, Theme, Window};
 use kas::draw::{color, DrawIface, DrawSharedImpl, SharedState};
 use kas::event::EventState;
-use kas::theme::{DrawHandle, SizeHandle, ThemeControl};
+use kas::theme::{SizeHandle, ThemeControl, ThemeDraw};
 use kas::TkAction;
 
 /// An optionally-owning (boxed) reference
@@ -63,7 +63,7 @@ pub trait ThemeDst<DS: DrawSharedImpl>: ThemeControl {
     /// See also [`Theme::update_window`].
     fn update_window(&self, window: &mut dyn Window, dpi_factor: f32);
 
-    /// Construct a [`DrawHandle`] object
+    /// Construct a [`ThemeDraw`] object
     ///
     /// Uses a [`StackDst`] to avoid requiring an associated type.
     ///
@@ -78,9 +78,9 @@ pub trait ThemeDst<DS: DrawSharedImpl>: ThemeControl {
         draw: DrawIface<DS>,
         ev: &mut EventState,
         window: &mut dyn Window,
-    ) -> StackDst<dyn DrawHandle>;
+    ) -> StackDst<dyn ThemeDraw>;
 
-    /// Construct a [`DrawHandle`] object
+    /// Construct a [`ThemeDraw`] object
     ///
     /// Uses a [`StackDst`] to avoid requiring an associated type.
     ///
@@ -91,7 +91,7 @@ pub trait ThemeDst<DS: DrawSharedImpl>: ThemeControl {
         draw: DrawIface<'a, DS>,
         ev: &'a mut EventState,
         window: &'a mut dyn Window,
-    ) -> StackDst<dyn DrawHandle + 'a>;
+    ) -> StackDst<dyn ThemeDraw + 'a>;
 
     /// Background colour
     ///
@@ -146,7 +146,7 @@ where
         draw: DrawIface<DS>,
         ev: &mut EventState,
         window: &mut dyn Window,
-    ) -> StackDst<dyn DrawHandle> {
+    ) -> StackDst<dyn ThemeDraw> {
         let window = window.as_any_mut().downcast_mut().unwrap();
         let h = <T as Theme<DS>>::draw_handle(self, draw, ev, window);
         #[cfg(feature = "unsize")]
@@ -155,7 +155,7 @@ where
         }
         #[cfg(not(feature = "unsize"))]
         {
-            StackDst::new_stable(h, |h| h as &dyn DrawHandle)
+            StackDst::new_stable(h, |h| h as &dyn ThemeDraw)
                 .ok()
                 .expect("handle too big for StackDst!")
         }
@@ -198,7 +198,7 @@ impl<'a, DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T {
         draw: DrawIface<'b, DS>,
         ev: &'b mut EventState,
         window: &'b mut dyn Window,
-    ) -> StackDst<dyn DrawHandle + 'b> {
+    ) -> StackDst<dyn ThemeDraw + 'b> {
         let window = window.as_any_mut().downcast_mut().unwrap();
         let h = <T as Theme<DS>>::draw_handle(self, draw, ev, window);
         StackDst::new_or_boxed(h)

--- a/crates/kas-theme/src/theme_dst.rs
+++ b/crates/kas-theme/src/theme_dst.rs
@@ -67,13 +67,13 @@ pub trait ThemeDst<DS: DrawSharedImpl>: ThemeControl {
     ///
     /// Uses a [`StackDst`] to avoid requiring an associated type.
     ///
-    /// See also [`Theme::draw_handle`].
+    /// See also [`Theme::draw`].
     ///
     /// # Safety
     ///
     /// All references passed into the method must outlive the returned object.
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
+    unsafe fn draw(
         &self,
         draw: DrawIface<DS>,
         ev: &mut EventState,
@@ -84,9 +84,9 @@ pub trait ThemeDst<DS: DrawSharedImpl>: ThemeControl {
     ///
     /// Uses a [`StackDst`] to avoid requiring an associated type.
     ///
-    /// See also [`Theme::draw_handle`].
+    /// See also [`Theme::draw`].
     #[cfg(feature = "gat")]
-    fn draw_handle<'a>(
+    fn draw<'a>(
         &'a self,
         draw: DrawIface<'a, DS>,
         ev: &'a mut EventState,
@@ -102,7 +102,7 @@ pub trait ThemeDst<DS: DrawSharedImpl>: ThemeControl {
 #[cfg(not(feature = "gat"))]
 impl<'a, DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T
 where
-    <T as Theme<DS>>::DrawHandle: 'static,
+    <T as Theme<DS>>::Draw: 'static,
 {
     fn config(&self) -> MaybeBoxed<dyn Any> {
         match self.config() {
@@ -141,14 +141,14 @@ where
         self.update_window(window, dpi_factor);
     }
 
-    unsafe fn draw_handle(
+    unsafe fn draw(
         &self,
         draw: DrawIface<DS>,
         ev: &mut EventState,
         window: &mut dyn Window,
     ) -> StackDst<dyn ThemeDraw> {
         let window = window.as_any_mut().downcast_mut().unwrap();
-        let h = <T as Theme<DS>>::draw_handle(self, draw, ev, window);
+        let h = <T as Theme<DS>>::draw(self, draw, ev, window);
         #[cfg(feature = "unsize")]
         {
             StackDst::new_or_boxed(h)
@@ -193,14 +193,14 @@ impl<'a, DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T {
         self.update_window(window, dpi_factor);
     }
 
-    fn draw_handle<'b>(
+    fn draw<'b>(
         &'b self,
         draw: DrawIface<'b, DS>,
         ev: &'b mut EventState,
         window: &'b mut dyn Window,
     ) -> StackDst<dyn ThemeDraw + 'b> {
         let window = window.as_any_mut().downcast_mut().unwrap();
-        let h = <T as Theme<DS>>::draw_handle(self, draw, ev, window);
+        let h = <T as Theme<DS>>::draw(self, draw, ev, window);
         StackDst::new_or_boxed(h)
     }
 
@@ -210,8 +210,8 @@ impl<'a, DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T {
 }
 
 impl Window for StackDst<dyn Window> {
-    fn size_handle(&self) -> &dyn ThemeSize {
-        self.deref().size_handle()
+    fn size(&self) -> &dyn ThemeSize {
+        self.deref().size()
     }
 
     fn as_any_mut(&mut self) -> &mut dyn Any {

--- a/crates/kas-theme/src/theme_dst.rs
+++ b/crates/kas-theme/src/theme_dst.rs
@@ -12,7 +12,7 @@ use std::ops::{Deref, DerefMut};
 use super::{StackDst, Theme, Window};
 use kas::draw::{color, DrawIface, DrawSharedImpl, SharedState};
 use kas::event::EventState;
-use kas::theme::{SizeHandle, ThemeControl, ThemeDraw};
+use kas::theme::{ThemeControl, ThemeDraw, ThemeSize};
 use kas::TkAction;
 
 /// An optionally-owning (boxed) reference
@@ -210,7 +210,7 @@ impl<'a, DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T {
 }
 
 impl Window for StackDst<dyn Window> {
-    fn size_handle(&self) -> &dyn SizeHandle {
+    fn size_handle(&self) -> &dyn ThemeSize {
         self.deref().size_handle()
     }
 

--- a/crates/kas-theme/src/traits.rs
+++ b/crates/kas-theme/src/traits.rs
@@ -7,7 +7,7 @@
 
 use kas::draw::{color, DrawIface, DrawSharedImpl, SharedState};
 use kas::event::EventState;
-use kas::theme::{SizeHandle, ThemeControl, ThemeDraw};
+use kas::theme::{ThemeControl, ThemeDraw, ThemeSize};
 use kas::TkAction;
 use std::any::Any;
 use std::ops::{Deref, DerefMut};
@@ -135,8 +135,8 @@ pub trait Theme<DS: DrawSharedImpl>: ThemeControl {
 /// The main reason for this separation is to allow proper handling of
 /// multi-window applications across screens with differing DPIs.
 pub trait Window: 'static {
-    /// Construct a [`SizeHandle`] object
-    fn size_handle(&self) -> &dyn SizeHandle;
+    /// Construct a [`ThemeSize`] object
+    fn size_handle(&self) -> &dyn ThemeSize;
 
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
@@ -196,7 +196,7 @@ impl<T: Theme<DS>, DS: DrawSharedImpl> Theme<DS> for Box<T> {
 }
 
 impl<W: Window> Window for Box<W> {
-    fn size_handle(&self) -> &dyn SizeHandle {
+    fn size_handle(&self) -> &dyn ThemeSize {
         self.deref().size_handle()
     }
 

--- a/crates/kas-theme/src/traits.rs
+++ b/crates/kas-theme/src/traits.rs
@@ -7,6 +7,7 @@
 
 use kas::draw::{color, DrawIface, DrawSharedImpl, SharedState};
 use kas::event::EventState;
+use kas::macros::autoimpl;
 use kas::theme::{ThemeControl, ThemeDraw, ThemeSize};
 use kas::TkAction;
 use std::any::Any;
@@ -52,9 +53,9 @@ pub trait Theme<DS: DrawSharedImpl>: ThemeControl {
 
     /// The associated [`ThemeDraw`] implementation.
     #[cfg(not(feature = "gat"))]
-    type DrawHandle: ThemeDraw;
+    type Draw: ThemeDraw;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a>: ThemeDraw
+    type Draw<'a>: ThemeDraw
     where
         DS: 'a,
         Self: 'a;
@@ -101,8 +102,7 @@ pub trait Theme<DS: DrawSharedImpl>: ThemeControl {
     /// Drawing via this [`ThemeDraw`] object is restricted to the specified `rect`.
     ///
     /// The `window` is guaranteed to be one created by a call to
-    /// [`Theme::new_window`] on `self`, and the `draw` reference is guaranteed
-    /// to be identical to the one passed to [`Theme::new_window`].
+    /// [`Theme::new_window`] on `self`.
     ///
     /// # Safety
     ///
@@ -110,19 +110,19 @@ pub trait Theme<DS: DrawSharedImpl>: ThemeControl {
     ///
     /// All references passed into the method must outlive the returned object.
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
+    unsafe fn draw(
         &self,
         draw: DrawIface<DS>,
         ev: &mut EventState,
         window: &mut Self::Window,
-    ) -> Self::DrawHandle;
+    ) -> Self::Draw;
     #[cfg(feature = "gat")]
-    fn draw_handle<'a>(
+    fn draw<'a>(
         &'a self,
         draw: DrawIface<'a, DS>,
         ev: &'a mut EventState,
         window: &'a mut Self::Window,
-    ) -> Self::DrawHandle<'a>;
+    ) -> Self::Draw<'a>;
 
     /// Background colour
     fn clear_color(&self) -> color::Rgba;
@@ -134,9 +134,10 @@ pub trait Theme<DS: DrawSharedImpl>: ThemeControl {
 ///
 /// The main reason for this separation is to allow proper handling of
 /// multi-window applications across screens with differing DPIs.
+#[autoimpl(for<T: trait> Box<T>)]
 pub trait Window: 'static {
     /// Construct a [`ThemeSize`] object
-    fn size_handle(&self) -> &dyn ThemeSize;
+    fn size(&self) -> &dyn ThemeSize;
 
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
@@ -146,12 +147,12 @@ impl<T: Theme<DS>, DS: DrawSharedImpl> Theme<DS> for Box<T> {
     type Config = <T as Theme<DS>>::Config;
 
     #[cfg(not(feature = "gat"))]
-    type DrawHandle = <T as Theme<DS>>::DrawHandle;
+    type Draw = <T as Theme<DS>>::Draw;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a>
+    type Draw<'a>
     where
         T: 'a,
-    = <T as Theme<DS>>::DrawHandle<'a>;
+    = <T as Theme<DS>>::Draw<'a>;
 
     fn config(&self) -> std::borrow::Cow<Self::Config> {
         self.deref().config()
@@ -172,35 +173,25 @@ impl<T: Theme<DS>, DS: DrawSharedImpl> Theme<DS> for Box<T> {
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
+    unsafe fn draw(
         &self,
         draw: DrawIface<DS>,
         ev: &mut EventState,
         window: &mut Self::Window,
-    ) -> Self::DrawHandle {
-        self.deref().draw_handle(draw, ev, window)
+    ) -> Self::Draw {
+        self.deref().draw(draw, ev, window)
     }
     #[cfg(feature = "gat")]
-    fn draw_handle<'a>(
+    fn draw<'a>(
         &'a self,
         draw: DrawIface<'a, DS>,
         ev: &'a mut EventState,
         window: &'a mut Self::Window,
-    ) -> Self::DrawHandle<'a> {
-        self.deref().draw_handle(draw, ev, window)
+    ) -> Self::Draw<'a> {
+        self.deref().draw(draw, ev, window)
     }
 
     fn clear_color(&self) -> color::Rgba {
         self.deref().clear_color()
-    }
-}
-
-impl<W: Window> Window for Box<W> {
-    fn size_handle(&self) -> &dyn ThemeSize {
-        self.deref().size_handle()
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self.deref_mut().as_any_mut()
     }
 }

--- a/crates/kas-theme/src/traits.rs
+++ b/crates/kas-theme/src/traits.rs
@@ -7,7 +7,7 @@
 
 use kas::draw::{color, DrawIface, DrawSharedImpl, SharedState};
 use kas::event::EventState;
-use kas::theme::{DrawHandle, SizeHandle, ThemeControl};
+use kas::theme::{SizeHandle, ThemeControl, ThemeDraw};
 use kas::TkAction;
 use std::any::Any;
 use std::ops::{Deref, DerefMut};
@@ -50,11 +50,11 @@ pub trait Theme<DS: DrawSharedImpl>: ThemeControl {
     /// The associated [`Window`] implementation.
     type Window: Window;
 
-    /// The associated [`DrawHandle`] implementation.
+    /// The associated [`ThemeDraw`] implementation.
     #[cfg(not(feature = "gat"))]
-    type DrawHandle: DrawHandle;
+    type DrawHandle: ThemeDraw;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a>: DrawHandle
+    type DrawHandle<'a>: ThemeDraw
     where
         DS: 'a,
         Self: 'a;
@@ -92,13 +92,13 @@ pub trait Theme<DS: DrawSharedImpl>: ThemeControl {
     /// This is called when the DPI factor changes or theme dimensions change.
     fn update_window(&self, window: &mut Self::Window, dpi_factor: f32);
 
-    /// Prepare to draw and construct a [`DrawHandle`] object
+    /// Prepare to draw and construct a [`ThemeDraw`] object
     ///
     /// This is called once per window per frame and should do any necessary
     /// preparation such as loading fonts and textures which are loaded on
     /// demand.
     ///
-    /// Drawing via this [`DrawHandle`] is restricted to the specified `rect`.
+    /// Drawing via this [`ThemeDraw`] object is restricted to the specified `rect`.
     ///
     /// The `window` is guaranteed to be one created by a call to
     /// [`Theme::new_window`] on `self`, and the `draw` reference is guaranteed

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -82,7 +82,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         let mut tkw = TkWindow::new(shared, None, &mut theme_window);
         ev_state.full_configure(&mut tkw, widget.as_widget_mut());
 
-        let size_mgr = SizeMgr::new(theme_window.size_handle());
+        let size_mgr = SizeMgr::new(theme_window.size());
         let mut solve_cache = SolveCache::find_constraints(widget.as_widget_mut(), size_mgr);
 
         // Opening a zero-size window causes a crash, so force at least 1x1:
@@ -327,7 +327,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
         let solve_cache = &mut self.solve_cache;
         let widget = &mut self.widget;
         let mut mgr = SetRectMgr::new(
-            self.theme_window.size_handle(),
+            self.theme_window.size(),
             &mut shared.draw,
             &mut self.ev_state,
         );
@@ -386,21 +386,19 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
 
             #[cfg(not(feature = "gat"))]
             unsafe {
-                // Safety: lifetimes do not escape the returned draw_handle value.
-                let mut draw_handle =
-                    shared
-                        .theme
-                        .draw_handle(draw, &mut self.ev_state, &mut self.theme_window);
-                let draw_mgr = DrawMgr::new(&mut draw_handle, self.widget.id());
+                // Safety: lifetimes do not escape the returned draw value.
+                let mut draw = shared
+                    .theme
+                    .draw(draw, &mut self.ev_state, &mut self.theme_window);
+                let draw_mgr = DrawMgr::new(&mut draw, self.widget.id());
                 self.widget.draw(draw_mgr);
             }
             #[cfg(feature = "gat")]
             {
-                let mut draw_handle =
-                    shared
-                        .theme
-                        .draw_handle(draw, &mut self.ev_state, &mut self.theme_window);
-                let draw_mgr = DrawMgr::new(&mut draw_handle, self.widget.id());
+                let mut draw = shared
+                    .theme
+                    .draw(draw, &mut self.ev_state, &mut self.theme_window);
+                let draw_mgr = DrawMgr::new(&mut draw, self.widget.id());
                 self.widget.draw(draw_mgr);
             }
         }
@@ -548,8 +546,8 @@ where
 
     fn size_and_draw_shared(&mut self, f: &mut dyn FnMut(&mut dyn ThemeSize, &mut dyn DrawShared)) {
         use kas_theme::Window;
-        let mut size_handle = self.theme_window.size_handle();
-        f(&mut size_handle, &mut self.shared.draw);
+        let mut size = self.theme_window.size();
+        f(&mut size, &mut self.shared.draw);
     }
 
     #[inline]

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -13,7 +13,7 @@ use kas::draw::{AnimationState, DrawIface, DrawShared, PassId};
 use kas::event::{CursorIcon, EventState, SetRectMgr, UpdateId};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
-use kas::theme::{DrawMgr, SizeHandle, SizeMgr, ThemeControl};
+use kas::theme::{DrawMgr, SizeMgr, ThemeControl, ThemeSize};
 use kas::{Layout, TkAction, WidgetCore, WidgetExt, WindowId};
 use kas_theme::{Theme, Window as _};
 use winit::dpi::PhysicalSize;
@@ -546,10 +546,7 @@ where
         self.shared.pending.push(PendingAction::TkAction(action));
     }
 
-    fn size_and_draw_shared(
-        &mut self,
-        f: &mut dyn FnMut(&mut dyn SizeHandle, &mut dyn DrawShared),
-    ) {
+    fn size_and_draw_shared(&mut self, f: &mut dyn FnMut(&mut dyn ThemeSize, &mut dyn DrawShared)) {
         use kas_theme::Window;
         let mut size_handle = self.theme_window.size_handle();
         f(&mut size_handle, &mut self.shared.draw);

--- a/crates/kas-widgets/src/checkbox.rs
+++ b/crates/kas-widgets/src/checkbox.rs
@@ -7,6 +7,7 @@
 
 use super::AccelLabel;
 use kas::prelude::*;
+use kas::theme::Feature;
 use std::rc::Rc;
 use std::time::Instant;
 
@@ -28,15 +29,11 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            let size = size_mgr.checkbox();
-            let margins = size_mgr.outer_margins();
-            SizeRules::extract_fixed(axis, size, margins)
+            size_mgr.feature(Feature::CheckBox, axis)
         }
 
         fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
-            let rect = align
-                .complete(Align::Center, Align::Center)
-                .aligned_rect(mgr.size_mgr().checkbox(), rect);
+            let rect = mgr.align_feature(Feature::CheckBox, rect, align);
             self.core.rect = rect;
         }
 

--- a/crates/kas-widgets/src/mark.rs
+++ b/crates/kas-widgets/src/mark.rs
@@ -40,7 +40,7 @@ impl_scope! {
     }
     impl Layout for Self {
         fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            mgr.mark(self.style, axis)
+            mgr.feature(self.style.into(), axis)
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
@@ -80,7 +80,7 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            mgr.mark(self.style, axis).with_stretch(Stretch::Low)
+            mgr.feature(self.style.into(), axis).with_stretch(Stretch::Low)
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {

--- a/crates/kas-widgets/src/progress.rs
+++ b/crates/kas-widgets/src/progress.rs
@@ -8,6 +8,7 @@
 use std::fmt::Debug;
 
 use kas::prelude::*;
+use kas::theme::Feature;
 
 impl_scope! {
     /// A progress bar
@@ -18,7 +19,6 @@ impl_scope! {
     pub struct ProgressBar<D: Directional> {
         core: widget_core!(),
         direction: D,
-        width: i32,
         value: f32,
     }
 
@@ -41,9 +41,14 @@ impl_scope! {
             ProgressBar {
                 core: Default::default(),
                 direction,
-                width: 0,
                 value: 0.0,
             }
+        }
+
+        /// Get the progress bar's direction
+        #[inline]
+        pub fn direction(&self) -> Direction {
+            self.direction.as_direction()
         }
 
         /// Set the initial value
@@ -77,25 +82,11 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            let mut size = size_mgr.progress_bar();
-            if self.direction.is_vertical() {
-                size = size.transpose();
-            }
-            let margins = (0, 0);
-            if self.direction.is_vertical() == axis.is_vertical() {
-                SizeRules::new(size.0, size.0, margins, Stretch::High)
-            } else {
-                self.width = size.1;
-                SizeRules::fixed(size.1, margins)
-            }
+            size_mgr.feature(Feature::ProgressBar(self.direction()), axis)
         }
 
-        fn set_rect(&mut self, _: &mut SetRectMgr, rect: Rect, align: AlignHints) {
-            let mut ideal_size = Size::splat(self.width);
-            ideal_size.set_component(self.direction, i32::MAX);
-            let rect = align
-                .complete(Align::Center, Align::Center)
-                .aligned_rect(ideal_size, rect);
+        fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
+            let rect = mgr.align_feature(Feature::ProgressBar(self.direction()), rect, align);
             self.core.rect = rect;
         }
 

--- a/crates/kas-widgets/src/radiobox.rs
+++ b/crates/kas-widgets/src/radiobox.rs
@@ -7,6 +7,7 @@
 
 use super::AccelLabel;
 use kas::prelude::*;
+use kas::theme::Feature;
 use kas::updatable::{SharedRc, SingleData};
 use log::trace;
 use std::fmt::Debug;
@@ -63,15 +64,11 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            let size = size_mgr.radiobox();
-            let margins = size_mgr.outer_margins();
-            SizeRules::extract_fixed(axis, size, margins)
+            size_mgr.feature(Feature::RadioBox, axis)
         }
 
         fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
-            let rect = align
-                .complete(Align::Center, Align::Center)
-                .aligned_rect(mgr.size_mgr().radiobox(), rect);
+            let rect = mgr.align_feature(Feature::RadioBox, rect, align);
             self.core.rect = rect;
         }
 

--- a/crates/kas-widgets/src/separator.rs
+++ b/crates/kas-widgets/src/separator.rs
@@ -32,7 +32,7 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            SizeRules::extract_fixed(axis, size_mgr.separator(), Margins::ZERO)
+            size_mgr.feature(kas::theme::Feature::Separator, axis)
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use super::DragHandle;
 use kas::event::{Command, MsgPressFocus, Scroll};
 use kas::prelude::*;
+use kas::theme::Feature;
 
 /// Requirements on type used by [`Slider`]
 pub trait SliderType:
@@ -144,6 +145,12 @@ impl_scope! {
             }
         }
 
+        /// Get the slider's direction
+        #[inline]
+        pub fn direction(&self) -> Direction {
+            self.direction.as_direction()
+        }
+
         /// Set the initial value
         #[inline]
         #[must_use]
@@ -220,24 +227,19 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            let (size, min_len) = size_mgr.slider();
-            let margins = (0, 0);
-            if self.direction.is_vertical() == axis.is_vertical() {
-                SizeRules::new(min_len, min_len, margins, Stretch::High)
-            } else {
-                SizeRules::fixed(size.1, margins)
-            }
+            size_mgr.feature(Feature::Slider(self.direction()), axis)
         }
 
         fn set_rect(&mut self, mgr: &mut SetRectMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
             self.handle.set_rect(mgr, rect, align);
-            let min_handle_size = (mgr.size_mgr().slider().0).0;
+            let dir = Direction::Right;
+            let handle_size = mgr.size_mgr().feature(Feature::Slider(dir), dir).min_size();
             let mut size = rect.size;
             if self.direction.is_horizontal() {
-                size.0 = min_handle_size.min(rect.size.0);
+                size.0 = size.0.min(handle_size);
             } else {
-                size.1 = min_handle_size.min(rect.size.1);
+                size.1 = size.1.min(handle_size);
             }
             let _ = self.handle.set_size_and_offset(size, self.offset());
         }

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -13,6 +13,7 @@ use kas::dir::{Down, Right};
 use kas::event::MsgPressFocus;
 use kas::layout::{self, RulesSetter, RulesSolver};
 use kas::prelude::*;
+use kas::theme::Feature;
 
 /// A generic row widget
 ///
@@ -141,7 +142,7 @@ impl_scope! {
             }
             assert_eq!(self.handles.len() + 1, self.widgets.len());
 
-            let handle_size = size_mgr.separator().extract(axis);
+            let handle_rules = size_mgr.feature(Feature::Separator, axis);
 
             let dim = (self.direction, self.num_children());
             let mut solver = layout::RowSolver::new(axis, dim, &mut self.data);
@@ -157,9 +158,7 @@ impl_scope! {
                 if n >= self.handles.len() {
                     break;
                 }
-                solver.for_child(&mut self.data, (n << 1) + 1, |_axis| {
-                    SizeRules::fixed(handle_size, (0, 0))
-                });
+                solver.for_child(&mut self.data, (n << 1) + 1, |_axis| handle_rules);
                 n += 1;
             }
             solver.finish(&mut self.data)

--- a/examples/custom-theme.rs
+++ b/examples/custom-theme.rs
@@ -37,9 +37,9 @@ where
     type Window = <FlatTheme as Theme<DS>>::Window;
 
     #[cfg(not(feature = "gat"))]
-    type DrawHandle = <FlatTheme as Theme<DS>>::DrawHandle;
+    type Draw = <FlatTheme as Theme<DS>>::Draw;
     #[cfg(feature = "gat")]
-    type DrawHandle<'a> = <FlatTheme as Theme<DS>>::DrawHandle<'a>;
+    type Draw<'a> = <FlatTheme as Theme<DS>>::Draw<'a>;
 
     fn config(&self) -> std::borrow::Cow<Self::Config> {
         Theme::<DS>::config(&self.inner)
@@ -62,22 +62,22 @@ where
     }
 
     #[cfg(not(feature = "gat"))]
-    unsafe fn draw_handle(
+    unsafe fn draw(
         &self,
         draw: DrawIface<DS>,
         ev: &mut EventState,
         window: &mut Self::Window,
-    ) -> Self::DrawHandle {
-        Theme::<DS>::draw_handle(&self.inner, draw, ev, window)
+    ) -> Self::Draw {
+        Theme::<DS>::draw(&self.inner, draw, ev, window)
     }
     #[cfg(feature = "gat")]
-    fn draw_handle<'a>(
+    fn draw<'a>(
         &'a self,
         draw: DrawIface<'a, DS>,
         ev: &'a mut EventState,
         window: &'a mut Self::Window,
-    ) -> Self::DrawHandle<'a> {
-        Theme::<DS>::draw_handle(&self.inner, draw, ev, window)
+    ) -> Self::Draw<'a> {
+        Theme::<DS>::draw(&self.inner, draw, ev, window)
     }
 
     fn clear_color(&self) -> Rgba {

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -5,17 +5,16 @@
 
 //! Data list example (direct representation)
 //!
-//! This example exists in part to demonstrate use of dynamically-allocated
-//! widgets (note also one can use `Column<Box<dyn Widget>>`).
+//! Objective: test performance using a naive list design; stress test with
+//! ridiculous numbers of widgets.
 //!
-//! In part, this also serves as a stress-test of how many widgets it is viable
-//! to have in an app. In my testing:
+//! Compare: `data-list-view.rs` has the same functionality but with a dynamic
+//! view, and thus scales *much* better to large numbers of rows.
 //!
-//! -   hundreds of widgets performs mostly flawlessly even in debug mode
-//! -   thousands of widgets performs flawlessly in release mode
-//! -   hundreds of thousands of widgets has some issues (slow creation,
-//!     very slow activation of a RadioBox in a chain hundreds-of-thousands
-//!     long), but in many ways still performs well in release mode
+//! Conclusion: naive lists are perfectly fine for 100 entries; even with 10k
+//! entries in a debug build only initialisation (and to a lesser extent
+//! resizing) is slow.
+//! In a release build, 250k entries (1M widgets) is quite viable!
 
 use kas::prelude::*;
 use kas::widgets::*;


### PR DESCRIPTION
New feature: `ThemeDraw` implementations may be an extension over a specified "base" theme (omitted methods use shims around base). This uses a macro, which *shouldn't* be necessary but the alternative (outlined in code doc) requires three features missing from stable Rust.

Other:

- Rename `DrawHandle` → `ThemeDraw` and `SizeHandle` → `ThemeSize`
- Add `kas::theme::Feature` enum
- Replace most methods in `SizeMgr` and `ThemeSize` with two new ones: (size rules of) `feature`, and `align_feature`
- Unhandled message warnings now include type
- Remove "glow" shadows from `FlatTheme` in dark mode