### PR TITLE
Provide align hints to size_rules

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -18,7 +18,7 @@ use kas_macros::autoimpl;
 #[allow(unused)]
 use crate::event::EventState;
 #[allow(unused)]
-use crate::layout::{self, AutoLayout};
+use crate::layout::{self, AlignPair, AutoLayout};
 #[allow(unused)]
 use crate::TkAction;
 #[allow(unused)]

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -9,7 +9,7 @@ use std::fmt;
 
 use crate::event::{ConfigMgr, Event, EventMgr, Response, Scroll};
 use crate::geom::{Coord, Offset, Rect};
-use crate::layout::{AlignHints, AxisInfo, SizeRules};
+use crate::layout::{AxisInfo, SizeRules};
 use crate::theme::{DrawMgr, SizeMgr};
 use crate::util::IdentifyWidget;
 use crate::WidgetId;
@@ -187,13 +187,12 @@ pub trait Layout {
     /// outside of its assigned `rect` and to not function as normal.
     ///
     /// The assigned `rect` may be larger than the widget's size requirements,
-    /// regardless of the [`Stretch`] policy used. The [`AlignHints`] should be
-    /// used to align content such as text within this space, and also content
-    /// such as a button (which could, but does not need to, stretch).
-    ///
-    /// The [`AlignHints`] are usually passed down to children, though there are
-    /// some exceptions: a `Button` always centers content; a `ScrollRegion`
-    /// isolates the inside from outside influence over layout.
+    /// regardless of the [`Stretch`] policy used. If the widget should never
+    /// stretch, it must align itself.
+    /// Example: the `CheckBox` widget uses an [`AlignPair`] (set from
+    /// `size_rules`'s [`AxisInfo`]) and uses [`ConfigMgr::align_feature`].
+    /// Another example: `Label` uses a `Text` object which handles alignment
+    /// internally.
     ///
     /// Default implementation:
     ///
@@ -205,7 +204,7 @@ pub trait Layout {
     /// is used, also calls `<Self as AutoLayout>::set_rect`.
     ///
     /// [`Stretch`]: crate::layout::Stretch
-    fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints);
+    fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect);
 
     /// Translate a coordinate to a [`WidgetId`]
     ///
@@ -348,14 +347,14 @@ pub trait Layout {
 ///     }
 ///
 ///     impl Layout for Self {
-///         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+///         fn size_rules(&mut self, size_mgr: SizeMgr, mut axis: AxisInfo) -> SizeRules {
+///             axis.set_default_align_hv(Align::Default, Align::Center);
 ///             size_mgr.text_rules(&mut self.label, self.class, axis)
 ///         }
 ///
-///         fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+///         fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
 ///             self.core.rect = rect;
-///             let align = align.unwrap_or(Align::Default, Align::Center);
-///             mgr.text_set_size(&mut self.label, self.class, rect.size, align);
+///             mgr.text_set_size(&mut self.label, self.class, rect.size, None);
 ///         }
 ///
 ///         fn draw(&mut self, mut draw: DrawMgr) {

--- a/crates/kas-core/src/event/manager/config_mgr.rs
+++ b/crates/kas-core/src/event/manager/config_mgr.rs
@@ -9,7 +9,7 @@ use super::Pending;
 use crate::draw::DrawShared;
 use crate::event::EventState;
 use crate::geom::{Rect, Size};
-use crate::layout::{Align, AlignHints};
+use crate::layout::{AlignHints, AlignPair};
 use crate::text::TextApi;
 use crate::theme::{Feature, SizeMgr, TextClass, ThemeSize};
 use crate::{TkAction, Widget, WidgetExt, WidgetId};
@@ -109,15 +109,18 @@ impl<'a> ConfigMgr<'a> {
 
     /// Prepare a text object
     ///
-    /// This sets the text's font, font size, wrapping and alignment and
-    /// performs text preparation necessary before display.
+    /// This sets the text's font, font size, wrapping and optionally alignment,
+    /// then performs the text preparation necessary before display.
+    ///
+    /// Note: setting alignment here is not necessary when the default alignment
+    /// is desired or when [`SizeMgr::text_rules`] is used.
     #[inline]
     pub fn text_set_size(
         &self,
         text: &mut dyn TextApi,
         class: TextClass,
         size: Size,
-        align: (Align, Align),
+        align: Option<AlignPair>,
     ) {
         self.sh.text_set_size(text, class, size, align)
     }

--- a/crates/kas-core/src/event/manager/config_mgr.rs
+++ b/crates/kas-core/src/event/manager/config_mgr.rs
@@ -9,7 +9,7 @@ use super::Pending;
 use crate::draw::DrawShared;
 use crate::event::EventState;
 use crate::geom::{Rect, Size};
-use crate::layout::{AlignHints, AlignPair};
+use crate::layout::AlignPair;
 use crate::text::TextApi;
 use crate::theme::{Feature, SizeMgr, TextClass, ThemeSize};
 use crate::{TkAction, Widget, WidgetExt, WidgetId};
@@ -103,8 +103,8 @@ impl<'a> ConfigMgr<'a> {
     /// In case the input `rect` is larger than desired on either axis, it is
     /// reduced in size and offset within the original `rect` as is preferred.
     #[inline]
-    pub fn align_feature(&self, feature: Feature, rect: Rect, hints: AlignHints) -> Rect {
-        self.sh.align_feature(feature, rect, hints)
+    pub fn align_feature(&self, feature: Feature, rect: Rect, align: AlignPair) -> Rect {
+        self.sh.align_feature(feature, rect, align)
     }
 
     /// Prepare a text object

--- a/crates/kas-core/src/label.rs
+++ b/crates/kas-core/src/label.rs
@@ -53,7 +53,7 @@ impl_scope! {
         fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
             let align = align.unwrap_or(Align::Default, Align::Center);
-            mgr.text_set_size(&mut self.label, Self::CLASS, rect.size, align);
+            mgr.text_set_size(&mut self.label, Self::CLASS, rect.size, Some(align.into()));
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {

--- a/crates/kas-core/src/label.rs
+++ b/crates/kas-core/src/label.rs
@@ -11,7 +11,7 @@
 use crate::class::HasStr;
 use crate::event::ConfigMgr;
 use crate::geom::Rect;
-use crate::layout::{Align, AlignHints, AxisInfo, SizeRules};
+use crate::layout::{Align, AxisInfo, SizeRules};
 use crate::text::{Text, TextApi};
 use crate::theme::{DrawMgr, SizeMgr, TextClass};
 use crate::{Layout, WidgetCore};
@@ -46,14 +46,14 @@ impl_scope! {
 
     impl Layout for Self {
         #[inline]
-        fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+        fn size_rules(&mut self, size_mgr: SizeMgr, mut axis: AxisInfo) -> SizeRules {
+            axis.set_default_align_hv(Align::Default, Align::Center);
             size_mgr.text_rules(&mut self.label, Self::CLASS, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
-            let align = align.unwrap_or(Align::Default, Align::Center);
-            mgr.text_set_size(&mut self.label, Self::CLASS, rect.size, Some(align.into()));
+            mgr.text_set_size(&mut self.label, Self::CLASS, rect.size, None);
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {

--- a/crates/kas-core/src/layout/align.rs
+++ b/crates/kas-core/src/layout/align.rs
@@ -7,6 +7,7 @@
 
 #[allow(unused)]
 use super::Stretch; // for doc-links
+use crate::dir::Directional;
 use crate::geom::{Rect, Size};
 
 pub use crate::text::Align;
@@ -29,7 +30,7 @@ pub use crate::text::Align;
 ///     .aligned_rect(pref_size, rect);
 /// // self.core.rect = rect;
 /// ```
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct AlignHints {
     pub horiz: Option<Align>,
     pub vert: Option<Align>,
@@ -48,6 +49,24 @@ impl AlignHints {
     /// Construct with optional horiz. and vert. alignment
     pub const fn new(horiz: Option<Align>, vert: Option<Align>) -> Self {
         Self { horiz, vert }
+    }
+
+    /// Take horizontal/vertical component
+    #[inline]
+    pub fn extract(self, dir: impl Directional) -> Option<Align> {
+        match dir.is_vertical() {
+            false => self.horiz,
+            true => self.vert,
+        }
+    }
+
+    /// Set one component of self, based on a direction
+    #[inline]
+    pub fn set_component<D: Directional>(&mut self, dir: D, align: Option<Align>) {
+        match dir.is_vertical() {
+            false => self.horiz = align,
+            true => self.vert = align,
+        }
     }
 
     /// Combine two hints (first takes priority)

--- a/crates/kas-core/src/layout/grid_solver.rs
+++ b/crates/kas-core/src/layout/grid_solver.rs
@@ -7,7 +7,7 @@
 
 use std::marker::PhantomData;
 
-use super::{AlignHints, AxisInfo, SizeRules};
+use super::{AxisInfo, SizeRules};
 use super::{GridStorage, RowTemp, RulesSetter, RulesSolver};
 use crate::cast::{Cast, Conv};
 use crate::geom::{Coord, Offset, Rect, Size};
@@ -270,9 +270,8 @@ impl<CT: RowTemp, RT: RowTemp, S: GridStorage> GridSetter<CT, RT, S> {
     ///
     /// -   `rect`: the [`Rect`] within which to position children
     /// -   `dim`: grid dimensions
-    /// -   `align`: alignment hints
     /// -   `storage`: access to the solver's storage
-    pub fn new(rect: Rect, dim: GridDimensions, _: AlignHints, storage: &mut S) -> Self {
+    pub fn new(rect: Rect, dim: GridDimensions, storage: &mut S) -> Self {
         let (cols, rows) = (dim.cols.cast(), dim.rows.cast());
         let mut w_offsets = CT::default();
         w_offsets.set_len(cols);

--- a/crates/kas-core/src/layout/grid_solver.rs
+++ b/crates/kas-core/src/layout/grid_solver.rs
@@ -137,41 +137,41 @@ where
     fn for_child<CR: FnOnce(AxisInfo) -> SizeRules>(
         &mut self,
         storage: &mut Self::Storage,
-        child_info: Self::ChildInfo,
+        info: Self::ChildInfo,
         child_rules: CR,
     ) {
         if self.axis.has_fixed {
             if self.axis.is_horizontal() {
-                self.axis.other_axis = ((child_info.row + 1)..child_info.row_end)
-                    .fold(storage.heights()[usize::conv(child_info.row)], |h, i| {
+                self.axis.other_axis = ((info.row + 1)..info.row_end)
+                    .fold(storage.heights()[usize::conv(info.row)], |h, i| {
                         h + storage.heights()[usize::conv(i)]
                     });
             } else {
-                self.axis.other_axis = ((child_info.col + 1)..child_info.col_end)
-                    .fold(storage.widths()[usize::conv(child_info.col)], |w, i| {
+                self.axis.other_axis = ((info.col + 1)..info.col_end)
+                    .fold(storage.widths()[usize::conv(info.col)], |w, i| {
                         w + storage.widths()[usize::conv(i)]
                     });
             }
         }
         let child_rules = child_rules(self.axis);
         if self.axis.is_horizontal() {
-            if child_info.col_end > child_info.col + 1 {
+            if info.col_end > info.col + 1 {
                 let span = &mut self.col_spans.as_mut()[self.next_col_span];
                 span.0.max_with(child_rules);
-                span.1 = child_info.col;
-                span.2 = child_info.col_end;
+                span.1 = info.col;
+                span.2 = info.col_end;
                 self.next_col_span += 1;
             } else {
-                storage.width_rules()[usize::conv(child_info.col)].max_with(child_rules);
+                storage.width_rules()[usize::conv(info.col)].max_with(child_rules);
             }
-        } else if child_info.row_end > child_info.row + 1 {
+        } else if info.row_end > info.row + 1 {
             let span = &mut self.row_spans.as_mut()[self.next_row_span];
             span.0.max_with(child_rules);
-            span.1 = child_info.row;
-            span.2 = child_info.row_end;
+            span.1 = info.row;
+            span.2 = info.row_end;
             self.next_row_span += 1;
         } else {
-            storage.height_rules()[usize::conv(child_info.row)].max_with(child_rules);
+            storage.height_rules()[usize::conv(info.row)].max_with(child_rules);
         };
     }
 
@@ -364,7 +364,7 @@ impl<CT: RowTemp, RT: RowTemp, S: GridStorage> RulesSetter for GridSetter<CT, RT
         Rect { pos, size }
     }
 
-    fn maximal_rect_of(&mut self, _storage: &mut Self::Storage, _index: Self::ChildInfo) -> Rect {
+    fn maximal_rect_of(&mut self, _: &mut Self::Storage, _: Self::ChildInfo) -> Rect {
         unimplemented!()
     }
 }

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -87,6 +87,13 @@ impl AxisInfo {
         }
     }
 
+    /// Construct a copy using the given alignment hints
+    #[inline]
+    pub fn with_align_hints(mut self, hints: AlignHints) -> Self {
+        self.align = hints.extract(self);
+        self
+    }
+
     /// True if the current axis is vertical
     #[inline]
     pub fn is_vertical(self) -> bool {
@@ -103,6 +110,55 @@ impl AxisInfo {
     #[inline]
     pub fn align(self) -> Option<Align> {
         self.align
+    }
+
+    /// Set align parameter
+    #[inline]
+    pub fn set_align(&mut self, align: Option<Align>) {
+        self.align = align;
+    }
+
+    /// Set default alignment
+    ///
+    /// If the optional alignment parameter is `None`, replace with `align`.
+    #[inline]
+    pub fn set_default_align(&mut self, align: Align) {
+        if self.align.is_none() {
+            self.align = Some(align);
+        }
+    }
+
+    /// Set default alignment
+    ///
+    /// If the optional alignment parameter is `None`, replace with either
+    /// `horiz` or `vert` depending on this axis' orientation.
+    #[inline]
+    pub fn set_default_align_hv(&mut self, horiz: Align, vert: Align) {
+        if self.align.is_none() {
+            if self.is_horizontal() {
+                self.align = Some(horiz);
+            } else {
+                self.align = Some(vert);
+            }
+        }
+    }
+
+    /// Get align parameter, defaulting to [`Align::Default`]
+    #[inline]
+    pub fn align_or_default(self) -> Align {
+        self.align.unwrap_or(Align::Default)
+    }
+
+    /// Get align parameter, defaulting to [`Align::Center`]
+    #[inline]
+    pub fn align_or_center(self) -> Align {
+        self.align.unwrap_or(Align::Center)
+    }
+
+    /// Get align parameter, defaulting to [`Align::Stretch`]
+    #[inline]
+    pub fn align_or_stretch(self) -> Align {
+        self.align.unwrap_or(Align::Stretch)
     }
 
     /// Size of other axis, if fixed

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -52,7 +52,7 @@ use crate::WidgetId;
 #[allow(unused)]
 use crate::Layout;
 
-pub use align::{Align, AlignHints, CompleteAlignment};
+pub use align::{Align, AlignHints, AlignPair};
 pub use grid_solver::{DefaultWithLen, GridChildInfo, GridDimensions, GridSetter, GridSolver};
 pub use row_solver::{RowPositionSolver, RowSetter, RowSolver};
 pub use single_solver::{SingleSetter, SingleSolver};

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -60,7 +60,7 @@ pub use size_rules::SizeRules;
 pub use size_types::*;
 pub use sizer::{solve_size_rules, RulesSetter, RulesSolver, SolveCache};
 pub use storage::*;
-pub use visitor::{FrameStorage, Visitor};
+pub use visitor::{FrameStorage, PackStorage, Visitor};
 
 /// Information on which axis is being resized
 ///
@@ -90,7 +90,7 @@ impl AxisInfo {
     /// Construct a copy using the given alignment hints
     #[inline]
     pub fn with_align_hints(mut self, hints: AlignHints) -> Self {
-        self.align = hints.extract(self);
+        self.align = hints.extract(self).or(self.align);
         self
     }
 

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -258,7 +258,7 @@ pub trait AutoLayout {
     ///
     /// The implementation does not assign to `self.core.rect`;
     /// [`Layout::set_rect`] should do so before calling this method.
-    fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints);
+    fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect);
 
     /// Translate a coordinate to a [`WidgetId`]
     ///

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -70,6 +70,7 @@ pub struct AxisInfo {
     vertical: bool,
     has_fixed: bool,
     other_axis: i32,
+    align: Option<Align>,
 }
 
 impl AxisInfo {
@@ -77,17 +78,18 @@ impl AxisInfo {
     ///
     /// This method is *usually* not required by user code.
     #[inline]
-    pub fn new(vertical: bool, fixed: Option<i32>) -> Self {
+    pub fn new(vertical: bool, fixed: Option<i32>, align: Option<Align>) -> Self {
         AxisInfo {
             vertical,
             has_fixed: fixed.is_some(),
             other_axis: fixed.unwrap_or(0),
+            align,
         }
     }
 
     /// True if the current axis is vertical
     #[inline]
-    pub fn is_vertical(&self) -> bool {
+    pub fn is_vertical(self) -> bool {
         self.vertical
     }
 
@@ -95,6 +97,12 @@ impl AxisInfo {
     #[inline]
     pub fn is_horizontal(self) -> bool {
         !self.vertical
+    }
+
+    /// Get align parameter
+    #[inline]
+    pub fn align(self) -> Option<Align> {
+        self.align
     }
 
     /// Size of other axis, if fixed
@@ -115,6 +123,12 @@ impl AxisInfo {
         } else {
             None
         }
+    }
+
+    /// Subtract `x` from size of other axis (if applicable)
+    #[inline]
+    pub fn sub_other(&mut self, x: i32) {
+        self.other_axis -= x;
     }
 }
 
@@ -203,4 +217,10 @@ pub trait AutoLayout {
     ///
     /// This functions identically to [`Layout::draw`].
     fn draw(&mut self, draw: DrawMgr);
+}
+
+#[cfg(test)]
+#[test]
+fn size() {
+    assert_eq!(std::mem::size_of::<AxisInfo>(), 8);
 }

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -8,7 +8,7 @@
 use std::marker::PhantomData;
 use std::ops::Range;
 
-use super::{AlignHints, AxisInfo, SizeRules};
+use super::{AxisInfo, SizeRules};
 use super::{RowStorage, RowTemp, RulesSetter, RulesSolver};
 use crate::dir::{Direction, Directional};
 use crate::geom::{Coord, Rect};
@@ -117,9 +117,8 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
     ///
     /// -   `rect`: the [`Rect`] within which to position children
     /// - `(direction, len)`: direction and number of items
-    /// -   `align`: alignment hints
     /// -   `storage`: access to the solver's storage
-    pub fn new(rect: Rect, (direction, len): (D, usize), _: AlignHints, storage: &mut S) -> Self {
+    pub fn new(rect: Rect, (direction, len): (D, usize), storage: &mut S) -> Self {
         let mut offsets = T::default();
         offsets.set_len(len);
         storage.set_dim(len);

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -147,8 +147,6 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RowSetter<D, T, S> {
     /// previous `RowSetter`. The user should optionally call `solve_range` on
     /// any ranges needing updating and finally call `update_offsets` before
     /// using this `RowSetter` to calculate child positions.
-    ///
-    /// It is also assumed that alignment is [`Align::Stretch`].
     pub fn new_unsolved(rect: Rect, (direction, len): (D, usize), storage: &mut S) -> Self {
         let mut offsets = T::default();
         offsets.set_len(len);

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -63,15 +63,16 @@ impl<S: RowStorage> RulesSolver for RowSolver<S> {
     fn for_child<CR: FnOnce(AxisInfo) -> SizeRules>(
         &mut self,
         storage: &mut Self::Storage,
-        child_info: Self::ChildInfo,
+        index: Self::ChildInfo,
         child_rules: CR,
     ) {
         if self.axis.has_fixed && self.axis_is_vertical {
-            self.axis.other_axis = storage.widths()[child_info];
+            self.axis.other_axis = storage.widths()[index];
         }
         let child_rules = child_rules(self.axis);
+
         if !self.axis_is_vertical {
-            storage.rules()[child_info] = child_rules;
+            storage.rules()[index] = child_rules;
             if let Some(rules) = self.rules {
                 if self.axis_is_reversed {
                     self.rules = Some(child_rules.appended(rules));

--- a/crates/kas-core/src/layout/size_types.rs
+++ b/crates/kas-core/src/layout/size_types.rs
@@ -184,15 +184,20 @@ impl From<Size> for Margins {
 
 /// Priority for stretching widgets beyond ideal size
 ///
-/// Space is allocated based on priority, with extra space (beyond the minimum)
-/// shared between widgets in the highest priority class.
+/// When more space is available than required to meet widgets' "ideal size",
+/// that extra space is allocated based on the `Stretch` priority: the widget(s)
+/// with the highest priority level represented are allocated extra space (the
+/// excess is evenly divided between these widgets).
+///
+/// Note that `Stretch` only affects how much space is *made available*, not
+/// how that space is used. By default, widgets expand to fill all space made
+/// available to them; any other behaviour requires alignment.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Stretch {
     /// Prefer no stretching
     ///
-    /// This does not prevent stretching. In particular, if the widget is in a
-    /// column or row with a larger widget, that larger width/height will be
-    /// provided.
+    /// This is the default value and indicates that stretching is undesirable,
+    /// but does not prevent it.
     None,
     /// Fill unwanted space
     ///

--- a/crates/kas-core/src/layout/size_types.rs
+++ b/crates/kas-core/src/layout/size_types.rs
@@ -5,7 +5,7 @@
 
 //! Types used by size rules
 
-use super::{Align, AlignHints, AxisInfo, SizeRules};
+use super::{AlignPair, AxisInfo, SizeRules};
 use crate::cast::*;
 use crate::dir::Directional;
 use crate::geom::{Rect, Size, Vec2};
@@ -239,6 +239,8 @@ impl_scope! {
         ///
         /// If is `None`, max size is limited to ideal size.
         pub stretch: Stretch,
+        /// Alignment (set by `Self::size_rules`)
+        align: AlignPair,
     }
 }
 
@@ -255,13 +257,14 @@ impl PixmapScaling {
             .size
             .to_physical(scale_factor * self.ideal_factor)
             .extract(axis);
+        self.align.set_component(axis, axis.align_or_center());
         SizeRules::new(min, ideal, margins, self.stretch)
     }
 
     /// Constrains and aligns within `rect`
     ///
     /// The resulting size is then aligned using the `align` hints, defaulting to centered.
-    pub fn align_rect(&mut self, rect: Rect, align: AlignHints, scale_factor: f32) -> Rect {
+    pub fn align_rect(&mut self, rect: Rect, scale_factor: f32) -> Rect {
         let mut size = rect.size;
 
         if self.stretch == Stretch::None {
@@ -281,9 +284,7 @@ impl PixmapScaling {
             }
         }
 
-        align
-            .complete(Align::Center, Align::Center)
-            .aligned_rect(size, rect)
+        self.align.aligned_rect(size, rect)
     }
 }
 

--- a/crates/kas-core/src/layout/sizer.rs
+++ b/crates/kas-core/src/layout/sizer.rs
@@ -7,7 +7,7 @@
 
 use std::fmt;
 
-use super::{Align, AlignHints, AxisInfo, Margins, SizeRules};
+use super::{Align, AxisInfo, Margins, SizeRules};
 use crate::cast::Conv;
 use crate::event::ConfigMgr;
 use crate::geom::{Rect, Size};
@@ -221,7 +221,7 @@ impl SolveCache {
             rect.size.0 = width;
             rect.size.1 -= self.margins.sum_vert();
         }
-        widget.set_rect(mgr, rect, AlignHints::NONE);
+        widget.set_rect(mgr, rect);
 
         log::trace!(target: "kas_perf::layout", "apply_rect: {}μs", start.elapsed().as_micros());
         if print_heirarchy {

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -497,10 +497,7 @@ pub struct FrameStorage {
 impl FrameStorage {
     /// Calculate child's "other axis" size
     pub fn child_axis(&self, mut axis: AxisInfo) -> AxisInfo {
-        if let Some(mut other) = axis.other() {
-            other -= self.size.extract(axis.flipped());
-            axis = AxisInfo::new(axis.is_vertical(), Some(other));
-        }
+        axis.sub_other(self.size.extract(axis.flipped()));
         axis
     }
 

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -236,21 +236,19 @@ impl<'a> Visitor<'a> {
     }
 
     /// Apply a given `rect` to self
-    ///
-    /// Return the aligned rect.
     #[inline]
-    pub fn set_rect(mut self, mgr: &mut ConfigMgr, rect: Rect) -> Rect {
-        self.set_rect_(mgr, rect)
+    pub fn set_rect(mut self, mgr: &mut ConfigMgr, rect: Rect) {
+        self.set_rect_(mgr, rect);
     }
-    fn set_rect_(&mut self, mgr: &mut ConfigMgr, rect: Rect) -> Rect {
+    fn set_rect_(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
         match &mut self.layout {
             LayoutType::None => (),
             LayoutType::Component(component) => component.set_rect(mgr, rect),
             LayoutType::BoxComponent(layout) => layout.set_rect(mgr, rect),
             LayoutType::Single(child) => child.set_rect(mgr, rect),
             LayoutType::AlignSingle(child, _) => child.set_rect(mgr, rect),
-            LayoutType::AlignLayout(layout, _) => return layout.set_rect_(mgr, rect),
-            LayoutType::Margins(child, _, _) => return child.set_rect_(mgr, rect),
+            LayoutType::AlignLayout(layout, _) => layout.set_rect_(mgr, rect),
+            LayoutType::Margins(child, _, _) => child.set_rect_(mgr, rect),
             LayoutType::Frame(child, storage, _) | LayoutType::Button(child, storage, _) => {
                 storage.rect = rect;
                 let child_rect = Rect {
@@ -260,7 +258,6 @@ impl<'a> Visitor<'a> {
                 child.set_rect_(mgr, child_rect);
             }
         }
-        rect
     }
 
     /// Find a widget by coordinate

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -8,7 +8,7 @@
 // Methods have to take `&mut self`
 #![allow(clippy::wrong_self_convention)]
 
-use super::{Align, AlignHints, AxisInfo, SizeRules};
+use super::{AlignHints, AxisInfo, SizeRules};
 use super::{DynRowStorage, RowPositionSolver, RowSetter, RowSolver, RowStorage};
 use super::{GridChildInfo, GridDimensions, GridSetter, GridSolver, GridStorage};
 use super::{RulesSetter, RulesSolver};
@@ -237,7 +237,7 @@ impl<'a> Visitor<'a> {
     pub fn set_rect(mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) -> Rect {
         self.set_rect_(mgr, rect, align)
     }
-    fn set_rect_(&mut self, mgr: &mut ConfigMgr, mut rect: Rect, align: AlignHints) -> Rect {
+    fn set_rect_(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) -> Rect {
         match &mut self.layout {
             LayoutType::None => (),
             LayoutType::Component(component) => component.set_rect(mgr, rect, align),
@@ -261,9 +261,6 @@ impl<'a> Visitor<'a> {
                 child.set_rect_(mgr, child_rect, align);
             }
             LayoutType::Button(child, storage, _) => {
-                rect = align
-                    .complete(Align::Stretch, Align::Stretch)
-                    .aligned_rect(storage.ideal_size, rect);
                 storage.rect = rect;
                 let child_rect = Rect {
                     pos: rect.pos + storage.offset,
@@ -492,7 +489,6 @@ pub struct FrameStorage {
     pub size: Size,
     /// Offset of frame contents from parent position
     pub offset: Offset,
-    ideal_size: Size,
     // NOTE: potentially rect is redundant (e.g. with widget's rect) but if we
     // want an alternative as a generic solution then all draw methods must
     // calculate and pass the child's rect, which is probably worse.
@@ -520,7 +516,6 @@ impl FrameStorage {
         let (rules, offset, size) = frame_rules.surround(child_rules);
         self.offset.set_component(axis, offset);
         self.size.set_component(axis, size);
-        self.ideal_size.set_component(axis, rules.ideal_size());
         rules
     }
 }

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -25,8 +25,9 @@ use std::iter::ExactSizeIterator;
 /// This constitutes a "visitor" which iterates over each child widget. Layout
 /// algorithm details are implemented over this visitor.
 ///
-/// TODO: consider removal. This is currently used to implement the
-/// `layout = ..` property of `#[widget]`, but may not be the best approach.
+/// This is an internal API and may be subject to unexpected breaking changes.
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+#[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 pub struct Visitor<'a> {
     layout: LayoutType<'a>,
 }

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -19,7 +19,7 @@ pub use crate::event::{ConfigMgr, Event, EventMgr, EventState, Response};
 #[doc(no_inline)]
 pub use crate::geom::{Coord, Offset, Rect, Size};
 #[doc(no_inline)]
-pub use crate::layout::{Align, AlignHints, AxisInfo, SizeRules, Stretch};
+pub use crate::layout::{Align, AlignHints, AlignPair, AxisInfo, SizeRules, Stretch};
 #[doc(no_inline)]
 pub use crate::macros::{autoimpl, impl_default, impl_scope, impl_singleton, widget, widget_index};
 #[doc(no_inline)]

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -19,7 +19,7 @@ pub use crate::event::{ConfigMgr, Event, EventMgr, EventState, Response};
 #[doc(no_inline)]
 pub use crate::geom::{Coord, Offset, Rect, Size};
 #[doc(no_inline)]
-pub use crate::layout::{Align, AlignHints, AlignPair, AxisInfo, SizeRules, Stretch};
+pub use crate::layout::{Align, AlignPair, AxisInfo, SizeRules, Stretch};
 #[doc(no_inline)]
 pub use crate::macros::{autoimpl, impl_default, impl_scope, impl_singleton, widget, widget_index};
 #[doc(no_inline)]

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -8,7 +8,7 @@
 use crate::dir::Directional;
 use crate::event::{ConfigMgr, EventMgr};
 use crate::geom::{Coord, Rect, Size};
-use crate::layout::{self, AlignHints, AxisInfo, SizeRules};
+use crate::layout::{self, AxisInfo, SizeRules};
 use crate::theme::{DrawMgr, SizeMgr};
 use crate::{Layout, TkAction, Widget, WidgetExt, WidgetId, Window, WindowId};
 use kas_macros::{autoimpl, impl_scope};
@@ -35,9 +35,9 @@ impl_scope! {
         }
 
         #[inline]
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
-            self.w.set_rect(mgr, rect, align);
+            self.w.set_rect(mgr, rect);
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 use super::{Feature, FrameStyle, MarginStyle, TextClass};
 use crate::dir::Directional;
 use crate::geom::{Rect, Size};
-use crate::layout::{AlignHints, AlignPair, AxisInfo, FrameRules, Margins, SizeRules};
+use crate::layout::{AlignPair, AxisInfo, FrameRules, Margins, SizeRules};
 use crate::macros::autoimpl;
 use crate::text::TextApi;
 
@@ -221,7 +221,7 @@ pub trait ThemeSize {
     ///
     /// In case the input `rect` is larger than desired on either axis, it is
     /// reduced in size and offset within the original `rect` as is preferred.
-    fn align_feature(&self, feature: Feature, rect: Rect, hints: AlignHints) -> Rect;
+    fn align_feature(&self, feature: Feature, rect: Rect, align: AlignPair) -> Rect;
 
     /// Size of a frame around another element
     fn frame(&self, style: FrameStyle, axis_is_vertical: bool) -> FrameRules;

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -10,9 +10,9 @@ use std::ops::Deref;
 use super::{Feature, FrameStyle, MarginStyle, TextClass};
 use crate::dir::Directional;
 use crate::geom::{Rect, Size};
-use crate::layout::{AlignHints, AxisInfo, FrameRules, Margins, SizeRules};
+use crate::layout::{AlignHints, AlignPair, AxisInfo, FrameRules, Margins, SizeRules};
 use crate::macros::autoimpl;
-use crate::text::{Align, TextApi};
+use crate::text::TextApi;
 
 #[allow(unused)]
 use crate::text::TextApiExt;
@@ -178,8 +178,9 @@ impl<'a> SizeMgr<'a> {
     /// Widgets with editable text contents or internal scrolling enabled may
     /// wish to adjust the result.
     ///
-    /// Note: this method partially prepares the `text` object. It is still
-    /// required to call [`ConfigMgr::text_set_size`] for correct results.
+    /// Note: this method partially prepares the `text` object. It is not
+    /// required to call this method but it is required to call
+    /// [`ConfigMgr::text_set_size`] before text display for correct results.
     pub fn text_rules(
         &self,
         text: &mut dyn TextApi,
@@ -237,6 +238,6 @@ pub trait ThemeSize {
         text: &mut dyn TextApi,
         class: TextClass,
         size: Size,
-        align: (Align, Align),
+        align: Option<AlignPair>,
     );
 }

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -165,6 +165,9 @@ impl<'a> SizeMgr<'a> {
     /// The [`TextClass`] is used to select a font and controls whether line
     /// wrapping is enabled.
     ///
+    /// Alignment is set from [`AxisInfo::align_or_default`]. If other alignment
+    /// is desired, modify `axis` before calling this method.
+    ///
     /// Horizontal size without wrapping is simply the size the text.
     /// Horizontal size with wrapping is bounded to some width dependant on the
     /// theme, and may have non-zero [`Stretch`] depending on the size.

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -219,7 +219,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; A two-dimensional layout, supporting cell spans, defined via a list of cells (see _GridCell_ below).
 ///
 /// > _Float_ :\
-/// > &nbsp;&nbsp; _float_ `:` `[` ( _Layout_ `,`? ) * `]`\
+/// > &nbsp;&nbsp; `float` `:` `[` ( _Layout_ `,`? ) * `]`\
 /// > &nbsp;&nbsp; A stack of overlapping elements, top-most first.
 ///
 /// > _Align_ :\

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -224,7 +224,11 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 ///
 /// > _Align_ :\
 /// > &nbsp;&nbsp; `align` `(` _AlignType_ ( `,` _AlignType_ )? `)` `:` _Layout_\
-/// > &nbsp;&nbsp; Applies some alignment to a sub-layout, e.g. `align(top): self.foo`. Two-dimensional alignment is possible but must be horizontal first, e.g. `align(left, top): ..`
+/// > &nbsp;&nbsp; Applies some alignment to a sub-layout, e.g. `align(top): self.foo`. Two-dimensional alignment is possible but must be horizontal first, e.g. `align(left, top): ..`. Note: this does not constrain the size of the widget but merely adjusts content alignment; see also _Pack_.
+/// >
+/// > _Pack_ :\
+/// > &nbsp;&nbsp; `pack` `(` _AlignType_ ( `,` _AlignType_ )? `)` _Storage_? `:` _Layout_\
+/// > &nbsp;&nbsp; As `align`, this applies some alignment to content, but also restricts the size of that content to its ideal size (i.e. no stretching).
 /// >
 /// > _Frame_ :\
 /// > &nbsp;&nbsp; `frame` ( `(` _Expr_ `)` )? _Storage_? `:` _Layout_\

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -695,28 +695,22 @@ impl Layout {
             Layout::AlignSingle(..) | Layout::Margins(..) | Layout::Single(_) => (),
             Layout::Widget(stor, expr) => {
                 children.push(stor.to_token_stream());
-                stor.to_tokens(ty_toks);
-                ty_toks.append_all(quote! { : Box<dyn ::kas::Widget>, });
-                stor.to_tokens(def_toks);
-                def_toks.append_all(quote! { : Box::new(#expr), });
+                ty_toks.append_all(quote! { #stor: Box<dyn ::kas::Widget>, });
+                def_toks.append_all(quote! { #stor: Box::new(#expr), });
             }
             Layout::Frame(stor, layout, _) | Layout::Button(stor, layout, _) => {
-                stor.to_tokens(ty_toks);
-                ty_toks.append_all(quote! { : ::kas::layout::FrameStorage, });
-                stor.to_tokens(def_toks);
-                def_toks.append_all(quote! { : Default::default(), });
+                ty_toks.append_all(quote! { #stor: ::kas::layout::FrameStorage, });
+                def_toks.append_all(quote! { #stor: Default::default(), });
                 layout.append_fields(ty_toks, def_toks, children);
             }
             Layout::List(stor, _, vec) => {
-                stor.to_tokens(ty_toks);
-                stor.to_tokens(def_toks);
-                def_toks.append_all(quote! { : Default::default(), });
+                def_toks.append_all(quote! { #stor: Default::default(), });
 
                 let len = vec.len();
                 ty_toks.append_all(if len > 16 {
-                    quote! { : ::kas::layout::DynRowStorage, }
+                    quote! { #stor: ::kas::layout::DynRowStorage, }
                 } else {
-                    quote! { : ::kas::layout::FixedRowStorage<#len>, }
+                    quote! { #stor: ::kas::layout::FixedRowStorage<#len>, }
                 });
                 for item in vec {
                     item.append_fields(ty_toks, def_toks, children);
@@ -728,17 +722,14 @@ impl Layout {
                 }
             }
             Layout::Slice(stor, _, _) => {
-                stor.to_tokens(ty_toks);
-                ty_toks.append_all(quote! { : ::kas::layout::DynRowStorage, });
-                stor.to_tokens(def_toks);
-                def_toks.append_all(quote! { : Default::default(), });
+                ty_toks.append_all(quote! { #stor: ::kas::layout::DynRowStorage, });
+                def_toks.append_all(quote! { #stor: Default::default(), });
             }
             Layout::Grid(stor, dim, cells) => {
                 let (cols, rows) = (dim.cols as usize, dim.rows as usize);
-                stor.to_tokens(ty_toks);
-                ty_toks.append_all(quote! { : ::kas::layout::FixedGridStorage<#cols, #rows>, });
-                stor.to_tokens(def_toks);
-                def_toks.append_all(quote! { : Default::default(), });
+                ty_toks
+                    .append_all(quote! { #stor: ::kas::layout::FixedGridStorage<#cols, #rows>, });
+                def_toks.append_all(quote! { #stor: Default::default(), });
 
                 for (_info, layout) in cells {
                     layout.append_fields(ty_toks, def_toks, children);
@@ -746,10 +737,8 @@ impl Layout {
             }
             Layout::Label(stor, text) => {
                 children.push(stor.to_token_stream());
-                stor.to_tokens(ty_toks);
-                ty_toks.append_all(quote! { : ::kas::label::StrLabel, });
-                stor.to_tokens(def_toks);
-                def_toks.append_all(quote! { : ::kas::label::StrLabel::new(#text), });
+                ty_toks.append_all(quote! { #stor: ::kas::label::StrLabel, });
+                def_toks.append_all(quote! { #stor: ::kas::label::StrLabel::new(#text), });
             }
         }
     }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -311,9 +311,8 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 &mut self,
                 mgr: &mut ::kas::event::ConfigMgr,
                 rect: ::kas::geom::Rect,
-                align: ::kas::layout::AlignHints,
             ) {
-                self.#inner.set_rect(mgr, rect, align);
+                self.#inner.set_rect(mgr, rect);
             }
         };
         fn_find_id = quote! {
@@ -540,10 +539,9 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                         &mut self,
                         mgr: &mut ::kas::event::ConfigMgr,
                         rect: ::kas::geom::Rect,
-                        align: ::kas::layout::AlignHints,
                     ) {
                         use ::kas::{WidgetCore, layout};
-                        self.#core.rect = (#layout).set_rect(mgr, rect, align);
+                        self.#core.rect = (#layout).set_rect(mgr, rect);
                     }
 
                     fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
@@ -572,7 +570,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 }
             });
             set_rect = quote! {
-                <Self as ::kas::layout::AutoLayout>::set_rect(self, mgr, rect, align);
+                <Self as ::kas::layout::AutoLayout>::set_rect(self, mgr, rect);
             };
             find_id = quote! {
                 <Self as ::kas::layout::AutoLayout>::find_id(self, coord)
@@ -588,7 +586,6 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 &mut self,
                 mgr: &mut ::kas::event::ConfigMgr,
                 rect: ::kas::geom::Rect,
-                align: ::kas::layout::AlignHints,
             ) {
                 #set_rect
             }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -541,7 +541,8 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                         rect: ::kas::geom::Rect,
                     ) {
                         use ::kas::{WidgetCore, layout};
-                        self.#core.rect = (#layout).set_rect(mgr, rect);
+                        self.#core.rect = rect;
+                        (#layout).set_rect(mgr, rect);
                     }
 
                     fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -128,7 +128,7 @@ impl_scope! {
             self.scaling.size_rules(size_mgr, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             let scale_factor = mgr.size_mgr().scale_factor();
             self.core.rect = self.scaling.align_rect(rect, scale_factor);
             let size: (u32, u32) = self.core.rect.size.cast();

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -63,13 +63,13 @@ impl_scope! {
         /// Use [`Self::with_size`] or [`Self::with_scaling`] to set the initial size.
         #[inline]
         pub fn new(program: P) -> Self {
+            let mut scaling = PixmapScaling::default();
+            scaling.size = LogicalSize(128.0, 128.0);
+            scaling.stretch = Stretch::High;
+
             Canvas {
                 core: Default::default(),
-                scaling: PixmapScaling {
-                    size: LogicalSize(128.0, 128.0),
-                    stretch: Stretch::High,
-                    ..Default::default()
-                },
+                scaling,
                 pixmap: None,
                 image: None,
                 program,
@@ -128,9 +128,9 @@ impl_scope! {
             self.scaling.size_rules(size_mgr, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
             let scale_factor = mgr.size_mgr().scale_factor();
-            self.core.rect = self.scaling.align_rect(rect, align, scale_factor);
+            self.core.rect = self.scaling.align_rect(rect, scale_factor);
             let size: (u32, u32) = self.core.rect.size.cast();
 
             let pm_size = self.pixmap.as_ref().map(|pm| (pm.width(), pm.height()));

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -130,9 +130,9 @@ impl_scope! {
             self.scaling.size_rules(size_mgr, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
             let scale_factor = mgr.size_mgr().scale_factor();
-            self.core.rect = self.scaling.align_rect(rect, align, scale_factor);
+            self.core.rect = self.scaling.align_rect(rect, scale_factor);
             let size: (u32, u32) = self.core.rect.size.cast();
 
             let pm_size = self.pixmap.as_ref().map(|pm| (pm.width(), pm.height()));

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -130,7 +130,7 @@ impl_scope! {
             self.scaling.size_rules(size_mgr, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             let scale_factor = mgr.size_mgr().scale_factor();
             self.core.rect = self.scaling.align_rect(rect, scale_factor);
             let size: (u32, u32) = self.core.rect.size.cast();

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -14,9 +14,9 @@ use crate::anim::AnimState;
 use kas::cast::traits::*;
 use kas::dir::Directional;
 use kas::geom::{Rect, Size, Vec2};
-use kas::layout::{AlignHints, AlignPair, AxisInfo, FrameRules, Margins, SizeRules, Stretch};
+use kas::layout::{AlignPair, AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::macros::impl_scope;
-use kas::text::{fonts::FontId, Align, TextApi, TextApiExt};
+use kas::text::{fonts::FontId, TextApi, TextApiExt};
 use kas::theme::{Feature, FrameStyle, MarginStyle, MarkStyle, TextClass, ThemeSize};
 
 impl_scope! {
@@ -266,7 +266,7 @@ impl<D: 'static> ThemeSize for Window<D> {
         SizeRules::new(size.0, ideal_mul * size.0, (m, m), stretch)
     }
 
-    fn align_feature(&self, feature: Feature, rect: Rect, hints: AlignHints) -> Rect {
+    fn align_feature(&self, feature: Feature, rect: Rect, align: AlignPair) -> Rect {
         let mut ideal_size = rect.size;
         match feature {
             Feature::Separator => (), // has no direction so we cannot align
@@ -284,9 +284,7 @@ impl<D: 'static> ThemeSize for Window<D> {
                 ideal_size.set_component(dir.flipped(), self.dims.progress_bar.1);
             }
         }
-        hints
-            .complete(Align::Center, Align::Center)
-            .aligned_rect(ideal_size, rect)
+        align.aligned_rect(ideal_size, rect)
     }
 
     fn frame(&self, style: FrameStyle, _is_vert: bool) -> FrameRules {

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -330,6 +330,12 @@ impl<D: 'static> ThemeSize for Window<D> {
         // text. Unfortunately we don't know the desired alignment here.
         let wrap = class.multi_line();
         env.wrap = wrap;
+        let align = axis.align_or_default();
+        if axis.is_horizontal() {
+            env.align.0 = align;
+        } else {
+            env.align.1 = align;
+        }
         if let Some(size) = axis.size_other_if_fixed(true) {
             env.bounds.0 = size.cast();
         }
@@ -362,6 +368,9 @@ impl<D: 'static> ThemeSize for Window<D> {
             }
         } else {
             let bound: i32 = text.measure_height().expect("invalid font_id").cast_ceil();
+            // Reset env since measure_height adjusts vertical alignment:
+            text.set_env(env);
+
             let line_height = self.dims.dpem.cast_ceil();
             let min = bound.max(line_height);
             SizeRules::new(min, min, margins, Stretch::Filler)

--- a/crates/kas-theme/src/dim.rs
+++ b/crates/kas-theme/src/dim.rs
@@ -14,7 +14,7 @@ use crate::anim::AnimState;
 use kas::cast::traits::*;
 use kas::dir::Directional;
 use kas::geom::{Rect, Size, Vec2};
-use kas::layout::{AlignHints, AxisInfo, FrameRules, Margins, SizeRules, Stretch};
+use kas::layout::{AlignHints, AlignPair, AxisInfo, FrameRules, Margins, SizeRules, Stretch};
 use kas::macros::impl_scope;
 use kas::text::{fonts::FontId, Align, TextApi, TextApiExt};
 use kas::theme::{Feature, FrameStyle, MarginStyle, MarkStyle, TextClass, ThemeSize};
@@ -382,7 +382,7 @@ impl<D: 'static> ThemeSize for Window<D> {
         text: &mut dyn TextApi,
         class: TextClass,
         size: Size,
-        align: (Align, Align),
+        align: Option<AlignPair>,
     ) {
         let mut env = text.env();
         if let Some(font_id) = self.fonts.get(&class).cloned() {
@@ -390,7 +390,9 @@ impl<D: 'static> ThemeSize for Window<D> {
         }
         env.dpem = self.dims.dpem;
         env.wrap = class.multi_line();
-        env.align = align;
+        if let Some(align) = align {
+            env.align = align.into();
+        }
         env.bounds = size.cast();
         text.update_env(env).expect("invalid font_id");
     }

--- a/crates/kas-theme/src/simple_theme.rs
+++ b/crates/kas-theme/src/simple_theme.rs
@@ -490,7 +490,7 @@ where
                     true => Size(self.w.dims.mark / 2, self.w.dims.mark),
                     false => Size(self.w.dims.mark, self.w.dims.mark / 2),
                 };
-                let offset = Offset::conv(rect.size.clamped_sub(size) / 2);
+                let offset = Offset::conv((rect.size - size) / 2);
                 let q = Quad::conv(Rect::new(rect.pos + offset, size));
 
                 let (p1, p2, p3);

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -481,6 +481,8 @@ impl_scope! {
                 self.child_inter_margin = m.0.max(m.1).max(inner_margin.0).max(inner_margin.1).cast();
                 rules.multiply_with_margin(2, self.ideal_visible);
                 rules.set_stretch(rules.stretch().max(Stretch::High));
+            } else {
+                rules.set_stretch(rules.stretch().max(Stretch::Low));
             }
             let (rules, offset, size) = frame.surround(rules);
             self.frame_offset.set_component(axis, offset);

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -371,6 +371,8 @@ impl_scope! {
                             mgr.size_mgr(),
                             Some(self.child_size.0),
                             Some(self.child_size.1),
+                            self.align_hints.horiz,
+                            self.align_hints.vert,
                         );
                         w.key = Some(key);
                     } else {
@@ -460,7 +462,7 @@ impl_scope! {
                 }
                 size
             });
-            axis = AxisInfo::new(axis.is_vertical(), other);
+            axis = AxisInfo::new(axis.is_vertical(), other, axis.align());
 
             let mut rules = self.default_widget.size_rules(size_mgr.re(), axis);
             if axis.is_vertical() == self.direction.is_vertical() {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -8,7 +8,7 @@
 use super::{driver, Driver, PressPhase, SelectionError, SelectionMode, SelectionMsg};
 use kas::event::components::ScrollComponent;
 use kas::event::{Command, CursorIcon, Scroll};
-use kas::layout::solve_size_rules;
+use kas::layout::{solve_size_rules, AlignHints};
 use kas::model::ListData;
 #[allow(unused)]
 use kas::model::SharedData;
@@ -379,7 +379,7 @@ impl_scope! {
                         w.key = None; // disables drawing and clicking
                     }
                 }
-                w.widget.set_rect(mgr, solver.rect(i), self.align_hints);
+                w.widget.set_rect(mgr, solver.rect(i));
             }
             *mgr |= action;
             let dur = (Instant::now() - time).as_micros();
@@ -487,10 +487,11 @@ impl_scope! {
             let (rules, offset, size) = frame.surround(rules);
             self.frame_offset.set_component(axis, offset);
             self.frame_size.set_component(axis, size);
+            self.align_hints.set_component(axis, axis.align());
             rules
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
 
             let mut child_size = rect.size - self.frame_size;
@@ -509,7 +510,6 @@ impl_scope! {
             };
 
             self.child_size = child_size;
-            self.align_hints = align;
 
             let data_len = self.data.len();
             let avail_widgets = self.widgets.len();

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -8,7 +8,7 @@
 use super::{driver, Driver, PressPhase, SelectionError, SelectionMode, SelectionMsg};
 use kas::event::components::ScrollComponent;
 use kas::event::{Command, CursorIcon, Scroll};
-use kas::layout::solve_size_rules;
+use kas::layout::{solve_size_rules, AlignHints};
 use kas::model::MatrixData;
 #[allow(unused)]
 use kas::model::SharedData;
@@ -358,7 +358,7 @@ impl_scope! {
                             w.key = None; // disables drawing and clicking
                         }
                     }
-                    w.widget.set_rect(mgr, solver.rect(ci, ri), self.align_hints);
+                    w.widget.set_rect(mgr, solver.rect(ci, ri));
                 }
             }
             *mgr |= action;
@@ -468,17 +468,17 @@ impl_scope! {
             let (rules, offset, size) = frame.surround(rules);
             self.frame_offset.set_component(axis, offset);
             self.frame_size.set_component(axis, size);
+            self.align_hints.set_component(axis, axis.align());
             rules
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
 
             let avail = rect.size - self.frame_size;
             let child_size = Size(avail.0 / self.ideal_len.cols, avail.1 / self.ideal_len.rows)
                 .min(self.child_size_ideal).max(self.child_size_min);
             self.child_size = child_size;
-            self.align_hints = align;
 
             let (d_cols, d_rows) = self.data.len();
             let data_len = Size(d_cols.cast(), d_rows.cast());

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -351,6 +351,8 @@ impl_scope! {
                                 mgr.size_mgr(),
                                 Some(self.child_size.0),
                                 Some(self.child_size.1),
+                                self.align_hints.horiz,
+                                self.align_hints.vert,
                             );
                         } else {
                             w.key = None; // disables drawing and clicking
@@ -440,7 +442,7 @@ impl_scope! {
                     .min(self.child_size_ideal.extract(other_axis))
                     .max(self.child_size_min.extract(other_axis))
             });
-            axis = AxisInfo::new(axis.is_vertical(), other);
+            axis = AxisInfo::new(axis.is_vertical(), other, axis.align());
 
             let mut rules = self.default_widget.size_rules(size_mgr.re(), axis);
             self.child_size_min.set_component(axis, rules.min_size());

--- a/crates/kas-view/src/single_view.rs
+++ b/crates/kas-view/src/single_view.rs
@@ -106,6 +106,14 @@ impl_scope! {
         }
     }
 
+    impl Layout for Self {
+        fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            let mut rules = self.child.size_rules(size_mgr, axis);
+            rules.set_stretch(rules.stretch().max(Stretch::Low));
+            rules
+        }
+    }
+
     impl Widget for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             // We set data now, after child is configured

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -236,14 +236,6 @@ impl_scope! {
         }
     }
 
-    impl Layout for Self {
-        fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            let mut rules = kas::layout::AutoLayout::size_rules(self, size_mgr, axis);
-            rules.set_stretch(Stretch::Low);
-            rules
-        }
-    }
-
     impl Widget for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.add_accel_keys(self.id_ref(), &self.keys1);

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -23,6 +23,7 @@ impl_scope! {
     }]
     pub struct CheckBox {
         core: widget_core!(),
+        align: AlignPair,
         state: bool,
         editable: bool,
         last_change: Option<Instant>,
@@ -31,11 +32,12 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            self.align.set_component(axis, axis.align_or_center());
             size_mgr.feature(Feature::CheckBox, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
-            let rect = mgr.align_feature(Feature::CheckBox, rect, align);
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+            let rect = mgr.align_feature(Feature::CheckBox, rect, self.align);
             self.core.rect = rect;
         }
 
@@ -50,6 +52,7 @@ impl_scope! {
         pub fn new() -> Self {
             CheckBox {
                 core: Default::default(),
+                align: Default::default(),
                 state: false,
                 editable: true,
                 last_change: None,
@@ -68,6 +71,7 @@ impl_scope! {
         {
             CheckBox {
                 core: self.core,
+                align: self.align,
                 state: self.state,
                 editable: self.editable,
                 last_change: self.last_change,

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -36,7 +36,7 @@ impl_scope! {
             size_mgr.feature(Feature::CheckBox, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             let rect = mgr.align_feature(Feature::CheckBox, rect, self.align);
             self.core.rect = rect;
         }
@@ -191,8 +191,8 @@ impl_scope! {
     }
 
     impl Layout for Self {
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
-            <Self as kas::layout::AutoLayout>::set_rect(self, mgr, rect, align);
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
+            <Self as kas::layout::AutoLayout>::set_rect(self, mgr, rect);
             let dir = self.direction();
             shrink_to_text(&mut self.core.rect, dir, &self.label);
         }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -547,7 +547,7 @@ impl_scope! {
 
             self.core.rect = rect;
             let align = align.unwrap_or(Align::Default, valign);
-            mgr.text_set_size(&mut self.text, self.class, rect.size, align);
+            mgr.text_set_size(&mut self.text, self.class, rect.size, Some(align.into()));
             self.text_size = Vec2::from(self.text.bounding_box().unwrap().1).cast_ceil();
             self.view_offset = self.view_offset.min(self.max_scroll_offset());
         }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -207,10 +207,7 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, mgr: SizeMgr, mut axis: AxisInfo) -> SizeRules {
-            if let Some(mut other) = axis.other() {
-                other -= self.frame_size.extract(axis.flipped());
-                axis = AxisInfo::new(axis.is_vertical(), Some(other));
-            }
+            axis.sub_other(self.frame_size.extract(axis.flipped()));
 
             let mut rules = self.inner.size_rules(mgr.re(), axis);
             if axis.is_horizontal() && self.multi_line() {

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -223,7 +223,7 @@ impl_scope! {
             rules
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, mut rect: Rect, hints: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, mut rect: Rect) {
             self.core.rect = rect;
             rect.pos += self.frame_offset;
             rect.size -= self.frame_size;
@@ -232,10 +232,10 @@ impl_scope! {
                 let x1 = rect.pos.0 + rect.size.0;
                 let x0 = x1 - bar_width;
                 let bar_rect = Rect::new(Coord(x0, rect.pos.1), Size(bar_width, rect.size.1));
-                self.bar.set_rect(mgr, bar_rect, hints);
+                self.bar.set_rect(mgr, bar_rect);
                 rect.size.0 = (rect.size.0 - bar_width - self.inner_margin).max(0);
             }
-            self.inner.set_rect(mgr, rect, hints);
+            self.inner.set_rect(mgr, rect);
             self.update_scroll_bar(mgr);
         }
 
@@ -540,7 +540,7 @@ impl_scope! {
             SizeRules::new(min, ideal, margins, stretch)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
             mgr.text_set_size(&mut self.text, self.class, rect.size, Some(self.align));
             self.text_size = Vec2::from(self.text.bounding_box().unwrap().1).cast_ceil();

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -86,11 +86,11 @@ impl_scope! {
             solver.finish(&mut self.data)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
-            let mut setter = GridSetter::<Vec<_>, Vec<_>, _>::new(rect, self.dim, align, &mut self.data);
+            let mut setter = GridSetter::<Vec<_>, Vec<_>, _>::new(rect, self.dim, &mut self.data);
             for (info, child) in &mut self.widgets {
-                child.set_rect(mgr, setter.child_rect(&mut self.data, *info), align);
+                child.set_rect(mgr, setter.child_rect(&mut self.data, *info));
             }
         }
 

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -80,7 +80,7 @@ impl_scope! {
             SizeRules::EMPTY
         }
 
-        fn set_rect(&mut self, _: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, _: &mut ConfigMgr, rect: Rect) {
             self.track = rect;
         }
 

--- a/crates/kas-widgets/src/image.rs
+++ b/crates/kas-widgets/src/image.rs
@@ -154,9 +154,9 @@ impl_scope! {
             self.scaling.size_rules(size_mgr, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
             let scale_factor = mgr.size_mgr().scale_factor();
-            self.core.rect = self.scaling.align_rect(rect, align, scale_factor);
+            self.core.rect = self.scaling.align_rect(rect, scale_factor);
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {

--- a/crates/kas-widgets/src/image.rs
+++ b/crates/kas-widgets/src/image.rs
@@ -154,7 +154,7 @@ impl_scope! {
             self.scaling.size_rules(size_mgr, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             let scale_factor = mgr.size_mgr().scale_factor();
             self.core.rect = self.scaling.align_rect(rect, scale_factor);
         }

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -104,14 +104,14 @@ impl_scope! {
 
     impl Layout for Self {
         #[inline]
-        fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+        fn size_rules(&mut self, size_mgr: SizeMgr, mut axis: AxisInfo) -> SizeRules {
+            axis.set_default_align_hv(Align::Default, Align::Center);
             size_mgr.text_rules(&mut self.label, self.class, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
-            let align = align.unwrap_or(Align::Default, Align::Center);
-            mgr.text_set_size(&mut self.label, self.class, rect.size, Some(align.into()));
+            mgr.text_set_size(&mut self.label, self.class, rect.size, None);
         }
 
         #[cfg(feature = "min_spec")]

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -111,7 +111,7 @@ impl_scope! {
         fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
             let align = align.unwrap_or(Align::Default, Align::Center);
-            mgr.text_set_size(&mut self.label, self.class, rect.size, align);
+            mgr.text_set_size(&mut self.label, self.class, rect.size, Some(align.into()));
         }
 
         #[cfg(feature = "min_spec")]

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -73,10 +73,11 @@ impl_scope! {
     }
 
     impl Layout for Self {
-        fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+        fn size_rules(&mut self, mgr: SizeMgr, mut axis: AxisInfo) -> SizeRules {
             // Unusual behaviour: children's SizeRules are padded with a frame,
             // but the frame does not adjust the children's rects.
 
+            axis.set_default_align(Align::Center);
             let dim = (self.direction, self.widgets.len());
             let mut solver = RowSolver::new(axis, dim, &mut self.layout_store);
             let frame_rules = mgr.frame(FrameStyle::MenuEntry, axis);
@@ -89,13 +90,13 @@ impl_scope! {
             solver.finish(&mut self.layout_store)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
             let dim = (self.direction, self.widgets.len());
-            let mut setter = RowSetter::<D, Vec<i32>, _>::new(rect, dim, align, &mut self.layout_store);
+            let mut setter = RowSetter::<D, Vec<i32>, _>::new(rect, dim, &mut self.layout_store);
 
             for (n, child) in self.widgets.iter_mut().enumerate() {
-                child.set_rect(mgr, setter.child_rect(&mut self.layout_store, n), AlignHints::CENTER);
+                child.set_rect(mgr, setter.child_rect(&mut self.layout_store, n));
             }
         }
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -335,10 +335,10 @@ impl_scope! {
             solver.finish(store)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
             let store = &mut self.store;
-            let mut setter = layout::GridSetter::<Vec<_>, Vec<_>, _>::new(rect, self.dim, align, store);
+            let mut setter = layout::GridSetter::<Vec<_>, Vec<_>, _>::new(rect, self.dim, store);
 
             // Assumption: frame inner margin is at least as large as content margins
             let child_rules = SizeRules::EMPTY;
@@ -362,28 +362,28 @@ impl_scope! {
                 let row = u32::conv(row);
                 let child_rect = setter.child_rect(store, menu_view_row_info(row));
                 // Note: we are required to call child.set_rect even if sub_items are used
-                child.set_rect(mgr, child_rect, align);
+                child.set_rect(mgr, child_rect);
 
                 if let Some(items) = child.sub_items() {
                     if let Some(w) = items.toggle {
                         let info = layout::GridChildInfo::new(0, row);
-                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)), align);
+                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)));
                     }
                     if let Some(w) = items.icon {
                         let info = layout::GridChildInfo::new(1, row);
-                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)), align);
+                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)));
                     }
                     if let Some(w) =  items.label {
                         let info = layout::GridChildInfo::new(2, row);
-                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)), align);
+                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)));
                     }
                     if let Some(w) = items.label2 {
                         let info = layout::GridChildInfo::new(3, row);
-                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)), align);
+                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)));
                     }
                     if let Some(w) = items.submenu {
                         let info = layout::GridChildInfo::new(4, row);
-                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)), align);
+                        w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)));
                     }
                 }
             }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -286,10 +286,7 @@ impl_scope! {
                 .surround(child_rules);
 
             let child_rules = |mgr: SizeMgr, w: &mut dyn Layout, mut axis: AxisInfo| {
-                if let Some(mut other) = axis.other() {
-                    other -= frame_size_flipped;
-                    axis = AxisInfo::new(axis.is_vertical(), Some(other));
-                }
+                axis.sub_other(frame_size_flipped);
                 let rules = w.size_rules(mgr, axis);
                 frame_rules.surround(rules).0
             };

--- a/crates/kas-widgets/src/progress.rs
+++ b/crates/kas-widgets/src/progress.rs
@@ -91,7 +91,7 @@ impl_scope! {
             size_mgr.feature(Feature::ProgressBar(self.direction()), axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             let rect = mgr.align_feature(Feature::ProgressBar(self.direction()), rect, self.align);
             self.core.rect = rect;
         }

--- a/crates/kas-widgets/src/progress.rs
+++ b/crates/kas-widgets/src/progress.rs
@@ -18,6 +18,7 @@ impl_scope! {
     #[widget]
     pub struct ProgressBar<D: Directional> {
         core: widget_core!(),
+        align: AlignPair,
         direction: D,
         value: f32,
     }
@@ -40,6 +41,7 @@ impl_scope! {
         pub fn new_with_direction(direction: D) -> Self {
             ProgressBar {
                 core: Default::default(),
+                align: Default::default(),
                 direction,
                 value: 0.0,
             }
@@ -82,11 +84,15 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            self.align.set_component(axis, match axis.is_vertical() == self.direction.is_vertical() {
+                false => axis.align_or_center(),
+                true => axis.align_or_stretch(),
+            });
             size_mgr.feature(Feature::ProgressBar(self.direction()), axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
-            let rect = mgr.align_feature(Feature::ProgressBar(self.direction()), rect, align);
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+            let rect = mgr.align_feature(Feature::ProgressBar(self.direction()), rect, self.align);
             self.core.rect = rect;
         }
 

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -60,6 +60,7 @@ impl_scope! {
     }]
     pub struct RadioBox {
         core: widget_core!(),
+        align: AlignPair,
         state: bool,
         last_change: Option<Instant>,
         group: RadioGroup,
@@ -92,11 +93,12 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            self.align.set_component(axis, axis.align_or_center());
             size_mgr.feature(Feature::RadioBox, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
-            let rect = mgr.align_feature(Feature::RadioBox, rect, align);
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+            let rect = mgr.align_feature(Feature::RadioBox, rect, self.align);
             self.core.rect = rect;
         }
 
@@ -114,6 +116,7 @@ impl_scope! {
         pub fn new(group: RadioGroup) -> Self {
             RadioBox {
                 core: Default::default(),
+                align: Default::default(),
                 state: false,
                 last_change: None,
                 group,
@@ -134,6 +137,7 @@ impl_scope! {
         {
             RadioBox {
                 core: self.core,
+                align: self.align,
                 state: self.state,
                 last_change: self.last_change,
                 group: self.group,

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -97,7 +97,7 @@ impl_scope! {
             size_mgr.feature(Feature::RadioBox, axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             let rect = mgr.align_feature(Feature::RadioBox, rect, self.align);
             self.core.rect = rect;
         }
@@ -234,8 +234,8 @@ impl_scope! {
     }
 
     impl Layout for Self {
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
-            <Self as kas::layout::AutoLayout>::set_rect(self, mgr, rect, align);
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
+            <Self as kas::layout::AutoLayout>::set_rect(self, mgr, rect);
             let dir = self.direction();
             crate::check_box::shrink_to_text(&mut self.core.rect, dir, &self.label);
         }

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -105,11 +105,11 @@ impl_scope! {
             rules
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
             let child_size = (rect.size - self.frame_size).max(self.min_child_size);
             let child_rect = Rect::new(rect.pos + self.offset, child_size);
-            self.inner.set_rect(mgr, child_rect, AlignHints::NONE);
+            self.inner.set_rect(mgr, child_rect);
             let _ = self
                 .scroll
                 .set_sizes(rect.size, child_size + self.frame_size);

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -91,10 +91,7 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, mut axis: AxisInfo) -> SizeRules {
-            if let Some(mut other) = axis.other() {
-                other -= self.frame_size.extract(axis.flipped());
-                axis = AxisInfo::new(axis.is_vertical(), Some(other));
-            }
+            axis.sub_other(self.frame_size.extract(axis.flipped()));
 
             let mut rules = self.inner.size_rules(size_mgr.re(), axis);
             self.min_child_size.set_component(axis, rules.min_size());

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -260,10 +260,10 @@ impl_scope! {
             size_mgr.feature(Feature::ScrollBar(self.direction()), axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             let rect = mgr.align_feature(Feature::ScrollBar(self.direction()), rect, self.align);
             self.core.rect = rect;
-            self.handle.set_rect(mgr, rect, align);
+            self.handle.set_rect(mgr, rect);
             self.min_handle_len = mgr.size_mgr().handle_len();
             let _ = self.update_widgets();
         }
@@ -453,7 +453,7 @@ impl_scope! {
             rules
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
             let pos = rect.pos;
             let mut child_size = rect.size;
@@ -470,21 +470,21 @@ impl_scope! {
             }
 
             let child_rect = Rect::new(pos, child_size);
-            self.inner.set_rect(mgr, child_rect, align);
+            self.inner.set_rect(mgr, child_rect);
             let max_scroll_offset = self.inner.max_scroll_offset();
 
             if self.show_bars.0 {
                 let pos = Coord(pos.0, rect.pos2().1 - bar_width);
                 let size = Size::new(child_size.0, bar_width);
                 self.horiz_bar
-                    .set_rect(mgr, Rect { pos, size }, AlignHints::NONE);
+                    .set_rect(mgr, Rect { pos, size });
                 let _ = self.horiz_bar.set_limits(max_scroll_offset.0, rect.size.0);
             }
             if self.show_bars.1 {
                 let pos = Coord(rect.pos2().0 - bar_width, pos.1);
                 let size = Size::new(bar_width, self.core.rect.size.1);
                 self.vert_bar
-                    .set_rect(mgr, Rect { pos, size }, AlignHints::NONE);
+                    .set_rect(mgr, Rect { pos, size });
                 let _ = self.vert_bar.set_limits(max_scroll_offset.1, rect.size.1);
             }
         }

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -32,6 +32,7 @@ impl_scope! {
     #[widget]
     pub struct ScrollBar<D: Directional> {
         core: widget_core!(),
+        align: AlignPair,
         direction: D,
         // Terminology assumes vertical orientation:
         min_handle_len: i32,
@@ -63,6 +64,7 @@ impl_scope! {
         pub fn new_with_direction(direction: D) -> Self {
             ScrollBar {
                 core: Default::default(),
+                align: Default::default(),
                 direction,
                 min_handle_len: 0,
                 handle_len: 0,
@@ -251,11 +253,15 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            self.align.set_component(axis, match axis.is_vertical() == self.direction.is_vertical() {
+                false => axis.align_or_center(),
+                true => axis.align_or_stretch(),
+            });
             size_mgr.feature(Feature::ScrollBar(self.direction()), axis)
         }
 
         fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
-            let rect = mgr.align_feature(Feature::ScrollBar(self.direction()), rect, align);
+            let rect = mgr.align_feature(Feature::ScrollBar(self.direction()), rect, self.align);
             self.core.rect = rect;
             self.handle.set_rect(mgr, rect, align);
             self.min_handle_len = mgr.size_mgr().handle_len();

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -47,7 +47,7 @@ impl_scope! {
             self.core.rect = rect;
             // Note: if text height exceeds rect, it will always align to the top.
             let align = hints.unwrap_or(Align::Default, Align::Default);
-            mgr.text_set_size(&mut self.text, TextClass::LabelScroll, rect.size, align);
+            mgr.text_set_size(&mut self.text, TextClass::LabelScroll, rect.size, Some(align.into()));
             self.text_size = Vec2::from(self.text.bounding_box().unwrap().1).cast_ceil();
 
             let max_offset = self.max_scroll_offset();

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -43,11 +43,9 @@ impl_scope! {
             rules
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, mut rect: Rect, hints: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, mut rect: Rect) {
             self.core.rect = rect;
-            // Note: if text height exceeds rect, it will always align to the top.
-            let align = hints.unwrap_or(Align::Default, Align::Default);
-            mgr.text_set_size(&mut self.text, TextClass::LabelScroll, rect.size, Some(align.into()));
+            mgr.text_set_size(&mut self.text, TextClass::LabelScroll, rect.size, None);
             self.text_size = Vec2::from(self.text.bounding_box().unwrap().1).cast_ceil();
 
             let max_offset = self.max_scroll_offset();
@@ -56,7 +54,7 @@ impl_scope! {
             let w = mgr.size_mgr().scroll_bar_width().min(rect.size.0);
             rect.pos.0 += rect.size.0 - w;
             rect.size.0 = w;
-            self.bar.set_rect(mgr, rect, hints);
+            self.bar.set_rect(mgr, rect);
             let _ = self.bar.set_limits(max_offset.1, rect.size.1);
             self.bar.set_value(mgr, self.view_offset.1);
         }

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -98,6 +98,7 @@ impl_scope! {
     }]
     pub struct Slider<T: SliderValue, D: Directional> {
         core: widget_core!(),
+        align: AlignPair,
         direction: D,
         // Terminology assumes vertical orientation:
         range: (T, T),
@@ -149,6 +150,7 @@ impl_scope! {
             let value = *range.start();
             Slider {
                 core: Default::default(),
+                align: Default::default(),
                 direction,
                 range: range.into_inner(),
                 step,
@@ -256,10 +258,15 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
+            self.align.set_component(axis, match axis.is_vertical() == self.direction.is_vertical() {
+                false => axis.align_or_center(),
+                true => axis.align_or_stretch(),
+            });
             size_mgr.feature(Feature::Slider(self.direction()), axis)
         }
 
         fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+            let rect = mgr.align_feature(Feature::Slider(self.direction()), rect, self.align);
             self.core.rect = rect;
             self.handle.set_rect(mgr, rect, align);
             let mut size = rect.size;

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -265,10 +265,10 @@ impl_scope! {
             size_mgr.feature(Feature::Slider(self.direction()), axis)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             let rect = mgr.align_feature(Feature::Slider(self.direction()), rect, self.align);
             self.core.rect = rect;
-            self.handle.set_rect(mgr, rect, align);
+            self.handle.set_rect(mgr, rect);
             let mut size = rect.size;
             size.set_component(self.direction, mgr.size_mgr().handle_len());
             let _ = self.handle.set_size_and_offset(size, self.offset());

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -168,7 +168,7 @@ impl_scope! {
             solver.finish(&mut self.data)
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
             self.size_solved = true;
             if self.widgets.is_empty() {
@@ -177,13 +177,12 @@ impl_scope! {
             assert!(self.handles.len() + 1 == self.widgets.len());
 
             let dim = (self.direction, self.num_children());
-            let mut setter = layout::RowSetter::<D, Vec<i32>, _>::new(rect, dim, align, &mut self.data);
+            let mut setter = layout::RowSetter::<D, Vec<i32>, _>::new(rect, dim, &mut self.data);
 
             let mut n = 0;
             loop {
                 assert!(n < self.widgets.len());
-                let align = AlignHints::default();
-                self.widgets[n].set_rect(mgr, setter.child_rect(&mut self.data, n << 1), align);
+                self.widgets[n].set_rect(mgr, setter.child_rect(&mut self.data, n << 1));
 
                 if n >= self.handles.len() {
                     break;
@@ -192,7 +191,7 @@ impl_scope! {
                 // TODO(opt): calculate all maximal sizes simultaneously
                 let index = (n << 1) + 1;
                 let track = setter.maximal_rect_of(&mut self.data, index);
-                self.handles[n].set_rect(mgr, track, AlignHints::default());
+                self.handles[n].set_rect(mgr, track);
                 let handle = setter.child_rect(&mut self.data, index);
                 let _ = self.handles[n].set_size_and_offset(handle.size, handle.pos - track.pos);
 
@@ -335,8 +334,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
         let mut n = 0;
         loop {
             assert!(n < self.widgets.len());
-            let align = AlignHints::default();
-            self.widgets[n].set_rect(mgr, setter.child_rect(&mut self.data, n << 1), align);
+            self.widgets[n].set_rect(mgr, setter.child_rect(&mut self.data, n << 1));
 
             if n >= self.handles.len() {
                 break;
@@ -344,7 +342,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
 
             let index = (n << 1) + 1;
             let track = self.handles[n].track();
-            self.handles[n].set_rect(mgr, track, AlignHints::default());
+            self.handles[n].set_rect(mgr, track);
             let handle = setter.child_rect(&mut self.data, index);
             let _ = self.handles[n].set_size_and_offset(handle.size, handle.pos - track.pos);
 

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -38,7 +38,6 @@ impl_scope! {
     #[widget]
     pub struct Stack<W: Widget> {
         core: widget_core!(),
-        align_hints: AlignHints,
         widgets: Vec<W>,
         sized_range: Range<usize>, // range of pages for which size rules are solved
         active: usize,
@@ -100,11 +99,10 @@ impl_scope! {
             rules
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
-            self.align_hints = align;
             if let Some(child) = self.widgets.get_mut(self.active) {
-                child.set_rect(mgr, rect, align);
+                child.set_rect(mgr, rect);
             }
         }
 
@@ -172,7 +170,6 @@ impl<W: Widget> Stack<W> {
     pub fn new_vec(widgets: Vec<W>) -> Self {
         Stack {
             core: Default::default(),
-            align_hints: Default::default(),
             widgets,
             sized_range: 0..0,
             active: 0,
@@ -247,7 +244,7 @@ impl<W: Widget> Stack<W> {
 
         if self.sized_range.contains(&index) {
             if old_index != index {
-                self.widgets[index].set_rect(mgr, self.core.rect, self.align_hints);
+                self.widgets[index].set_rect(mgr, self.core.rect);
                 *mgr |= TkAction::REGION_MOVED;
             }
         } else {
@@ -319,7 +316,7 @@ impl<W: Widget> Stack<W> {
             if self.active > 0 && self.active == self.widgets.len() {
                 self.active -= 1;
                 if self.sized_range.contains(&self.active) {
-                    self.widgets[self.active].set_rect(mgr, self.core.rect, self.align_hints);
+                    self.widgets[self.active].set_rect(mgr, self.core.rect);
                 } else {
                     *mgr |= TkAction::RESIZE;
                 }
@@ -375,7 +372,7 @@ impl<W: Widget> Stack<W> {
         if self.active == index {
             self.active = self.active.saturating_sub(1);
             if self.sized_range.contains(&self.active) {
-                self.widgets[self.active].set_rect(mgr, self.core.rect, self.align_hints);
+                self.widgets[self.active].set_rect(mgr, self.core.rect);
             } else {
                 *mgr |= TkAction::RESIZE;
             }

--- a/examples/async-event.rs
+++ b/examples/async-event.rs
@@ -69,7 +69,7 @@ impl_scope! {
         fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
             self.core.rect = rect;
             let align = align.unwrap_or(Align::Center, Align::Center);
-            mgr.text_set_size(&mut self.loading_text, TextClass::Label(false), rect.size, align);
+            mgr.text_set_size(&mut self.loading_text, TextClass::Label(false), rect.size, Some(align.into()));
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {

--- a/examples/async-event.rs
+++ b/examples/async-event.rs
@@ -66,10 +66,10 @@ impl_scope! {
             SizeRules::fixed_scaled(100.0, 10.0, mgr.scale_factor())
         }
 
-        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect, align: AlignHints) {
+        fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
-            let align = align.unwrap_or(Align::Center, Align::Center);
-            mgr.text_set_size(&mut self.loading_text, TextClass::Label(false), rect.size, Some(align.into()));
+            let align = Some(AlignPair::new(Align::Center, Align::Center));
+            mgr.text_set_size(&mut self.loading_text, TextClass::Label(false), rect.size, align);
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -40,7 +40,7 @@ impl_scope! {
         }
 
         #[inline]
-        fn set_rect(&mut self, _: &mut ConfigMgr, rect: Rect, _align: AlignHints) {
+        fn set_rect(&mut self, _: &mut ConfigMgr, rect: Rect) {
             // Force to square
             let size = rect.size.0.min(rect.size.1);
             let size = Size::splat(size);

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -122,7 +122,7 @@ fn widgets() -> Box<dyn SetDisabled> {
                 row: ["ScrollLabel", self.sl],
                 row: ["EditBox", self.eb],
                 row: ["TextButton", self.tb],
-                row: ["Button<Image>", self.bi],
+                row: ["Button<Image>", pack(center): self.bi],
                 row: ["CheckButton", self.cb],
                 row: ["RadioButton", self.rb],
                 row: ["RadioButton", self.rb2],
@@ -239,7 +239,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
     Box::new(impl_singleton! {
         #[widget{
             layout = float: [
-                align(right, top): TextButton::new_msg("↻", MsgDirection),
+                pack(right, top): TextButton::new_msg("↻", MsgDirection),
                 list(self.dir): [self.editor, non_navigable: self.label],
             ];
         }]

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -199,7 +199,7 @@ fn widgets() -> Box<dyn SetDisabled> {
             }
         }
     };
-    Box::new(ScrollBarRegion::new(widgets).with_invisible_bars(true, true))
+    Box::new(ScrollBarRegion::new(widgets))
 }
 
 fn editor() -> Box<dyn SetDisabled> {
@@ -453,7 +453,7 @@ KAS_CONFIG_MODE=readwrite
 ```
 ";
 
-    Box::new(impl_singleton! {
+    Box::new(ScrollBarRegion::new(impl_singleton! {
         #[widget{
             layout = column: [
                 ScrollLabel::new(Markdown::new(DESC).unwrap()),
@@ -473,7 +473,7 @@ KAS_CONFIG_MODE=readwrite
                 mgr.set_disabled(self.view.id(), state);
             }
         }
-    })
+    }))
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -338,7 +338,7 @@ impl_scope! {
         }
 
         #[inline]
-        fn set_rect(&mut self, _: &mut ConfigMgr, rect: Rect, _: AlignHints) {
+        fn set_rect(&mut self, _: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
             let size = DVec2::conv(rect.size);
             let rel_width = DVec2(size.0 / size.1, 1.0);


### PR DESCRIPTION
Re-work how alignment is handled: pass through `size_rules`, and do not prevent stretching by default. A new layout specifier, `pack`, is used to limit size *and* set alignment.

Motivation: #329 — alignment is now available when calculating `size_rules`, albeit only the input (or parent item's) alignment. The result here is clean enough code.

It is also possible to add alignment information to the returned `SizeRules`, thus exposing per-item alignment, however this leads to messier code (e.g. content alignment and widget alignment are not always equal, especially for `Text` content). Moreover, many widgets will prefer to stretch to all available space, thus making [more refined combination of margins](https://github.com/kas-gui/kas/issues/329#issuecomment-1213125198) ineffective.

- Add field `AxisInfo::align: Option<Align>` for passing an align-hint into `Layout::size_rules`
- Remove `AlignHints` parameter from `Layout::set_rect`
- Add `pack` layout specifier to size-limit and align content
- Buttons are no longer automatically size-limited and aligned when not using `Align::Stretch`
- `Stretch::None` does not prevent stretching (see also #349)
- Add `AlignPair`, replacing `CompleteAlignment`
- Text: `SizeMgr::text_rules` now sets alignment; `ConfigMgr::text_set_size` can optionally set alignment
- `Slider` widget: use `ConfigMgr::align_feature`
- Gallery: adjust scroll bars; pack theme-colour buttons
- `Sub` and `SubAssign` impls for `Size` now use saturating subtraction; remove `Size::clamped_sub`