### PR TITLE
Rustfmt: adjust opts and format within macro braces

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -3,5 +3,6 @@
 
 inline_attribute_width = 60
 overflow_delimited_expr = true
+single_line_if_else_max_width = 60
 use_field_init_shorthand = true
 use_try_shorthand = true

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+# This may be useful to run occasionally, but has issues:
+#format_code_in_doc_comments = true
+
+use_field_init_shorthand = true
+use_try_shorthand = true

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,6 @@
 # This may be useful to run occasionally, but has issues:
 #format_code_in_doc_comments = true
 
+inline_attribute_width = 60
 use_field_init_shorthand = true
 use_try_shorthand = true

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -2,5 +2,6 @@
 #format_code_in_doc_comments = true
 
 inline_attribute_width = 60
+overflow_delimited_expr = true
 use_field_init_shorthand = true
 use_try_shorthand = true

--- a/crates/kas-core/src/core/data.rs
+++ b/crates/kas-core/src/core/data.rs
@@ -5,15 +5,13 @@
 
 //! Widget data types
 
-#[allow(unused)]
-use super::Layout;
+#[allow(unused)] use super::Layout;
 use super::{Widget, WidgetId};
 use crate::dir::Direction;
 use crate::event::EventMgr;
 use crate::geom::Rect;
 
-#[cfg(feature = "winit")]
-pub use winit::window::Icon;
+#[cfg(feature = "winit")] pub use winit::window::Icon;
 
 /// An icon used for the window titlebar, taskbar, etc.
 #[cfg(not(feature = "winit"))]

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -309,8 +309,8 @@ pub trait Layout {
 /// and [`kas_widgets` code](https://github.com/kas-gui/kas/tree/master/crates/kas-widgets).
 /// ```
 /// # extern crate kas_core as kas;
-/// use kas::prelude::*;
 /// use kas::event;
+/// use kas::prelude::*;
 /// use kas::theme::TextClass;
 /// use std::fmt::Debug;
 ///

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -15,14 +15,11 @@ use crate::util::IdentifyWidget;
 use crate::WidgetId;
 use kas_macros::autoimpl;
 
-#[allow(unused)]
-use crate::event::EventState;
+#[allow(unused)] use crate::event::EventState;
 #[allow(unused)]
 use crate::layout::{self, AlignPair, AutoLayout};
-#[allow(unused)]
-use crate::TkAction;
-#[allow(unused)]
-use kas_macros as macros;
+#[allow(unused)] use crate::TkAction;
+#[allow(unused)] use kas_macros as macros;
 
 /// Base functionality for [`Widget`]s
 ///

--- a/crates/kas-core/src/dir.rs
+++ b/crates/kas-core/src/dir.rs
@@ -99,16 +99,12 @@ pub enum Direction {
 
 impl fmt::Display for Direction {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(
-            f,
-            "{}",
-            match self {
-                Direction::Right => "Right",
-                Direction::Down => "Down",
-                Direction::Left => "Left",
-                Direction::Up => "Up",
-            }
-        )
+        write!(f, "{}", match self {
+            Direction::Right => "Right",
+            Direction::Down => "Down",
+            Direction::Left => "Left",
+            Direction::Up => "Up",
+        })
     }
 }
 

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -6,12 +6,10 @@
 //! Drawing APIs — draw interface
 
 use super::{color::Rgba, AnimationState};
-#[allow(unused)]
-use super::{DrawRounded, DrawRoundedImpl};
+#[allow(unused)] use super::{DrawRounded, DrawRoundedImpl};
 use super::{DrawShared, DrawSharedImpl, ImageId, PassId, PassType, SharedState};
 use crate::geom::{Offset, Quad, Rect};
-#[allow(unused)]
-use crate::text::TextApi;
+#[allow(unused)] use crate::text::TextApi;
 use crate::text::{Effect, TextDisplay};
 use std::any::Any;
 use std::time::Instant;

--- a/crates/kas-core/src/draw/mod.rs
+++ b/crates/kas-core/src/draw/mod.rs
@@ -37,14 +37,12 @@
 
 pub mod color;
 
-#[allow(clippy::module_inception)]
-mod draw;
+#[allow(clippy::module_inception)] mod draw;
 mod draw_rounded;
 mod draw_shared;
 
 use crate::cast::Cast;
-#[allow(unused)]
-use crate::theme::DrawMgr;
+#[allow(unused)] use crate::theme::DrawMgr;
 
 pub use draw::{Draw, DrawIface, DrawImpl};
 pub use draw_rounded::{DrawRounded, DrawRoundedImpl};

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -9,8 +9,7 @@ use super::ScrollDelta::{LineDelta, PixelDelta};
 use super::{Command, CursorIcon, Event, EventMgr, PressSource, Response, Scroll};
 use crate::cast::traits::*;
 use crate::geom::{Coord, Offset, Rect, Size, Vec2};
-#[allow(unused)]
-use crate::text::SelectionHelper;
+#[allow(unused)] use crate::text::SelectionHelper;
 use crate::{TkAction, WidgetId};
 use kas_macros::impl_default;
 use std::time::{Duration, Instant};

--- a/crates/kas-core/src/event/config/shortcuts.rs
+++ b/crates/kas-core/src/event/config/shortcuts.rs
@@ -12,8 +12,7 @@ use serde::de::{self, Deserialize, Deserializer, MapAccess, Unexpected, Visitor}
 #[cfg(feature = "config")]
 use serde::ser::{Serialize, SerializeMap, Serializer};
 use std::collections::HashMap;
-#[cfg(feature = "config")]
-use std::fmt;
+#[cfg(feature = "config")] use std::fmt;
 
 /// Shortcut manager
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -58,7 +58,7 @@ pub enum Event {
     /// # use kas_core::cast::{Cast, CastFloat};
     /// # use kas_core::geom::{Coord, DVec2};
     /// # let (alpha, delta) = (DVec2::ZERO, DVec2::ZERO);
-    ///  let mut p = Coord::ZERO; // or whatever
+    /// let mut p = Coord::ZERO; // or whatever
     /// p = (alpha.complex_mul(p.cast()) + delta).cast_nearest();
     /// ```
     ///

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -12,8 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::{EventMgr, EventState, GrabMode, Response}; // for doc-links
 use super::{MouseButton, UpdateId, VirtualKeyCode};
 use crate::geom::{Coord, DVec2, Offset};
-#[allow(unused)]
-use crate::Widget;
+#[allow(unused)] use crate::Widget;
 use crate::{dir::Direction, WidgetId, WindowId};
 
 /// Events addressed to a widget

--- a/crates/kas-core/src/event/manager/config_mgr.rs
+++ b/crates/kas-core/src/event/manager/config_mgr.rs
@@ -15,8 +15,7 @@ use crate::theme::{Feature, SizeMgr, TextClass, ThemeSize};
 use crate::{TkAction, Widget, WidgetExt, WidgetId};
 use std::ops::{Deref, DerefMut};
 
-#[allow(unused)]
-use crate::{event::Event, Layout};
+#[allow(unused)] use crate::{event::Event, Layout};
 
 /// Manager used to configure widgets and layout
 ///

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -13,8 +13,7 @@ use crate::cast::Conv;
 use crate::draw::DrawShared;
 use crate::geom::{Coord, Offset, Vec2};
 use crate::theme::{SizeMgr, ThemeControl};
-#[allow(unused)]
-use crate::{Layout, Widget}; // for doc-links
+#[allow(unused)] use crate::{Layout, Widget}; // for doc-links
 use crate::{TkAction, WidgetId, WindowId};
 
 impl<'a> std::ops::BitOrAssign<TkAction> for EventMgr<'a> {

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -54,8 +54,7 @@
 //! [`Unused`]: Response::Unused
 
 pub mod config;
-#[cfg(not(feature = "winit"))]
-mod enums;
+#[cfg(not(feature = "winit"))] mod enums;
 mod events;
 mod manager;
 mod response;
@@ -68,13 +67,10 @@ use std::fmt::Debug;
 
 #[cfg(feature = "winit")]
 pub use winit::event::{ModifiersState, MouseButton, VirtualKeyCode};
-#[cfg(feature = "winit")]
-pub use winit::window::CursorIcon;
+#[cfg(feature = "winit")] pub use winit::window::CursorIcon;
 
-#[allow(unused)]
-use crate::Widget;
-#[doc(no_inline)]
-pub use config::Config;
+#[allow(unused)] use crate::Widget;
+#[doc(no_inline)] pub use config::Config;
 #[cfg(not(feature = "winit"))]
 pub use enums::{CursorIcon, ModifiersState, MouseButton, VirtualKeyCode};
 pub use events::*;

--- a/crates/kas-core/src/layout/align.rs
+++ b/crates/kas-core/src/layout/align.rs
@@ -5,8 +5,7 @@
 
 //! Alignment types
 
-#[allow(unused)]
-use super::Stretch; // for doc-links
+#[allow(unused)] use super::Stretch; // for doc-links
 use crate::dir::Directional;
 use crate::geom::{Rect, Size};
 

--- a/crates/kas-core/src/layout/mod.rs
+++ b/crates/kas-core/src/layout/mod.rs
@@ -51,8 +51,7 @@ use crate::geom::{Coord, Rect};
 use crate::theme::{DrawMgr, SizeMgr};
 use crate::WidgetId;
 
-#[allow(unused)]
-use crate::Layout;
+#[allow(unused)] use crate::Layout;
 
 pub use align::{Align, AlignHints, AlignPair};
 pub use grid_solver::{DefaultWithLen, GridChildInfo, GridDimensions, GridSetter, GridSolver};

--- a/crates/kas-core/src/layout/size_rules.rs
+++ b/crates/kas-core/src/layout/size_rules.rs
@@ -14,10 +14,8 @@ use crate::dir::Directional;
 use crate::geom::Size;
 
 // for doc use
-#[allow(unused)]
-use super::FrameRules;
-#[allow(unused)]
-use crate::theme::SizeMgr;
+#[allow(unused)] use super::FrameRules;
+#[allow(unused)] use crate::theme::SizeMgr;
 
 /// Widget sizing information
 ///

--- a/crates/kas-core/src/layout/size_types.rs
+++ b/crates/kas-core/src/layout/size_types.rs
@@ -13,8 +13,7 @@ use crate::theme::MarginStyle;
 use kas_macros::impl_scope;
 
 // for doc use
-#[allow(unused)]
-use crate::theme::SizeMgr;
+#[allow(unused)] use crate::theme::SizeMgr;
 
 /// Logical (pre-scaling) pixel size
 ///

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -20,8 +20,7 @@
 
 extern crate self as kas;
 
-#[macro_use]
-extern crate bitflags;
+#[macro_use] extern crate bitflags;
 
 pub extern crate easy_cast as cast;
 pub extern crate kas_macros as macros;

--- a/crates/kas-core/src/model/shared_arc.rs
+++ b/crates/kas-core/src/model/shared_arc.rs
@@ -5,8 +5,7 @@
 
 //! `SharedArc` data type
 
-#[allow(unused)]
-use crate::event::Event;
+#[allow(unused)] use crate::event::Event;
 use crate::event::{EventMgr, UpdateId};
 use crate::model::*;
 use std::fmt::Debug;

--- a/crates/kas-core/src/model/shared_rc.rs
+++ b/crates/kas-core/src/model/shared_rc.rs
@@ -5,8 +5,7 @@
 
 //! `SharedRc` data type
 
-#[allow(unused)]
-use crate::event::Event;
+#[allow(unused)] use crate::event::Event;
 use crate::event::{EventMgr, UpdateId};
 use crate::model::*;
 use std::cell::{Ref, RefCell, RefMut};

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -8,10 +8,8 @@
 //! It is recommended to use `kas::prelude` instead, which is an extension of
 //! this crate's prelude.
 
-#[doc(no_inline)]
-pub use crate::cast::traits::*;
-#[doc(no_inline)]
-pub use crate::class::*;
+#[doc(no_inline)] pub use crate::cast::traits::*;
+#[doc(no_inline)] pub use crate::class::*;
 #[doc(no_inline)]
 pub use crate::dir::{Direction, Directional};
 #[doc(no_inline)]
@@ -22,16 +20,12 @@ pub use crate::geom::{Coord, Offset, Rect, Size};
 pub use crate::layout::{Align, AlignPair, AxisInfo, SizeRules, Stretch};
 #[doc(no_inline)]
 pub use crate::macros::{autoimpl, impl_default, impl_scope, singleton, widget, widget_index};
-#[doc(no_inline)]
-pub use crate::text::AccelString;
+#[doc(no_inline)] pub use crate::text::AccelString;
 #[doc(no_inline)]
 pub use crate::text::{EditableTextApi, Text, TextApi, TextApiExt};
-#[doc(no_inline)]
-pub use crate::theme::{DrawMgr, SizeMgr};
-#[doc(no_inline)]
-pub use crate::TkAction;
-#[doc(no_inline)]
-pub use crate::WidgetId;
+#[doc(no_inline)] pub use crate::theme::{DrawMgr, SizeMgr};
+#[doc(no_inline)] pub use crate::TkAction;
+#[doc(no_inline)] pub use crate::WidgetId;
 #[doc(no_inline)]
 pub use crate::{HasScrollBars, ScrollBarMode, Scrollable};
 #[doc(no_inline)]

--- a/crates/kas-core/src/text.rs
+++ b/crates/kas-core/src/text.rs
@@ -15,8 +15,7 @@
 //!
 //! [KAS Text]: https://github.com/kas-gui/kas-text/
 
-#[allow(unused)]
-use kas::{event::ConfigMgr, Layout};
+#[allow(unused)] use kas::{event::ConfigMgr, Layout};
 
 pub use kas_text::*;
 

--- a/crates/kas-core/src/theme/mod.rs
+++ b/crates/kas-core/src/theme/mod.rs
@@ -13,8 +13,7 @@ pub use draw::{Background, DrawMgr, ThemeDraw};
 pub use size::{SizeMgr, ThemeSize};
 pub use style::*;
 
-#[allow(unused)]
-use crate::event::EventMgr;
+#[allow(unused)] use crate::event::EventMgr;
 use crate::TkAction;
 use std::ops::{Deref, DerefMut};
 

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -14,8 +14,7 @@ use crate::layout::{AlignPair, AxisInfo, FrameRules, Margins, SizeRules};
 use crate::macros::autoimpl;
 use crate::text::TextApi;
 
-#[allow(unused)]
-use crate::text::TextApiExt;
+#[allow(unused)] use crate::text::TextApiExt;
 #[allow(unused)]
 use crate::{event::ConfigMgr, layout::Stretch, theme::DrawMgr};
 

--- a/crates/kas-dylib/src/lib.rs
+++ b/crates/kas-dylib/src/lib.rs
@@ -12,8 +12,7 @@
 #![allow(clippy::single_component_path_imports)]
 
 use kas_core;
-#[cfg(feature = "kas-resvg")]
-use kas_resvg;
+#[cfg(feature = "kas-resvg")] use kas_resvg;
 use kas_theme;
 use kas_wgpu;
 use kas_widgets;

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -687,9 +687,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
             set_rect = quote! {
                 <Self as ::kas::layout::AutoLayout>::set_rect(self, mgr, rect);
             };
-            find_id = quote! {
-                <Self as ::kas::layout::AutoLayout>::find_id(self, coord)
-            };
+            find_id = quote! { <Self as ::kas::layout::AutoLayout>::find_id(self, coord) };
             fn_draw = Some(quote! {
                 fn draw(&mut self, draw: ::kas::theme::DrawMgr) {
                     <Self as ::kas::layout::AutoLayout>::draw(self, draw);

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -46,7 +46,7 @@ impl_scope! {
     /// The canvas (re)creates the backing pixmap when the size is set and draws
     /// to the new pixmap immediately. If the canvas program is modified then
     /// [`Canvas::redraw`] must be called to update the pixmap.
-    #[derive(Clone, Debug,)]
+    #[derive(Clone, Debug)]
     #[widget]
     pub struct Canvas<P: CanvasProgram> {
         core: widget_core!(),
@@ -118,7 +118,8 @@ impl_scope! {
             if let Some((pm, h)) = self.pixmap.as_mut().zip(self.image.as_ref()) {
                 pm.fill(Color::TRANSPARENT);
                 self.program.draw(pm);
-                mgr.draw_shared().image_upload(h, pm.data(), ImageFormat::Rgba8);
+                mgr.draw_shared()
+                    .image_upload(h, pm.data(), ImageFormat::Rgba8);
             }
         }
     }
@@ -144,7 +145,8 @@ impl_scope! {
                     program.draw(pm);
                     let (w, h) = (pm.width(), pm.height());
                     let handle = mgr.draw_shared().image_alloc((w, h)).unwrap();
-                    mgr.draw_shared().image_upload(&handle, pm.data(), ImageFormat::Rgba8);
+                    mgr.draw_shared()
+                        .image_upload(&handle, pm.data(), ImageFormat::Rgba8);
                     handle
                 });
             }

--- a/crates/kas-resvg/src/lib.rs
+++ b/crates/kas-resvg/src/lib.rs
@@ -18,7 +18,5 @@ pub extern crate tiny_skia;
 mod canvas;
 pub use canvas::{Canvas, CanvasProgram};
 
-#[cfg(feature = "svg")]
-mod svg;
-#[cfg(feature = "svg")]
-pub use svg::Svg;
+#[cfg(feature = "svg")] mod svg;
+#[cfg(feature = "svg")] pub use svg::Svg;

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -50,9 +50,7 @@ impl_scope! {
         pub fn load(&mut self, data: &[u8], resources_dir: Option<&Path>) {
             let fonts_db = kas::text::fonts::fonts().read_db();
             let fontdb = fonts_db.db();
-            let font_family = fonts_db
-                .font_family_from_alias("SERIF")
-                .unwrap_or_default();
+            let font_family = fonts_db.font_family_from_alias("SERIF").unwrap_or_default();
 
             // Defaults are taken from usvg::Options::default(). Notes:
             // - adjusting for screen scale factor is purely a property of
@@ -76,7 +74,9 @@ impl_scope! {
             };
 
             self.tree = Some(usvg::Tree::from_data(data, &opts).unwrap());
-            self.scaling.size = self.tree.as_ref()
+            self.scaling.size = self
+                .tree
+                .as_ref()
                 .map(|tree| LogicalSize::conv(tree.svg_node().size.to_screen_size().dimensions()))
                 .unwrap_or(LogicalSize(128.0, 128.0));
         }
@@ -147,7 +147,8 @@ impl_scope! {
                         resvg::render(tree, usvg::FitTo::Size(w, h), transform, pm.as_mut());
 
                         let handle = mgr.draw_shared().image_alloc((w, h)).unwrap();
-                        mgr.draw_shared().image_upload(&handle, pm.data(), ImageFormat::Rgba8);
+                        mgr.draw_shared()
+                            .image_upload(&handle, pm.data(), ImageFormat::Rgba8);
                         handle
                     });
                 }

--- a/crates/kas-theme/src/flat_theme.rs
+++ b/crates/kas-theme/src/flat_theme.rs
@@ -197,11 +197,7 @@ where
                 b = b * SHADOW_HOVER;
             }
             let shadow_outer = Quad::from_coords(a + inner.a, b + inner.b);
-            let col1 = if self.cols.is_dark {
-                col_frame
-            } else {
-                Rgba::BLACK
-            };
+            let col1 = if self.cols.is_dark { col_frame } else { Rgba::BLACK };
             let mut col2 = col1;
             col2.a = 0.0;
             self.draw

--- a/crates/kas-theme/src/shaded_theme.rs
+++ b/crates/kas-theme/src/shaded_theme.rs
@@ -186,11 +186,7 @@ where
         }
 
         let outer_col = self.cols.background;
-        let inner_col = if nav_focus {
-            self.cols.accent_soft
-        } else {
-            outer_col
-        };
+        let inner_col = if nav_focus { self.cols.accent_soft } else { outer_col };
         self.draw
             .shaded_square_frame(outer, inner, NORMS_SUNK, outer_col, inner_col);
 

--- a/crates/kas-view/src/driver/config.rs
+++ b/crates/kas-view/src/driver/config.rs
@@ -49,17 +49,28 @@ impl_scope! {
     #[derive(Debug)]
     pub struct EventConfigWidget {
         core: widget_core!(),
-        #[widget] menu_delay: Spinner<u32>,
-        #[widget] touch_select_delay: Spinner<u32>,
-        #[widget] scroll_flick_timeout: Spinner<u32>,
-        #[widget] scroll_flick_mul: Spinner<f32>,
-        #[widget] scroll_flick_sub: Spinner<f32>,
-        #[widget] scroll_dist_em: Spinner<f32>,
-        #[widget] pan_dist_thresh: Spinner<f32>,
-        #[widget] mouse_pan: ComboBox<MousePan>,
-        #[widget] mouse_text_pan: ComboBox<MousePan>,
-        #[widget] mouse_nav_focus: CheckButton,
-        #[widget] touch_nav_focus: CheckButton,
+        #[widget]
+        menu_delay: Spinner<u32>,
+        #[widget]
+        touch_select_delay: Spinner<u32>,
+        #[widget]
+        scroll_flick_timeout: Spinner<u32>,
+        #[widget]
+        scroll_flick_mul: Spinner<f32>,
+        #[widget]
+        scroll_flick_sub: Spinner<f32>,
+        #[widget]
+        scroll_dist_em: Spinner<f32>,
+        #[widget]
+        pan_dist_thresh: Spinner<f32>,
+        #[widget]
+        mouse_pan: ComboBox<MousePan>,
+        #[widget]
+        mouse_text_pan: ComboBox<MousePan>,
+        #[widget]
+        mouse_nav_focus: CheckButton,
+        #[widget]
+        touch_nav_focus: CheckButton,
     }
 }
 

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -9,8 +9,7 @@ use super::{driver, Driver, PressPhase, SelectionError, SelectionMode, Selection
 use kas::event::components::ScrollComponent;
 use kas::event::{Command, CursorIcon, Scroll};
 use kas::layout::{solve_size_rules, AlignHints};
-#[allow(unused)]
-use kas::model::SharedData;
+#[allow(unused)] use kas::model::SharedData;
 use kas::model::{ListData, SharedDataMut};
 use kas::prelude::*;
 #[allow(unused)] // doc links

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -50,11 +50,7 @@ impl_scope! {
     /// widget emits a [`SelectionMsg`].
     #[derive(Clone, Debug)]
     #[widget]
-    pub struct ListView<
-        D: Directional,
-        T: ListData,
-        V: Driver<T::Item, T> = driver::View,
-    > {
+    pub struct ListView<D: Directional, T: ListData, V: Driver<T::Item, T> = driver::View> {
         core: widget_core!(),
         frame_offset: Offset,
         frame_size: Size,
@@ -82,7 +78,11 @@ impl_scope! {
         press_target: Option<T::Key>,
     }
 
-    impl Self where D: Default, V: Default {
+    impl Self
+    where
+        D: Default,
+        V: Default,
+    {
         /// Construct a new instance
         ///
         /// This constructor is available where the direction is determined by the
@@ -92,13 +92,19 @@ impl_scope! {
             Self::new_with_dir_driver(D::default(), <V as Default>::default(), data)
         }
     }
-    impl Self where V: Default {
+    impl Self
+    where
+        V: Default,
+    {
         /// Construct a new instance with explicit direction
         pub fn new_with_direction(direction: D, data: T) -> Self {
             Self::new_with_dir_driver(direction, <V as Default>::default(), data)
         }
     }
-    impl Self where D: Default {
+    impl Self
+    where
+        D: Default,
+    {
         /// Construct a new instance with explicit driver
         pub fn new_with_driver(driver: V, data: T) -> Self {
             Self::new_with_dir_driver(D::default(), driver, data)
@@ -167,7 +173,10 @@ impl_scope! {
         /// This method updates the shared data, if supported (see
         /// [`SharedDataMut::borrow_mut`]). Other widgets sharing this data
         /// are notified of the update, if data is changed.
-        pub fn set_value(&self, mgr: &mut EventMgr, key: &T::Key, data: T::Item) where T: SharedDataMut {
+        pub fn set_value(&self, mgr: &mut EventMgr, key: &T::Key, data: T::Item)
+        where
+            T: SharedDataMut,
+        {
             self.data.set(mgr, key, data);
         }
 
@@ -176,7 +185,15 @@ impl_scope! {
         /// This method updates the shared data, if supported (see
         /// [`SharedDataMut::with_ref_mut`]). Other widgets sharing this data
         /// are notified of the update, if data is changed.
-        pub fn update_value<U>(&self, mgr: &mut EventMgr, key: &T::Key, f: impl FnOnce(&mut T::Item) -> U) -> Option<U> where T: SharedDataMut {
+        pub fn update_value<U>(
+            &self,
+            mgr: &mut EventMgr,
+            key: &T::Key,
+            f: impl FnOnce(&mut T::Item) -> U,
+        ) -> Option<U>
+        where
+            T: SharedDataMut,
+        {
             self.data.with_ref_mut(mgr, key, f)
         }
 
@@ -348,9 +365,7 @@ impl_scope! {
             let solver = self.position_solver(mgr);
             let mut action = TkAction::empty();
 
-            let keys = self
-                .data
-                .iter_from(solver.first_data, solver.cur_len);
+            let keys = self.data.iter_from(solver.first_data, solver.cur_len);
 
             let mut count = 0;
             for (i, key) in keys.enumerate() {
@@ -465,7 +480,9 @@ impl_scope! {
                 let other_axis = axis.flipped();
                 size -= self.frame_size.extract(other_axis);
                 if self.direction.is_horizontal() == other_axis.is_horizontal() {
-                    size = (size / self.ideal_visible).min(self.child_size_ideal).max(self.child_size_min);
+                    size = (size / self.ideal_visible)
+                        .min(self.child_size_ideal)
+                        .max(self.child_size_min);
                 }
                 size
             });
@@ -485,7 +502,8 @@ impl_scope! {
             if axis.is_vertical() == self.direction.is_vertical() {
                 self.child_size_ideal = rules.ideal_size();
                 let m = rules.margins();
-                self.child_inter_margin = m.0.max(m.1).max(inner_margin.0).max(inner_margin.1).cast();
+                self.child_inter_margin =
+                    m.0.max(m.1).max(inner_margin.0).max(inner_margin.1).cast();
                 rules.multiply_with_margin(2, self.ideal_visible);
                 rules.set_stretch(rules.stretch().max(Stretch::High));
             } else {
@@ -524,7 +542,11 @@ impl_scope! {
             if data_len <= avail_widgets {
                 req_widgets = data_len
             } else if avail_widgets < req_widgets {
-                log::debug!("set_rect: allocating widgets (old len = {}, new = {})", avail_widgets, req_widgets);
+                log::debug!(
+                    "set_rect: allocating widgets (old len = {}, new = {})",
+                    avail_widgets,
+                    req_widgets
+                );
                 self.widgets.reserve(req_widgets - avail_widgets);
                 for _ in avail_widgets..req_widgets {
                     let widget = self.driver.make();
@@ -737,7 +759,8 @@ impl_scope! {
                     };
                     return if let Some(i_data) = data {
                         // Set nav focus to i_data and update scroll position
-                        let (rect, action) = self.scroll.focus_rect(solver.rect(i_data), self.core.rect);
+                        let (rect, action) =
+                            self.scroll.focus_rect(solver.rect(i_data), self.core.rect);
                         if !action.is_empty() {
                             *mgr |= action;
                             mgr.config_mgr(|mgr| self.update_widgets(mgr));
@@ -753,7 +776,9 @@ impl_scope! {
                 _ => (), // fall through to scroll handler
             }
 
-            let (moved, r) = self.scroll.scroll_by_event(mgr, event, self.id(), self.core.rect);
+            let (moved, r) = self
+                .scroll
+                .scroll_by_event(mgr, event, self.id(), self.core.rect);
             if moved {
                 mgr.config_mgr(|mgr| self.update_widgets(mgr));
             }

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -9,8 +9,7 @@ use super::{driver, Driver, PressPhase, SelectionError, SelectionMode, Selection
 use kas::event::components::ScrollComponent;
 use kas::event::{Command, CursorIcon, Scroll};
 use kas::layout::{solve_size_rules, AlignHints};
-#[allow(unused)]
-use kas::model::SharedData;
+#[allow(unused)] use kas::model::SharedData;
 use kas::model::{MatrixData, SharedDataMut};
 use kas::prelude::*;
 #[allow(unused)] // doc links

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -56,10 +56,7 @@ impl_scope! {
     /// widget emits a [`SelectionMsg`].
     #[derive(Clone, Debug)]
     #[widget]
-    pub struct MatrixView<
-        T: MatrixData,
-        V: Driver<T::Item, T> = driver::View,
-    > {
+    pub struct MatrixView<T: MatrixData, V: Driver<T::Item, T> = driver::View> {
         core: widget_core!(),
         frame_offset: Offset,
         frame_size: Size,
@@ -87,7 +84,10 @@ impl_scope! {
         press_target: Option<T::Key>,
     }
 
-    impl Self where V: Default {
+    impl Self
+    where
+        V: Default,
+    {
         /// Construct a new instance
         pub fn new(data: T) -> Self {
             Self::new_with_driver(<V as Default>::default(), data)
@@ -149,7 +149,10 @@ impl_scope! {
         /// This method updates the shared data, if supported (see
         /// [`SharedDataMut::borrow_mut`]). Other widgets sharing this data
         /// are notified of the update, if data is changed.
-        pub fn set_value(&self, mgr: &mut EventMgr, key: &T::Key, data: T::Item) where T: SharedDataMut {
+        pub fn set_value(&self, mgr: &mut EventMgr, key: &T::Key, data: T::Item)
+        where
+            T: SharedDataMut,
+        {
             self.data.set(mgr, key, data);
         }
 
@@ -158,7 +161,15 @@ impl_scope! {
         /// This method updates the shared data, if supported (see
         /// [`SharedDataMut::with_ref_mut`]). Other widgets sharing this data
         /// are notified of the update, if data is changed.
-        pub fn update_value<U>(&self, mgr: &mut EventMgr, key: &T::Key, f: impl FnOnce(&mut T::Item) -> U) -> Option<U> where T: SharedDataMut {
+        pub fn update_value<U>(
+            &self,
+            mgr: &mut EventMgr,
+            key: &T::Key,
+            f: impl FnOnce(&mut T::Item) -> U,
+        ) -> Option<U>
+        where
+            T: SharedDataMut,
+        {
             self.data.with_ref_mut(mgr, key, f)
         }
 
@@ -325,9 +336,7 @@ impl_scope! {
                 );
             }
 
-            let row_iter = self
-                .data
-                .row_iter_from(solver.first_row, solver.row_len);
+            let row_iter = self.data.row_iter_from(solver.first_row, solver.row_len);
 
             let mut action = TkAction::empty();
             let mut row_count = 0;
@@ -381,7 +390,8 @@ impl_scope! {
             let avail = size - self.frame_size;
             let m = self.child_inter_margin;
             let child_size = Size(avail.0 / self.ideal_len.cols, avail.1 / self.ideal_len.rows)
-                .min(self.child_size_ideal).max(self.child_size_min);
+                .min(self.child_size_ideal)
+                .max(self.child_size_min);
             let (d_cols, d_rows) = self.data.len();
             let data_len = Size(d_cols.cast(), d_rows.cast());
             let content_size = ((child_size + m).cwise_mul(data_len) - m).max(Size::ZERO);
@@ -461,10 +471,13 @@ impl_scope! {
                 }
             }
 
-            self.child_size_ideal.set_component(axis, rules.ideal_size());
+            self.child_size_ideal
+                .set_component(axis, rules.ideal_size());
             let m = rules.margins();
-            self.child_inter_margin
-                .set_component(axis, m.0.max(m.1).max(inner_margin.0).max(inner_margin.1).cast());
+            self.child_inter_margin.set_component(
+                axis,
+                m.0.max(m.1).max(inner_margin.0).max(inner_margin.1).cast(),
+            );
 
             let ideal_len = match axis.is_vertical() {
                 false => self.ideal_len.cols,
@@ -485,7 +498,8 @@ impl_scope! {
 
             let avail = rect.size - self.frame_size;
             let child_size = Size(avail.0 / self.ideal_len.cols, avail.1 / self.ideal_len.rows)
-                .min(self.child_size_ideal).max(self.child_size_min);
+                .min(self.child_size_ideal)
+                .max(self.child_size_min);
             self.child_size = child_size;
 
             let (d_cols, d_rows) = self.data.len();
@@ -498,9 +512,8 @@ impl_scope! {
             } else {
                 // Case: reallocate children when scrolling
                 let skip = child_size + self.child_inter_margin;
-                vis_len = data_len.min(
-                    (rect.size + skip - Size::splat(1)).cwise_div(skip) + Size::splat(1)
-                );
+                vis_len = data_len
+                    .min((rect.size + skip - Size::splat(1)).cwise_div(skip) + Size::splat(1));
                 req_widgets = usize::conv(vis_len.0) * usize::conv(vis_len.1);
             }
             self.alloc_len = Dim {
@@ -509,7 +522,11 @@ impl_scope! {
             };
 
             if avail_widgets < req_widgets {
-                log::debug!("set_rect: allocating widgets (old len = {}, new = {})", avail_widgets, req_widgets);
+                log::debug!(
+                    "set_rect: allocating widgets (old len = {}, new = {})",
+                    avail_widgets,
+                    req_widgets
+                );
                 self.widgets.reserve(req_widgets - avail_widgets);
                 for _ in avail_widgets..req_widgets {
                     let widget = self.driver.make();
@@ -567,7 +584,10 @@ impl_scope! {
             // widgets (this allows resource loading which may affect size.)
             self.data_ver = self.data.version();
             if self.widgets.is_empty() && !self.data.is_empty() {
-                let cols: Vec<_> = self.data.col_iter_limit(self.ideal_len.cols.cast()).collect();
+                let cols: Vec<_> = self
+                    .data
+                    .col_iter_limit(self.ideal_len.cols.cast())
+                    .collect();
                 let rows = self.data.row_iter_limit(self.ideal_len.rows.cast());
                 let lbound = cols.len() * rows.size_hint().0;
                 log::debug!("configure: allocating {} widgets", lbound);
@@ -607,7 +627,7 @@ impl_scope! {
             let (ci, ri) = if let Some(index) = from {
                 let (ci, ri) = solver.child_to_data(index);
                 if !reverse {
-                    if ci + 1 < d_cols{
+                    if ci + 1 < d_cols {
                         (ci + 1, ri)
                     } else if ri + 1 < d_rows {
                         (0, ri + 1)
@@ -737,9 +757,7 @@ impl_scope! {
                         C::Up if ri > 0 => Some((ci, ri - 1)),
                         C::Right | C::WordRight if ci < last_col => Some((ci + 1, ri)),
                         C::Down if ri < last_row => Some((ci, ri + 1)),
-                        C::PageUp if ri > 0 => {
-                            Some((ci, ri.saturating_sub(solver.row_len / 2)))
-                        }
+                        C::PageUp if ri > 0 => Some((ci, ri.saturating_sub(solver.row_len / 2))),
                         C::PageDown if ri < last_row => {
                             Some((ci, (ri + solver.row_len / 2).min(last_row)))
                         }
@@ -748,19 +766,23 @@ impl_scope! {
                     };
                     return if let Some((ci, ri)) = data {
                         // Set nav focus and update scroll position
-                        let (rect, action) = self.scroll.focus_rect(solver.rect(ci, ri), self.core.rect);
+                        let (rect, action) =
+                            self.scroll.focus_rect(solver.rect(ci, ri), self.core.rect);
                         if !action.is_empty() {
                             *mgr |= action;
                             solver = mgr.config_mgr(|mgr| self.update_widgets(mgr));
                         }
 
                         let index = solver.data_to_child(ci, ri);
-                        #[cfg(debug_assertions)] {
-                            let rk = self.data
+                        #[cfg(debug_assertions)]
+                        {
+                            let rk = self
+                                .data
                                 .row_iter_from(ri, 1)
                                 .next()
                                 .expect("data row len > data.row_iter_vec len");
-                            let ck = self.data
+                            let ck = self
+                                .data
                                 .col_iter_from(ci, 1)
                                 .next()
                                 .expect("data col len > data.col_iter_vec len");
@@ -781,7 +803,9 @@ impl_scope! {
                 _ => (), // fall through to scroll handler
             }
 
-            let (moved, r) = self.scroll.scroll_by_event(mgr, event, self.id(), self.core.rect);
+            let (moved, r) = self
+                .scroll
+                .scroll_by_event(mgr, event, self.id(), self.core.rect);
             if moved {
                 mgr.config_mgr(|mgr| self.update_widgets(mgr));
             }

--- a/crates/kas-view/src/single_view.rs
+++ b/crates/kas-view/src/single_view.rs
@@ -32,10 +32,7 @@ impl_scope! {
     #[widget{
         layout = self.child;
     }]
-    pub struct SingleView<
-        T: SingleData,
-        V: Driver<T::Item, T> = driver::View,
-    > {
+    pub struct SingleView<T: SingleData, V: Driver<T::Item, T> = driver::View> {
         core: widget_core!(),
         driver: V,
         data: T,
@@ -53,7 +50,10 @@ impl_scope! {
             Self::new(T::default())
         }
     }
-    impl Self where V: Default {
+    impl Self
+    where
+        V: Default,
+    {
         /// Construct a new instance
         pub fn new(data: T) -> Self {
             Self::new_with_driver(<V as Default>::default(), data)
@@ -98,7 +98,10 @@ impl_scope! {
         /// This method updates the shared data, if supported (see
         /// [`SharedDataMut::borrow_mut`]). Other widgets sharing this data
         /// are notified of the update, if data is changed.
-        pub fn set_value(&self, mgr: &mut EventMgr, data: T::Item) where T: SharedDataMut {
+        pub fn set_value(&self, mgr: &mut EventMgr, data: T::Item)
+        where
+            T: SharedDataMut,
+        {
             self.data.set(mgr, &(), data);
         }
 
@@ -107,7 +110,14 @@ impl_scope! {
         /// This method updates the shared data, if supported (see
         /// [`SharedDataMut::with_ref_mut`]). Other widgets sharing this data
         /// are notified of the update, if data is changed.
-        pub fn update_value<U>(&self, mgr: &mut EventMgr, f: impl FnOnce(&mut T::Item) -> U) -> Option<U> where T: SharedDataMut {
+        pub fn update_value<U>(
+            &self,
+            mgr: &mut EventMgr,
+            f: impl FnOnce(&mut T::Item) -> U,
+        ) -> Option<U>
+        where
+            T: SharedDataMut,
+        {
             self.data.with_ref_mut(mgr, &(), f)
         }
     }
@@ -143,7 +153,8 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
-            self.driver.on_message(mgr, &mut self.child, &self.data, &());
+            self.driver
+                .on_message(mgr, &mut self.child, &self.data, &());
         }
     }
 }

--- a/crates/kas-widgets/src/adapter/adapt_widget.rs
+++ b/crates/kas-widgets/src/adapter/adapt_widget.rs
@@ -54,23 +54,22 @@ pub trait AdaptWidget: Widget {
     /// widget, for example:
     ///```
     /// # use kas_widgets::adapter::AdaptWidget;
-    /// use kas_widgets::Label;
     /// use kas::prelude::*;
+    /// use kas_widgets::Label;
     ///
-    /// let label = Label::new("0").with_reserve(|size_mgr, axis| {
-    ///     Label::new("00000").size_rules(size_mgr, axis)
-    /// });
-    ///```
+    /// let label = Label::new("0")
+    ///     .with_reserve(|size_mgr, axis| Label::new("00000").size_rules(size_mgr, axis));
+    /// ```
     /// Alternatively one may use virtual pixels:
     ///```
     /// # use kas_widgets::adapter::AdaptWidget;
-    /// use kas_widgets::Filler;
     /// use kas::prelude::*;
+    /// use kas_widgets::Filler;
     ///
     /// let label = Filler::new().with_reserve(|mgr, axis| {
     ///     kas::layout::LogicalSize(5.0, 5.0).to_rules(axis, mgr.scale_factor())
     /// });
-    ///```
+    /// ```
     /// The resulting `SizeRules` will be the max of those for the inner widget
     /// and the result of the `reserve` closure.
     #[must_use]

--- a/crates/kas-widgets/src/adapter/adapt_widget.rs
+++ b/crates/kas-widgets/src/adapter/adapt_widget.rs
@@ -12,8 +12,7 @@ use kas::geom::Vec2;
 use kas::layout::{AxisInfo, SizeRules};
 use kas::text::AccelString;
 use kas::theme::SizeMgr;
-#[allow(unused)]
-use kas::Layout;
+#[allow(unused)] use kas::Layout;
 use kas::Widget;
 use std::fmt::Debug;
 

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -19,7 +19,12 @@ impl_scope! {
     #[widget{
         layout = self.inner;
     }]
-    pub struct MapMessage<W: Widget, M: Debug + 'static, N: Debug + 'static, F: FnMut(M) -> N + 'static> {
+    pub struct MapMessage<
+        W: Widget,
+        M: Debug + 'static,
+        N: Debug + 'static,
+        F: FnMut(M) -> N + 'static,
+    > {
         core: widget_core!(),
         #[widget]
         inner: W,
@@ -52,14 +57,22 @@ impl_scope! {
         }
     }
 
-    impl Menu for Self where W: Menu {
+    impl Menu for Self
+    where
+        W: Menu,
+    {
         fn sub_items(&mut self) -> Option<menu::SubItems> {
             self.inner.sub_items()
         }
         fn menu_is_open(&self) -> bool {
             self.inner.menu_is_open()
         }
-        fn set_menu_path(&mut self, mgr: &mut EventMgr, target: Option<&WidgetId>, set_focus: bool) {
+        fn set_menu_path(
+            &mut self,
+            mgr: &mut EventMgr,
+            target: Option<&WidgetId>,
+            set_focus: bool,
+        ) {
             self.inner.set_menu_path(mgr, target, set_focus);
         }
     }

--- a/crates/kas-widgets/src/adapter/reserve.rs
+++ b/crates/kas-widgets/src/adapter/reserve.rs
@@ -85,10 +85,7 @@ impl_scope! {
         /// and the result of the `reserve` closure.
         #[inline]
         pub fn new(inner: W, reserve: R) -> Self {
-            Reserve {
-                inner,
-                reserve,
-            }
+            Reserve { inner, reserve }
         }
     }
 

--- a/crates/kas-widgets/src/adapter/with_label.rs
+++ b/crates/kas-widgets/src/adapter/with_label.rs
@@ -29,7 +29,10 @@ impl_scope! {
         label: AccelLabel,
     }
 
-    impl Self where D: Default {
+    impl Self
+    where
+        D: Default,
+    {
         /// Construct from `inner` widget and `label`
         #[inline]
         pub fn new<T: Into<AccelString>>(inner: W, label: T) -> Self {

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -198,8 +198,10 @@ impl_scope! {
     #[widget]
     pub struct EditBox<G: EditGuard = ()> {
         core: widget_core!(),
-        #[widget] inner: EditField<G>,
-        #[widget] bar: ScrollBar<kas::dir::Down>,
+        #[widget]
+        inner: EditField<G>,
+        #[widget]
+        bar: ScrollBar<kas::dir::Down>,
         frame_offset: Offset,
         frame_size: Size,
         inner_margin: i32,
@@ -271,7 +273,8 @@ impl_scope! {
     impl Widget for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr<'_>, _: usize) {
             if let Some(ScrollMsg(y)) = mgr.try_pop_msg() {
-                self.inner.set_scroll_offset(mgr, Offset(self.inner.view_offset.0, y));
+                self.inner
+                    .set_scroll_offset(mgr, Offset(self.inner.view_offset.0, y));
             }
         }
 

--- a/crates/kas-widgets/src/filler.rs
+++ b/crates/kas-widgets/src/filler.rs
@@ -22,11 +22,7 @@ impl_scope! {
 
     impl Layout for Filler {
         fn size_rules(&mut self, _: SizeMgr, axis: AxisInfo) -> SizeRules {
-            let stretch = if axis.is_horizontal() {
-                self.horiz
-            } else {
-                self.vert
-            };
+            let stretch = if axis.is_horizontal() { self.horiz } else { self.vert };
             SizeRules::empty(stretch)
         }
 

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -81,7 +81,9 @@ impl_scope! {
         fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
             let mut solver = GridSolver::<Vec<_>, Vec<_>, _>::new(axis, self.dim, &mut self.data);
             for (info, child) in &mut self.widgets {
-                solver.for_child(&mut self.data, *info, |axis| child.size_rules(mgr.re(), axis));
+                solver.for_child(&mut self.data, *info, |axis| {
+                    child.size_rules(mgr.re(), axis)
+                });
             }
             solver.finish(&mut self.data)
         }
@@ -98,7 +100,10 @@ impl_scope! {
             if !self.rect().contains(coord) {
                 return None;
             }
-            self.widgets.iter_mut().find_map(|(_, child)| child.find_id(coord)).or_else(|| Some(self.id()))
+            self.widgets
+                .iter_mut()
+                .find_map(|(_, child)| child.find_id(coord))
+                .or_else(|| Some(self.id()))
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {

--- a/crates/kas-widgets/src/image.rs
+++ b/crates/kas-widgets/src/image.rs
@@ -91,7 +91,7 @@ impl_scope! {
         pub fn load_path<P: AsRef<std::path::Path>>(
             &mut self,
             path: P,
-            draw: &mut dyn DrawShared
+            draw: &mut dyn DrawShared,
         ) -> Result<TkAction> {
             let image = image::io::Reader::open(path)?
                 .with_guessed_format()?

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -94,7 +94,8 @@ impl_scope! {
         }
 
         fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
-            id.next_key_after(self.id_ref()).and_then(|k| self.id_map.get(&k).cloned())
+            id.next_key_after(self.id_ref())
+                .and_then(|k| self.id_map.get(&k).cloned())
         }
 
         fn make_child_id(&mut self, index: usize) -> WidgetId {
@@ -132,7 +133,10 @@ impl_scope! {
         }
     }
 
-    impl Self where D: Default {
+    impl Self
+    where
+        D: Default,
+    {
         /// Construct a new instance
         ///
         /// This constructor is available where the direction is determined by the

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -164,7 +164,7 @@ impl_scope! {
         where
             F: Fn(&mut EventMgr, bool) + 'static,
         {
-             MenuToggle {
+            MenuToggle {
                 core: self.core,
                 checkbox: self.checkbox.on_toggle(f),
                 label: self.label,

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -26,7 +26,10 @@ impl_scope! {
         delayed_open: Option<WidgetId>,
     }
 
-    impl Self where D: Default {
+    impl Self
+    where
+        D: Default,
+    {
         /// Construct a menubar
         ///
         /// Note: it appears that `MenuBar::new(..)` causes a type inference error,
@@ -133,7 +136,11 @@ impl_scope! {
                     start_id,
                     coord,
                 } => {
-                    if start_id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
+                    if start_id
+                        .as_ref()
+                        .map(|id| self.is_ancestor_of(id))
+                        .unwrap_or(false)
+                    {
                         if source.is_primary() {
                             let any_menu_open = self.widgets.iter().any(|w| w.menu_is_open());
                             let press_in_the_bar = self.rect().contains(coord);
@@ -193,7 +200,12 @@ impl_scope! {
                     }
                     Response::Used
                 }
-                Event::PressEnd { coord, end_id, success, .. } if success => {
+                Event::PressEnd {
+                    coord,
+                    end_id,
+                    success,
+                    ..
+                } if success => {
                     let id = match end_id {
                         Some(x) => x,
                         None => return Response::Used,
@@ -241,8 +253,16 @@ impl_scope! {
     }
 
     impl Self {
-        fn set_menu_path(&mut self, mgr: &mut EventMgr, target: Option<&WidgetId>, set_focus: bool) {
-            log::trace!("set_menu_path: self={}, target={target:?}, set_focus={set_focus}", self.identify());
+        fn set_menu_path(
+            &mut self,
+            mgr: &mut EventMgr,
+            target: Option<&WidgetId>,
+            set_focus: bool,
+        ) {
+            log::trace!(
+                "set_menu_path: self={}, target={target:?}, set_focus={set_focus}",
+                self.identify()
+            );
             self.delayed_open = None;
             for i in 0..self.widgets.len() {
                 self.widgets[i].set_menu_path(mgr, target, set_focus);

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -32,7 +32,10 @@ impl_scope! {
         popup_id: Option<WindowId>,
     }
 
-    impl Self where D: Default {
+    impl Self
+    where
+        D: Default,
+    {
         /// Construct a sub-menu
         #[inline]
         pub fn new<S: Into<AccelString>>(label: S, list: Vec<BoxedMenu>) -> Self {
@@ -65,7 +68,9 @@ impl_scope! {
         /// The sub-menu is opened in the `direction` given (contents are always vertical).
         #[inline]
         pub fn new_with_direction<S: Into<AccelString>>(
-            direction: D, label: S, list: Vec<BoxedMenu>
+            direction: D,
+            label: S,
+            list: Vec<BoxedMenu>,
         ) -> Self {
             SubMenu {
                 core: Default::default(),
@@ -196,7 +201,12 @@ impl_scope! {
             self.popup_id.is_some()
         }
 
-        fn set_menu_path(&mut self, mgr: &mut EventMgr, target: Option<&WidgetId>, set_focus: bool) {
+        fn set_menu_path(
+            &mut self,
+            mgr: &mut EventMgr,
+            target: Option<&WidgetId>,
+            set_focus: bool,
+        ) {
             match target {
                 Some(id) if self.is_ancestor_of(id) => {
                     if self.popup_id.is_none() {
@@ -373,7 +383,7 @@ impl_scope! {
                         let info = layout::GridChildInfo::new(1, row);
                         w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)));
                     }
-                    if let Some(w) =  items.label {
+                    if let Some(w) = items.label {
                         let info = layout::GridChildInfo::new(2, row);
                         w.set_rect(mgr, subtract_frame(setter.child_rect(store, info)));
                     }

--- a/crates/kas-widgets/src/progress.rs
+++ b/crates/kas-widgets/src/progress.rs
@@ -23,7 +23,10 @@ impl_scope! {
         value: f32,
     }
 
-    impl Self where D: Default {
+    impl Self
+    where
+        D: Default,
+    {
         /// Construct a progress bar
         ///
         /// The initial value is `0.0`; use `ProgressBar::with_value` to override.
@@ -84,10 +87,13 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            self.align.set_component(axis, match axis.is_vertical() == self.direction.is_vertical() {
-                false => axis.align_or_center(),
-                true => axis.align_or_stretch(),
-            });
+            self.align.set_component(
+                axis,
+                match axis.is_vertical() == self.direction.is_vertical() {
+                    false => axis.align_or_center(),
+                    true => axis.align_or_stretch(),
+                },
+            );
             size_mgr.feature(Feature::ProgressBar(self.direction()), axis)
         }
 

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -86,7 +86,7 @@ impl_scope! {
                         }
                     }
                     Response::Used
-                })
+                }),
             }
         }
     }

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -140,7 +140,9 @@ impl_scope! {
         }
 
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
-            self.scroll.scroll_by_event(mgr, event, self.id(), self.core.rect).1
+            self.scroll
+                .scroll_by_event(mgr, event, self.id(), self.core.rect)
+                .1
         }
 
         fn handle_scroll(&mut self, mgr: &mut EventMgr, scroll: Scroll) {

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -47,7 +47,10 @@ impl_scope! {
         handle: GripPart,
     }
 
-    impl Self where D: Default {
+    impl Self
+    where
+        D: Default,
+    {
         /// Construct a scroll bar
         ///
         /// Default values are assumed for all parameters.
@@ -253,10 +256,13 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            self.align.set_component(axis, match axis.is_vertical() == self.direction.is_vertical() {
-                false => axis.align_or_center(),
-                true => axis.align_or_stretch(),
-            });
+            self.align.set_component(
+                axis,
+                match axis.is_vertical() == self.direction.is_vertical() {
+                    false => axis.align_or_center(),
+                    true => axis.align_or_stretch(),
+                },
+            );
             size_mgr.feature(Feature::ScrollBar(self.direction()), axis)
         }
 
@@ -279,9 +285,9 @@ impl_scope! {
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
-            if !self.invisible ||
-                (self.max_value != 0 && (self.hover || self.force_visible)) ||
-                draw.ev_state().is_depressed(self.handle.id_ref())
+            if !self.invisible
+                || (self.max_value != 0 && (self.hover || self.force_visible))
+                || draw.ev_state().is_depressed(self.handle.id_ref())
             {
                 let dir = self.direction.as_direction();
                 draw.scroll_bar(self.rect(), &self.handle, dir);
@@ -302,7 +308,7 @@ impl_scope! {
                     self.apply_grip_offset(mgr, offset);
                     Response::Used
                 }
-                _ => Response::Unused
+                _ => Response::Unused,
             }
         }
 
@@ -476,15 +482,13 @@ impl_scope! {
             if self.show_bars.0 {
                 let pos = Coord(pos.0, rect.pos2().1 - bar_width);
                 let size = Size::new(child_size.0, bar_width);
-                self.horiz_bar
-                    .set_rect(mgr, Rect { pos, size });
+                self.horiz_bar.set_rect(mgr, Rect { pos, size });
                 let _ = self.horiz_bar.set_limits(max_scroll_offset.0, rect.size.0);
             }
             if self.show_bars.1 {
                 let pos = Coord(rect.pos2().0 - bar_width, pos.1);
                 let size = Size::new(bar_width, self.core.rect.size.1);
-                self.vert_bar
-                    .set_rect(mgr, Rect { pos, size });
+                self.vert_bar.set_rect(mgr, Rect { pos, size });
                 let _ = self.vert_bar.set_limits(max_scroll_offset.1, rect.size.1);
             }
         }
@@ -493,7 +497,8 @@ impl_scope! {
             if !self.rect().contains(coord) {
                 return None;
             }
-            self.vert_bar.find_id(coord)
+            self.vert_bar
+                .find_id(coord)
                 .or_else(|| self.horiz_bar.find_id(coord))
                 .or_else(|| self.inner.find_id(coord))
                 .or_else(|| Some(self.id()))

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -30,7 +30,8 @@ impl_scope! {
         text_size: Size,
         selection: SelectionHelper,
         input_handler: TextInput,
-        #[widget] bar: ScrollBar<kas::dir::Down>,
+        #[widget]
+        bar: ScrollBar<kas::dir::Down>,
     }
 
     impl Layout for Self {
@@ -77,12 +78,7 @@ impl_scope! {
                     // TODO(opt): we could cache the selection rectangles here to make
                     // drawing more efficient (self.text.highlight_lines(range) output).
                     // The same applies to the edit marker below.
-                    draw.text_selected(
-                        rect,
-                        &self.text,
-                        self.selection.range(),
-                        class,
-                    );
+                    draw.text_selected(rect, &self.text, self.selection.range(), class);
                 }
             });
             draw.with_pass(|mut draw| {
@@ -111,7 +107,9 @@ impl_scope! {
         /// Note: this must not be called before fonts have been initialised
         /// (usually done by the theme when the main loop starts).
         pub fn set_text(&mut self, text: T) -> TkAction {
-            self.text.set_and_try_prepare(text).expect("invalid font_id");
+            self.text
+                .set_and_try_prepare(text)
+                .expect("invalid font_id");
 
             self.text_size = Vec2::from(self.text.bounding_box().unwrap().1).cast_ceil();
             let max_offset = self.max_scroll_offset();
@@ -137,18 +135,19 @@ impl_scope! {
 
         // Pan by given delta. Return `Response::Scrolled` or `Response::Pan(remaining)`.
         fn pan_delta(&mut self, mgr: &mut EventMgr, mut delta: Offset) -> Response {
-            let new_offset = (self.view_offset - delta).min(self.max_scroll_offset()).max(Offset::ZERO);
+            let new_offset = (self.view_offset - delta)
+                .min(self.max_scroll_offset())
+                .max(Offset::ZERO);
             if new_offset != self.view_offset {
                 delta -= self.view_offset - new_offset;
                 self.set_offset(mgr, new_offset);
             }
 
             mgr.set_scroll(if delta == Offset::ZERO {
-                    Scroll::Scrolled
-                } else {
-                    Scroll::Offset(delta)
-                }
-            );
+                Scroll::Scrolled
+            } else {
+                Scroll::Offset(delta)
+            });
             Response::Used
         }
 

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -109,7 +109,10 @@ impl_scope! {
         on_move: Option<Rc<dyn Fn(&mut EventMgr, T)>>,
     }
 
-    impl Self where D: Default {
+    impl Self
+    where
+        D: Default,
+    {
         /// Construct a slider
         ///
         /// Values vary within the given `range`. When keyboard navigation
@@ -258,10 +261,13 @@ impl_scope! {
 
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
-            self.align.set_component(axis, match axis.is_vertical() == self.direction.is_vertical() {
-                false => axis.align_or_center(),
-                true => axis.align_or_stretch(),
-            });
+            self.align.set_component(
+                axis,
+                match axis.is_vertical() == self.direction.is_vertical() {
+                    false => axis.align_or_center(),
+                    true => axis.align_or_stretch(),
+                },
+            );
             size_mgr.feature(Feature::Slider(self.direction()), axis)
         }
 

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -318,13 +318,11 @@ impl_scope! {
 
         fn steal_event(&mut self, mgr: &mut EventMgr, _: &WidgetId, event: &Event) -> Response {
             let btn = match event {
-                Event::Command(cmd) => {
-                    match cmd {
-                        Command::Down => SpinBtn::Down,
-                        Command::Up => SpinBtn::Up,
-                        _ => return Response::Unused,
-                    }
-                }
+                Event::Command(cmd) => match cmd {
+                    Command::Down => SpinBtn::Down,
+                    Command::Up => SpinBtn::Up,
+                    _ => return Response::Unused,
+                },
                 Event::Scroll(ScrollDelta::LineDelta(_, y)) => {
                     if *y > 0.0 {
                         SpinBtn::Up

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -130,7 +130,8 @@ impl_scope! {
         }
 
         fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
-            id.next_key_after(self.id_ref()).and_then(|k| self.id_map.get(&k).cloned())
+            id.next_key_after(self.id_ref())
+                .and_then(|k| self.id_map.get(&k).cloned())
         }
 
         fn make_child_id(&mut self, child_index: usize) -> WidgetId {

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -61,7 +61,8 @@ impl_scope! {
         }
 
         fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
-            id.next_key_after(self.id_ref()).and_then(|k| self.id_map.get(&k).cloned())
+            id.next_key_after(self.id_ref())
+                .and_then(|k| self.id_map.get(&k).cloned())
         }
 
         fn make_child_id(&mut self, index: usize) -> WidgetId {
@@ -89,7 +90,10 @@ impl_scope! {
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
             let mut rules = SizeRules::EMPTY;
-            let end = self.active.saturating_add(self.size_limit).min(self.widgets.len());
+            let end = self
+                .active
+                .saturating_add(self.size_limit)
+                .min(self.widgets.len());
             let start = end.saturating_sub(self.size_limit);
             self.sized_range = start..end;
             debug_assert!(self.sized_range.contains(&self.active));
@@ -127,11 +131,7 @@ impl_scope! {
             self.id_map.clear();
         }
 
-        fn nav_next(&mut self,
-            _: &mut ConfigMgr,
-            _: bool,
-            from: Option<usize>,
-        ) -> Option<usize> {
+        fn nav_next(&mut self, _: &mut ConfigMgr, _: bool, from: Option<usize>) -> Option<usize> {
             match from {
                 None => Some(self.active),
                 Some(active) if active != self.active => Some(self.active),

--- a/examples/async-event.rs
+++ b/examples/async-event.rs
@@ -69,7 +69,12 @@ impl_scope! {
         fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect) {
             self.core.rect = rect;
             let align = Some(AlignPair::new(Align::Center, Align::Center));
-            mgr.text_set_size(&mut self.loading_text, TextClass::Label(false), rect.size, align);
+            mgr.text_set_size(
+                &mut self.loading_text,
+                TextClass::Label(false),
+                rect.size,
+                align,
+            );
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
@@ -95,7 +100,9 @@ impl_scope! {
         }
     }
     impl Window for Self {
-        fn title(&self) -> &str { "Async event demo" }
+        fn title(&self) -> &str {
+            "Async event demo"
+        }
     }
 }
 

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -126,8 +126,12 @@ impl_scope! {
                     self.now = Local::now();
                     let date = self.now.format("%Y-%m-%d").to_string();
                     let time = self.now.format("%H:%M:%S").to_string();
-                    self.date.set_and_try_prepare(date).expect("invalid font_id");
-                    self.time.set_and_try_prepare(time).expect("invalid font_id");
+                    self.date
+                        .set_and_try_prepare(date)
+                        .expect("invalid font_id");
+                    self.time
+                        .set_and_try_prepare(time)
+                        .expect("invalid font_id");
                     let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
                     log::info!("Requesting update in {}ns", ns);
                     mgr.request_update(self.id(), 0, Duration::new(0, ns), true);
@@ -159,7 +163,9 @@ impl_scope! {
     }
 
     impl Window for Self {
-        fn title(&self) -> &str { "Clock" }
+        fn title(&self) -> &str {
+            "Clock"
+        }
     }
 }
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -46,7 +46,9 @@ impl_scope! {
         }
     }
     impl Window for Self {
-        fn title(&self) -> &str { "Counter" }
+        fn title(&self) -> &str {
+            "Counter"
+        }
     }
 }
 

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -437,11 +437,15 @@ impl_scope! {
     }]
     struct MandlebrotWindow {
         core: widget_core!(),
-        #[widget] label: Label<String>,
-        #[widget] iters: ReserveP<Label<String>>,
-        #[widget] slider: Slider<i32, kas::dir::Up>,
+        #[widget]
+        label: Label<String>,
+        #[widget]
+        iters: ReserveP<Label<String>>,
+        #[widget]
+        slider: Slider<i32, kas::dir::Up>,
         // extra col span allows use of Label's margin
-        #[widget] mbrot: Mandlebrot,
+        #[widget]
+        mbrot: Mandlebrot,
     }
 
     impl MandlebrotWindow {
@@ -473,7 +477,9 @@ impl_scope! {
         }
     }
     impl Window for Self {
-        fn title(&self) -> &str { "Mandlebrot" }
+        fn title(&self) -> &str {
+            "Mandlebrot"
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,7 @@ pub mod prelude {
 
 pub use kas_core::*;
 
-#[doc(inline)]
-pub extern crate kas_widgets as widgets;
+#[doc(inline)] pub extern crate kas_widgets as widgets;
 
 #[cfg(any(feature = "view"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "view")))]


### PR DESCRIPTION
Uses https://github.com/rust-lang/rustfmt/pull/5538 to format code within `impl_scope! { .. }`