### PR TITLE
Small fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,14 +49,11 @@ jobs:
         run: cargo test --manifest-path examples/mandlebrot/Cargo.toml --all-features
       - name: Clippy
         run: |
-          # TODO: allow manual_clamp in source code, when lint is stable
           cargo clippy --all --features nightly -- -W clippy::all \
-          -A clippy::bool-assert-comparison \
           -A clippy::collapsible-if \
           -A clippy::collapsible_else_if \
           -A clippy::single_match \
           -A clippy::comparison_chain \
-          -A clippy::manual_clamp \
           -A clippy::unit_arg
 
   test:
@@ -104,4 +101,10 @@ jobs:
         run: cargo test --manifest-path examples/mandlebrot/Cargo.toml
       - name: Clippy (stable)
         if: matrix.os == 'macos-latest'
-        run: cargo clippy --all -- -D warnings -W clippy::all -A clippy::collapsible-if -A clippy::collapsible_else_if -A clippy::single_match -A clippy::comparison_chain -A clippy::unit_arg
+        run: |
+          cargo clippy --all -- -D warnings -W clippy::all \
+          -A clippy::collapsible-if \
+          -A clippy::collapsible_else_if \
+          -A clippy::single_match \
+          -A clippy::comparison_chain \
+          -A clippy::unit_arg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] — 2022-12-22
+
+### Fixes
+
+-   Use `PresentMode::Fifo`, improving compatibility with older Intel graphics,
+    at the cost of some hangs with multiple windows on X11 (#369)
+-   Fix mouse highlighting for `Spinner` widget (#369)
+-   Show mnemonic (`AccelLabel`) hints with Alt key when edit field has focus (#369)
+
 ## [0.12.0] — 2022-12-13
 
 Stabilise support for Generic Associated Types (GATs). This requires Rust 1.65.0,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -104,9 +104,9 @@ macros_log = ["kas-core/macros_log"]
 winit = ["kas-core/winit"]
 
 [dependencies]
-kas-core = { version = "0.12.0", path = "crates/kas-core" }
+kas-core = { version = "0.12.1", path = "crates/kas-core" }
 kas-dylib = { version = "0.12.0", path = "crates/kas-dylib", optional = true }
-kas-widgets = { version = "0.12.0", path = "crates/kas-widgets" }
+kas-widgets = { version = "0.12.1", path = "crates/kas-widgets" }
 kas-view = { version = "0.12.0", path = "crates/kas-view", optional = true }
 kas-resvg = { version = "0.12.0", path = "crates/kas-resvg", optional = true }
 
@@ -117,7 +117,7 @@ optional = true
 default-features = false
 
 [dependencies.kas-wgpu]
-version = "0.12.0"
+version = "0.12.1"
 path = "crates/kas-wgpu"
 optional = true
 default-features = false

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-core"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -45,7 +45,7 @@ impl EventState {
     /// This is a fast check.
     #[inline]
     pub fn show_accel_labels(&self) -> bool {
-        self.modifiers.alt() && !self.char_focus
+        self.modifiers.alt()
     }
 
     /// Get whether this widget has `(char_focus, sel_focus)`

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -161,7 +161,7 @@ impl RootWidget {
                 (cp + cs + m.0, after)
             }
         };
-        // TODO when stable: #[allow(clippy::manual_clamp)]
+        #[allow(clippy::manual_clamp)]
         let place_out = |rp, rs, cp: i32, cs, ideal: i32| -> (i32, i32) {
             let pos = cp.min(rp + rs - ideal).max(rp);
             let size = ideal.max(cs).min(rs);

--- a/crates/kas-core/src/text/string.rs
+++ b/crates/kas-core/src/text/string.rs
@@ -18,11 +18,14 @@ use crate::text::{Effect, EffectFlags};
 
 /// An accelerator key string
 ///
-/// This is a label which supports highlighting of accelerator keys.
+/// This is a label which supports highlighting of accelerator keys (elsewhere
+/// called "access keys" or "mnemonics"). This type represents both the
+/// displayed text (via [`FormattableText`] implementation)
+/// and the shortcut (via [`AccelString::keys`]).
 ///
 /// Markup: `&&` translates to `&`; `&x` for any `x` translates to `x` and
 /// identifies `x` as an "accelerator key"; this may be drawn underlined and
-/// may support keyboard access via e.g. `Alt+X`.
+/// may support keyboard access via e.g. `Alt+X`
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AccelString {
     label: String,
@@ -91,6 +94,9 @@ impl AccelString {
     }
 
     /// Get the key bindings
+    ///
+    /// Usually this list has length zero or one, but nothing prevents the use
+    /// multiple mnemonic key bindings.
     pub fn keys(&self) -> &[VK] {
         &self.keys
     }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -471,7 +471,7 @@ impl_scope! {
         }
     }
 
-    // TODO when stable: #[allow(clippy::manual_clamp)]
+    #[allow(clippy::manual_clamp)]
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, mut axis: AxisInfo) -> SizeRules {
             // We use an invisible frame for highlighting selections, drawing into the margin

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -449,7 +449,7 @@ impl_scope! {
         }
     }
 
-    // TODO when stable: #[allow(clippy::manual_clamp)]
+    #[allow(clippy::manual_clamp)]
     impl Layout for Self {
         fn size_rules(&mut self, size_mgr: SizeMgr, mut axis: AxisInfo) -> SizeRules {
             // We use an invisible frame for highlighting selections, drawing into the margin

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-wgpu"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/kas-wgpu/src/window.rs
+++ b/crates/kas-wgpu/src/window.rs
@@ -138,7 +138,7 @@ impl<C: CustomPipe, T: Theme<DrawPipe<C>>> Window<C, T> {
             format: crate::draw::RENDER_TEX_FORMAT,
             width: size.0.cast(),
             height: size.1.cast(),
-            present_mode: wgpu::PresentMode::Mailbox,
+            present_mode: wgpu::PresentMode::Fifo,
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
         };
         surface.configure(&shared.draw.draw.device, &sc_desc);

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-widgets"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -252,6 +252,8 @@ impl_scope! {
                 }
             }
 
+            // If coord is over self but not over self.bar, we assign
+            // the event to self.inner without further question.
             Some(self.inner.id())
         }
 

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -194,7 +194,7 @@ impl_scope! {
             }
         }
 
-        // TODO when stable: #[allow(clippy::manual_clamp)]
+        #[allow(clippy::manual_clamp)]
         fn update_widgets(&mut self) -> TkAction {
             let len = self.bar_len();
             let total = i64::from(self.max_value) + i64::from(self.handle_value);

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -542,6 +542,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[widget{
             layout = column: [
                 self.menubar,
+                Separator::new(),
                 self.stack,
             ];
         }]


### PR DESCRIPTION
Use [`PresentMode::Fifo`](https://docs.rs/wgpu/latest/wgpu/struct.SurfaceConfiguration.html#structfield.present_mode). This is documented as the only supported mode. Fixes #367 and #368. Unfortunately this presents another issue: hang on exit on X11 in some circumstances (related to usage of multiple windows). I believe this is a WGPU issue: https://github.com/gfx-rs/wgpu/issues/1446

Also fix a couple of issues reported [on reddit](https://www.reddit.com/r/rust/comments/zl69lo/kas_rust_state_of_gui/j0nauao/):

- Mouse focus/highlighting for Spinner widget
- Show mnemonic labels when an edit box has input focus
- Update docs to use "mnemonics"

Note: other fixes would be breaking changes and/or significant work and are post-poned.