### PR TITLE
SimpleTheme, KAS-text updates

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -78,7 +78,7 @@ path = "../kas-macros"
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "f7f348105b8f7ddb79f05aa9c5c307a3160a9a8d"
+rev = "5d77e53166a42352c8f72942ff9ce4ee004a6ffd"
 
 [dependencies.easy-cast]
 git = "https://github.com/kas-gui/easy-cast.git"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -78,7 +78,7 @@ path = "../kas-macros"
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "d90004a0fb4fc794392ce3f1a9e46ca86a8a8b08"
+rev = "02a1e4449a8ec48fc691afc43241201366fa67cb"
 
 [dependencies.easy-cast]
 git = "https://github.com/kas-gui/easy-cast.git"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -78,7 +78,7 @@ path = "../kas-macros"
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "78f2e6037ab3f2a1d646f263ca4973c54d81676c"
+rev = "c65118c07015902d983c3c0335f4b0a4e602993e"
 
 [dependencies.easy-cast]
 git = "https://github.com/kas-gui/easy-cast.git"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -78,7 +78,7 @@ path = "../kas-macros"
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "35164030dd3adf5ddf99efae8bbc1da986ee41af"
+rev = "78f2e6037ab3f2a1d646f263ca4973c54d81676c"
 
 [dependencies.easy-cast]
 git = "https://github.com/kas-gui/easy-cast.git"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -78,7 +78,7 @@ path = "../kas-macros"
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "5d77e53166a42352c8f72942ff9ce4ee004a6ffd"
+rev = "35164030dd3adf5ddf99efae8bbc1da986ee41af"
 
 [dependencies.easy-cast]
 git = "https://github.com/kas-gui/easy-cast.git"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -78,7 +78,7 @@ path = "../kas-macros"
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "02a1e4449a8ec48fc691afc43241201366fa67cb"
+rev = "9537fe88c32c911cb104cf1951ea1eb9cb6f50ff"
 
 [dependencies.easy-cast]
 git = "https://github.com/kas-gui/easy-cast.git"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -78,7 +78,7 @@ path = "../kas-macros"
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "9537fe88c32c911cb104cf1951ea1eb9cb6f50ff"
+rev = "f7f348105b8f7ddb79f05aa9c5c307a3160a9a8d"
 
 [dependencies.easy-cast]
 git = "https://github.com/kas-gui/easy-cast.git"

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -320,7 +320,7 @@ pub trait Layout {
 ///             AccelLabel {
 ///                 core: Default::default(),
 ///                 class: TextClass::AccelLabel(true),
-///                 label: Text::new_multi(label.into()),
+///                 label: Text::new(label.into()),
 ///             }
 ///         }
 ///

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -196,7 +196,7 @@ pub trait Draw {
 
     /// Draw text with a colour
     ///
-    /// It is required to call [`TextDisplay::prepare`] or [`TextApi::prepare`]
+    /// It is required to call [`TextApi::prepare`] or equivalent
     /// prior to this method to select a font, font size and perform layout.
     fn text(&mut self, pos: Vec2, text: &TextDisplay, col: Rgba);
 
@@ -205,7 +205,7 @@ pub trait Draw {
     /// The effects list does not contain colour information, but may contain
     /// underlining/strikethrough information. It may be empty.
     ///
-    /// It is required to call [`TextDisplay::prepare`] or [`TextApi::prepare`]
+    /// It is required to call [`TextApi::prepare`] or equivalent
     /// prior to this method to select a font, font size and perform layout.
     fn text_col_effects(
         &mut self,
@@ -221,7 +221,7 @@ pub trait Draw {
     /// If the `effects` list is empty or the first entry has `start > 0`, a
     /// default entity will be assumed.
     ///
-    /// It is required to call [`TextDisplay::prepare`] or [`TextApi::prepare`]
+    /// It is required to call [`TextApi::prepare`] or equivalent
     /// prior to this method to select a font, font size and perform layout.
     fn text_effects(&mut self, pos: Vec2, text: &TextDisplay, effects: &[Effect<Rgba>]);
 }

--- a/crates/kas-core/src/event/manager/config_mgr.rs
+++ b/crates/kas-core/src/event/manager/config_mgr.rs
@@ -8,7 +8,7 @@
 use super::Pending;
 use crate::draw::DrawShared;
 use crate::event::EventState;
-use crate::geom::{Rect, Size, Vec2};
+use crate::geom::{Rect, Size};
 use crate::layout::{Align, AlignHints};
 use crate::text::TextApi;
 use crate::theme::{Feature, SizeMgr, TextClass, ThemeSize};
@@ -90,8 +90,6 @@ impl<'a> ConfigMgr<'a> {
     }
 
     /// Update a text object, setting font properties and wrap size
-    ///
-    /// Returns required size.
     #[inline]
     pub fn text_set_size(
         &self,
@@ -99,7 +97,7 @@ impl<'a> ConfigMgr<'a> {
         class: TextClass,
         size: Size,
         align: (Align, Align),
-    ) -> Vec2 {
+    ) {
         self.sh.text_set_size(text, class, size, align)
     }
 

--- a/crates/kas-core/src/text.rs
+++ b/crates/kas-core/src/text.rs
@@ -22,44 +22,26 @@ pub use string::AccelString;
 /// Utilities integrating `kas-text` functionality
 pub mod util {
     use super::{fonts, format, EditableTextApi, Text, TextApi};
-    use crate::cast::Conv;
-    use crate::{geom::Size, TkAction};
+    use crate::TkAction;
     use log::trace;
 
     /// Set the text and prepare
     ///
     /// Update text and trigger a resize if necessary.
-    ///
-    /// The `avail` parameter is used to determine when a resize is required. If
-    /// this parameter is a little bit wrong then resizes may sometimes happen
-    /// unnecessarily or may not happen when text is slightly too big (e.g.
-    /// spills into the margin area); this behaviour is probably acceptable.
-    /// Passing `Size::ZERO` will always resize (unless text is empty).
-    /// Passing `Size::MAX` should never resize.
-    pub fn set_text_and_prepare<T: format::FormattableText>(
-        text: &mut Text<T>,
-        s: T,
-        avail: Size,
-    ) -> TkAction {
+    pub fn set_text_and_prepare<T: format::FormattableText>(text: &mut Text<T>, s: T) -> TkAction {
         text.set_text(s);
-        prepare_if_needed(text, avail)
+        prepare_if_needed(text)
     }
 
     /// Set the text from a string and prepare
     ///
     /// Update text and trigger a resize if necessary.
-    ///
-    /// The `avail` parameter is used to determine when a resize is required. If
-    /// this parameter is a little bit wrong then resizes may sometimes happen
-    /// unnecessarily or may not happen when text is slightly too big (e.g.
-    /// spills into the margin area); this behaviour is probably acceptable.
     pub fn set_string_and_prepare<T: format::EditableText>(
         text: &mut Text<T>,
         s: String,
-        avail: Size,
     ) -> TkAction {
         text.set_string(s);
-        prepare_if_needed(text, avail)
+        prepare_if_needed(text)
     }
 
     /// Do text preparation, if required/possible
@@ -69,25 +51,20 @@ pub mod util {
     ///
     /// Note: an alternative approach would be to delay text preparation by
     /// adding TkAction::PREPARE and a new method, perhaps in Layout.
-    pub(crate) fn prepare_if_needed<T: format::FormattableText>(
-        text: &mut Text<T>,
-        avail: Size,
-    ) -> TkAction {
+    pub(crate) fn prepare_if_needed<T: format::FormattableText>(text: &mut Text<T>) -> TkAction {
         if fonts::fonts().num_faces() == 0 {
             // Fonts not loaded yet: cannot prepare and can assume it will happen later anyway.
             return TkAction::empty();
         }
+
         if let Some(req) = text.prepare() {
-            let avail = crate::geom::Vec2::conv(avail);
+            let avail = text.env().bounds;
             if !(req.0 <= avail.0 && req.1 <= avail.1) {
-                trace!(
-                    "set_text_and_prepare triggers RESIZE: req={:?}, avail={:?}",
-                    req,
-                    avail
-                );
+                trace!("set_text_and_prepare triggers RESIZE");
                 return TkAction::RESIZE;
             }
         }
+
         TkAction::REDRAW
     }
 }

--- a/crates/kas-core/src/text.rs
+++ b/crates/kas-core/src/text.rs
@@ -57,12 +57,9 @@ pub mod util {
             return TkAction::empty();
         }
 
-        if let Some(req) = text.prepare() {
-            let avail = text.env().bounds;
-            if !(req.0 <= avail.0 && req.1 <= avail.1) {
-                trace!("set_text_and_prepare triggers RESIZE");
-                return TkAction::RESIZE;
-            }
+        if text.prepare() {
+            trace!("set_text_and_prepare triggers RESIZE");
+            return TkAction::RESIZE;
         }
 
         TkAction::REDRAW

--- a/crates/kas-core/src/text/string.rs
+++ b/crates/kas-core/src/text/string.rs
@@ -119,12 +119,12 @@ impl FormattableText for AccelString {
 
     #[cfg(feature = "gat")]
     #[inline]
-    fn font_tokens(&self, _: f32, _: f32) -> Self::FontTokenIter<'_> {
+    fn font_tokens(&self, _: f32) -> Self::FontTokenIter<'_> {
         std::iter::empty()
     }
     #[cfg(not(feature = "gat"))]
     #[inline]
-    fn font_tokens(&self, _: f32, _: f32) -> OwningVecIter<FontToken> {
+    fn font_tokens(&self, _: f32) -> OwningVecIter<FontToken> {
         OwningVecIter::new(vec![])
     }
 

--- a/crates/kas-core/src/text/string.rs
+++ b/crates/kas-core/src/text/string.rs
@@ -25,7 +25,7 @@ use crate::text::{Effect, EffectFlags};
 /// Markup: `&&` translates to `&`; `&x` for any `x` translates to `x` and
 /// identifies `x` as an "accelerator key"; this may be drawn underlined and
 /// may support keyboard access via e.g. `Alt+X`.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AccelString {
     label: String,
     effects: SmallVec<[Effect<()>; 2]>,

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -521,7 +521,7 @@ mod test {
 
         let _scale = draw.size_mgr().scale_factor();
 
-        let text = crate::text::Text::new_single("sample");
+        let text = crate::text::Text::new("sample");
         let class = TextClass::Label(false);
         draw.text_selected(Coord::ZERO, &text, .., class)
     }

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -121,7 +121,11 @@ impl<'a> SizeMgr<'a> {
         self.0.frame(style, axis.is_vertical())
     }
 
-    /// The height of a line of text
+    /// The height of a line of text using the standard font
+    ///
+    /// Note: `self.pixels_from_em(1.0)` returns approximately the same value
+    /// and is faster since it only converts units.
+    /// This method reads font metrics.
     pub fn line_height(&self, class: TextClass) -> i32 {
         self.0.line_height(class)
     }
@@ -190,7 +194,7 @@ pub trait ThemeSize {
     /// Size of a frame around another element
     fn frame(&self, style: FrameStyle, axis_is_vertical: bool) -> FrameRules;
 
-    /// The height of a line of text
+    /// The height of a line of text using the standard font
     fn line_height(&self, class: TextClass) -> i32;
 
     /// Update a text object, setting font properties and getting a size bound

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -9,7 +9,7 @@ use std::ops::Deref;
 
 use super::{Feature, FrameStyle, TextClass};
 use crate::dir::Directional;
-use crate::geom::{Rect, Size, Vec2};
+use crate::geom::{Rect, Size};
 use crate::layout::{AlignHints, AxisInfo, FrameRules, Margins, SizeRules};
 use crate::macros::autoimpl;
 use crate::text::{Align, TextApi};
@@ -205,13 +205,11 @@ pub trait ThemeSize {
     fn text_bound(&self, text: &mut dyn TextApi, class: TextClass, axis: AxisInfo) -> SizeRules;
 
     /// Update a text object, setting font properties and wrap size
-    ///
-    /// Returns required size.
     fn text_set_size(
         &self,
         text: &mut dyn TextApi,
         class: TextClass,
         size: Size,
         align: (Align, Align),
-    ) -> Vec2;
+    );
 }

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -729,10 +729,16 @@ impl Layout {
                     items.append_all(quote! {{ #item },});
                 }
                 let iter = quote! { { let arr = [#items]; arr.into_iter() } };
-                quote! { layout::Visitor::list(#iter, #dir, &mut self.#core.#stor) }
+                quote! {{
+                    let dir = #dir;
+                    layout::Visitor::list(#iter, dir, &mut self.#core.#stor)
+                }}
             }
             Layout::Slice(stor, dir, expr) => {
-                quote! { layout::Visitor::slice(&mut #expr, #dir, &mut self.#core.#stor) }
+                quote! {{
+                    let dir = #dir;
+                    layout::Visitor::slice(&mut #expr, dir, &mut self.#core.#stor)
+                }}
             }
             Layout::Grid(stor, dim, cells) => {
                 let mut items = Toks::new();

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -303,10 +303,6 @@ impl<D: 'static> ThemeSize for Window<D> {
             env.bounds.0 = size.cast();
         }
 
-        // Force this for vertical size calculation. (Note: fixing vertical alignment is fast.)
-        env.align.1 = Align::TL;
-        env.bounds.1 = f32::INFINITY;
-
         text.set_env(env);
 
         if axis.is_horizontal() {

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -15,7 +15,7 @@ use kas::cast::traits::*;
 use kas::dir::Directional;
 use kas::geom::{Rect, Size, Vec2};
 use kas::layout::{AlignHints, AxisInfo, FrameRules, Margins, SizeRules, Stretch};
-use kas::text::{fonts::FontId, Align, TextApi, TextApiExt};
+use kas::text::{fonts::FontId, Align, TextApi};
 use kas::theme::{Feature, FrameStyle, MarkStyle, TextClass, ThemeSize};
 
 /// Parameterisation of [`Dimensions`]
@@ -290,22 +290,24 @@ impl<D: 'static> ThemeSize for Window<D> {
             }
         }
 
-        let required = text.update_env(|env| {
-            if let Some(font_id) = self.fonts.get(&class).cloned() {
-                env.set_font_id(font_id);
-            }
-            env.set_dpem(self.dims.dpem);
+        let mut env = text.env();
 
-            let mut bounds = kas::text::Vec2::INFINITY;
-            if let Some(size) = axis.size_other_if_fixed(false) {
-                bounds.1 = size.cast();
-            } else if let Some(size) = axis.size_other_if_fixed(true) {
-                bounds.0 = size.cast();
-            }
-            env.set_bounds(bounds);
-            env.set_align((Align::TL, Align::TL)); // force top-left alignment for sizing
-            env.set_wrap(class.multi_line());
-        });
+        if let Some(font_id) = self.fonts.get(&class).cloned() {
+            env.font_id = font_id;
+        }
+        env.dpem = self.dims.dpem;
+
+        env.bounds = kas::text::Vec2::INFINITY;
+        if let Some(size) = axis.size_other_if_fixed(false) {
+            env.bounds.1 = size.cast();
+        } else if let Some(size) = axis.size_other_if_fixed(true) {
+            env.bounds.0 = size.cast();
+        }
+        env.align = (Align::TL, Align::TL); // force top-left alignment for sizing
+        env.wrap = class.multi_line();
+
+        text.set_env(env);
+        let required = text.prepare_lines();
 
         if axis.is_horizontal() {
             let min = self.dims.min_line_length;
@@ -354,17 +356,18 @@ impl<D: 'static> ThemeSize for Window<D> {
         size: Size,
         align: (Align, Align),
     ) -> Vec2 {
-        // TODO(opt): we don't always need to do this work
-        text.update_env(|env| {
-            if let Some(font_id) = self.fonts.get(&class).cloned() {
-                env.set_font_id(font_id);
-            }
-            env.set_dpem(self.dims.dpem);
+        let mut env = text.env();
+        if let Some(font_id) = self.fonts.get(&class).cloned() {
+            env.font_id = font_id;
+        }
+        env.dpem = self.dims.dpem;
 
-            env.set_bounds(size.cast());
-            env.set_align(align);
-            env.set_wrap(class.multi_line());
-        })
-        .into()
+        env.bounds = size.cast();
+        env.align = align;
+        env.wrap = class.multi_line();
+
+        text.set_env(env);
+        // TODO(opt): we don't always need to do this work
+        text.prepare_lines().into()
     }
 }

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -59,7 +59,7 @@ pub struct Parameters {
 pub struct Dimensions {
     pub scale_factor: f32,
     pub dpp: f32,
-    pub pt_size: f32,
+    pub dpem: f32,
     pub mark_line: f32,
     pub min_line_length: i32,
     pub outer_margin: u16,
@@ -97,7 +97,7 @@ impl Dimensions {
         Dimensions {
             scale_factor,
             dpp,
-            pt_size,
+            dpem,
             mark_line: (1.2 * dpp).round().max(1.0),
             min_line_length: (8.0 * dpem).cast_nearest(),
             outer_margin,
@@ -165,7 +165,7 @@ impl<D: 'static> ThemeSize for Window<D> {
     }
 
     fn pixels_from_em(&self, em: f32) -> f32 {
-        self.dims.dpp * self.dims.pt_size * em
+        self.dims.dpem * em
     }
 
     fn inner_margin(&self) -> Size {
@@ -265,10 +265,9 @@ impl<D: 'static> ThemeSize for Window<D> {
 
     fn line_height(&self, class: TextClass) -> i32 {
         let font_id = self.fonts.get(&class).cloned().unwrap_or_default();
-        let dpem = self.dims.dpp * self.dims.pt_size;
         kas::text::fonts::fonts()
             .get_first_face(font_id)
-            .height(dpem)
+            .height(self.dims.dpem)
             .cast_ceil()
     }
 
@@ -295,8 +294,7 @@ impl<D: 'static> ThemeSize for Window<D> {
             if let Some(font_id) = self.fonts.get(&class).cloned() {
                 env.set_font_id(font_id);
             }
-            env.set_dpp(self.dims.dpp);
-            env.set_pt_size(self.dims.pt_size);
+            env.set_dpem(self.dims.dpem);
 
             let mut bounds = kas::text::Vec2::INFINITY;
             if let Some(size) = axis.size_other_if_fixed(false) {
@@ -361,8 +359,7 @@ impl<D: 'static> ThemeSize for Window<D> {
             if let Some(font_id) = self.fonts.get(&class).cloned() {
                 env.set_font_id(font_id);
             }
-            env.set_dpp(self.dims.dpp);
-            env.set_pt_size(self.dims.pt_size);
+            env.set_dpem(self.dims.dpem);
 
             env.set_bounds(size.cast());
             env.set_align(align);

--- a/crates/kas-theme/src/lib.rs
+++ b/crates/kas-theme/src/lib.rs
@@ -26,6 +26,7 @@ mod flat_theme;
 #[cfg(feature = "stack_dst")]
 mod multi;
 mod shaded_theme;
+mod simple_theme;
 #[cfg(feature = "stack_dst")]
 mod theme_dst;
 mod traits;
@@ -39,6 +40,7 @@ pub use flat_theme::FlatTheme;
 #[cfg(feature = "stack_dst")]
 pub use multi::{MultiTheme, MultiThemeBuilder};
 pub use shaded_theme::ShadedTheme;
+pub use simple_theme::SimpleTheme;
 #[cfg(feature = "stack_dst")]
 pub use theme_dst::{MaybeBoxed, ThemeDst};
 pub use traits::{Theme, ThemeConfig, Window};

--- a/crates/kas-theme/src/theme_dst.rs
+++ b/crates/kas-theme/src/theme_dst.rs
@@ -167,11 +167,11 @@ where
 }
 
 #[cfg(feature = "gat")]
-impl<'a, DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T {
+impl<DS: DrawSharedImpl, T: Theme<DS>> ThemeDst<DS> for T {
     fn config(&self) -> MaybeBoxed<dyn Any> {
         match self.config() {
             Cow::Borrowed(config) => MaybeBoxed::Borrowed(config),
-            Cow::Owned(config) => MaybeBoxed::Boxed(Box::new(config.to_owned())),
+            Cow::Owned(config) => MaybeBoxed::Boxed(Box::new(config)),
         }
     }
 

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -61,7 +61,7 @@ default-features = false
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "35164030dd3adf5ddf99efae8bbc1da986ee41af"
+rev = "78f2e6037ab3f2a1d646f263ca4973c54d81676c"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -61,7 +61,7 @@ default-features = false
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "78f2e6037ab3f2a1d646f263ca4973c54d81676c"
+rev = "c65118c07015902d983c3c0335f4b0a4e602993e"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -61,7 +61,7 @@ default-features = false
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "d90004a0fb4fc794392ce3f1a9e46ca86a8a8b08"
+rev = "02a1e4449a8ec48fc691afc43241201366fa67cb"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -61,7 +61,7 @@ default-features = false
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "02a1e4449a8ec48fc691afc43241201366fa67cb"
+rev = "9537fe88c32c911cb104cf1951ea1eb9cb6f50ff"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -61,7 +61,7 @@ default-features = false
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "5d77e53166a42352c8f72942ff9ce4ee004a6ffd"
+rev = "35164030dd3adf5ddf99efae8bbc1da986ee41af"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -61,7 +61,7 @@ default-features = false
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "9537fe88c32c911cb104cf1951ea1eb9cb6f50ff"
+rev = "f7f348105b8f7ddb79f05aa9c5c307a3160a9a8d"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -61,7 +61,7 @@ default-features = false
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "f7f348105b8f7ddb79f05aa9c5c307a3160a9a8d"
+rev = "5d77e53166a42352c8f72942ff9ce4ee004a6ffd"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -251,7 +251,9 @@ impl Window {
                 self.atlas.rect(pass, sprite.atlas, instance);
             }
         };
-        let _ = text.glyphs(for_glyph);
+        if let Err(e) = text.glyphs(for_glyph) {
+            log::warn!("Text display failed: {e}");
+        }
 
         self.duration += time.elapsed();
     }
@@ -292,7 +294,7 @@ impl Window {
             }
         };
 
-        if effects.len() > 1
+        let result = if effects.len() > 1
             || effects
                 .get(0)
                 .map(|e| *e != Effect::default(()))
@@ -304,9 +306,13 @@ impl Window {
                 let quad = Quad::from_coords(pos + Vec2(x1, y), pos + Vec2(x2, y2));
                 rects.push(quad);
             };
-            let _ = text.glyphs_with_effects(effects, (), for_glyph, for_rect);
+            text.glyphs_with_effects(effects, (), for_glyph, for_rect)
         } else {
-            let _ = text.glyphs(|face, dpem, glyph| for_glyph(face, dpem, glyph, 0, ()));
+            text.glyphs(|face, dpem, glyph| for_glyph(face, dpem, glyph, 0, ()))
+        };
+
+        if let Err(e) = result {
+            log::warn!("Text display failed: {e}");
         }
 
         self.duration += time.elapsed();
@@ -356,7 +362,9 @@ impl Window {
             rects.push((quad, col));
         };
 
-        let _ = text.glyphs_with_effects(effects, Rgba::BLACK, for_glyph, for_rect);
+        if let Err(e) = text.glyphs_with_effects(effects, Rgba::BLACK, for_glyph, for_rect) {
+            log::warn!("Text display failed: {e}");
+        }
 
         self.duration += time.elapsed();
         rects

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -154,7 +154,7 @@ impl_scope! {
     #[autoimpl(HasBool using self.inner)]
     #[derive(Clone, Default)]
     #[widget{
-        layout = row: [self.inner, self.label];
+        layout = list(self.direction()): [self.inner, self.label];
     }]
     pub struct CheckButton {
         core: widget_core!(),
@@ -246,6 +246,13 @@ impl_scope! {
         #[inline]
         pub fn set_editable(&mut self, editable: bool) {
             self.inner.set_editable(editable);
+        }
+
+        fn direction(&self) -> Direction {
+            match self.label.text().text_is_rtl() {
+                Ok(false) | Err(_) => Direction::Right,
+                Ok(true) => Direction::Left,
+            }
         }
     }
 }

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -462,8 +462,8 @@ impl_scope! {
                 Event::Scroll(delta) => {
                     let delta2 = match delta {
                         ScrollDelta::LineDelta(x, y) => {
-                            // We arbitrarily scroll 3 lines:
-                            let dist = 3.0 * self.text.env().height(Default::default());
+                            // We arbitrarily scroll 3 Em:
+                            let dist = 3.0 * self.text.env().dpem;
                             Offset((x * dist).cast_nearest(), (y * dist).cast_nearest())
                         }
                         ScrollDelta::PixelDelta(coord) => coord,

--- a/crates/kas-widgets/src/edit_field.rs
+++ b/crates/kas-widgets/src/edit_field.rs
@@ -564,7 +564,7 @@ impl EditField<()> {
             view_offset: Default::default(),
             editable: true,
             multi_line: false,
-            text: Text::new(Default::default(), text),
+            text: Text::new(text),
             required: Vec2::ZERO,
             selection: SelectionHelper::new(len, len),
             edit_x_coord: None,

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -34,7 +34,7 @@ impl_scope! {
             Label {
                 core: Default::default(),
                 class: TextClass::Label(true),
-                label: Text::new_multi(label),
+                label: Text::new(label),
             }
         }
 

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -89,7 +89,7 @@ impl_scope! {
         /// Note: this must not be called before fonts have been initialised
         /// (usually done by the theme when the main loop starts).
         pub fn set_text(&mut self, text: T) -> TkAction {
-            kas::text::util::set_text_and_prepare(&mut self.label, text, self.core.rect.size)
+            kas::text::util::set_text_and_prepare(&mut self.label, text)
         }
     }
 
@@ -126,7 +126,7 @@ impl_scope! {
         T: EditableText,
     {
         fn set_string(&mut self, string: String) -> TkAction {
-            kas::text::util::set_string_and_prepare(&mut self.label, string, self.core.rect.size)
+            kas::text::util::set_string_and_prepare(&mut self.label, string)
         }
     }
 }
@@ -264,7 +264,7 @@ impl_scope! {
         /// Note: this must not be called before fonts have been initialised
         /// (usually done by the theme when the main loop starts).
         pub fn set_text(&mut self, text: AccelString) -> TkAction {
-            kas::text::util::set_text_and_prepare(&mut self.0.label, text, self.0.core.rect.size)
+            kas::text::util::set_text_and_prepare(&mut self.0.label, text)
         }
     }
 
@@ -308,7 +308,7 @@ impl_scope! {
             if self.0.label.text().keys() != string.keys() {
                 action |= TkAction::RECONFIGURE;
             }
-            action | kas::text::util::set_text_and_prepare(&mut self.0.label, string, self.0.core.rect.size)
+            action | kas::text::util::set_text_and_prepare(&mut self.0.label, string)
         }
     }
 }

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -84,6 +84,12 @@ impl_scope! {
             self
         }
 
+        /// Get read access to the text object
+        #[inline]
+        pub fn text(&self) -> &Text<T> {
+            &self.label
+        }
+
         /// Set text in an existing `Label`
         ///
         /// Note: this must not be called before fonts have been initialised
@@ -257,6 +263,12 @@ impl_scope! {
         pub fn with_wrap(mut self, wrap: bool) -> Self {
             self.0.set_wrap(wrap);
             self
+        }
+
+        /// Get read access to the text object
+        #[inline]
+        pub fn text(&self) -> &Text<AccelString> {
+            self.0.text()
         }
 
         /// Set text in an existing `Label`

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -176,7 +176,7 @@ impl_scope! {
     #[autoimpl(HasBool using self.inner)]
     #[derive(Clone)]
     #[widget{
-        layout = row: [self.inner, self.label];
+        layout = list(self.direction()): [self.inner, self.label];
     }]
     pub struct RadioButton {
         core: widget_core!(),
@@ -287,6 +287,13 @@ impl_scope! {
         #[inline]
         pub fn unset_all(&self, mgr: &mut EventMgr) {
             self.inner.unset_all(mgr)
+        }
+
+        fn direction(&self) -> Direction {
+            match self.label.text().text_is_rtl() {
+                Ok(false) | Err(_) => Direction::Right,
+                Ok(true) => Direction::Left,
+            }
         }
     }
 }

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -364,13 +364,15 @@ impl_scope! {
         }
 
         fn draw_(&mut self, mut draw: DrawMgr) {
-            if self.show_bars.0 {
-                draw.recurse(&mut self.horiz_bar);
-            }
-            if self.show_bars.1 {
-                draw.recurse(&mut self.vert_bar);
-            }
             draw.recurse(&mut self.inner);
+            draw.with_pass(|mut draw| {
+                if self.show_bars.0 {
+                    draw.recurse(&mut self.horiz_bar);
+                }
+                if self.show_bars.1 {
+                    draw.recurse(&mut self.vert_bar);
+                }
+            });
         }
 
         fn force_visible_bars(&mut self, mgr: &mut EventMgr, horiz: bool, vert: bool) {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -26,7 +26,7 @@ impl_scope! {
         core: widget_core!(),
         view_offset: Offset,
         text: Text<T>,
-        required: Vec2,
+        bounding_corner: Vec2,
         selection: SelectionHelper,
         input_handler: TextInput,
     }
@@ -39,7 +39,8 @@ impl_scope! {
         fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
             let align = align.unwrap_or(Align::Default, Align::Default);
-            self.required = mgr.text_set_size(&mut self.text, TextClass::LabelScroll, rect.size, align);
+            mgr.text_set_size(&mut self.text, TextClass::LabelScroll, rect.size, align);
+            self.bounding_corner = self.text.bounding_box().into();
             self.set_view_offset_from_edit_pos();
         }
 
@@ -71,7 +72,7 @@ impl_scope! {
                 core: Default::default(),
                 view_offset: Default::default(),
                 text: Text::new(text),
-                required: Vec2::ZERO,
+                bounding_corner: Vec2::ZERO,
                 selection: SelectionHelper::new(0, 0),
                 input_handler: Default::default(),
             }
@@ -229,7 +230,7 @@ impl_scope! {
 
         fn max_scroll_offset(&self) -> Offset {
             let bounds = Vec2::from(self.text.env().bounds);
-            let max_offset = Offset::conv_ceil(self.required - bounds);
+            let max_offset = Offset::conv_ceil(self.bounding_corner - bounds);
             max_offset.max(Offset::ZERO)
         }
 

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -82,7 +82,7 @@ impl_scope! {
         /// Note: this must not be called before fonts have been initialised
         /// (usually done by the theme when the main loop starts).
         pub fn set_text(&mut self, text: T) -> TkAction {
-            kas::text::util::set_text_and_prepare(&mut self.text, text, self.core.rect.size)
+            kas::text::util::set_text_and_prepare(&mut self.text, text)
         }
 
         fn set_edit_pos_from_coord(&mut self, mgr: &mut EventMgr, coord: Coord) {
@@ -149,8 +149,7 @@ impl_scope! {
         T: EditableText,
     {
         fn set_string(&mut self, string: String) -> TkAction {
-            let avail = self.core.rect.size;
-            kas::text::util::set_string_and_prepare(&mut self.text, string, avail)
+            kas::text::util::set_string_and_prepare(&mut self.text, string)
         }
     }
 

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -190,8 +190,8 @@ impl_scope! {
                 Event::Scroll(delta) => {
                     let delta2 = match delta {
                         ScrollDelta::LineDelta(x, y) => {
-                            // We arbitrarily scroll 3 lines:
-                            let dist = 3.0 * self.text.env().height(Default::default());
+                            // We arbitrarily scroll 3 Em:
+                            let dist = 3.0 * self.text.env().dpem;
                             Offset((x * dist).cast_nearest(), (y * dist).cast_nearest())
                         }
                         ScrollDelta::PixelDelta(coord) => coord,

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -70,7 +70,7 @@ impl_scope! {
             ScrollLabel {
                 core: Default::default(),
                 view_offset: Default::default(),
-                text: Text::new_multi(text),
+                text: Text::new(text),
                 required: Vec2::ZERO,
                 selection: SelectionHelper::new(0, 0),
                 input_handler: Default::default(),

--- a/examples/async-event.rs
+++ b/examples/async-event.rs
@@ -54,7 +54,7 @@ impl_scope! {
                 core: Default::default(),
                 colour,
                 update_id,
-                loading_text: Text::new_single("Loading..."),
+                loading_text: Text::new("Loading..."),
                 loaded: false,
             }
         }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -50,17 +50,22 @@ impl_scope! {
             let pos = rect.pos + excess / 2;
             self.core.rect = Rect { pos, size };
 
-            let half_size = Size(size.0, size.1 / 2);
-            self.date.update_env(|env| {
-                env.set_dpem(size.1 as f32 * 0.12);
-                env.set_bounds(half_size.cast());
-            });
-            self.time.update_env(|env| {
-                env.set_dpem(size.1 as f32 * 0.15);
-                env.set_bounds(half_size.cast());
-            });
-            self.date_pos = pos + Size(0, size.1 - half_size.1);
-            self.time_pos = pos;
+            let text_height = size.1 / 3;
+            let half_size = Size(size.0, text_height).cast();
+
+            let mut env = self.date.env();
+            env.dpem = size.1 as f32 * 0.12;
+            env.bounds = half_size;
+            self.date.update_env(env);
+
+            let mut env = self.time.env();
+            env.dpem = size.1 as f32 * 0.15;
+            env.bounds = half_size;
+            self.time.update_env(env);
+
+            let mid_pos = pos + Offset(0, size.1 / 2);
+            self.date_pos = mid_pos;
+            self.time_pos = mid_pos - Offset(0, text_height);
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
@@ -146,7 +151,7 @@ impl_scope! {
                 align: (Align::Center, Align::Center),
                 ..Default::default()
             };
-            let date = Text::new_env(env.clone(), "0000-00-00".into());
+            let date = Text::new_env(env, "0000-00-00".into());
             let time = Text::new_env(env, "00:00:00".into());
             Clock {
                 core: Default::default(),

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -50,15 +50,13 @@ impl_scope! {
             let pos = rect.pos + excess / 2;
             self.core.rect = Rect { pos, size };
 
-            // Note: font size is calculated as dpem = dpp * pt_size. Instead of
-            // the usual semantics we set dpp=1 (in constructor) and pt_size=dpem.
             let half_size = Size(size.0, size.1 / 2);
             self.date.update_env(|env| {
-                env.set_pt_size(size.1 as f32 * 0.12);
+                env.set_dpem(size.1 as f32 * 0.12);
                 env.set_bounds(half_size.cast());
             });
             self.time.update_env(|env| {
-                env.set_pt_size(size.1 as f32 * 0.15);
+                env.set_dpem(size.1 as f32 * 0.15);
                 env.set_bounds(half_size.cast());
             });
             self.date_pos = pos + Size(0, size.1 - half_size.1);
@@ -146,7 +144,6 @@ impl_scope! {
         fn new() -> Self {
             let env = kas::text::Environment {
                 align: (Align::Center, Align::Center),
-                dpp: 1.0,
                 ..Default::default()
             };
             let date = Text::new(env.clone(), "0000-00-00".into());

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -146,8 +146,8 @@ impl_scope! {
                 align: (Align::Center, Align::Center),
                 ..Default::default()
             };
-            let date = Text::new(env.clone(), "0000-00-00".into());
-            let time = Text::new(env, "00:00:00".into());
+            let date = Text::new_env(env.clone(), "0000-00-00".into());
+            let time = Text::new_env(env, "00:00:00".into());
             Clock {
                 core: Default::default(),
                 date_pos: Coord::ZERO,

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -131,10 +131,9 @@ impl_scope! {
                     self.now = Local::now();
                     let date = self.now.format("%Y-%m-%d").to_string();
                     let time = self.now.format("%H:%M:%S").to_string();
-                    let avail = Size(self.core.rect.size.0, self.core.rect.size.1 / 2);
                     *mgr |= TkAction::REDRAW
-                        | set_text_and_prepare(&mut self.date, date, avail)
-                        | set_text_and_prepare(&mut self.time, time, avail);
+                        | set_text_and_prepare(&mut self.date, date)
+                        | set_text_and_prepare(&mut self.time, time);
                     let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
                     info!("Requesting update in {}ns", ns);
                     mgr.request_update(self.id(), 0, Duration::new(0, ns), true);

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -434,10 +434,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "stack_dst")]
     let theme = kas::theme::MultiTheme::builder()
         .add("flat", kas::theme::FlatTheme::new())
+        .add("simple", kas::theme::SimpleTheme::new())
         .add("shaded", kas::theme::ShadedTheme::new())
         .build();
     #[cfg(not(feature = "stack_dst"))]
-    let theme = kas::theme::ShadedTheme::new();
+    let theme = kas::theme::FlatTheme::new();
     let mut toolkit = kas::shell::Toolkit::new(theme)?;
 
     // TODO: use as logo of tab
@@ -456,8 +457,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             menu.entry("&Quit", Menu::Quit);
         })
         .menu("&Theme", |menu| {
-            menu.entry("&Flat", Menu::Theme("flat"))
-                .entry("&Shaded", Menu::Theme("shaded"));
+            menu.entry("&Simple", Menu::Theme("simple"))
+                .entry("&Flat", Menu::Theme("flat"))
+                .entry("S&haded", Menu::Theme("shaded"));
         })
         .menu("&Style", |menu| {
             menu.submenu("&Colours", |mut menu| {

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -21,7 +21,7 @@ fn main() -> kas::shell::Result<()> {
                 2, 0: self.check;
                 0..3, 1: Label::new(LIPSUM);
                 0, 2: align(center): "abc אבג def";
-                1..3, 2..4: align(stretch): ScrollLabel::new(CRASIT);
+                1..3, 3: align(stretch): ScrollLabel::new(CRASIT);
                 0, 3: self.edit;
             };
         }]

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -99,6 +99,6 @@ fn main() -> kas::shell::Result<()> {
         }
     };
 
-    let theme = kas::theme::ShadedTheme::new().with_font_size(16.0);
+    let theme = kas::theme::SimpleTheme::new().with_font_size(16.0);
     kas::shell::Toolkit::new(theme)?.with(window)?.run()
 }


### PR DESCRIPTION
Adds the `SimpleTheme`. Ugly, but potentially useful as a base for developing other themes. Currently this uses the same dimensions as `FlatTheme`.
![SimpleTheme](https://user-images.githubusercontent.com/134893/178102614-f28f3ec4-b3cd-4070-bfcf-ecc52fae366a.png)

- Fix for scroll bars drawn over other content
- KAS-text: various API tweaks: https://github.com/kas-gui/kas-text/pull/68
- Text: combine `dpp` and `pt_size` parameters
- Check/radio buttons: layout direction inferred from text label (i.e. reversed for RTL texts)