### PR TITLE
Derive with children

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -117,6 +117,12 @@ pub trait WidgetChildren: WidgetCore {
     }
 }
 
+/// Marker trait indicating that a widget has a fixed number of children
+#[autoimpl(for<T: trait + ?Sized> &'_ mut T, Box<T>)]
+pub trait WidgetChildrenConst: WidgetChildren {
+    const NUM_CHILDREN: usize;
+}
+
 /// Positioning and drawing routines for [`Widget`]s
 ///
 /// This trait is related to [`Widget`], but may be used independently.

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -38,16 +38,12 @@ mod kw {
 #[derive(Debug)]
 pub struct Tree(Layout);
 impl Tree {
-    /// If extra fields are needed for storage, return these: `(fields_ty, fields_init)`
+    /// Return extra fields needed for storage (may be empty)
     /// (e.g. `({ layout_frame: FrameStorage, }, { layout_frame: Default::default()), }`).
-    pub fn storage_fields(&self, children: &mut Vec<Toks>) -> Option<(Toks, Toks)> {
+    pub fn storage_fields(&self, children: &mut Vec<Toks>) -> (Toks, Toks) {
         let (mut ty_toks, mut def_toks) = (Toks::new(), Toks::new());
         self.0.append_fields(&mut ty_toks, &mut def_toks, children);
-        if ty_toks.is_empty() && def_toks.is_empty() {
-            None
-        } else {
-            Some((ty_toks, def_toks))
-        }
+        (ty_toks, def_toks)
     }
 
     pub fn generate(&self, core: &Member) -> Result<Toks> {

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -192,7 +192,7 @@ impl_scope! {
         derive = self.inner;
     }]
     pub struct EditBox<G: EditGuard = ()> {
-        #[widget] inner: EditField<G>,
+        inner: EditField<G>,
         #[widget] bar: ScrollBar<kas::dir::Down>,
         frame_rect: Rect,
         frame_offset: Offset,
@@ -267,12 +267,17 @@ impl_scope! {
     }
 
     impl Widget for Self {
+        // TODO: we cannot allow handle_event with derive mode. (Not strictly true,
+        // so long as it does forward events.)
+        // We *can* allow handle_message, handle_scroll and maybe handle_unused,
+        // but these are only useful when a non-derived child receives an event. Confusing?
         fn handle_message(&mut self, mgr: &mut EventMgr<'_>, _: usize) {
             if let Some(ScrollMsg(y)) = mgr.try_pop_msg() {
                 self.inner.set_scroll_offset(mgr, Offset(self.inner.view_offset.0, y));
             }
         }
 
+        // TODO: handle_scroll should not be allowed with derive, unless it is called on self after handle_event... but that case is still dodgy (as is the case with all handlers).
         fn handle_scroll(&mut self, mgr: &mut EventMgr<'_>, _: Scroll) {
             self.update_scroll_bar(mgr);
         }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -188,11 +188,13 @@ impl_scope! {
     /// [`Self::with_multi_line`] and [`Self::with_class`] can be used to change this.
     #[autoimpl(Deref, DerefMut, HasStr, HasString using self.inner)]
     #[derive(Clone, Default, Debug)]
-    #[widget]
+    #[widget {
+        derive = self.inner;
+    }]
     pub struct EditBox<G: EditGuard = ()> {
-        core: widget_core!(),
         #[widget] inner: EditField<G>,
         #[widget] bar: ScrollBar<kas::dir::Down>,
+        frame_rect: Rect,
         frame_offset: Offset,
         frame_size: Size,
         inner_margin: i32,
@@ -220,7 +222,7 @@ impl_scope! {
         }
 
         fn set_rect(&mut self, mgr: &mut ConfigMgr, mut rect: Rect, hints: AlignHints) {
-            self.core.rect = rect;
+            self.frame_rect = rect;
             rect.pos += self.frame_offset;
             rect.size -= self.frame_size;
             if self.multi_line() {
@@ -236,7 +238,7 @@ impl_scope! {
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
-            if !self.rect().contains(coord) {
+            if !self.frame_rect.contains(coord) {
                 return None;
             }
 
@@ -259,7 +261,7 @@ impl_scope! {
             } else {
                 Background::Default
             };
-            draw.frame(self.rect(), FrameStyle::EditBox, bg);
+            draw.frame(self.frame_rect, FrameStyle::EditBox, bg);
             self.inner.draw(draw);
         }
     }
@@ -313,9 +315,9 @@ impl EditBox<()> {
     #[inline]
     pub fn new<S: ToString>(text: S) -> Self {
         EditBox {
-            core: Default::default(),
             inner: EditField::new(text),
             bar: ScrollBar::new(),
+            frame_rect: Rect::ZERO,
             frame_offset: Offset::ZERO,
             frame_size: Size::ZERO,
             inner_margin: 0,
@@ -339,9 +341,9 @@ impl EditBox<()> {
     #[must_use]
     pub fn with_guard<G: EditGuard>(self, guard: G) -> EditBox<G> {
         EditBox {
-            core: self.core,
             inner: self.inner.with_guard(guard),
             bar: self.bar,
+            frame_rect: self.frame_rect,
             frame_offset: self.frame_offset,
             frame_size: self.frame_size,
             inner_margin: self.inner_margin,


### PR DESCRIPTION
An alternative explored while writing #342: extend derive mode, allowing child widgets with derive.

(Or, as an alternative to this, let the wrapping widget keep its own `id` but still forward events from `handle_event` to the inner widget.)

Problem with both of these approaches: when should `handle_scroll` get called?

-   If `handle_scroll` gets called after `handle_event` on self, then the method
    call must also be forwarded, which is a problem for `EditBox` (which needs to react to the inner `EditField` scrolling).
-   If not, and the inner `handle_event` causes a scroll, then `handle_scroll`
    would be called on the outer widget only if the inner widget was the
    direct event target. Workaround: the forwarding of `handle_event` must
    call `handle_scroll` itself? Possible, but over-complex.

Conclusion: neither of these approaches should be used.