### PR TITLE
README, model/view docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,52 +9,37 @@ KAS GUI
 
 KAS is a pure-Rust GUI toolkit with stateful widgets:
 
--   Widgets retain state (retained mode), also supporting shared data (models)
--   Powerful, simple event model: events go down the widget tree, messages come back up
--   Layout DSL and complex layout solver
--   Widget library uses only user-facing parts of the core API
--   Abstraction for widget, theme and backend graphics code
--   Widget *and* theme driven animations
--   Embedded accelerated graphics (see [Mandlebrot example](examples/mandlebrot))
--   Accessible (full keyboard control, no screen reader yet)
--   Stepless DPI scaling
--   Very fast and low CPU usage
+- [x] Pure, portable Rust
+- [x] Very fast and CPU efficient
+- [x] Flexible event handling without data races
+- [x] Theme abstraction layer
+- [x] [Winit] + [WGPU] shell supporting embedded accelerated content
+- [ ] More portable shells: OpenGL, CPU-rendered, integration
+- [x] [Complex text](https://github.com/kas-gui/kas-text/)
+- [ ] OS integration: menus, fonts, IME
+- [ ] Accessibility: screen reader, translation
 
 ![Animated](https://github.com/kas-gui/data-dump/blob/master/kas_0_11/video/animations.apng)
 ![Scalable](https://github.com/kas-gui/data-dump/blob/master/kas_0_10/image/scalable.png)
 
-### Limitations
-
--   Slow compile times. See [Faster builds](https://github.com/kas-gui/kas/wiki/Getting-started#faster-builds).
--   Somewhat large binaries; e.g. for the `gallery` example: 333M (debug),
-    38M (debug + strip), 20M (release), 12M (release + strip).
-    Note that these binaries are statically linked, as is the norm for Rust.
-    Some improvements may be possible, e.g. disabling features such as `shaping`
-    and `image` or replacing the rendering backend.
+[Winit]: https://github.com/rust-windowing/winit
+[WGPU]: https://github.com/gfx-rs/wgpu
 
 ### Documentation
 
 -   Wiki: [Getting started](https://github.com/kas-gui/kas/wiki/Getting-started),
     [Configuration](https://github.com/kas-gui/kas/wiki/Configuration),
     [Troubleshooting](https://github.com/kas-gui/kas/wiki/Troubleshooting)
--   API docs: <https://docs.rs/kas>, <https://docs.rs/kas-core>,
-    <https://docs.rs/kas-widgets>, <https://docs.rs/kas-theme>, <https://docs.rs/kas-wgpu>
--   [KAS Tutorials](https://kas-gui.github.io/tutorials/)
--   [Changlelog](CHANGELOG.md)
--   [Roadmap](ROADMAP.md)
--   [Discuss](https://github.com/kas-gui/kas/discussions)
--   [KAS Blog](https://kas-gui.github.io/blog/)
+-   API docs: [kas](https://docs.rs/kas), [kas-core](https://docs.rs/kas-core),
+    [kas-widgets](https://docs.rs/kas-widgets),
+    [kas-theme](https://docs.rs/kas-theme), [kas-wgpu](https://docs.rs/kas-wgpu)
+-   Prose: [Tutorials](https://kas-gui.github.io/tutorials/),
+    [Blog](https://kas-gui.github.io/blog/)
 
 ### Examples
 
 See the [`examples`](examples) directory and
 [kas-gui/7guis](https://github.com/kas-gui/7guis/).
-
-Precompiled example apps can be downloaded as follows:
-
--   go to <https://github.com/kas-gui/kas/actions/workflows/build.yml>
--   select the latest (complete) run
--   download one of the `examples-*` artifacts
 
 
 Design
@@ -62,21 +47,28 @@ Design
 
 ### Data or widget first?
 
-KAS uses a widget-first design: widgets are persistent and retain state; data
-must be pushed into widgets. *Many* modern UIs are data-first: widgets are
-built per-frame over a single persistent data object. There are significant
-trade-offs of a widget-first design:
+KAS attempts to blend several GUI models:
 
--   (for) widgets have embedded state; data-first designs may require explicitly
-    connecting widgets to state, for those that need it
--   (for) enables more complex layout solvers
--   (against) dynamic layout is harder
--   (for) updates are fast since only affected widgets need be touched
--   (against) (re)building the UI is slower
--   (for) pre-built "view widgets" providing scrolling and selection support
-    over large external databases (only retrieving visible entries)
--   (against) "view widgets" are an emulation of data-first design over a
-    widget-first model, and less flexible
+-   Like many older GUIs, there is a persistent tree of widgets with state
+-   Like Elm, event handling uses messages; unlike Elm, messages may be handled
+    anywhere in the widget tree (proceeding from leaf to root until handled)
+-   Widgets have a stable identity using a path over optionally explicit
+    components
+-   Like Model-View-Controller designs, data separation is possible; unlike Elm
+    this is not baked into the core of the design
+
+The results:
+
+-   Natural support for multiple windows (there is no central data model)
+-   Widget trees (without MVC) are static and pre-allocated, though efficient
+    enough that maintaining (*many*) thousands
+    of not-currently-visible widgets isn't a problem
+-   Support for accessibility (only navigation aspects so far)
+-   MVC supports virtual scrolling (including persistent IDs for unrealised
+    widgets)
+-   MVC supports shared (`Rc` or `Arc`) data
+-   MVC and stateful widget designs feel like two different architectures
+    forced into the same UI toolkit
 
 
 Crates and features

--- a/crates/kas-core/src/model/data_traits.rs
+++ b/crates/kas-core/src/model/data_traits.rs
@@ -153,6 +153,9 @@ pub trait SharedDataMut: SharedData {
 /// Trait bound for viewable single data
 ///
 /// This is automatically implemented for every type implementing `SharedData<()>`.
+///
+/// Provided implementations: [`SharedRc`](super::SharedRc),
+/// [`SharedArc`](super::SharedArc).
 // TODO(trait aliases): make this an actual trait alias
 pub trait SingleData: SharedData<Key = ()> {}
 impl<T: SharedData<Key = ()>> SingleData for T {}
@@ -160,11 +163,16 @@ impl<T: SharedData<Key = ()>> SingleData for T {}
 /// Trait bound for mutable single data
 ///
 /// This is automatically implemented for every type implementing `SharedDataMut<()>`.
+///
+/// Provided implementations: [`SharedRc`](super::SharedRc),
+/// [`SharedArc`](super::SharedArc).
 // TODO(trait aliases): make this an actual trait alias
 pub trait SingleDataMut: SharedDataMut<Key = ()> {}
 impl<T: SharedDataMut<Key = ()>> SingleDataMut for T {}
 
 /// Trait for viewable data lists
+///
+/// Provided implementations: `[T]`, `Vec<T>`.
 #[allow(clippy::len_without_is_empty)]
 #[autoimpl(for<T: trait + ?Sized> &T, &mut T, std::rc::Rc<T>, std::sync::Arc<T>, Box<T>)]
 pub trait ListData: SharedData {

--- a/crates/kas-view/src/driver.rs
+++ b/crates/kas-view/src/driver.rs
@@ -5,12 +5,17 @@
 
 //! View drivers
 //!
-//! This module provides the [`Driver`] trait along with three classes of
-//! implementations:
+//! The [`Driver`] trait is used as a binding between data models and
+//! controllers. Implementations define the view (using widgets) and
+//! message handling (mapping widget messages to actions).
 //!
-//! -   [`View`], [`NavView`] provide "default views" over simple content
+//! Several implementations are provided to cover simpler cases:
+//!
+//! -   [`View`] is the default, providing a simple read-only view over content
+//! -   [`NavView`] is like [`View`], but using keyboard navigable widgets
+//! -   [`EditBox`], [`CheckBox`] etc. provide an interactive view over common
+//!     data types using the like-named widgets
 //! -   [`EventConfig`] provides an editor over a specific complex data type
-//! -   Other types construct a (parametrized) input control over simple data
 //!
 //! Intended usage is to import the module name rather than its contents, thus
 //! allowing referal to e.g. `driver::View`.
@@ -96,7 +101,7 @@ pub trait Driver<Item, Data: SharedData<Item = Item>>: Debug {
     ///     parameter is not used.
     /// 3.  On user input actions, view widgets send a "trigger" message (likely
     ///     a unit struct). The implementation of this method retrieves this
-    ///     message updates `data` using values read from `widget`.
+    ///     message and updates `data` using values read from `widget`.
     ///
     /// See, for example, the implementation for [`CheckButton`]: the `make`
     /// method assigns a state-change handler which `on_message` uses to update

--- a/crates/kas-view/src/lib.rs
+++ b/crates/kas-view/src/lib.rs
@@ -5,28 +5,29 @@
 
 //! View widgets and shared data
 //!
-//! So called "view widgets" allow separation of data and view. This system has
-//! three parts:
+//! View widgets allow data-oriented design. This is vaguely similar to the
+//! Model-View-Controller pattern or Elm's Model-View-Update design, but with
+//! no direct link between Model and Controller:
 //!
-//! 1.  **Data model** traits are defined by [`kas::model`].
-//! 2.  **Views** are widgets constructed over shared data by a controller.
-//!     The **view controller** is a special widget responsible for constructing
-//!     and managing view widgets over data.
+//! 1.  [`kas::model`] traits describe data **models**:
+//!     [`SingleData`](kas::model::SingleData),
+//!     [`ListData`](kas::model::ListData),
+//!     [`MatrixData`](kas::model::MatrixData)
+//! 2.  [**Drivers**](`driver`) describe how to build a widget view over data
+//!     and (optionally) how to handle **messages** from view widgets
+//! 3.  **Controllers** are special widgets which manage views over data
 //!
-//!     Three controllers are available:
-//!     [`SingleView`], [`ListView`] and [`MatrixView`].
+//! Three controllers are provided by this crate:
 //!
-//!     In the case of [`ListView`] and [`MatrixView`], the controller provides
-//!     additional features: enabling scrolling of content, "paging" (loading
-//!     only visible content) and (optionally) allowing selection of items.
-//! 3.  **Drivers** are the "glue" enabling a view controller to build view
-//!     widget(s) tailored to a specific data type as well as (optionally)
-//!     updating this data in response to widget events.
+//! -   [`SingleView`] constructs a single view over a simple data model
+//! -   [`ListView`] constructs a row or column of views over indexable data
+//! -   [`MatrixView`] constructs a table/sheet of views over two-dimensional
+//!     indexable data
 //!
-//!     If the driver is not explicitly provided, [`driver::View`] is used,
-//!     which provides a read-only view over several data types.
-//!     Other options are available in the [`driver`] module, or [`Driver`] may
-//!     be implemented directly.
+//! Both [`ListView`] and [`MatrixView`] support virtual scrolling: the number
+//! of view widget instances is limited (approximately) to the number required
+//! to cover the visible area, and these are re-used to enable fast scrolling
+//! through large data sets.
 
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -374,7 +374,9 @@ impl_scope! {
                 let id = self.data.make_id(self.id_ref(), &key);
                 let w = &mut self.widgets[i % solver.cur_len];
                 if w.key.as_ref() != Some(&key) {
-                    // TODO(opt): we only need to configure the widget once
+                    // Reset widgets to ensure input state such as cursor
+                    // position does not bleed over to next data entry
+                    w.widget = self.driver.make();
                     mgr.configure(id, &mut w.widget);
 
                     if let Some(item) = self.data.borrow(&key) {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -26,7 +26,7 @@ struct WidgetData<K, W> {
 }
 
 impl_scope! {
-    /// List view controller
+    /// View controller for 1D indexable data (list)
     ///
     /// This widget supports a view over a list of shared data items.
     ///

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -350,7 +350,11 @@ impl_scope! {
                     let id = self.data.make_id(self.id_ref(), &key);
                     let w = &mut self.widgets[i];
                     if w.key.as_ref() != Some(&key) {
+                        // Reset widgets to ensure input state such as cursor
+                        // position does not bleed over to next data entry
+                        w.widget = self.driver.make();
                         mgr.configure(id, &mut w.widget);
+
                         if let Some(item) = self.data.borrow(&key) {
                             action |= self.driver.set(&mut w.widget, &key, item.borrow());
                             w.key = Some(key);

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -32,7 +32,7 @@ struct WidgetData<K, W> {
 }
 
 impl_scope! {
-    /// Matrix view controller
+    /// View controller for 2D indexable data (matrix)
     ///
     /// This widget supports a view over a matrix of shared data items.
     ///

--- a/crates/kas-view/src/single_view.rs
+++ b/crates/kas-view/src/single_view.rs
@@ -13,7 +13,7 @@ use kas::prelude::*;
 use std::borrow::Borrow;
 
 impl_scope! {
-    /// Single view controller
+    /// View controller for 0D data (singe item)
     ///
     /// This widget supports a view over a single shared data item.
     ///


### PR DESCRIPTION
Also: fully reset view widgets when changing data binding. This fixes weird issues with text cursor/selection carrying over to new entries when scrolling `examples/data-list-view` at the cost of also clearing this state for the original entry when scrolling back (an argument for moving this state up to the event viewer, though that approach could only work for "blessed" types of widget interaction state).