### PR TITLE
Auto-detect dark theme; fix text clamping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 [features]
 #########  meta / build features  #########
 
-default = ["theme", "view", "wgpu", "winit", "yaml", "image", "resvg", "clipboard", "markdown", "shaping"]
+default = ["theme", "view", "wgpu", "winit", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light"]
 
 # Enable dynamic linking (faster linking via an extra run-time dependency):
 dynamic = ["dep:kas-dylib"]
@@ -84,6 +84,9 @@ image = ["kas-widgets/image"]
 resvg = ["dep:kas-resvg", "kas-resvg?/svg"]
 # Enable resvg module (Canvas only)
 tiny-skia = ["dep:kas-resvg"]
+
+# Automatically detect usage of dark theme
+dark-light = ["kas-theme?/dark-light"]
 
 # Support SVG images
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,17 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 [features]
 #########  meta / build features  #########
 
-default = ["theme", "view", "wgpu", "winit", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light"]
+# All recommended features for optimal experience
+default = ["minimal", "view", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light"]
+
+# Include only "required" features.
+#
+#  A shell is required and wgpu is currently the only shell; this shell uses and
+#  requires theme support to function.
+#
+# Note: only some examples build in this configuration; others need view,
+# markdown, resvg. Recommended also: clipboard, yaml (or some config format).
+minimal = ["theme", "wgpu"]
 
 # Enable dynamic linking (faster linking via an extra run-time dependency):
 dynamic = ["dep:kas-dylib"]

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -82,7 +82,7 @@ path = "../kas-macros"
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "9b4aee7d8e72ecbe4f69deca881de2519609bce8"
+rev = "027b32abab85317bebed96d438f244532f2dd427"
 
 [dependencies.easy-cast]
 git = "https://github.com/kas-gui/easy-cast.git"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -82,7 +82,7 @@ path = "../kas-macros"
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "027b32abab85317bebed96d438f244532f2dd427"
+rev = "e4490ebfc7e58d670e3910f7e7574821532a032b"
 
 [dependencies.easy-cast]
 git = "https://github.com/kas-gui/easy-cast.git"

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -194,11 +194,17 @@ pub trait Draw {
 
     /// Draw text with a colour
     ///
+    /// Text is drawn from `rect.pos` and clipped to `rect`. If the text
+    /// scrolls, `rect` should be the size of the whole text, not the window.
+    ///
     /// It is required to call [`TextApi::prepare`] or equivalent
     /// prior to this method to select a font, font size and perform layout.
     fn text(&mut self, rect: Rect, text: &TextDisplay, col: Rgba);
 
     /// Draw text with a single color and effects
+    ///
+    /// Text is drawn from `rect.pos` and clipped to `rect`. If the text
+    /// scrolls, `rect` should be the size of the whole text, not the window.
     ///
     /// The effects list does not contain colour information, but may contain
     /// underlining/strikethrough information. It may be empty.
@@ -208,6 +214,9 @@ pub trait Draw {
     fn text_effects(&mut self, rect: Rect, text: &TextDisplay, col: Rgba, effects: &[Effect<()>]);
 
     /// Draw text with effects (including [`Rgba`] color)
+    ///
+    /// Text is drawn from `rect.pos` and clipped to `rect`. If the text
+    /// scrolls, `rect` should be the size of the whole text, not the window.
     ///
     /// The `effects` list provides both underlining and colour information.
     /// If the `effects` list is empty or the first entry has `start > 0`, a

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -205,15 +205,9 @@ pub trait Draw {
     ///
     /// It is required to call [`TextApi::prepare`] or equivalent
     /// prior to this method to select a font, font size and perform layout.
-    fn text_col_effects(
-        &mut self,
-        rect: Rect,
-        text: &TextDisplay,
-        col: Rgba,
-        effects: &[Effect<()>],
-    );
+    fn text_effects(&mut self, rect: Rect, text: &TextDisplay, col: Rgba, effects: &[Effect<()>]);
 
-    /// Draw text with effects (including colors)
+    /// Draw text with effects (including [`Rgba`] color)
     ///
     /// The `effects` list provides both underlining and colour information.
     /// If the `effects` list is empty or the first entry has `start > 0`, a
@@ -221,7 +215,7 @@ pub trait Draw {
     ///
     /// It is required to call [`TextApi::prepare`] or equivalent
     /// prior to this method to select a font, font size and perform layout.
-    fn text_effects(&mut self, rect: Rect, text: &TextDisplay, effects: &[Effect<Rgba>]);
+    fn text_effects_rgba(&mut self, rect: Rect, text: &TextDisplay, effects: &[Effect<Rgba>]);
 }
 
 impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
@@ -275,22 +269,16 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
             .draw_text(self.draw, self.pass, rect, text, col);
     }
 
-    fn text_col_effects(
-        &mut self,
-        rect: Rect,
-        text: &TextDisplay,
-        col: Rgba,
-        effects: &[Effect<()>],
-    ) {
+    fn text_effects(&mut self, rect: Rect, text: &TextDisplay, col: Rgba, effects: &[Effect<()>]) {
         self.shared
             .draw
-            .draw_text_col_effects(self.draw, self.pass, rect, text, col, effects);
+            .draw_text_effects(self.draw, self.pass, rect, text, col, effects);
     }
 
-    fn text_effects(&mut self, rect: Rect, text: &TextDisplay, effects: &[Effect<Rgba>]) {
+    fn text_effects_rgba(&mut self, rect: Rect, text: &TextDisplay, effects: &[Effect<Rgba>]) {
         self.shared
             .draw
-            .draw_text_effects(self.draw, self.pass, rect, text, effects);
+            .draw_text_effects_rgba(self.draw, self.pass, rect, text, effects);
     }
 }
 

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -196,7 +196,7 @@ pub trait Draw {
     ///
     /// It is required to call [`TextApi::prepare`] or equivalent
     /// prior to this method to select a font, font size and perform layout.
-    fn text(&mut self, rect: Quad, text: &TextDisplay, col: Rgba);
+    fn text(&mut self, rect: Rect, text: &TextDisplay, col: Rgba);
 
     /// Draw text with a single color and effects
     ///
@@ -207,7 +207,7 @@ pub trait Draw {
     /// prior to this method to select a font, font size and perform layout.
     fn text_col_effects(
         &mut self,
-        rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         col: Rgba,
         effects: &[Effect<()>],
@@ -221,7 +221,7 @@ pub trait Draw {
     ///
     /// It is required to call [`TextApi::prepare`] or equivalent
     /// prior to this method to select a font, font size and perform layout.
-    fn text_effects(&mut self, rect: Quad, text: &TextDisplay, effects: &[Effect<Rgba>]);
+    fn text_effects(&mut self, rect: Rect, text: &TextDisplay, effects: &[Effect<Rgba>]);
 }
 
 impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
@@ -269,7 +269,7 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
         self.shared.draw.draw_image(self.draw, self.pass, id, rect);
     }
 
-    fn text(&mut self, rect: Quad, text: &TextDisplay, col: Rgba) {
+    fn text(&mut self, rect: Rect, text: &TextDisplay, col: Rgba) {
         self.shared
             .draw
             .draw_text(self.draw, self.pass, rect, text, col);
@@ -277,7 +277,7 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
 
     fn text_col_effects(
         &mut self,
-        rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         col: Rgba,
         effects: &[Effect<()>],
@@ -287,7 +287,7 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
             .draw_text_col_effects(self.draw, self.pass, rect, text, col, effects);
     }
 
-    fn text_effects(&mut self, rect: Quad, text: &TextDisplay, effects: &[Effect<Rgba>]) {
+    fn text_effects(&mut self, rect: Rect, text: &TextDisplay, effects: &[Effect<Rgba>]) {
         self.shared
             .draw
             .draw_text_effects(self.draw, self.pass, rect, text, effects);
@@ -300,8 +300,9 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
 /// provided by the shell; extension traits such as [`DrawRoundedImpl`]
 /// optionally provide more functionality.
 ///
-/// Coordinates are specified via a [`Vec2`] and rectangular regions via
-/// [`Quad`] allowing fractional positions.
+/// Coordinates for many primitives are specified using floating-point types
+/// allowing fractional precision, deliberately excepting text which must be
+/// pixel-aligned for best appearance.
 ///
 /// All draw operations may be batched; when drawn primitives overlap, the
 /// results are only loosely defined. Draw operations involving transparency

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -182,7 +182,7 @@ pub trait DrawSharedImpl: Any {
     ///
     /// The effects list does not contain colour information, but may contain
     /// underlining/strikethrough information. It may be empty.
-    fn draw_text_col_effects(
+    fn draw_text_effects(
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,
@@ -197,7 +197,7 @@ pub trait DrawSharedImpl: Any {
     /// The `effects` list provides both underlining and colour information.
     /// If the `effects` list is empty or the first entry has `start > 0`, a
     /// default entity will be assumed.
-    fn draw_text_effects(
+    fn draw_text_effects_rgba(
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -8,7 +8,7 @@
 use super::color::Rgba;
 use super::{DrawImpl, PassId};
 use crate::cast::Cast;
-use crate::geom::{Quad, Size};
+use crate::geom::{Quad, Rect, Size};
 use crate::text::{Effect, TextDisplay};
 use std::any::Any;
 use std::num::NonZeroU32;
@@ -173,7 +173,7 @@ pub trait DrawSharedImpl: Any {
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,
-        rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         col: Rgba,
     );
@@ -186,7 +186,7 @@ pub trait DrawSharedImpl: Any {
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,
-        rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         col: Rgba,
         effects: &[Effect<()>],
@@ -201,7 +201,7 @@ pub trait DrawSharedImpl: Any {
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,
-        rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         effects: &[Effect<Rgba>],
     );

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -123,6 +123,24 @@ impl SubAssign<Vec2> for Quad {
     }
 }
 
+impl Add<Vec2> for Quad {
+    type Output = Quad;
+    #[inline]
+    fn add(mut self, rhs: Vec2) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
+
+impl Sub<Vec2> for Quad {
+    type Output = Quad;
+    #[inline]
+    fn sub(mut self, rhs: Vec2) -> Self::Output {
+        self -= rhs;
+        self
+    }
+}
+
 impl Conv<Rect> for Quad {
     #[inline]
     fn try_conv(rect: Rect) -> Result<Self> {

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -203,6 +203,9 @@ impl<'a> DrawMgr<'a> {
 
     /// Draw text
     ///
+    /// Text is drawn from `rect.pos` and clipped to `rect`. If the text
+    /// scrolls, `rect` should be the size of the whole text, not the window.
+    ///
     /// [`SizeMgr::text_bound`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
     pub fn text(&mut self, rect: Rect, text: impl AsRef<TextDisplay>, class: TextClass) {
@@ -210,6 +213,9 @@ impl<'a> DrawMgr<'a> {
     }
 
     /// Draw text with effects
+    ///
+    /// Text is drawn from `rect.pos` and clipped to `rect`. If the text
+    /// scrolls, `rect` should be the size of the whole text, not the window.
     ///
     /// [`Self::text`] already supports *font* effects: bold,
     /// emphasis, text size. In addition, this method supports underline and
@@ -249,6 +255,9 @@ impl<'a> DrawMgr<'a> {
     }
 
     /// Draw an edit marker at the given `byte` index on this `text`
+    ///
+    /// The text cursor is draw from `rect.pos` and clipped to `rect`. If the text
+    /// scrolls, `rect` should be the size of the whole text, not the window.
     ///
     /// [`SizeMgr::text_bound`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).

--- a/crates/kas-theme/Cargo.toml
+++ b/crates/kas-theme/Cargo.toml
@@ -33,6 +33,9 @@ config = ["dep:serde", "kas/config"]
 # Use Generic Associated Types (this is too unstable to include in nightly!)
 gat = ["kas/gat"]
 
+# Automatically detect usage of dark theme
+dark-light = ["dep:dark-light"]
+
 [dependencies]
 # Rename package purely for convenience:
 kas = { version = "0.11.0", package = "kas-core", path = "../kas-core" }
@@ -40,3 +43,4 @@ linear-map = "1.2.0"
 log = "0.4"
 serde = { version = "1.0.123", features = ["derive"], optional = true }
 bitflags = "1.3.1"
+dark-light = { version = "0.2.2", optional = true }

--- a/crates/kas-theme/src/colors.rs
+++ b/crates/kas-theme/src/colors.rs
@@ -212,6 +212,15 @@ impl From<ColorsLinear> for ColorsSrgb {
 }
 
 impl Default for ColorsLinear {
+    #[cfg(feature = "dark-light")]
+    fn default() -> Self {
+        match dark_light::detect() {
+            dark_light::Mode::Dark => ColorsSrgb::dark().into(),
+            dark_light::Mode::Light => ColorsSrgb::light().into(),
+        }
+    }
+
+    #[cfg(not(feature = "dark-light"))]
     #[inline]
     fn default() -> Self {
         ColorsSrgb::default().into()

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -610,9 +610,4 @@ where
         let inner = outer.shrink(outer.size().min_comp() / 2.0);
         self.draw.rounded_frame(outer, inner, 0.0, self.cols.accent);
     }
-
-    fn image(&mut self, id: ImageId, rect: Rect) {
-        let rect = Quad::conv(rect);
-        self.draw.image(id, rect);
-    }
 }

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -5,19 +5,17 @@
 
 //! Flat theme
 
-use linear_map::LinearMap;
 use std::f32;
 use std::ops::Range;
-use std::rc::Rc;
 use std::time::Instant;
 
-use crate::{dim, ColorsLinear, Config, InputState, Theme};
+use crate::{dim, ColorsLinear, Config, InputState, SimpleTheme, Theme};
 use kas::cast::traits::*;
 use kas::dir::{Direction, Directional};
 use kas::draw::{color::Rgba, *};
 use kas::event::EventState;
 use kas::geom::*;
-use kas::text::{fonts, TextApi, TextDisplay};
+use kas::text::{TextApi, TextDisplay};
 use kas::theme::{Background, FrameStyle, MarkStyle, TextClass};
 use kas::theme::{ThemeControl, ThemeDraw, ThemeSize};
 use kas::{TkAction, WidgetId};
@@ -34,10 +32,7 @@ const SHADOW_POPUP: f32 = 1.2;
 /// A theme with flat (unshaded) rendering
 #[derive(Clone, Debug)]
 pub struct FlatTheme {
-    pub(crate) config: Config,
-    pub(crate) cols: ColorsLinear,
-    dims: dim::Parameters,
-    pub(crate) fonts: Option<Rc<LinearMap<TextClass, fonts::FontId>>>,
+    base: SimpleTheme,
 }
 
 impl Default for FlatTheme {
@@ -50,13 +45,8 @@ impl FlatTheme {
     /// Construct
     #[inline]
     pub fn new() -> Self {
-        let cols = ColorsLinear::default();
-        FlatTheme {
-            config: Default::default(),
-            cols,
-            dims: DIMS,
-            fonts: None,
-        }
+        let base = SimpleTheme::new();
+        FlatTheme { base }
     }
 
     /// Set font size
@@ -65,7 +55,7 @@ impl FlatTheme {
     #[inline]
     #[must_use]
     pub fn with_font_size(mut self, pt_size: f32) -> Self {
-        self.config.set_font_size(pt_size);
+        self.base.config.set_font_size(pt_size);
         self
     }
 
@@ -74,17 +64,12 @@ impl FlatTheme {
     /// If no scheme by this name is found the scheme is left unchanged.
     #[inline]
     #[must_use]
-    pub fn with_colours(mut self, name: &str) -> Self {
-        if let Some(scheme) = self.config.get_color_scheme(name) {
-            self.config.set_active_scheme(name);
-            let _ = self.set_colors(scheme.into());
+    pub fn with_colours(mut self, scheme: &str) -> Self {
+        self.base.config.set_active_scheme(scheme);
+        if let Some(scheme) = self.base.config.get_color_scheme(scheme) {
+            self.base.cols = scheme.into();
         }
         self
-    }
-
-    pub fn set_colors(&mut self, cols: ColorsLinear) -> TkAction {
-        self.cols = cols;
-        TkAction::REDRAW
     }
 }
 
@@ -126,37 +111,24 @@ where
     type Draw<'a> = DrawHandle<'a, DS>;
 
     fn config(&self) -> std::borrow::Cow<Self::Config> {
-        std::borrow::Cow::Borrowed(&self.config)
+        <SimpleTheme as Theme<DS>>::config(&self.base)
     }
 
     fn apply_config(&mut self, config: &Self::Config) -> TkAction {
-        let mut action = self.config.apply_config(config);
-        if let Some(scheme) = self.config.get_active_scheme() {
-            action |= self.set_colors(scheme.into());
-        }
-        action
+        <SimpleTheme as Theme<DS>>::apply_config(&mut self.base, config)
     }
 
-    fn init(&mut self, _shared: &mut SharedState<DS>) {
-        let fonts = fonts::fonts();
-        if let Err(e) = fonts.select_default() {
-            panic!("Error loading font: {}", e);
-        }
-        self.fonts = Some(Rc::new(
-            self.config
-                .iter_fonts()
-                .filter_map(|(c, s)| fonts.select_font(s).ok().map(|id| (*c, id)))
-                .collect(),
-        ));
+    fn init(&mut self, shared: &mut SharedState<DS>) {
+        <SimpleTheme as Theme<DS>>::init(&mut self.base, shared)
     }
 
     fn new_window(&self, dpi_factor: f32) -> Self::Window {
-        let fonts = self.fonts.as_ref().unwrap().clone();
-        dim::Window::new(&self.dims, &self.config, dpi_factor, fonts)
+        let fonts = self.base.fonts.as_ref().unwrap().clone();
+        dim::Window::new(&DIMS, &self.base.config, dpi_factor, fonts)
     }
 
     fn update_window(&self, w: &mut Self::Window, dpi_factor: f32) {
-        w.update(&self.dims, &self.config, dpi_factor);
+        w.update(&DIMS, &self.base.config, dpi_factor);
     }
 
     #[cfg(not(feature = "gat"))]
@@ -182,7 +154,7 @@ where
             },
             ev: extend_lifetime_mut(ev),
             w: extend_lifetime_mut(w),
-            cols: extend_lifetime(&self.cols),
+            cols: extend_lifetime(&self.base.cols),
         }
     }
     #[cfg(feature = "gat")]
@@ -198,36 +170,26 @@ where
             draw,
             ev,
             w,
-            cols: &self.cols,
+            cols: &self.base.cols,
         }
     }
 
     fn clear_color(&self) -> Rgba {
-        self.cols.background
+        self.base.cols.background
     }
 }
 
 impl ThemeControl for FlatTheme {
     fn set_font_size(&mut self, pt_size: f32) -> TkAction {
-        self.config.set_font_size(pt_size);
-        TkAction::RESIZE | TkAction::THEME_UPDATE
+        self.base.set_font_size(pt_size)
     }
 
     fn list_schemes(&self) -> Vec<&str> {
-        self.config
-            .color_schemes_iter()
-            .map(|(name, _)| name)
-            .collect()
+        self.base.list_schemes()
     }
 
     fn set_scheme(&mut self, name: &str) -> TkAction {
-        if name != self.config.active_scheme() {
-            if let Some(scheme) = self.config.get_color_scheme(name) {
-                self.config.set_active_scheme(name);
-                return self.set_colors(scheme.into());
-            }
-        }
-        TkAction::empty()
+        self.base.set_scheme(name)
     }
 }
 
@@ -397,10 +359,6 @@ where
             cols: self.cols,
         };
         f(&mut handle);
-    }
-
-    fn get_clip_rect(&mut self) -> Rect {
-        self.draw.get_clip_rect()
     }
 
     fn frame(&mut self, id: &WidgetId, rect: Rect, style: FrameStyle, bg: Background) {

--- a/crates/kas-theme/src/simple_theme.rs
+++ b/crates/kas-theme/src/simple_theme.rs
@@ -394,17 +394,16 @@ where
         let sel_col = self.cols.text_over(self.cols.text_sel_bg);
 
         // Draw background:
-        for (p1, p2) in text
-            .highlight_lines(range.clone())
-            .iter()
-            .flat_map(|v| v.iter())
-        {
+        let result = text.highlight_range(range.clone(), &mut |p1, p2| {
             let q = Quad::conv(rect);
-            let p1 = Vec2::from(*p1);
-            let p2 = Vec2::from(*p2);
+            let p1 = Vec2::from(p1);
+            let p2 = Vec2::from(p2);
             if let Some(quad) = Quad::from_coords(q.a + p1, q.a + p2).intersection(&q) {
                 self.draw.rect(quad, self.cols.text_sel_bg);
             }
+        });
+        if let Err(e) = result {
+            log::error!("text.highlight_range() -> {e}");
         }
 
         let effects = [

--- a/crates/kas-theme/src/simple_theme.rs
+++ b/crates/kas-theme/src/simple_theme.rs
@@ -361,21 +361,20 @@ where
         } else {
             self.cols.text
         };
-        self.draw.text(rect.cast(), text, col);
+        self.draw.text(rect, text, col);
     }
 
     fn text_effects(&mut self, id: &WidgetId, rect: Rect, text: &dyn TextApi, class: TextClass) {
-        let quad = Quad::conv(rect);
         let col = if self.ev.is_disabled(id) {
             self.cols.text_disabled
         } else {
             self.cols.text
         };
         if class.is_accel() && !self.ev.show_accel_labels() {
-            self.draw.text(quad, text.display(), col);
+            self.draw.text(rect, text.display(), col);
         } else {
             self.draw
-                .text_col_effects(quad, text.display(), col, text.effect_tokens());
+                .text_col_effects(rect, text.display(), col, text.effect_tokens());
         }
     }
 
@@ -387,7 +386,6 @@ where
         range: Range<usize>,
         _: TextClass,
     ) {
-        let rect = Quad::conv(rect);
         let col = if self.ev.is_disabled(id) {
             self.cols.text_disabled
         } else {
@@ -401,9 +399,10 @@ where
             .iter()
             .flat_map(|v| v.iter())
         {
+            let q = Quad::conv(rect);
             let p1 = Vec2::from(*p1);
             let p2 = Vec2::from(*p2);
-            if let Some(quad) = Quad::from_coords(rect.a + p1, rect.a + p2).intersection(&rect) {
+            if let Some(quad) = Quad::from_coords(q.a + p1, q.a + p2).intersection(&q) {
                 self.draw.rect(quad, self.cols.text_sel_bg);
             }
         }
@@ -577,7 +576,6 @@ where
     }
 
     fn image(&mut self, id: ImageId, rect: Rect) {
-        let rect = Quad::conv(rect);
-        self.draw.image(id, rect);
+        self.draw.image(id, rect.cast());
     }
 }

--- a/crates/kas-theme/src/simple_theme.rs
+++ b/crates/kas-theme/src/simple_theme.rs
@@ -441,10 +441,12 @@ where
 
         let width = self.w.dims.mark_line;
         let pos = Vec2::conv(rect.pos);
+        let p10max = pos.0 + f32::conv(rect.size.0) - width;
 
         let mut col = self.cols.nav_focus;
         for cursor in text.text_glyph_pos(byte).iter_mut().flatten().rev() {
             let mut p1 = pos + Vec2::from(cursor.pos);
+            p1.0 = p1.0.min(p10max);
             let mut p2 = p1;
             p1.1 -= cursor.ascent;
             p2.1 -= cursor.descent;

--- a/crates/kas-theme/src/simple_theme.rs
+++ b/crates/kas-theme/src/simple_theme.rs
@@ -374,7 +374,7 @@ where
             self.draw.text(rect, text.display(), col);
         } else {
             self.draw
-                .text_col_effects(rect, text.display(), col, text.effect_tokens());
+                .text_effects(rect, text.display(), col, text.effect_tokens());
         }
     }
 
@@ -424,7 +424,7 @@ where
                 aux: col,
             },
         ];
-        self.draw.text_effects(rect, text, &effects);
+        self.draw.text_effects_rgba(rect, text, &effects);
     }
 
     fn text_cursor(

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -54,7 +54,7 @@ default-features = false
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "027b32abab85317bebed96d438f244532f2dd427"
+rev = "e4490ebfc7e58d670e3910f7e7574821532a032b"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -54,7 +54,7 @@ default-features = false
 [dependencies.kas-text]
 version = "0.5.0"
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "9b4aee7d8e72ecbe4f69deca881de2519609bce8"
+rev = "027b32abab85317bebed96d438f244532f2dd427"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -338,7 +338,7 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,
-        rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         col: Rgba,
     ) {
@@ -349,7 +349,7 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,
-        rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         col: Rgba,
         effects: &[Effect<()>],
@@ -366,7 +366,7 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,
-        rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         effects: &[Effect<Rgba>],
     ) {

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -345,7 +345,7 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
         draw.text.text(&mut self.text, pass, rect, text, col);
     }
 
-    fn draw_text_col_effects(
+    fn draw_text_effects(
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,
@@ -356,13 +356,13 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
     ) {
         let rects = draw
             .text
-            .text_col_effects(&mut self.text, pass, rect, text, col, effects);
+            .text_effects(&mut self.text, pass, rect, text, col, effects);
         for rect in rects {
             draw.shaded_square.rect(pass, rect, col);
         }
     }
 
-    fn draw_text_effects(
+    fn draw_text_effects_rgba(
         &mut self,
         draw: &mut Self::Draw,
         pass: PassId,
@@ -372,7 +372,7 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
     ) {
         let rects = draw
             .text
-            .text_effects(&mut self.text, pass, rect, text, effects);
+            .text_effects_rgba(&mut self.text, pass, rect, text, effects);
         for (rect, col) in rects {
             draw.shaded_square.rect(pass, rect, col);
         }

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -286,7 +286,7 @@ impl Window {
         self.duration += time.elapsed();
     }
 
-    pub fn text_col_effects(
+    pub fn text_effects(
         &mut self,
         pipe: &mut Pipeline,
         pass: PassId,
@@ -348,7 +348,7 @@ impl Window {
         rects
     }
 
-    pub fn text_effects(
+    pub fn text_effects_rgba(
         &mut self,
         pipe: &mut Pipeline,
         pass: PassId,

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -8,7 +8,7 @@
 use super::{atlases, ShaderManager};
 use kas::cast::*;
 use kas::draw::{color::Rgba, PassId};
-use kas::geom::{Quad, Vec2};
+use kas::geom::{Quad, Rect, Vec2};
 use kas::text::fonts::FaceId;
 use kas::text::{Effect, Glyph, TextDisplay};
 use kas_text::raster::{raster, Config, SpriteDescriptor};
@@ -263,12 +263,12 @@ impl Window {
         &mut self,
         pipe: &mut Pipeline,
         pass: PassId,
-        mut rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         col: Rgba,
     ) {
         let time = std::time::Instant::now();
-        rect.a = rect.a.round();
+        let rect = Quad::conv(rect);
 
         let for_glyph = |face: FaceId, dpem: f32, glyph: Glyph| {
             if let Some(sprite) = pipe.get_glyph(face, dpem, glyph) {
@@ -290,7 +290,7 @@ impl Window {
         &mut self,
         pipe: &mut Pipeline,
         pass: PassId,
-        mut rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         col: Rgba,
         effects: &[Effect<()>],
@@ -307,7 +307,7 @@ impl Window {
         }
 
         let time = std::time::Instant::now();
-        rect.a = rect.a.round();
+        let rect = Quad::conv(rect);
         let mut rects = vec![];
 
         let mut for_glyph = |face: FaceId, dpem: f32, glyph: Glyph, _: usize, _: ()| {
@@ -352,7 +352,7 @@ impl Window {
         &mut self,
         pipe: &mut Pipeline,
         pass: PassId,
-        mut rect: Quad,
+        rect: Rect,
         text: &TextDisplay,
         effects: &[Effect<Rgba>],
     ) -> Vec<(Quad, Rgba)> {
@@ -369,7 +369,7 @@ impl Window {
         }
 
         let time = std::time::Instant::now();
-        rect.a = rect.a.round();
+        let rect = Quad::conv(rect);
         let mut rects = vec![];
 
         let for_glyph = |face: FaceId, dpem: f32, glyph: Glyph, _, col: Rgba| {

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -1115,11 +1115,13 @@ impl<G: EditGuard> EditField<G> {
     fn set_edit_pos_from_coord(&mut self, mgr: &mut EventMgr, coord: Coord) {
         let rel_pos = (coord - self.rect().pos + self.view_offset).cast();
         if let Ok(pos) = self.text.text_index_nearest(rel_pos) {
-            self.selection.set_edit_pos(pos);
+            if pos != self.selection.edit_pos() {
+                self.selection.set_edit_pos(pos);
+                self.set_view_offset_from_edit_pos();
+                self.edit_x_coord = None;
+                mgr.redraw(self.id());
+            }
         }
-        self.set_view_offset_from_edit_pos();
-        self.edit_x_coord = None;
-        mgr.redraw(self.id());
     }
 
     // Pan by given delta. Return `Response::Scrolled` or `Response::Pan(remaining)`.

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -90,10 +90,12 @@ impl_scope! {
         fn set_edit_pos_from_coord(&mut self, mgr: &mut EventMgr, coord: Coord) {
             let rel_pos = (coord - self.rect().pos + self.view_offset).cast();
             if let Ok(pos) = self.text.text_index_nearest(rel_pos) {
-                self.selection.set_edit_pos(pos);
+                if pos != self.selection.edit_pos() {
+                    self.selection.set_edit_pos(pos);
+                    self.set_view_offset_from_edit_pos();
+                    mgr.redraw(self.id());
+                }
             }
-            self.set_view_offset_from_edit_pos();
-            mgr.redraw(self.id());
         }
 
         // Pan by given delta. Return `Response::Scrolled` or `Response::Pan(remaining)`.

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -26,7 +26,7 @@ impl_scope! {
         core: widget_core!(),
         view_offset: Offset,
         text: Text<T>,
-        bounding_corner: Vec2,
+        text_size: Size,
         selection: SelectionHelper,
         input_handler: TextInput,
     }
@@ -40,21 +40,22 @@ impl_scope! {
             self.core.rect = rect;
             let align = align.unwrap_or(Align::Default, Align::Default);
             mgr.text_set_size(&mut self.text, TextClass::LabelScroll, rect.size, align);
-            self.bounding_corner = self.text.bounding_box().unwrap().1.into();
+            self.text_size = Vec2::from(self.text.bounding_box().unwrap().1).cast_ceil();
             self.set_view_offset_from_edit_pos();
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
             let class = TextClass::LabelScroll;
+            let rect = Rect::new(self.rect().pos, self.text_size);
             draw.with_clip_region(self.rect(), self.view_offset, |mut draw| {
                 if self.selection.is_empty() {
-                    draw.text(self.rect(), &self.text, class);
+                    draw.text(rect, &self.text, class);
                 } else {
                     // TODO(opt): we could cache the selection rectangles here to make
                     // drawing more efficient (self.text.highlight_lines(range) output).
                     // The same applies to the edit marker below.
                     draw.text_selected(
-                        self.rect(),
+                        rect,
                         &self.text,
                         self.selection.range(),
                         class,
@@ -72,7 +73,7 @@ impl_scope! {
                 core: Default::default(),
                 view_offset: Default::default(),
                 text: Text::new(text),
-                bounding_corner: Vec2::ZERO,
+                text_size: Size::ZERO,
                 selection: SelectionHelper::new(0, 0),
                 input_handler: Default::default(),
             }
@@ -225,9 +226,9 @@ impl_scope! {
         }
 
         fn max_scroll_offset(&self) -> Offset {
-            let bounds = Vec2::from(self.text.env().bounds);
-            let max_offset = Offset::conv_ceil(self.bounding_corner - bounds);
-            max_offset.max(Offset::ZERO)
+            let text_size = Offset::conv(self.text_size);
+            let self_size = Offset::conv(self.rect().size);
+            (text_size - self_size).max(Offset::ZERO)
         }
 
         fn scroll_offset(&self) -> Offset {

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -17,7 +17,7 @@ use std::f32::consts::PI;
 use std::time::Duration;
 
 use kas::draw::{color, Draw, DrawIface, DrawRounded, PassType};
-use kas::geom::{Offset, Quad, Vec2};
+use kas::geom::{Offset, Quad, Rect, Vec2};
 use kas::prelude::*;
 use kas::shell::draw::DrawPipe;
 use kas::text::util::set_text_and_prepare;
@@ -27,8 +27,8 @@ impl_scope! {
     #[widget]
     struct Clock {
         core: widget_core!(),
-        date_rect: Quad,
-        time_rect: Quad,
+        date_rect: Rect,
+        time_rect: Rect,
         now: DateTime<Local>,
         date: Text<String>,
         time: Text<String>,
@@ -50,21 +50,19 @@ impl_scope! {
             let pos = rect.pos + excess / 2;
             self.core.rect = Rect { pos, size };
 
-            let size: Vec2 = size.cast();
-            let text_height = size.1 / 3.0;
-            let text_size = Vec2(size.0, text_height);
+            let text_height = size.1 / 3;
+            let text_size = Size(size.0, text_height);
 
             let mut env = self.date.env();
-            env.dpem = text_height * 0.4;
-            env.bounds = text_size.into();
+            env.dpem = text_height as f32 * 0.4;
+            env.bounds = text_size.cast();
             self.date.update_env(env);
-            env.dpem = text_height * 0.5;
+            env.dpem = text_height as f32 * 0.5;
             self.time.update_env(env);
 
-            let pos: Vec2 = pos.cast();
-            let y_mid = pos.0 + size.1 * 0.5;
-            self.date_rect = Quad::from_pos_and_size(Vec2(pos.0, y_mid - text_height), text_size);
-            self.time_rect = Quad::from_pos_and_size(Vec2(pos.0, y_mid), text_size);
+            let y_mid = pos.0 + size.1 / 2;
+            self.date_rect = Rect::new(Coord(pos.0, y_mid - text_height), text_size);
+            self.time_rect = Rect::new(Coord(pos.0, y_mid), text_size);
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
@@ -153,8 +151,8 @@ impl_scope! {
             let time = Text::new_env(env, "00:00:00".into());
             Clock {
                 core: Default::default(),
-                date_rect: Quad::NAN,
-                time_rect: Quad::NAN,
+                date_rect: Rect::ZERO,
+                time_rect: Rect::ZERO,
                 now: Local::now(),
                 date,
                 time,


### PR DESCRIPTION
Fixes text clamping for scrolled text (`ScrollLabel`, `EditField`) broken in #336.

Add [dark-light](https://crates.io/crates/dark-light) as an optional dependency to automatically use dark mode.