### PR TITLE
Support sending async messages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,11 +47,10 @@ jobs:
         run: cargo test --manifest-path examples/mandlebrot/Cargo.toml --all-features
       - name: Clippy
         run: |
-          cargo clippy --all --features nightly -- -W clippy::all \
+          cargo clippy --all --features nightly -- \
           -A clippy::collapsible-if \
           -A clippy::collapsible_else_if \
           -A clippy::module-inception \
-          -A clippy::single_match \
           -A clippy::too-many-arguments \
           -A clippy::comparison_chain \
           -A clippy::unit_arg
@@ -100,11 +99,10 @@ jobs:
       - name: Clippy (stable)
         if: matrix.os == 'macos-latest'
         run: |
-          cargo clippy --all -- -D warnings -W clippy::all \
+          cargo clippy --all -- -D warnings \
           -A clippy::collapsible-if \
           -A clippy::collapsible_else_if \
           -A clippy::module-inception \
-          -A clippy::single_match \
           -A clippy::too-many-arguments \
           -A clippy::comparison_chain \
           -A clippy::unit_arg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 #########  meta / build features  #########
 
 # All recommended features for optimal experience
-default = ["minimal", "view", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light"]
+default = ["minimal", "view", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light", "spawn"]
 
 # Include only "required" features.
 #
@@ -92,6 +92,9 @@ tiny-skia = ["dep:kas-resvg"]
 
 # Automatically detect usage of dark theme
 dark-light = ["kas-core/dark-light"]
+
+# Support spawning async tasks
+spawn = ["kas-core/spawn"]
 
 # Support SVG images
 

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -61,6 +61,9 @@ serde = ["dep:serde", "kas-text/serde", "winit?/serde"]
 # Automatically detect usage of dark theme
 dark-light = ["dep:dark-light"]
 
+# Support spawning async tasks
+spawn = ["dep:async-global-executor"]
+
 [dependencies]
 log = "0.4"
 smallvec = "1.6.1"
@@ -76,6 +79,7 @@ num_enum = "0.5.6"
 dark-light = { version = "0.2.2", optional = true }
 raw-window-handle = "0.5.0"
 window_clipboard = { version = "0.2.0", optional = true }
+async-global-executor = { version = "2.3.1", optional = true }
 
 [dependencies.kas-macros]
 version = "0.12.0"

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -544,7 +544,7 @@ pub trait Widget: WidgetChildren + Layout {
     /// This is the secondary event handler (see [documentation](crate::event)).
     ///
     /// It is implied that the stack contains at least one message.
-    /// Use [`EventMgr::try_pop_msg`] and/or [`EventMgr::try_observe_msg`].
+    /// Use [`EventMgr::try_pop`] and/or [`EventMgr::try_observe`].
     ///
     /// [`EventMgr::last_child`] may be called to find the message's sender.
     /// This may return [`None`] (if no child was visited, which implies that

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -392,7 +392,7 @@ pub trait Layout {
 ///
 ///         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
 ///             event.on_activate(mgr, self.id(), |mgr| {
-///                 mgr.push_msg(self.message.clone());
+///                 mgr.push(self.message.clone());
 ///                 Response::Used
 ///             })
 ///         }
@@ -500,7 +500,7 @@ pub trait Widget: WidgetChildren + Layout {
     /// -   If this method returns [`Response::Unused`], then
     ///     [`Widget::handle_unused`] is called on each parent until the event
     ///     is used (or the root widget is reached)
-    /// -   If a message is left on the stack by [`EventMgr::push_msg`], then
+    /// -   If a message is left on the stack by [`EventMgr::push`], then
     ///     [`Widget::handle_message`] is called on each parent until the stack is
     ///     empty (failing to empty the stack results in a warning in the log).
     /// -   If any scroll state is set by [`EventMgr::set_scroll`], then

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -528,9 +528,13 @@ pub trait Widget: WidgetChildren + Layout {
 
     /// Potentially steal an event before it reaches a child
     ///
-    /// This is called on each widget visited (excluding the target) while
-    /// sending an event.
+    /// This is called during downward traversal (see [`Widget::handle_event`]).
     /// If this returns [`Response::Used`], the event is not sent further.
+    ///
+    /// May cause a panic if this method returns [`Response::Unused`] but does
+    /// affect `mgr` (e.g. by calling [`EventMgr::set_scroll`] or leaving a
+    /// message on the stack, possibly from [`EventMgr::send`]).
+    /// This is considered a corner-case and not currently supported.
     ///
     /// Default implementation: return [`Response::Unused`].
     #[inline]

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -545,10 +545,12 @@ pub trait Widget: WidgetChildren + Layout {
 
     /// Handle an event sent to child `index` but left unhandled
     ///
+    /// [`EventMgr::last_child`] may be called to find the original target,
+    /// and should never return [`None`] (when called from this method).
+    ///
     /// Default implementation: call [`Self::handle_event`] with `event`.
     #[inline]
-    fn handle_unused(&mut self, mgr: &mut EventMgr, index: usize, event: Event) -> Response {
-        let _ = index;
+    fn handle_unused(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
         self.handle_event(mgr, event)
     }
 
@@ -557,10 +559,13 @@ pub trait Widget: WidgetChildren + Layout {
     /// This method is called when a child leaves a message on the stack. *Some*
     /// parent or ancestor widget should read this message.
     ///
+    /// [`EventMgr::last_child`] may be called to find the message's sender,
+    /// and should only return [`None`] if the message was sent by self.
+    ///
     /// The default implementation does nothing.
     #[inline]
-    fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
-        let _ = (mgr, index);
+    fn handle_message(&mut self, mgr: &mut EventMgr) {
+        let _ = mgr;
     }
 
     /// Handler for scrolling
@@ -578,6 +583,9 @@ pub trait Widget: WidgetChildren + Layout {
     /// If the child is in an independent coordinate space, then this method
     /// should call `mgr.set_scroll(Scroll::None)` to avoid any reactions to
     /// child's scroll requests.
+    ///
+    /// [`EventMgr::last_child`] may be called to find the child responsible,
+    /// and should never return [`None`] (when called from this method).
     ///
     /// The default implementation does nothing.
     #[inline]

--- a/crates/kas-core/src/erased.rs
+++ b/crates/kas-core/src/erased.rs
@@ -1,0 +1,63 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Erased type
+
+use std::any::Any;
+use std::fmt::Debug;
+
+/// A type-erased value
+///
+/// This is vaguely a wrapper over `Box<dyn (Any + Debug)>`, except that Rust
+/// doesn't (yet) support multi-trait objects.
+pub struct Erased {
+    // TODO: use trait_upcasting feature when stable: Box<dyn AnyDebug>
+    // where trait AnyDebug: Any + Debug {}. This replaces the fmt field.
+    any: Box<dyn Any>,
+    #[cfg(debug_assertions)]
+    fmt: String,
+}
+
+impl Erased {
+    /// Construct
+    pub fn new<V: Any + Debug>(v: V) -> Self {
+        #[cfg(debug_assertions)]
+        let fmt = format!("{}::{:?}", std::any::type_name::<V>(), &v);
+        let any = Box::new(v);
+        Erased {
+            #[cfg(debug_assertions)]
+            fmt,
+            any,
+        }
+    }
+
+    /// Returns `true` if the inner type is the same as `T`.
+    pub fn is<T: 'static>(&self) -> bool {
+        self.any.is::<T>()
+    }
+
+    /// Attempt to downcast self to a concrete type.
+    pub fn downcast<T: 'static>(self) -> Result<Box<T>, Box<dyn Any>> {
+        self.any.downcast::<T>()
+    }
+
+    /// Returns some reference to the inner value if it is of type `T`, or `None` if it isn’t.
+    pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+        self.any.downcast_ref::<T>()
+    }
+}
+
+/// Support debug formatting
+///
+/// Debug builds only. On release builds, a placeholder message is printed.
+impl std::fmt::Debug for Erased {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        #[cfg(debug_assertions)]
+        let r = f.write_str(&self.fmt);
+        #[cfg(not(debug_assertions))]
+        let r = f.write_str("[use debug build to see value]");
+        r
+    }
+}

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -169,13 +169,11 @@ pub enum Event {
     TimerUpdate(u64),
     /// Update triggerred via an [`UpdateId`]
     ///
-    /// This event is received by all widgets when [`EventMgr::update_all`]
-    /// is called.
-    ///
-    /// Note that this event is only received by [`Widget::handle_event`] and
-    /// not by [`Widget::steal_event`] or [`Widget::handle_unused`].
-    /// Messages and scroll actions will *not* be handled by parent's
-    /// [`Widget::handle_message`] or [`Widget::handle_scroll`] methods.
+    /// When [`EventMgr::update_all`] is called, this event is broadcast to all
+    /// widgets via depth-first traversal of the widget tree. As such,
+    /// [`Widget::steal_event`] and [`Widget::handle_unused`] are not called
+    /// with this `Event`, nor are [`Widget::handle_message`] or
+    /// [`Widget::handle_scroll`] called after a widget receives this `Event`.
     Update { id: UpdateId, payload: u64 },
     /// Notification that a popup has been destroyed
     ///

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -345,6 +345,20 @@ impl EventState {
         self.char_focus = char_focus;
         self.sel_focus = Some(wid);
     }
+
+    fn set_hover(&mut self, w_id: Option<WidgetId>) {
+        if self.hover != w_id {
+            log::trace!("set_hover: w_id={w_id:?}");
+            if let Some(id) = self.hover.take() {
+                self.pending.push_back(Pending::LostMouseHover(id));
+            }
+            self.hover = w_id.clone();
+
+            if let Some(id) = w_id {
+                self.pending.push_back(Pending::MouseHover(id));
+            }
+        }
+    }
 }
 
 /// A type-erased message
@@ -438,20 +452,6 @@ impl<'a> Drop for EventMgr<'a> {
 
 /// Internal methods
 impl<'a> EventMgr<'a> {
-    fn set_hover(&mut self, w_id: Option<WidgetId>) {
-        if self.hover != w_id {
-            log::trace!("set_hover: w_id={w_id:?}");
-            if let Some(id) = self.hover.take() {
-                self.pending.push_back(Pending::LostMouseHover(id));
-            }
-            self.hover = w_id.clone();
-
-            if let Some(id) = w_id {
-                self.pending.push_back(Pending::MouseHover(id));
-            }
-        }
-    }
-
     fn start_key_event(&mut self, widget: &mut dyn Widget, vkey: VirtualKeyCode, scancode: u32) {
         log::trace!(
             "start_key_event: widget={}, vkey={vkey:?}, scancode={scancode}",

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -173,7 +173,7 @@ pub struct EventState {
     popup_removed: SmallVec<[(WidgetId, WindowId); 16]>,
     time_updates: Vec<(Instant, WidgetId, u64)>,
     // Set of futures of messages together with id of sending widget
-    fut_messages: Vec<(WidgetId, Pin<Box<dyn Future<Output = Option<Erased>>>>)>,
+    fut_messages: Vec<(WidgetId, Pin<Box<dyn Future<Output = Erased>>>)>,
     // FIFO queue of events pending handling
     pending: VecDeque<Pending>,
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -545,12 +545,19 @@ impl<'a> EventMgr<'a> {
             }
 
             if !disabled {
-                response |= widget.pre_handle_event(self, event)
+                response |= widget.pre_handle_event(self, event);
+
+                if self.has_msg() {
+                    widget.handle_message(self);
+                }
             }
 
             return response;
         } else {
             response = widget.steal_event(self, &id, &event);
+            if self.has_msg() {
+                widget.handle_message(self);
+            }
             if response.is_used() {
                 return response;
             } else if self.scroll != Scroll::None || !self.messages.is_empty() {
@@ -575,7 +582,8 @@ impl<'a> EventMgr<'a> {
 
             if matches!(response, Response::Unused) {
                 response = widget.handle_unused(self, event);
-            } else if self.has_msg() {
+            }
+            if self.has_msg() {
                 widget.handle_message(self);
             }
         } else {
@@ -609,6 +617,7 @@ impl<'a> EventMgr<'a> {
             }
         } else if id == widget.id_ref() {
             self.messages.push(msg);
+            widget.handle_message(self);
         } else {
             log::warn!(
                 "replay_recurse: Widget {} cannot find path to {id}",

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -375,7 +375,6 @@ pub struct EventMgr<'a> {
     messages: Vec<Erased>,
     last_child: Option<usize>,
     scroll: Scroll,
-    action: Action,
 }
 
 impl<'a> Deref for EventMgr<'a> {

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -385,7 +385,7 @@ impl ErasedMessage {
         #[cfg(debug_assertions)]
         let fmt = format!("{}::{:?}", std::any::type_name::<M>(), &msg);
         #[cfg(debug_assertions)]
-        log::debug!(target: "kas_core::event::ErasedMessage", "push_msg: {fmt}");
+        log::debug!(target: "kas_core::event::ErasedMessage", "push: {fmt}");
         let any = Box::new(msg);
         ErasedMessage {
             #[cfg(debug_assertions)]

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -528,14 +528,20 @@ impl<'a> EventMgr<'a> {
     /// The message is first type-erased by wrapping with [`Erased`],
     /// then pushed to the stack.
     ///
-    /// See also [`EventMgr::try_observe_msg`], `EventMgr::try_pop_msg`].
+    /// The message may be [popped](EventMgr::try_pop_msg) or
+    /// [observed](EventMgr::try_observe_msg) from [`Widget::handle_message`]
+    /// by the widget itself, its parent, or any ancestor.
     pub fn push<M: Debug + 'static>(&mut self, msg: M) {
         self.push_erased(Erased::new(msg));
     }
 
     /// Push a type-erased message to the stack
     ///
-    /// See also [`EventMgr::try_observe_msg`], `EventMgr::try_pop_msg`].
+    /// This is a lower-level variant of [`Self::push`].
+    ///
+    /// The message may be [popped](EventMgr::try_pop_msg) or
+    /// [observed](EventMgr::try_observe_msg) from [`Widget::handle_message`]
+    /// by the widget itself, its parent, or any ancestor.
     pub fn push_erased(&mut self, msg: Erased) {
         self.messages.push(msg);
     }

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -511,12 +511,12 @@ impl<'a> EventMgr<'a> {
     }
 
     /// Push a message to the stack
-    pub fn push_msg<M: Debug + 'static>(&mut self, msg: M) {
-        self.push_erased_msg(ErasedMessage::new(msg));
+    pub fn push<M: Debug + 'static>(&mut self, msg: M) {
+        self.push_erased(ErasedMessage::new(msg));
     }
 
     /// Push a type-erased message to the stack
-    pub fn push_erased_msg(&mut self, msg: ErasedMessage) {
+    pub fn push_erased(&mut self, msg: ErasedMessage) {
         self.messages.push(msg);
     }
 
@@ -526,12 +526,12 @@ impl<'a> EventMgr<'a> {
     /// This message is then pushed to the message stack, simultaneously sending
     /// [`Event::AsyncMessage`] to widget `id`.
     // TODO: Can we identify the calling widget `id` via the context (EventMgr)?
-    pub fn push_msg_async<Fut, Out>(&mut self, id: WidgetId, fut: Fut)
+    pub fn push_async<Fut, Out>(&mut self, id: WidgetId, fut: Fut)
     where
         Fut: IntoFuture<Output = Option<Out>> + 'static,
         Out: Debug + 'static,
     {
-        self.push_erased_msg_async(id, async { fut.await.map(ErasedMessage::new) });
+        self.push_async_erased(id, async { fut.await.map(ErasedMessage::new) });
     }
 
     /// Push a type-erased message to the stack via a [`Future`]
@@ -539,9 +539,9 @@ impl<'a> EventMgr<'a> {
     /// Expects a future which, on completion, returns a message.
     /// This message is then pushed to the message stack, simultaneously sending
     /// [`Event::AsyncMessage`] to widget `id`.
-    pub fn push_erased_msg_async<Fut>(&mut self, id: WidgetId, fut: Fut)
     // TODO: Should we use Future<Output = ErasedMessage> or Output = Option<ErasedMessage>
     // or Output = Vec<ErasedMessage> or Stream/AsyncIterator with Output = ErasedMessage?
+    pub fn push_async_erased<Fut>(&mut self, id: WidgetId, fut: Fut)
     where
         Fut: IntoFuture<Output = Option<ErasedMessage>> + 'static,
     {

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -523,8 +523,8 @@ impl<'a> EventMgr<'a> {
     /// Push a message to the stack via a [`Future`]
     ///
     /// Expects a future which, on completion, returns a message.
-    /// This message is then pushed to the message stack, simultaneously sending
-    /// [`Event::AsyncMessage`] to widget `id`.
+    /// This message is then pushed to the message stack as if it were pushed
+    /// with [`Self::push`] from widget `id`.
     // TODO: Can we identify the calling widget `id` via the context (EventMgr)?
     pub fn push_async<Fut, M>(&mut self, id: WidgetId, fut: Fut)
     where
@@ -537,8 +537,8 @@ impl<'a> EventMgr<'a> {
     /// Push a type-erased message to the stack via a [`Future`]
     ///
     /// Expects a future which, on completion, returns a message.
-    /// This message is then pushed to the message stack, simultaneously sending
-    /// [`Event::AsyncMessage`] to widget `id`.
+    /// This message is then pushed to the message stack as if it were pushed
+    /// with [`Self::push`] from widget `id`.
     // TODO: Should we use Future<Output = ErasedMessage> or Output = Option<ErasedMessage>
     // or Output = Vec<ErasedMessage> or Stream/AsyncIterator with Output = ErasedMessage?
     pub fn push_async_erased<Fut>(&mut self, id: WidgetId, fut: Fut)

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -73,6 +73,17 @@ impl EventState {
         self.mouse_grab.is_none() && *w_id == self.hover
     }
 
+    /// Get whether widget `id` or any of its descendants are under the mouse cursor
+    #[inline]
+    pub fn is_hovered_recursive(&self, id: &WidgetId) -> bool {
+        self.mouse_grab.is_none()
+            && self
+                .hover
+                .as_ref()
+                .map(|h| id.is_ancestor_of(h))
+                .unwrap_or(false)
+    }
+
     /// Check whether the given widget is visually depressed
     pub fn is_depressed(&self, w_id: &WidgetId) -> bool {
         for (_, id) in &self.key_depress {

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -518,13 +518,13 @@ impl<'a> EventMgr<'a> {
 
     /// Try popping the last message from the stack with the given type
     pub fn try_pop_msg<M: Debug + 'static>(&mut self) -> Option<M> {
-        self.try_pop_boxed_msg().map(|m| *m)
-    }
-
-    /// Try popping the last message from the stack with the given type
-    pub fn try_pop_boxed_msg<M: Debug + 'static>(&mut self) -> Option<Box<M>> {
         if self.messages.last().map(|m| m.is::<M>()).unwrap_or(false) {
-            self.messages.pop().unwrap().downcast::<M>().ok()
+            self.messages
+                .pop()
+                .unwrap()
+                .downcast::<M>()
+                .ok()
+                .map(|m| *m)
         } else {
             None
         }

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -503,12 +503,12 @@ impl<'a> EventMgr<'a> {
 
     /// Push a message to the stack
     pub fn push_msg<M: Debug + 'static>(&mut self, msg: M) {
-        self.push_boxed_msg(Box::new(msg));
+        self.push_erased_msg(ErasedMessage::new(msg));
     }
 
-    /// Push a pre-boxed message to the stack
-    pub fn push_boxed_msg<M: Debug + 'static>(&mut self, msg: Box<M>) {
-        self.messages.push(Message::new(msg));
+    /// Push a type-erased message to the stack
+    pub fn push_erased_msg(&mut self, msg: ErasedMessage) {
+        self.messages.push(msg);
     }
 
     /// True if the message stack is non-empty

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -554,10 +554,10 @@ impl<'a> EventMgr<'a> {
     // TODO: Can we identify the calling widget `id` via the context (EventMgr)?
     pub fn push_async<Fut, M>(&mut self, id: WidgetId, fut: Fut)
     where
-        Fut: IntoFuture<Output = Option<M>> + 'static,
+        Fut: IntoFuture<Output = M> + 'static,
         M: Debug + 'static,
     {
-        self.push_async_erased(id, async { fut.await.map(Erased::new) });
+        self.push_async_erased(id, async { Erased::new(fut.await) });
     }
 
     /// Push a type-erased message to the stack via a [`Future`]
@@ -565,11 +565,9 @@ impl<'a> EventMgr<'a> {
     /// Expects a future which, on completion, returns a message.
     /// This message is then pushed to the message stack as if it were pushed
     /// with [`Self::push_erased`] from widget `id`.
-    // TODO: Should we use Future<Output = Erased> or Output = Option<Erased>
-    // or Output = Vec<Erased> or Stream/AsyncIterator with Output = Erased?
     pub fn push_async_erased<Fut>(&mut self, id: WidgetId, fut: Fut)
     where
-        Fut: IntoFuture<Output = Option<Erased>> + 'static,
+        Fut: IntoFuture<Output = Erased> + 'static,
     {
         let fut = Box::pin(fut.into_future());
         self.fut_messages.push((id, fut));
@@ -602,7 +600,7 @@ impl<'a> EventMgr<'a> {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "spawn")))]
     pub fn push_spawn<Fut, M>(&mut self, id: WidgetId, fut: Fut)
     where
-        Fut: IntoFuture<Output = Option<M>> + 'static,
+        Fut: IntoFuture<Output = M> + 'static,
         Fut::IntoFuture: Send,
         M: Debug + Send + 'static,
     {

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -573,13 +573,14 @@ impl<'a> EventMgr<'a> {
             // Unused (hence noted possible panic in that method)!
             let last_child = std::mem::take(&mut self.last_child);
             let scroll = std::mem::take(&mut self.scroll);
-            self.send_event(widget, id, event);
+            self.send_event_impl(widget, id, event);
             self.last_child = last_child;
             if self.scroll == Scroll::None {
                 self.scroll = scroll;
             }
         } else {
             // Possibly not safe: send later.
+            log::debug!("queing event for later sending");
             self.pending.push_back(Pending::Send(id, event));
         }
     }

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -522,11 +522,18 @@ impl<'a> EventMgr<'a> {
     }
 
     /// Push a message to the stack
+    ///
+    /// The message is first type-erased by wrapping with [`Erased`],
+    /// then pushed to the stack.
+    ///
+    /// See also [`EventMgr::try_observe_msg`], `EventMgr::try_pop_msg`].
     pub fn push<M: Debug + 'static>(&mut self, msg: M) {
         self.push_erased(Erased::new(msg));
     }
 
     /// Push a type-erased message to the stack
+    ///
+    /// See also [`EventMgr::try_observe_msg`], `EventMgr::try_pop_msg`].
     pub fn push_erased(&mut self, msg: Erased) {
         self.messages.push(msg);
     }
@@ -549,7 +556,7 @@ impl<'a> EventMgr<'a> {
     ///
     /// Expects a future which, on completion, returns a message.
     /// This message is then pushed to the message stack as if it were pushed
-    /// with [`Self::push`] from widget `id`.
+    /// with [`Self::push_erased`] from widget `id`.
     // TODO: Should we use Future<Output = Erased> or Output = Option<Erased>
     // or Output = Vec<Erased> or Stream/AsyncIterator with Output = Erased?
     pub fn push_async_erased<Fut>(&mut self, id: WidgetId, fut: Fut)
@@ -600,6 +607,8 @@ impl<'a> EventMgr<'a> {
     }
 
     /// Try popping the last message from the stack with the given type
+    ///
+    /// This method may be called from [`Widget::handle_message`].
     pub fn try_pop_msg<M: Debug + 'static>(&mut self) -> Option<M> {
         if self.messages.last().map(|m| m.is::<M>()).unwrap_or(false) {
             self.messages
@@ -614,6 +623,8 @@ impl<'a> EventMgr<'a> {
     }
 
     /// Try observing the last message on the stack without popping
+    ///
+    /// This method may be called from [`Widget::handle_message`].
     pub fn try_observe_msg<M: Debug + 'static>(&self) -> Option<&M> {
         self.messages.last().and_then(|m| m.downcast_ref::<M>())
     }

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -528,8 +528,8 @@ impl<'a> EventMgr<'a> {
     /// The message is first type-erased by wrapping with [`Erased`],
     /// then pushed to the stack.
     ///
-    /// The message may be [popped](EventMgr::try_pop_msg) or
-    /// [observed](EventMgr::try_observe_msg) from [`Widget::handle_message`]
+    /// The message may be [popped](EventMgr::try_pop) or
+    /// [observed](EventMgr::try_observe) from [`Widget::handle_message`]
     /// by the widget itself, its parent, or any ancestor.
     pub fn push<M: Debug + 'static>(&mut self, msg: M) {
         self.push_erased(Erased::new(msg));
@@ -539,8 +539,8 @@ impl<'a> EventMgr<'a> {
     ///
     /// This is a lower-level variant of [`Self::push`].
     ///
-    /// The message may be [popped](EventMgr::try_pop_msg) or
-    /// [observed](EventMgr::try_observe_msg) from [`Widget::handle_message`]
+    /// The message may be [popped](EventMgr::try_pop) or
+    /// [observed](EventMgr::try_observe) from [`Widget::handle_message`]
     /// by the widget itself, its parent, or any ancestor.
     pub fn push_erased(&mut self, msg: Erased) {
         self.messages.push(msg);
@@ -617,7 +617,7 @@ impl<'a> EventMgr<'a> {
     /// Try popping the last message from the stack with the given type
     ///
     /// This method may be called from [`Widget::handle_message`].
-    pub fn try_pop_msg<M: Debug + 'static>(&mut self) -> Option<M> {
+    pub fn try_pop<M: Debug + 'static>(&mut self) -> Option<M> {
         if self.messages.last().map(|m| m.is::<M>()).unwrap_or(false) {
             self.messages
                 .pop()
@@ -633,7 +633,7 @@ impl<'a> EventMgr<'a> {
     /// Try observing the last message on the stack without popping
     ///
     /// This method may be called from [`Widget::handle_message`].
-    pub fn try_observe_msg<M: Debug + 'static>(&self) -> Option<&M> {
+    pub fn try_observe<M: Debug + 'static>(&self) -> Option<&M> {
         self.messages.last().and_then(|m| m.downcast_ref::<M>())
     }
 

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -85,17 +85,17 @@ impl EventState {
         });
 
         let hover = widget.find_id(self.last_mouse_coord);
-        self.with(shell, |mgr| mgr.set_hover(hover));
+        self.set_hover(hover);
     }
 
     /// Update the widgets under the cursor and touch events
-    pub(crate) fn region_moved(&mut self, shell: &mut dyn ShellWindow, widget: &mut dyn Widget) {
+    pub(crate) fn region_moved(&mut self, widget: &mut dyn Widget) {
         log::trace!(target: "kas_core::event::manager", "region_moved");
         // Note: redraw is already implied.
 
         // Update hovered widget
         let hover = widget.find_id(self.last_mouse_coord);
-        self.with(shell, |mgr| mgr.set_hover(hover));
+        self.set_hover(hover);
 
         for grab in self.touch_grab.iter_mut() {
             grab.cur_id = widget.find_id(grab.coord);

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -240,6 +240,7 @@ impl EventState {
                 }
                 Pending::LostCharFocus(id) => (id, Event::LostCharFocus),
                 Pending::LostSelFocus(id) => (id, Event::LostSelFocus),
+                Pending::Send(id, event) => (id, event),
             };
             mgr.send_event(widget, id, event);
         }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -123,12 +123,8 @@ impl EventState {
             messages: vec![],
             last_child: None,
             scroll: Scroll::None,
-            action: Action::empty(),
         };
         f(&mut mgr);
-        let action = mgr.action;
-        drop(mgr);
-        self.send_action(action);
     }
 
     /// Update, after receiving all events
@@ -146,7 +142,6 @@ impl EventState {
             messages: vec![],
             last_child: None,
             scroll: Scroll::None,
-            action: Action::empty(),
         };
 
         while let Some((parent, wid)) = mgr.popup_removed.pop() {
@@ -247,16 +242,13 @@ impl EventState {
             }
         }
 
-        let action = mgr.action;
         drop(mgr);
 
         if self.hover_icon != old_hover_icon && self.mouse_grab.is_none() {
             shell.set_cursor_icon(self.hover_icon);
         }
 
-        let action = action | self.action;
-        self.action = Action::empty();
-        action
+        std::mem::take(&mut self.action)
     }
 }
 

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -121,6 +121,7 @@ impl EventState {
             state: self,
             shell,
             messages: vec![],
+            last_child: None,
             scroll: Scroll::None,
             action: Action::empty(),
         };
@@ -143,6 +144,7 @@ impl EventState {
             state: self,
             shell,
             messages: vec![],
+            last_child: None,
             scroll: Scroll::None,
             action: Action::empty(),
         };

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -216,8 +216,7 @@ impl EventState {
                 .fut_messages
                 .retain_mut(|(id, fut)| match fut.as_mut().poll(&mut cx) {
                     Poll::Pending => true,
-                    Poll::Ready(None) => false,
-                    Poll::Ready(Some(msg)) => {
+                    Poll::Ready(msg) => {
                         msgs.push((std::mem::take(id), msg));
                         false
                     }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -14,7 +14,7 @@ use crate::cast::traits::*;
 use crate::geom::{Coord, DVec2};
 use crate::model::SharedRc;
 use crate::shell::ShellWindow;
-use crate::{Action, Widget, WidgetId};
+use crate::{Action, Erased, Widget, WidgetId};
 
 // TODO: this should be configurable or derived from the system
 const DOUBLE_CLICK_TIMEOUT: Duration = Duration::from_secs(1);
@@ -207,7 +207,7 @@ impl EventState {
         {
             // Poll futures. Any wake causes poll of all futures.
             // We "replay" messages from the viewpoint of the sending widget.
-            let mut msgs: Vec<(WidgetId, ErasedMessage)> = vec![];
+            let mut msgs: Vec<(WidgetId, Erased)> = vec![];
 
             let mut cx = std::task::Context::from_waker(mgr.shell.waker());
             mgr.state

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -262,7 +262,7 @@ impl<'a> EventMgr<'a> {
         }
 
         let start = Instant::now();
-        let count = self.send_all(widget, Event::Update { id, payload });
+        let count = self.send_update(widget, id, payload);
         log::debug!(
             target: "kas_core::event::manager",
             "update_widgets: sent Event::Update ({id:?}) to {count} widgets in {}μs",

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -74,7 +74,7 @@ pub use winit::event::{ModifiersState, MouseButton, VirtualKeyCode};
 #[cfg(not(feature = "winit"))]
 pub use enums::{CursorIcon, ModifiersState, MouseButton, VirtualKeyCode};
 pub use events::*;
-pub use manager::{ConfigMgr, EventMgr, EventState, GrabMode};
+pub use manager::{ConfigMgr, ErasedMessage, EventMgr, EventState, GrabMode};
 pub use response::{Response, Scroll};
 pub use update::UpdateId;
 

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -29,7 +29,7 @@
 //!     If no handler has yet returned [`Response::Used`], then call
 //!     [`Widget::handle_unused`] on each ancestor visited.
 //!
-//!     If the message stack is non-empty (due to a handler calling [`EventMgr::push_msg`]),
+//!     If the message stack is non-empty (due to a handler calling [`EventMgr::push`]),
 //!     call [`Widget::handle_message`] on each ancestor visited.
 //!
 //!     If a non-empty scroll action is set (due to a handler calling [`EventMgr::set_scroll`]),

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -74,7 +74,7 @@ pub use winit::event::{ModifiersState, MouseButton, VirtualKeyCode};
 #[cfg(not(feature = "winit"))]
 pub use enums::{CursorIcon, ModifiersState, MouseButton, VirtualKeyCode};
 pub use events::*;
-pub use manager::{ConfigMgr, ErasedMessage, EventMgr, EventState, GrabMode};
+pub use manager::{ConfigMgr, EventMgr, EventState, GrabMode};
 pub use response::{Response, Scroll};
 pub use update::UpdateId;
 

--- a/crates/kas-core/src/event/response.rs
+++ b/crates/kas-core/src/event/response.rs
@@ -56,10 +56,11 @@ impl std::ops::BitOrAssign for Response {
 }
 
 /// Request to / notification of scrolling from a child
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[must_use]
 pub enum Scroll {
     /// No scrolling
+    #[default]
     None,
     /// Child has scrolled; no further scrolling needed
     ///

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -27,7 +27,14 @@ pub extern crate easy_cast as cast;
 // internal modules:
 mod action;
 mod core;
+mod erased;
 mod root;
+
+pub use crate::core::*;
+pub use action::Action;
+pub use erased::Erased;
+pub use kas_macros::*;
+pub use root::RootWidget;
 
 // public implementations:
 pub mod class;
@@ -46,9 +53,3 @@ pub mod shell;
 pub mod text;
 pub mod theme;
 pub mod util;
-
-// export most important members directly for convenience and less redundancy:
-pub use crate::action::Action;
-pub use crate::core::*;
-pub use kas_macros::*;
-pub use root::RootWidget;

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -155,4 +155,7 @@ pub(crate) trait ShellWindow {
 
     /// Set the mouse cursor
     fn set_cursor_icon(&mut self, icon: CursorIcon);
+
+    /// Access a Waker
+    fn waker(&self) -> &std::task::Waker;
 }

--- a/crates/kas-core/src/shell/event_loop.rs
+++ b/crates/kas-core/src/shell/event_loop.rs
@@ -261,8 +261,8 @@ where
             RedrawEventsCleared => {
                 if matches!(control_flow, ControlFlow::Wait | ControlFlow::WaitUntil(_)) {
                     self.resumes.clear();
-                    for (window_id, window) in self.windows.iter() {
-                        if let Some(instant) = window.next_resume() {
+                    for (window_id, window) in self.windows.iter_mut() {
+                        if let Some(instant) = window.post_draw(&mut self.shared) {
                             self.resumes.push((instant, *window_id));
                         }
                     }

--- a/crates/kas-core/src/shell/event_loop.rs
+++ b/crates/kas-core/src/shell/event_loop.rs
@@ -123,6 +123,11 @@ where
                         .pending
                         .push(PendingAction::Update(handle, payload));
                 }
+                ProxyAction::WakeAsync => {
+                    // We don't need to do anything: MainEventsCleared will
+                    // automatically be called after, which automatically calls
+                    // window.update(..), which calls EventState::Update.
+                }
             },
 
             // TODO: windows should be constructed in Resumed and destroyed

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -38,4 +38,5 @@ enum ProxyAction {
     CloseAll,
     Close(kas::WindowId),
     Update(kas::event::UpdateId, u64),
+    WakeAsync,
 }

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -6,6 +6,7 @@
 //! Shared state
 
 use std::num::NonZeroU32;
+use std::task::Waker;
 
 use super::{PendingAction, WindowSurface};
 use kas::config::Options;
@@ -29,6 +30,7 @@ pub struct SharedState<S: WindowSurface, T> {
     pub(super) pending: Vec<PendingAction>,
     /// Estimated scale factor (from last window constructed or available screens)
     pub(super) scale_factor: f64,
+    pub(super) waker: Waker,
     window_id: u32,
     options: Options,
 }
@@ -44,6 +46,7 @@ where
         options: Options,
         config: SharedRc<kas::event::Config>,
         scale_factor: f64,
+        waker: Waker,
     ) -> Result<Self, Error> {
         let mut draw = kas::draw::SharedState::new(draw_shared);
         theme.init(&mut draw);
@@ -56,6 +59,7 @@ where
             config,
             pending: vec![],
             scale_factor,
+            waker,
             window_id: 0,
             options,
         })

--- a/crates/kas-core/src/shell/shell.rs
+++ b/crates/kas-core/src/shell/shell.rs
@@ -110,12 +110,17 @@ where
         config: SharedRc<event::Config>,
     ) -> Result<Self> {
         let el = EventLoopBuilder::with_user_event().build();
-        let scale_factor = find_scale_factor(&el);
+        let windows = vec![];
+
         let draw_shared = graphical_shell.into().build(theme.config().raster())?;
+        let scale_factor = find_scale_factor(&el);
+        let waker = create_waker(Proxy(el.create_proxy()));
+        let shared = SharedState::new(draw_shared, theme, options, config, scale_factor, waker)?;
+
         Ok(Shell {
             el,
-            windows: vec![],
-            shared: SharedState::new(draw_shared, theme, options, config, scale_factor)?,
+            windows,
+            shared,
         })
     }
 
@@ -181,9 +186,7 @@ where
 
     /// Create a proxy which can be used to update the UI from another thread
     pub fn create_proxy(&self) -> Proxy {
-        Proxy {
-            proxy: self.el.create_proxy(),
-        }
+        Proxy(self.el.create_proxy())
     }
 
     /// Run the main loop.
@@ -205,12 +208,49 @@ fn find_scale_factor<T>(el: &EventLoopWindowTarget<T>) -> f64 {
     1.0
 }
 
+/// Create a waker
+///
+/// This waker may be used by a [`Future`](std::future::Future) to revive
+/// event handling.
+fn create_waker(proxy: Proxy) -> std::task::Waker {
+    use std::sync::{Arc, Mutex};
+    use std::task::{RawWaker, RawWakerVTable, Waker};
+
+    // NOTE: Proxy is Send but not Sync. Mutex<T> is Sync for T: Send.
+    // We wrap with Arc which is a Sync type supporting Clone and into_raw.
+    type Data = Mutex<Proxy>;
+    let a: Arc<Data> = Arc::new(Mutex::new(proxy));
+    let data = Arc::into_raw(a);
+
+    const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+
+    unsafe fn clone(data: *const ()) -> RawWaker {
+        let a = Arc::from_raw(data as *const Data);
+        let c = Arc::into_raw(a.clone());
+        let _do_not_drop = Arc::into_raw(a);
+        RawWaker::new(c as *const (), &VTABLE)
+    }
+    unsafe fn wake(data: *const ()) {
+        let a = Arc::from_raw(data as *const Data);
+        a.lock().unwrap().wake_async();
+    }
+    unsafe fn wake_by_ref(data: *const ()) {
+        let a = Arc::from_raw(data as *const Data);
+        a.lock().unwrap().wake_async();
+        let _do_not_drop = Arc::into_raw(a);
+    }
+    unsafe fn drop(data: *const ()) {
+        let _ = Arc::from_raw(data as *const Data);
+    }
+
+    let raw_waker = RawWaker::new(data as *const (), &VTABLE);
+    unsafe { Waker::from_raw(raw_waker) }
+}
+
 /// A proxy allowing control of a [`Shell`] from another thread.
 ///
 /// Created by [`Shell::create_proxy`].
-pub struct Proxy {
-    proxy: EventLoopProxy<ProxyAction>,
-}
+pub struct Proxy(EventLoopProxy<ProxyAction>);
 
 /// Error type returned by [`Proxy`] functions.
 ///
@@ -220,22 +260,29 @@ pub struct ClosedError;
 impl Proxy {
     /// Close a specific window.
     pub fn close(&self, id: WindowId) -> std::result::Result<(), ClosedError> {
-        self.proxy
+        self.0
             .send_event(ProxyAction::Close(id))
             .map_err(|_| ClosedError)
     }
 
     /// Close all windows and terminate the UI.
     pub fn close_all(&self) -> std::result::Result<(), ClosedError> {
-        self.proxy
+        self.0
             .send_event(ProxyAction::CloseAll)
             .map_err(|_| ClosedError)
     }
 
     /// Trigger an update
     pub fn update_all(&self, id: UpdateId, payload: u64) -> std::result::Result<(), ClosedError> {
-        self.proxy
+        self.0
             .send_event(ProxyAction::Update(id, payload))
             .map_err(|_| ClosedError)
+    }
+
+    /// Wake async methods
+    fn wake_async(&self) {
+        if let Err(_) = self.0.send_event(ProxyAction::WakeAsync) {
+            // ignore: if the loop closed the future has been dropped
+        }
     }
 }

--- a/crates/kas-core/src/shell/shell.rs
+++ b/crates/kas-core/src/shell/shell.rs
@@ -281,8 +281,7 @@ impl Proxy {
 
     /// Wake async methods
     fn wake_async(&self) {
-        if let Err(_) = self.0.send_event(ProxyAction::WakeAsync) {
-            // ignore: if the loop closed the future has been dropped
-        }
+        // ignore error: if the loop closed the future has been dropped
+        let _ = self.0.send_event(ProxyAction::WakeAsync);
     }
 }

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -231,12 +231,10 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
         /*if action.contains(Action::Popup) {
             let widget = &mut self.widget;
             self.ev_state.with(&mut tkw, |mgr| widget.resize_popups(mgr));
-            self.ev_state.region_moved(&mut tkw, &mut *self.widget);
+            self.ev_state.region_moved(&mut *self.widget);
         } else*/
         if action.contains(Action::REGION_MOVED) {
-            let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
-            self.ev_state
-                .region_moved(&mut tkw, self.widget.as_widget_mut());
+            self.ev_state.region_moved(&mut self.widget.as_widget_mut());
         }
         if !action.is_empty() {
             self.queued_frame_time = Some(self.next_avail_frame_time);

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -492,4 +492,9 @@ where
             window.set_cursor_icon(icon);
         }
     }
+
+    #[inline]
+    fn waker(&self) -> &std::task::Waker {
+        &self.shared.waker
+    }
 }

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -88,7 +88,7 @@ impl<'a> DrawMgr<'a> {
     }
 
     /// Access event-management state
-    pub fn ev_state(&mut self) -> &EventState {
+    pub fn ev_state(&mut self) -> &mut EventState {
         self.h.components().2
     }
 

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -511,20 +511,15 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
             fn handle_unused(
                 &mut self,
                 mgr: &mut ::kas::event::EventMgr,
-                index: usize,
                 event: ::kas::event::Event,
             ) -> ::kas::event::Response {
-                self.#inner.handle_unused(mgr, index, event)
+                self.#inner.handle_unused(mgr, event)
             }
         };
         let handle_message = quote! {
             #[inline]
-            fn handle_message(
-                &mut self,
-                mgr: &mut ::kas::event::EventMgr,
-                index: usize,
-            ) {
-                self.#inner.handle_message(mgr, index);
+            fn handle_message(&mut self, mgr: &mut ::kas::event::EventMgr) {
+                self.#inner.handle_message(mgr);
             }
         };
         let handle_scroll = quote! {

--- a/crates/kas-resvg/Cargo.toml
+++ b/crates/kas-resvg/Cargo.toml
@@ -27,5 +27,9 @@ tiny-skia = { version = "0.8.2" }
 resvg = { version = "0.28.0", optional = true }
 usvg = { version = "0.28.0", optional = true }
 
+[dependencies.kas]
 # We must rename this package since macros expect kas to be in scope:
-kas = { version = "0.12.0", package = "kas-core", path = "../kas-core" }
+version = "0.12.0"
+package = "kas-core"
+path = "../kas-core"
+features = ["spawn"]

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -191,7 +191,7 @@ impl_scope! {
                     }
 
                     if let Some(handle) = self.image.as_ref() {
-                        ds.image_upload(&handle, pixmap.data(), ImageFormat::Rgba8);
+                        ds.image_upload(handle, pixmap.data(), ImageFormat::Rgba8);
                     }
                 });
 

--- a/crates/kas-view/src/driver.rs
+++ b/crates/kas-view/src/driver.rs
@@ -83,7 +83,7 @@ pub trait Driver<Item, Data: SharedData<Item = Item>>: Debug {
     /// Handle a message from a widget
     ///
     /// This method is called when a view widget returns with a message; it
-    /// may retrieve this message with [`EventMgr::try_pop_msg`].
+    /// may retrieve this message with [`EventMgr::try_pop`].
     ///
     /// There are three main ways of implementing this method:
     ///
@@ -247,7 +247,7 @@ impl<G: EditGuard + Clone, Data: SharedDataMut<Item = String>> Driver<String, Da
         widget.set_string(item.into_owned())
     }
     fn on_message(&self, mgr: &mut EventMgr, _: &mut Self::Widget, data: &Data, key: &Data::Key) {
-        if let Some(item) = mgr.try_pop_msg() {
+        if let Some(item) = mgr.try_pop() {
             data.set(mgr, key, item);
         }
     }
@@ -311,7 +311,7 @@ impl<G: EditGuard + Clone, Data: SharedDataMut<Item = String>> Driver<String, Da
         widget.set_string(item.into_owned())
     }
     fn on_message(&self, mgr: &mut EventMgr, _: &mut Self::Widget, data: &Data, key: &Data::Key) {
-        if let Some(item) = mgr.try_pop_msg() {
+        if let Some(item) = mgr.try_pop() {
             data.set(mgr, key, item);
         }
     }
@@ -365,7 +365,7 @@ impl<Data: SharedDataMut<Item = bool>> Driver<bool, Data> for CheckButton {
         widget.set_bool(item.into_owned())
     }
     fn on_message(&self, mgr: &mut EventMgr, _: &mut Self::Widget, data: &Data, key: &Data::Key) {
-        if let Some(state) = mgr.try_pop_msg() {
+        if let Some(state) = mgr.try_pop() {
             data.set(mgr, key, state);
         }
     }
@@ -391,7 +391,7 @@ impl<Data: SharedDataMut<Item = bool>> Driver<bool, Data> for RadioBox {
         widget.set_bool(item.into_owned())
     }
     fn on_message(&self, mgr: &mut EventMgr, _: &mut Self::Widget, data: &Data, key: &Data::Key) {
-        if let Some(state) = mgr.try_pop_msg() {
+        if let Some(state) = mgr.try_pop() {
             data.set(mgr, key, state);
         }
     }
@@ -420,7 +420,7 @@ impl<Data: SharedDataMut<Item = bool>> Driver<bool, Data> for RadioButton {
         widget.set_bool(item.into_owned())
     }
     fn on_message(&self, mgr: &mut EventMgr, _: &mut Self::Widget, data: &Data, key: &Data::Key) {
-        if let Some(state) = mgr.try_pop_msg() {
+        if let Some(state) = mgr.try_pop() {
             data.set(mgr, key, state);
         }
     }
@@ -472,7 +472,7 @@ where
         widget.set_value(item.into_owned())
     }
     fn on_message(&self, mgr: &mut EventMgr, _: &mut Self::Widget, data: &Data, key: &Data::Key) {
-        if let Some(state) = mgr.try_pop_msg() {
+        if let Some(state) = mgr.try_pop() {
             data.set(mgr, key, state);
         }
     }
@@ -511,7 +511,7 @@ where
         widget.set_value(item.into_owned())
     }
     fn on_message(&self, mgr: &mut EventMgr, _: &mut Self::Widget, data: &Data, key: &Data::Key) {
-        if let Some(state) = mgr.try_pop_msg() {
+        if let Some(state) = mgr.try_pop() {
             data.set(mgr, key, state);
         }
     }

--- a/crates/kas-view/src/driver.rs
+++ b/crates/kas-view/src/driver.rs
@@ -168,7 +168,7 @@ impl_via_to_string!(f32, f64);
 impl<Data: SharedData<Item = bool>> Driver<bool, Data> for View {
     type Widget = CheckBox;
     fn make(&self) -> Self::Widget {
-        CheckBox::new_on(|mgr, state| mgr.push_msg(state)).with_editable(false)
+        CheckBox::new_on(|mgr, state| mgr.push(state)).with_editable(false)
     }
     fn set_mo(&self, widget: &mut Self::Widget, _: &Data::Key, item: MaybeOwned<bool>) -> Action {
         widget.set_bool(item.into_owned())
@@ -178,7 +178,7 @@ impl<Data: SharedData<Item = bool>> Driver<bool, Data> for View {
 impl<Data: SharedData<Item = bool>> Driver<bool, Data> for NavView {
     type Widget = CheckBox;
     fn make(&self) -> Self::Widget {
-        CheckBox::new_on(|mgr, state| mgr.push_msg(state)).with_editable(false)
+        CheckBox::new_on(|mgr, state| mgr.push(state)).with_editable(false)
     }
     fn set_mo(&self, widget: &mut Self::Widget, _: &Data::Key, item: MaybeOwned<bool>) -> Action {
         widget.set_bool(item.into_owned())
@@ -359,7 +359,7 @@ impl CheckButton {
 impl<Data: SharedDataMut<Item = bool>> Driver<bool, Data> for CheckButton {
     type Widget = kas_widgets::CheckButton;
     fn make(&self) -> Self::Widget {
-        kas_widgets::CheckButton::new_on(self.label.clone(), |mgr, state| mgr.push_msg(state))
+        kas_widgets::CheckButton::new_on(self.label.clone(), |mgr, state| mgr.push(state))
     }
     fn set_mo(&self, widget: &mut Self::Widget, _: &Data::Key, item: MaybeOwned<bool>) -> Action {
         widget.set_bool(item.into_owned())
@@ -385,7 +385,7 @@ impl RadioBox {
 impl<Data: SharedDataMut<Item = bool>> Driver<bool, Data> for RadioBox {
     type Widget = kas_widgets::RadioBox;
     fn make(&self) -> Self::Widget {
-        kas_widgets::RadioBox::new_on(self.group.clone(), |mgr| mgr.push_msg(true))
+        kas_widgets::RadioBox::new_on(self.group.clone(), |mgr| mgr.push(true))
     }
     fn set_mo(&self, widget: &mut Self::Widget, _: &Data::Key, item: MaybeOwned<bool>) -> Action {
         widget.set_bool(item.into_owned())
@@ -414,7 +414,7 @@ impl<Data: SharedDataMut<Item = bool>> Driver<bool, Data> for RadioButton {
     type Widget = kas_widgets::RadioButton;
     fn make(&self) -> Self::Widget {
         kas_widgets::RadioButton::new(self.label.clone(), self.group.clone())
-            .on_select(|mgr| mgr.push_msg(true))
+            .on_select(|mgr| mgr.push(true))
     }
     fn set_mo(&self, widget: &mut Self::Widget, _: &Data::Key, item: MaybeOwned<bool>) -> Action {
         widget.set_bool(item.into_owned())
@@ -461,7 +461,7 @@ where
     fn make(&self) -> Self::Widget {
         let range = self.range.0..=self.range.1;
         kas_widgets::Slider::new_with_direction(range, self.step, self.direction)
-            .on_move(|mgr, value| mgr.push_msg(value))
+            .on_move(|mgr, value| mgr.push(value))
     }
     fn set_mo(
         &self,
@@ -500,7 +500,7 @@ where
     type Widget = kas_widgets::Spinner<Data::Item>;
     fn make(&self) -> Self::Widget {
         let range = self.range.0..=self.range.1;
-        kas_widgets::Spinner::new(range, self.step).on_change(|mgr, val| mgr.push_msg(val))
+        kas_widgets::Spinner::new(range, self.step).on_change(|mgr, val| mgr.push(val))
     }
     fn set_mo(
         &self,

--- a/crates/kas-view/src/driver/config.rs
+++ b/crates/kas-view/src/driver/config.rs
@@ -91,28 +91,27 @@ impl driver::Driver<Config, SharedRc<Config>> for EventConfig {
 
         EventConfigWidget {
             core: Default::default(),
-            menu_delay: Spinner::new(0..=5_000, 50)
-                .on_change(|mgr, v| mgr.push_msg(Msg::MenuDelay(v))),
+            menu_delay: Spinner::new(0..=5_000, 50).on_change(|mgr, v| mgr.push(Msg::MenuDelay(v))),
             touch_select_delay: Spinner::new(0..=5_000, 50)
-                .on_change(|mgr, v| mgr.push_msg(Msg::TouchSelectDelay(v))),
+                .on_change(|mgr, v| mgr.push(Msg::TouchSelectDelay(v))),
             scroll_flick_timeout: Spinner::new(0..=500, 5)
-                .on_change(|mgr, v| mgr.push_msg(Msg::ScrollFlickTimeout(v))),
+                .on_change(|mgr, v| mgr.push(Msg::ScrollFlickTimeout(v))),
             scroll_flick_mul: Spinner::new(0.0..=1.0, 0.03125)
-                .on_change(|mgr, v| mgr.push_msg(Msg::ScrollFlickMul(v))),
+                .on_change(|mgr, v| mgr.push(Msg::ScrollFlickMul(v))),
             scroll_flick_sub: Spinner::new(0.0..=1.0e4, 10.0)
-                .on_change(|mgr, v| mgr.push_msg(Msg::ScrollFlickSub(v))),
+                .on_change(|mgr, v| mgr.push(Msg::ScrollFlickSub(v))),
             scroll_dist_em: Spinner::new(0.125..=125.0, 0.125)
-                .on_change(|mgr, v| mgr.push_msg(Msg::ScrollDistEm(v))),
+                .on_change(|mgr, v| mgr.push(Msg::ScrollDistEm(v))),
             pan_dist_thresh: Spinner::new(0.25..=25.0, 0.25)
-                .on_change(|mgr, v| mgr.push_msg(Msg::PanDistThresh(v))),
+                .on_change(|mgr, v| mgr.push(Msg::PanDistThresh(v))),
             mouse_pan: mouse_pan
                 .clone()
-                .on_select(|mgr, v| mgr.push_msg(Msg::MousePan(v))),
-            mouse_text_pan: mouse_pan.on_select(|mgr, v| mgr.push_msg(Msg::MouseTextPan(v))),
+                .on_select(|mgr, v| mgr.push(Msg::MousePan(v))),
+            mouse_text_pan: mouse_pan.on_select(|mgr, v| mgr.push(Msg::MouseTextPan(v))),
             mouse_nav_focus: CheckButton::new("&Mouse navigation focus")
-                .on_toggle(|mgr, v| mgr.push_msg(Msg::MouseNavFocus(v))),
+                .on_toggle(|mgr, v| mgr.push(Msg::MouseNavFocus(v))),
             touch_nav_focus: CheckButton::new("&Touchscreen navigation focus")
-                .on_toggle(|mgr, v| mgr.push_msg(Msg::TouchNavFocus(v))),
+                .on_toggle(|mgr, v| mgr.push(Msg::TouchNavFocus(v))),
         }
     }
 

--- a/crates/kas-view/src/driver/config.rs
+++ b/crates/kas-view/src/driver/config.rs
@@ -142,7 +142,7 @@ impl driver::Driver<Config, SharedRc<Config>> for EventConfig {
         data: &SharedRc<Config>,
         _: &(),
     ) {
-        if let Some(msg) = mgr.try_pop_msg() {
+        if let Some(msg) = mgr.try_pop() {
             let mut data = data.borrow_mut(mgr);
             match msg {
                 Msg::MenuDelay(v) => data.menu_delay_ms = v,

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -715,15 +715,15 @@ impl_scope! {
                                     mgr.redraw(self.id());
                                     self.selection.clear();
                                     self.selection.insert(key.clone());
-                                    mgr.push_msg(SelectionMsg::Select(key.clone()));
+                                    mgr.push(SelectionMsg::Select(key.clone()));
                                 }
                                 SelectionMode::Multiple => {
                                     mgr.redraw(self.id());
                                     if self.selection.remove(key) {
-                                        mgr.push_msg(SelectionMsg::Deselect(key.clone()));
+                                        mgr.push(SelectionMsg::Deselect(key.clone()));
                                     } else {
                                         self.selection.insert(key.clone());
-                                        mgr.push_msg(SelectionMsg::Select(key.clone()));
+                                        mgr.push(SelectionMsg::Select(key.clone()));
                                     }
                                 }
                             }
@@ -821,15 +821,15 @@ impl_scope! {
                         mgr.redraw(self.id());
                         self.selection.clear();
                         self.selection.insert(key.clone());
-                        mgr.push_msg(SelectionMsg::Select(key));
+                        mgr.push(SelectionMsg::Select(key));
                     }
                     SelectionMode::Multiple => {
                         mgr.redraw(self.id());
                         if self.selection.remove(&key) {
-                            mgr.push_msg(SelectionMsg::Deselect(key));
+                            mgr.push(SelectionMsg::Deselect(key));
                         } else {
                             self.selection.insert(key.clone());
-                            mgr.push_msg(SelectionMsg::Select(key));
+                            mgr.push(SelectionMsg::Select(key));
                         }
                     }
                 }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -806,7 +806,7 @@ impl_scope! {
                 key = self.press_target.clone().unwrap();
             }
 
-            if let Some(SelectMsg) = mgr.try_pop_msg() {
+            if let Some(SelectMsg) = mgr.try_pop() {
                 match self.sel_mode {
                     SelectionMode::None => (),
                     SelectionMode::Single => {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -788,13 +788,14 @@ impl_scope! {
             r
         }
 
-        fn handle_unused(&mut self, mgr: &mut EventMgr, index: usize, event: Event) -> Response {
+        fn handle_unused(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             if let Event::PressStart { source, coord, .. } = event {
                 if source.is_primary() {
                     // We request a grab with our ID, hence the
                     // PressMove/PressEnd events are matched in handle_event().
                     mgr.grab_press_unique(self.id(), source, coord, None);
                     self.press_phase = PressPhase::Start(coord);
+                    let index = mgr.last_child().unwrap();
                     self.press_target = self.widgets[index].key.clone();
                     Response::Used
                 } else {
@@ -805,7 +806,8 @@ impl_scope! {
             }
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
+            let index = mgr.last_child().expect("message not sent from self");
             let w = &mut self.widgets[index];
             let key = match w.key.clone() {
                 Some(k) => k,

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -709,23 +709,8 @@ impl_scope! {
                                 }
                             }
 
-                            match self.sel_mode {
-                                SelectionMode::None => (),
-                                SelectionMode::Single => {
-                                    mgr.redraw(self.id());
-                                    self.selection.clear();
-                                    self.selection.insert(key.clone());
-                                    mgr.push(SelectionMsg::Select(key.clone()));
-                                }
-                                SelectionMode::Multiple => {
-                                    mgr.redraw(self.id());
-                                    if self.selection.remove(key) {
-                                        mgr.push(SelectionMsg::Deselect(key.clone()));
-                                    } else {
-                                        self.selection.insert(key.clone());
-                                        mgr.push(SelectionMsg::Select(key.clone()));
-                                    }
-                                }
+                            if !matches!(self.sel_mode, SelectionMode::None) {
+                                mgr.push(SelectMsg);
                             }
                         }
                         return Response::Used;
@@ -807,14 +792,19 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            let index = mgr.last_child().expect("message not sent from self");
-            let w = &mut self.widgets[index];
-            let key = match w.key.clone() {
-                Some(k) => k,
-                None => return,
-            };
+            let key;
+            if let Some(index) = mgr.last_child() {
+                let w = &mut self.widgets[index];
+                key = match w.key.clone() {
+                    Some(k) => k,
+                    None => return,
+                };
 
-            self.driver.on_message(mgr, &mut w.widget, &self.data, &key);
+                self.driver.on_message(mgr, &mut w.widget, &self.data, &key);
+            } else {
+                // Message is from self
+                key = self.press_target.clone().unwrap();
+            }
 
             if let Some(SelectMsg) = mgr.try_pop_msg() {
                 match self.sel_mode {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -721,15 +721,15 @@ impl_scope! {
                                     mgr.redraw(self.id());
                                     self.selection.clear();
                                     self.selection.insert(key.clone());
-                                    mgr.push_msg(SelectionMsg::Select(key.clone()));
+                                    mgr.push(SelectionMsg::Select(key.clone()));
                                 }
                                 SelectionMode::Multiple => {
                                     mgr.redraw(self.id());
                                     if self.selection.remove(key) {
-                                        mgr.push_msg(SelectionMsg::Deselect(key.clone()));
+                                        mgr.push(SelectionMsg::Deselect(key.clone()));
                                     } else {
                                         self.selection.insert(key.clone());
-                                        mgr.push_msg(SelectionMsg::Select(key.clone()));
+                                        mgr.push(SelectionMsg::Select(key.clone()));
                                     }
                                 }
                             }
@@ -850,15 +850,15 @@ impl_scope! {
                         mgr.redraw(self.id());
                         self.selection.clear();
                         self.selection.insert(key.clone());
-                        mgr.push_msg(SelectionMsg::Select(key));
+                        mgr.push(SelectionMsg::Select(key));
                     }
                     SelectionMode::Multiple => {
                         mgr.redraw(self.id());
                         if self.selection.remove(&key) {
-                            mgr.push_msg(SelectionMsg::Deselect(key));
+                            mgr.push(SelectionMsg::Deselect(key));
                         } else {
                             self.selection.insert(key.clone());
-                            mgr.push_msg(SelectionMsg::Select(key));
+                            mgr.push(SelectionMsg::Select(key));
                         }
                     }
                 }

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -835,7 +835,7 @@ impl_scope! {
                 key = self.press_target.clone().unwrap();
             }
 
-            if let Some(SelectMsg) = mgr.try_pop_msg() {
+            if let Some(SelectMsg) = mgr.try_pop() {
                 match self.sel_mode {
                     SelectionMode::None => (),
                     SelectionMode::Single => {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -817,13 +817,14 @@ impl_scope! {
             r
         }
 
-        fn handle_unused(&mut self, mgr: &mut EventMgr, index: usize, event: Event) -> Response {
+        fn handle_unused(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             if let Event::PressStart { source, coord, .. } = event {
                 if source.is_primary() {
                     // We request a grab with our ID, hence the
                     // PressMove/PressEnd events are matched in handle_event().
                     mgr.grab_press_unique(self.id(), source, coord, None);
                     self.press_phase = PressPhase::Start(coord);
+                    let index = mgr.last_child().unwrap();
                     self.press_target = self.widgets[index].key.clone();
                     Response::Used
                 } else {
@@ -834,7 +835,8 @@ impl_scope! {
             }
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
+            let index = mgr.last_child().expect("message not sent from self");
             let w = &mut self.widgets[index];
             let key = match w.key.clone() {
                 Some(k) => k,

--- a/crates/kas-view/src/single_view.rs
+++ b/crates/kas-view/src/single_view.rs
@@ -152,7 +152,7 @@ impl_scope! {
             }
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             self.driver
                 .on_message(mgr, &mut self.child, &self.data, &());
         }

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -27,7 +27,7 @@ raster = ["kas-text/raster"]
 
 [dependencies]
 bytemuck = "1.7.0"
-futures = "0.3"
+futures-lite = "1.12"
 log = "0.4"
 wgpu = { version = "0.14.0", features = ["spirv"] }
 thiserror = "1.0.23"

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -5,6 +5,7 @@
 
 //! Drawing API for `kas_wgpu`
 
+use futures_lite::future::block_on;
 use std::f32::consts::FRAC_PI_2;
 use wgpu::util::DeviceExt;
 
@@ -37,7 +38,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         let instance = wgpu::Instance::new(options.backend());
         let adapter_options = options.adapter_options();
         let req = instance.request_adapter(&adapter_options);
-        let adapter = match futures::executor::block_on(req) {
+        let adapter = match block_on(req) {
             Some(a) => a,
             None => return Err(Error::Graphics(Box::new(NoAdapter))),
         };
@@ -46,8 +47,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         let desc = CB::device_descriptor();
         let trace_path = options.wgpu_trace_path.as_deref();
         let req = adapter.request_device(&desc, trace_path);
-        let (device, queue) =
-            futures::executor::block_on(req).map_err(|e| Error::Graphics(Box::new(e)))?;
+        let (device, queue) = block_on(req).map_err(|e| Error::Graphics(Box::new(e)))?;
 
         let shaders = ShaderManager::new(&device);
 

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -52,7 +52,7 @@ impl_scope! {
     impl Widget for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
             if let Some(msg) = mgr.try_pop_msg() {
-                mgr.push_msg((self.map)(msg));
+                mgr.push((self.map)(msg));
             }
         }
     }

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -50,7 +50,7 @@ impl_scope! {
     }
 
     impl Widget for Self {
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(msg) = mgr.try_pop_msg() {
                 mgr.push((self.map)(msg));
             }

--- a/crates/kas-widgets/src/adapter/map.rs
+++ b/crates/kas-widgets/src/adapter/map.rs
@@ -51,7 +51,7 @@ impl_scope! {
 
     impl Widget for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(msg) = mgr.try_pop_msg() {
+            if let Some(msg) = mgr.try_pop() {
                 mgr.push((self.map)(msg));
             }
         }

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -85,7 +85,7 @@ impl_scope! {
         /// [`Widget::handle_message`].
         #[inline]
         pub fn new_msg<M: Clone + Debug + 'static>(inner: W, msg: M) -> Self {
-            Self::new_on(inner, move |mgr| mgr.push_msg(msg.clone()))
+            Self::new_on(inner, move |mgr| mgr.push(msg.clone()))
         }
 
         /// Add accelerator keys (chain style)
@@ -197,7 +197,7 @@ impl_scope! {
         /// [`Widget::handle_message`].
         #[inline]
         pub fn new_msg<S: Into<AccelString>, M: Clone + Debug + 'static>(label: S, msg: M) -> Self {
-            Self::new_on(label, move |mgr| mgr.push_msg(msg.clone()))
+            Self::new_on(label, move |mgr| mgr.push(msg.clone()))
         }
 
         /// Add accelerator keys (chain style)

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -177,13 +177,13 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(IndexMsg(index)) = mgr.try_pop_msg() {
+            if let Some(IndexMsg(index)) = mgr.try_pop() {
                 *mgr |= self.set_active(index);
                 if let Some(id) = self.popup_id {
                     mgr.close_window(id, true);
                 }
                 if let Some(ref f) = self.on_select {
-                    if let Some(msg) = mgr.try_pop_msg() {
+                    if let Some(msg) = mgr.try_pop() {
                         (f)(mgr, msg);
                     }
                 }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -157,7 +157,8 @@ impl_scope! {
                                 return Response::Used;
                             }
                         } else if self.popup_id.is_some() && self.popup.is_ancestor_of(&id) {
-                            return mgr.send(self, id, Event::Command(Command::Activate));
+                            mgr.send(self, id, Event::Command(Command::Activate));
+                            return Response::Used;
                         }
                     }
                     if let Some(id) = self.popup_id {

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -242,7 +242,7 @@ impl<M: Clone + Debug + 'static> ComboBox<M> {
             popup: ComboPopup {
                 core: Default::default(),
                 inner: PopupFrame::new(
-                    Column::new_vec(entries).on_message(|mgr, index| mgr.push_msg(IndexMsg(index))),
+                    Column::new_vec(entries).on_message(|mgr, index| mgr.push(IndexMsg(index))),
                 ),
             },
             ..Default::default()

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -176,7 +176,7 @@ impl_scope! {
             }
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(IndexMsg(index)) = mgr.try_pop_msg() {
                 *mgr |= self.set_active(index);
                 if let Some(id) = self.popup_id {

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -110,7 +110,7 @@ impl_scope! {
 
     impl Widget for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(MessageBoxOk) = mgr.try_pop_msg() {
+            if let Some(MessageBoxOk) = mgr.try_pop() {
                 mgr.send_action(Action::CLOSE);
             }
         }
@@ -199,7 +199,7 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(MsgClose(commit)) = mgr.try_pop_msg() {
+            if let Some(MsgClose(commit)) = mgr.try_pop() {
                 let _ = self.close(mgr, commit);
             }
         }

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -109,7 +109,7 @@ impl_scope! {
     }
 
     impl Widget for Self {
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(MessageBoxOk) = mgr.try_pop_msg() {
                 mgr.send_action(Action::CLOSE);
             }
@@ -198,7 +198,7 @@ impl_scope! {
             }
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(MsgClose(commit)) = mgr.try_pop_msg() {
                 let _ = self.close(mgr, commit);
             }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -268,7 +268,7 @@ impl_scope! {
     }
 
     impl Widget for Self {
-        fn handle_message(&mut self, mgr: &mut EventMgr<'_>, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr<'_>) {
             if let Some(ScrollMsg(y)) = mgr.try_pop_msg() {
                 self.inner
                     .set_scroll_offset(mgr, Offset(self.inner.view_offset.0, y));

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -36,7 +36,7 @@ enum EditAction {
 ///
 /// When an [`EditField`] receives input, it updates its contents as expected,
 /// then invokes a method of `EditGuard`. This method may update the
-/// [`EditField`] and may return a message via [`EventMgr::push_msg`].
+/// [`EditField`] and may return a message via [`EventMgr::push`].
 ///
 /// All methods on this trait are passed a reference to the [`EditField`] as
 /// parameter. The `EditGuard`'s state may be accessed via the
@@ -47,7 +47,7 @@ enum EditAction {
 /// Pre-built implementations:
 ///
 /// -   `()`: does nothing
-/// -   `GuardNotify`: clones text to a `String` and pushes as a message ([`EventMgr::push_msg`])
+/// -   `GuardNotify`: clones text to a `String` and pushes as a message ([`EventMgr::push`])
 ///     on `activate` and `focus_lost` events
 /// -   `GuardActivate: calls a closure on `activate`
 /// -   `GuardAFL`: calls a closure on `activate` and `focus_lost`
@@ -106,7 +106,7 @@ impl EditGuard for () {}
 
 /// An [`EditGuard`] impl which notifies on activate and focus lost
 ///
-/// On activate and focus-lost actions, calls [`EventMgr::push_msg`] with the
+/// On activate and focus-lost actions, calls [`EventMgr::push`] with the
 /// edit's contents as a [`String`].
 ///
 /// `Self::activate` returns [`Response::Used`].
@@ -121,7 +121,7 @@ impl EditGuard for GuardNotify {
 
     #[inline]
     fn focus_lost(edit: &mut EditField<Self>, mgr: &mut EventMgr) {
-        mgr.push_msg(edit.get_string());
+        mgr.push(edit.get_string());
     }
 }
 

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -269,7 +269,7 @@ impl_scope! {
 
     impl Widget for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr<'_>) {
-            if let Some(ScrollMsg(y)) = mgr.try_pop_msg() {
+            if let Some(ScrollMsg(y)) = mgr.try_pop() {
                 self.inner
                     .set_scroll_offset(mgr, Offset(self.inner.view_offset.0, y));
             }

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -114,8 +114,9 @@ impl_scope! {
     }
 
     impl Widget for Self {
-        fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(f) = self.on_message {
+                let index = mgr.last_child().expect("message not sent from self");
                 f(mgr, index);
             }
         }

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -91,7 +91,7 @@ impl_scope! {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::PressStart { source, coord, .. } => {
-                    mgr.push_msg(GripMsg::PressStart);
+                    mgr.push(GripMsg::PressStart);
                     mgr.grab_press_unique(self.id(), source, coord, Some(CursorIcon::Grabbing));
 
                     // Event delivery implies coord is over the grip.
@@ -101,11 +101,11 @@ impl_scope! {
                 Event::PressMove { coord, .. } => {
                     let offset = coord - self.press_coord;
                     let offset = offset.clamp(Offset::ZERO, self.max_offset());
-                    mgr.push_msg(GripMsg::PressMove(offset));
+                    mgr.push(GripMsg::PressMove(offset));
                     Response::Used
                 }
                 Event::PressEnd { .. } => {
-                    mgr.push_msg(GripMsg::PressEnd);
+                    mgr.push(GripMsg::PressEnd);
                     Response::Used
                 }
                 _ => Response::Unused,

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -126,8 +126,9 @@ impl_scope! {
             self.id_map.clear();
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(f) = self.on_message {
+                let index = mgr.last_child().expect("message not sent from self");
                 f(mgr, index);
             }
         }

--- a/crates/kas-widgets/src/mark.rs
+++ b/crates/kas-widgets/src/mark.rs
@@ -91,7 +91,7 @@ impl_scope! {
     impl Widget for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             event.on_activate(mgr, self.id(), |mgr| {
-                mgr.push_msg(self.msg.clone());
+                mgr.push(self.msg.clone());
                 Response::Used
             })
         }

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -82,7 +82,7 @@ impl_scope! {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::Command(cmd) if cmd.is_activate() => {
-                    mgr.push_msg(self.msg.clone());
+                    mgr.push(self.msg.clone());
                     Response::Used
                 }
                 _ => Response::Unused,

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -214,7 +214,7 @@ impl_scope! {
                     if !self.rect().contains(coord) {
                         // not on the menubar
                         self.delayed_open = None;
-                        return mgr.send(self, id, Event::Command(Command::Activate));
+                        mgr.send(self, id, Event::Command(Command::Activate));
                     }
                     Response::Used
                 }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -179,7 +179,7 @@ impl_scope! {
             }
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             self.close_menu(mgr, true);
         }
 

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -50,7 +50,7 @@ impl_scope! {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::Command(cmd) if cmd.is_activate() => {
-                    mgr.push_msg(SelectMsg);
+                    mgr.push(SelectMsg);
                     Response::Used
                 }
                 _ => Response::Unused,

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -314,7 +314,7 @@ impl_scope! {
         /// same `group` will be considered part of a single group.
         ///
         /// When the radio button is selected, a clone
-        /// of `msg` is returned to the parent widget via [`EventMgr::push_msg`].
+        /// of `msg` is returned to the parent widget via [`EventMgr::push`].
         ///
         /// No handler is called on deselection.
         #[inline]
@@ -323,7 +323,7 @@ impl_scope! {
             S: Into<AccelString>,
             M: Clone + Debug + 'static,
         {
-            Self::new_on(label, group, move |mgr| mgr.push_msg(msg.clone()))
+            Self::new_on(label, group, move |mgr| mgr.push(msg.clone()))
         }
 
         /// Set the initial state of the radio button.

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -250,7 +250,7 @@ impl_scope! {
             }
             let value = i32::conv((lhs + (rhs / 2)) / rhs);
             if self.set_value(mgr, value) {
-                mgr.push_msg(ScrollMsg(value));
+                mgr.push(ScrollMsg(value));
             }
         }
     }

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -318,7 +318,7 @@ impl_scope! {
             }
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(GripMsg::PressMove(offset)) = mgr.try_pop_msg() {
                 self.apply_grip_offset(mgr, offset);
             }
@@ -528,7 +528,8 @@ impl_scope! {
     }
 
     impl Widget for Self {
-        fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
+            let index = mgr.last_child().expect("message not sent from self");
             if index == widget_index![self.horiz_bar] {
                 if let Some(ScrollMsg(x)) = mgr.try_pop_msg() {
                     let offset = Offset(x, self.inner.scroll_offset().1);

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -29,7 +29,7 @@ impl_scope! {
     ///
     /// It is safe to not call `size_rules` before `set_rect` for this type.
     #[derive(Clone, Debug, Default)]
-    #[widget]
+    #[widget(hover_highlight = true;)]
     pub struct ScrollBar<D: Directional> {
         core: widget_core!(),
         align: AlignPair,
@@ -41,7 +41,6 @@ impl_scope! {
         max_value: i32,
         value: i32,
         invisible: bool,
-        hover: bool,
         force_visible: bool,
         #[widget]
         handle: GripPart,
@@ -75,7 +74,6 @@ impl_scope! {
                 max_value: 0,
                 value: 0,
                 invisible: false,
-                hover: false,
                 force_visible: false,
                 handle: GripPart::new(),
             }
@@ -178,12 +176,15 @@ impl_scope! {
             if changed {
                 self.value = value;
                 *mgr |= self.handle.set_offset(self.offset()).1;
-
-                self.force_visible = true;
-                let delay = mgr.config().menu_delay();
-                mgr.request_update(self.id(), 0, delay, false);
             }
+            self.force_visible(mgr);
             changed
+        }
+
+        fn force_visible(&mut self, mgr: &mut EventState) {
+            self.force_visible = true;
+            let delay = mgr.config().touch_select_delay();
+            mgr.request_update(self.id(), 0, delay, false);
         }
 
         #[inline]
@@ -286,8 +287,12 @@ impl_scope! {
         }
 
         fn draw(&mut self, mut draw: DrawMgr) {
+            if draw.ev_state().is_hovered_recursive(self.id_ref()) {
+                self.force_visible(draw.ev_state());
+            }
+
             if !self.invisible
-                || (self.max_value != 0 && (self.hover || self.force_visible))
+                || (self.max_value != 0 && self.force_visible)
                 || draw.ev_state().is_depressed(self.handle.id_ref())
             {
                 let dir = self.direction.as_direction();
@@ -311,18 +316,6 @@ impl_scope! {
                 }
                 _ => Response::Unused,
             }
-        }
-
-        fn steal_event(&mut self, mgr: &mut EventMgr, _: &WidgetId, event: &Event) -> Response {
-            match event {
-                Event::MouseHover | Event::LostMouseHover => {
-                    self.hover = matches!(event, Event::MouseHover);
-                    mgr.redraw(self.id());
-                    // Do not return Used: allow self.handle to handle this event
-                }
-                _ => (),
-            }
-            Response::Unused
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -319,7 +319,7 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(GripMsg::PressMove(offset)) = mgr.try_pop_msg() {
+            if let Some(GripMsg::PressMove(offset)) = mgr.try_pop() {
                 self.apply_grip_offset(mgr, offset);
             }
         }
@@ -531,12 +531,12 @@ impl_scope! {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             let index = mgr.last_child().expect("message not sent from self");
             if index == widget_index![self.horiz_bar] {
-                if let Some(ScrollMsg(x)) = mgr.try_pop_msg() {
+                if let Some(ScrollMsg(x)) = mgr.try_pop() {
                     let offset = Offset(x, self.inner.scroll_offset().1);
                     self.inner.set_scroll_offset(mgr, offset);
                 }
             } else if index == widget_index![self.vert_bar] {
-                if let Some(ScrollMsg(y)) = mgr.try_pop_msg() {
+                if let Some(ScrollMsg(y)) = mgr.try_pop() {
                     let offset = Offset(self.inner.scroll_offset().0, y);
                     self.inner.set_scroll_offset(mgr, offset);
                 }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -262,7 +262,7 @@ impl_scope! {
             }
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(ScrollMsg(y)) = mgr.try_pop_msg() {
                 let y = y.clamp(0, self.max_scroll_offset().1);
                 self.view_offset.1 = y;

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -263,7 +263,7 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(ScrollMsg(y)) = mgr.try_pop_msg() {
+            if let Some(ScrollMsg(y)) = mgr.try_pop() {
                 let y = y.clamp(0, self.max_scroll_offset().1);
                 self.view_offset.1 = y;
                 mgr.redraw(self.id());

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -342,7 +342,7 @@ impl_scope! {
             Response::Used
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             match mgr.try_pop_msg() {
                 Some(GripMsg::PressStart) => mgr.set_nav_focus(self.id(), false),
                 Some(GripMsg::PressMove(pos)) => {

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -343,7 +343,7 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            match mgr.try_pop_msg() {
+            match mgr.try_pop() {
                 Some(GripMsg::PressStart) => mgr.set_nav_focus(self.id(), false),
                 Some(GripMsg::PressMove(pos)) => {
                     self.apply_grip_offset(mgr, pos);

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -355,12 +355,12 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(ValueMsg(value)) = mgr.try_pop_msg() {
+            if let Some(ValueMsg(value)) = mgr.try_pop() {
                 if let Some(ref f) = self.on_change {
                     f(mgr, value);
                 }
             }
-            if let Some(btn) = mgr.try_pop_msg::<SpinBtn>() {
+            if let Some(btn) = mgr.try_pop::<SpinBtn>() {
                 self.handle_btn(mgr, btn);
             }
         }

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -354,7 +354,7 @@ impl_scope! {
             Response::Used
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(ValueMsg(value)) = mgr.try_pop_msg() {
                 if let Some(ref f) = self.on_change {
                     f(mgr, value);

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -116,7 +116,7 @@ impl<T: SpinnerValue> EditGuard for SpinnerGuard<T> {
             *mgr |= edit.set_string(edit.guard.value.to_string());
             edit.set_error_state(false);
         }
-        mgr.push_msg(ValueMsg(edit.guard.value));
+        mgr.push(ValueMsg(edit.guard.value));
         Response::Used
     }
 
@@ -132,7 +132,7 @@ impl<T: SpinnerValue> EditGuard for SpinnerGuard<T> {
             Ok(value) if edit.guard.range().contains(&value) => {
                 if value != edit.guard.value {
                     edit.guard.value = value;
-                    mgr.push_msg(ValueMsg(value));
+                    mgr.push(ValueMsg(value));
                 }
                 false
             }

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -249,7 +249,7 @@ impl_scope! {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             let index = mgr.last_child().expect("message not sent from self");
             if (index & 1) == 1 {
-                if let Some(GripMsg::PressMove(offset)) = mgr.try_pop_msg() {
+                if let Some(GripMsg::PressMove(offset)) = mgr.try_pop() {
                     let n = index >> 1;
                     assert!(n < self.handles.len());
                     *mgr |= self.handles[n].set_offset(offset).1;

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -246,7 +246,8 @@ impl_scope! {
             self.id_map.clear();
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
+            let index = mgr.last_child().expect("message not sent from self");
             if (index & 1) == 1 {
                 if let Some(GripMsg::PressMove(offset)) = mgr.try_pop_msg() {
                     let n = index >> 1;

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -66,7 +66,7 @@ impl_scope! {
                 direction: Direction::Up,
                 stack: Stack::new(),
                 tabs: Row::new().on_message(|mgr, index| {
-                    if let Some(MsgSelect) = mgr.try_pop_msg() {
+                    if let Some(MsgSelect) = mgr.try_pop() {
                         mgr.push(MsgSelectIndex(index));
                     }
                 }),
@@ -94,7 +94,7 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(MsgSelectIndex(index)) = mgr.try_pop_msg() {
+            if let Some(MsgSelectIndex(index)) = mgr.try_pop() {
                 mgr.config_mgr(|mgr| self.set_active(mgr, index));
             }
         }

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -67,7 +67,7 @@ impl_scope! {
                 stack: Stack::new(),
                 tabs: Row::new().on_message(|mgr, index| {
                     if let Some(MsgSelect) = mgr.try_pop_msg() {
-                        mgr.push_msg(MsgSelectIndex(index));
+                        mgr.push(MsgSelectIndex(index));
                     }
                 }),
             }
@@ -203,7 +203,7 @@ impl<W: Widget> TabStack<W> {
     ///
     /// Does not configure or size child.
     pub fn with_title(self, title: impl Into<AccelString>, widget: W) -> Self {
-        self.with_tab(Tab::new_on(title, |mgr| mgr.push_msg(MsgSelect)), widget)
+        self.with_tab(Tab::new_on(title, |mgr| mgr.push(MsgSelect)), widget)
     }
 
     /// Append a page

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -93,7 +93,7 @@ impl_scope! {
             kas::util::nav_next(reverse, from, self.num_children())
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(MsgSelectIndex(index)) = mgr.try_pop_msg() {
                 mgr.config_mgr(|mgr| self.set_active(mgr, index));
             }

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -84,9 +84,7 @@ impl_scope! {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::Command(Command::DelBack) => {
-                    if self.calc.handle(Key::DelBack) {
-                        *mgr |= self.display.set_string(self.calc.display());
-                    }
+                    mgr.push(Key::DelBack);
                     Response::Used
                 }
                 _ => Response::Unused,

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -92,7 +92,7 @@ impl_scope! {
         }
 
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(msg) = mgr.try_pop_msg::<Key>() {
+            if let Some(msg) = mgr.try_pop::<Key>() {
                 if self.calc.handle(msg) {
                     *mgr |= self.display.set_string(self.calc.display());
                 }

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -93,7 +93,7 @@ impl_scope! {
             }
         }
 
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(msg) = mgr.try_pop_msg::<Key>() {
                 if self.calc.handle(msg) {
                     *mgr |= self.display.set_string(self.calc.display());

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -39,7 +39,7 @@ impl_scope! {
     }
     impl Widget for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(Increment(incr)) = mgr.try_pop_msg() {
+            if let Some(Increment(incr)) = mgr.try_pop() {
                 self.count += incr;
                 *mgr |= self.display.set_string(self.count.to_string());
             }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -38,7 +38,7 @@ impl_scope! {
         }
     }
     impl Widget for Self {
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(Increment(incr)) = mgr.try_pop_msg() {
                 self.count += incr;
                 *mgr |= self.display.set_string(self.count.to_string());

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -195,7 +195,7 @@ impl Driver<(bool, String), MySharedData> for MyDriver {
         data: &MySharedData,
         key: &usize,
     ) {
-        if let Some(msg) = mgr.try_pop_msg() {
+        if let Some(msg) = mgr.try_pop() {
             let mut borrow = data.data.borrow_mut();
             borrow.ver += 1;
             match msg {
@@ -239,13 +239,13 @@ fn main() -> kas::shell::Result<()> {
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if mgr.last_child() == Some(widget_index![self.edit]) {
-                    if let Some(n) = mgr.try_pop_msg::<usize>() {
+                    if let Some(n) = mgr.try_pop::<usize>() {
                         if n != self.n {
                             self.n = n;
                             mgr.push(Control::Set(n))
                         }
                     }
-                } else if let Some(msg) = mgr.try_pop_msg::<Button>() {
+                } else if let Some(msg) = mgr.try_pop::<Button>() {
                     let n = match msg {
                         Button::Decr => self.n.saturating_sub(1),
                         Button::Incr => self.n.saturating_add(1),
@@ -287,7 +287,7 @@ fn main() -> kas::shell::Result<()> {
         }
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
-                if let Some(control) = mgr.try_pop_msg::<Control>() {
+                if let Some(control) = mgr.try_pop::<Control>() {
                     match control {
                         Control::Set(len) => {
                             if let Some(text) = self.list.data_mut().set_len(len) {

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -128,12 +128,12 @@ impl ListData for MySharedData {
 struct ListEntryGuard;
 impl EditGuard for ListEntryGuard {
     fn activate(_edit: &mut EditField<Self>, mgr: &mut EventMgr) -> Response {
-        mgr.push_msg(EntryMsg::Select);
+        mgr.push(EntryMsg::Select);
         Response::Used
     }
 
     fn edit(edit: &mut EditField<Self>, mgr: &mut EventMgr) {
-        mgr.push_msg(EntryMsg::Update(edit.get_string()));
+        mgr.push(EntryMsg::Update(edit.get_string()));
     }
 }
 
@@ -170,7 +170,7 @@ impl Driver<(bool, String), MySharedData> for MyDriver {
             core: Default::default(),
             label: Label::new(String::default()),
             radio: RadioButton::new("display this entry", self.radio_group.clone())
-                .on_select(|mgr| mgr.push_msg(EntryMsg::Select)),
+                .on_select(|mgr| mgr.push(EntryMsg::Select)),
             edit: EditBox::new(String::default()).with_guard(ListEntryGuard),
         }
     }
@@ -206,7 +206,7 @@ impl Driver<(bool, String), MySharedData> for MyDriver {
                     borrow.strings.insert(*key, text);
                 }
             }
-            mgr.push_msg(Control::Update(borrow.get(borrow.active)));
+            mgr.push(Control::Update(borrow.get(borrow.active)));
             mgr.update_all(0);
         }
     }
@@ -231,7 +231,7 @@ fn main() -> kas::shell::Result<()> {
             core: widget_core!(),
             #[widget] edit: EditBox<impl EditGuard> = EditBox::new("3")
                 .on_afl(|mgr, text| match text.parse::<usize>() {
-                    Ok(n) => mgr.push_msg(n),
+                    Ok(n) => mgr.push(n),
                     Err(_) => (),
                 }),
             n: usize = 3,
@@ -242,7 +242,7 @@ fn main() -> kas::shell::Result<()> {
                     if let Some(n) = mgr.try_pop_msg::<usize>() {
                         if n != self.n {
                             self.n = n;
-                            mgr.push_msg(Control::Set(n))
+                            mgr.push(Control::Set(n))
                         }
                     }
                 } else if let Some(msg) = mgr.try_pop_msg::<Button>() {
@@ -253,7 +253,7 @@ fn main() -> kas::shell::Result<()> {
                     };
                     *mgr |= self.edit.set_string(n.to_string());
                     self.n = n;
-                    mgr.push_msg(Control::Set(n));
+                    mgr.push(Control::Set(n));
                 }
             }
         }

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -237,8 +237,8 @@ fn main() -> kas::shell::Result<()> {
             n: usize = 3,
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
-                if index == widget_index![self.edit] {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
+                if mgr.last_child() == Some(widget_index![self.edit]) {
                     if let Some(n) = mgr.try_pop_msg::<usize>() {
                         if n != self.n {
                             self.n = n;
@@ -286,7 +286,7 @@ fn main() -> kas::shell::Result<()> {
                 ScrollBars::new(list).with_fixed_bars(false, true),
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(control) = mgr.try_pop_msg::<Control>() {
                     match control {
                         Control::Set(len) => {

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -19,8 +19,8 @@ use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 enum Control {
-    Set(usize),
-    Dir,
+    SetLen(usize),
+    Reverse,
     Update(String),
 }
 
@@ -223,7 +223,7 @@ fn main() -> kas::shell::Result<()> {
                 TextButton::new_msg("Set", Button::Set),
                 TextButton::new_msg("−", Button::Decr),
                 TextButton::new_msg("+", Button::Incr),
-                TextButton::new_msg("↓↑", Control::Dir),
+                TextButton::new_msg("↓↑", Control::Reverse),
             ];
         }]
         #[derive(Debug)]
@@ -242,7 +242,7 @@ fn main() -> kas::shell::Result<()> {
                     if let Some(n) = mgr.try_pop::<usize>() {
                         if n != self.n {
                             self.n = n;
-                            mgr.push(Control::Set(n))
+                            mgr.push(Control::SetLen(n))
                         }
                     }
                 } else if let Some(msg) = mgr.try_pop::<Button>() {
@@ -253,7 +253,7 @@ fn main() -> kas::shell::Result<()> {
                     };
                     *mgr |= self.edit.set_string(n.to_string());
                     self.n = n;
-                    mgr.push(Control::Set(n));
+                    mgr.push(Control::SetLen(n));
                 }
             }
         }
@@ -289,13 +289,13 @@ fn main() -> kas::shell::Result<()> {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(control) = mgr.try_pop::<Control>() {
                     match control {
-                        Control::Set(len) => {
+                        Control::SetLen(len) => {
                             if let Some(text) = self.list.data_mut().set_len(len) {
                                 *mgr |= self.display.set_string(text);
                             }
                             mgr.update_all(0);
                         }
-                        Control::Dir => {
+                        Control::Reverse => {
                             let dir = self.list.direction().reversed();
                             *mgr |= self.list.set_direction(dir);
                         }

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -117,8 +117,8 @@ fn main() -> kas::shell::Result<()> {
             n: usize = 3,
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
-                if index == widget_index![self.edit] {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
+                if mgr.last_child() == Some(widget_index![self.edit]) {
                     if let Some(n) = mgr.try_pop_msg::<usize>() {
                         if n != self.n {
                             self.n = n;
@@ -167,7 +167,7 @@ fn main() -> kas::shell::Result<()> {
             active: usize = 0,
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(control) = mgr.try_pop_msg() {
                     match control {
                         Control::Set(len) => {

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -48,12 +48,12 @@ enum EntryMsg {
 struct ListEntryGuard(usize);
 impl EditGuard for ListEntryGuard {
     fn activate(edit: &mut EditField<Self>, mgr: &mut EventMgr) -> Response {
-        mgr.push_msg(EntryMsg::Select(edit.guard.0));
+        mgr.push(EntryMsg::Select(edit.guard.0));
         Response::Used
     }
 
     fn edit(edit: &mut EditField<Self>, mgr: &mut EventMgr) {
-        mgr.push_msg(EntryMsg::Update(edit.guard.0, edit.get_string()));
+        mgr.push(EntryMsg::Update(edit.guard.0, edit.get_string()));
     }
 }
 
@@ -86,7 +86,7 @@ impl ListEntry {
             label: Label::new(format!("Entry number {}", n + 1)),
             radio: RadioButton::new("display this entry", RADIO.with(|g| g.clone()))
                 .with_state(active)
-                .on_select(move |mgr| mgr.push_msg(EntryMsg::Select(n))),
+                .on_select(move |mgr| mgr.push(EntryMsg::Select(n))),
             edit: EditBox::new(format!("Entry #{}", n + 1)).with_guard(ListEntryGuard(n)),
         }
     }
@@ -111,7 +111,7 @@ fn main() -> kas::shell::Result<()> {
             core: widget_core!(),
             #[widget] edit: EditBox<impl EditGuard> = EditBox::new("3")
                 .on_afl(|mgr, text| match text.parse::<usize>() {
-                    Ok(n) => mgr.push_msg(n),
+                    Ok(n) => mgr.push(n),
                     Err(_) => (),
                 }),
             n: usize = 3,
@@ -122,7 +122,7 @@ fn main() -> kas::shell::Result<()> {
                     if let Some(n) = mgr.try_pop_msg::<usize>() {
                         if n != self.n {
                             self.n = n;
-                            mgr.push_msg(Control::Set(n));
+                            mgr.push(Control::Set(n));
                         }
                     }
                 } else if let Some(msg) = mgr.try_pop_msg::<Button>() {
@@ -133,7 +133,7 @@ fn main() -> kas::shell::Result<()> {
                     };
                     *mgr |= self.edit.set_string(n.to_string());
                     self.n = n;
-                    mgr.push_msg(Control::Set(n));
+                    mgr.push(Control::Set(n));
                 }
             }
         }

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -119,13 +119,13 @@ fn main() -> kas::shell::Result<()> {
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if mgr.last_child() == Some(widget_index![self.edit]) {
-                    if let Some(n) = mgr.try_pop_msg::<usize>() {
+                    if let Some(n) = mgr.try_pop::<usize>() {
                         if n != self.n {
                             self.n = n;
                             mgr.push(Control::Set(n));
                         }
                     }
-                } else if let Some(msg) = mgr.try_pop_msg::<Button>() {
+                } else if let Some(msg) = mgr.try_pop::<Button>() {
                     let n = match msg {
                         Button::Decr => self.n.saturating_sub(1),
                         Button::Incr => self.n.saturating_add(1),
@@ -168,7 +168,7 @@ fn main() -> kas::shell::Result<()> {
         }
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
-                if let Some(control) = mgr.try_pop_msg() {
+                if let Some(control) = mgr.try_pop() {
                     match control {
                         Control::Set(len) => {
                             let active = self.active;
@@ -182,7 +182,7 @@ fn main() -> kas::shell::Result<()> {
                             *mgr |= self.list.set_direction(dir);
                         }
                     }
-                } else if let Some(msg) = mgr.try_pop_msg() {
+                } else if let Some(msg) = mgr.try_pop() {
                     match msg {
                         EntryMsg::Select(n) => {
                             self.active = n;

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -100,7 +100,7 @@ fn widgets() -> Box<dyn SetDisabled> {
         }
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
-                if let Some(MsgEdit) = mgr.try_pop_msg() {
+                if let Some(MsgEdit) = mgr.try_pop() {
                     let text = self.label.data().clone();
                     let window = dialog::TextEdit::new("Edit text", true, text);
                     mgr.add_window(Box::new(window));
@@ -180,15 +180,15 @@ fn widgets() -> Box<dyn SetDisabled> {
         }
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
-                if let Some(ScrollMsg(value)) = mgr.try_pop_msg() {
+                if let Some(ScrollMsg(value)) = mgr.try_pop() {
                     if mgr.last_child() == Some(widget_index![self.sc]) {
                         let ratio = value as f32 / self.sc.max_value() as f32;
                         *mgr |= self.pg.set_value(ratio);
                         mgr.push(Item::Scroll(value))
                     }
-                } else if let Some(Item::Spinner(value)) = mgr.try_observe_msg() {
+                } else if let Some(Item::Spinner(value)) = mgr.try_observe() {
                     *mgr |= self.sd.set_value(*value);
-                } else if let Some(Item::Slider(value)) = mgr.try_observe_msg() {
+                } else if let Some(Item::Slider(value)) = mgr.try_observe() {
                     *mgr |= self.spin.set_value(*value);
                 }
             }
@@ -257,13 +257,13 @@ Demonstration of *as-you-type* formatting from **Markdown**.
         }
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
-                if let Some(MsgDirection) = mgr.try_pop_msg() {
+                if let Some(MsgDirection) = mgr.try_pop() {
                     self.dir = match self.dir {
                         Direction::Up => Direction::Right,
                         _ => Direction::Up,
                     };
                     *mgr |= Action::RESIZE;
-                } else if let Some(md) = mgr.try_pop_msg::<Markdown>() {
+                } else if let Some(md) = mgr.try_pop::<Markdown>() {
                     *mgr |= self.label.set_text(md);
                 }
             }
@@ -328,9 +328,9 @@ fn filter_list() -> Box<dyn SetDisabled> {
         }
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
-                if let Some(mode) = mgr.try_pop_msg() {
+                if let Some(mode) = mgr.try_pop() {
                     *mgr |= self.list.set_selection_mode(mode);
-                } else if let Some(msg) = mgr.try_pop_msg::<SelectionMsg<usize>>() {
+                } else if let Some(msg) = mgr.try_pop::<SelectionMsg<usize>>() {
                     println!("Selection message: {msg:?}");
                 }
             }
@@ -557,7 +557,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
-                if let Some(msg) = mgr.try_pop_msg::<Menu>() {
+                if let Some(msg) = mgr.try_pop::<Menu>() {
                     match msg {
                         Menu::Theme(name) => {
                             println!("Theme: {name:?}");
@@ -574,7 +574,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             *mgr |= Action::EXIT;
                         }
                     }
-                } else if let Some(item) = mgr.try_pop_msg::<Item>() {
+                } else if let Some(item) = mgr.try_pop::<Item>() {
                     println!("Message: {item:?}");
                     match item {
                         Item::Theme(name) => mgr.adjust_theme(|theme| theme.set_scheme(name)),

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -99,7 +99,7 @@ fn widgets() -> Box<dyn SetDisabled> {
                 SingleView::new(SharedRc::new("Use button to edit →".to_string())),
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(MsgEdit) = mgr.try_pop_msg() {
                     let text = self.label.data().clone();
                     let window = dialog::TextEdit::new("Edit text", true, text);
@@ -179,9 +179,9 @@ fn widgets() -> Box<dyn SetDisabled> {
             #[widget] pu = popup_edit_box,
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(ScrollMsg(value)) = mgr.try_pop_msg() {
-                    if index == widget_index![self.sc] {
+                    if mgr.last_child() == Some(widget_index![self.sc]) {
                         let ratio = value as f32 / self.sc.max_value() as f32;
                         *mgr |= self.pg.set_value(ratio);
                         mgr.push(Item::Scroll(value))
@@ -256,7 +256,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
                 ScrollLabel::new(Markdown::new(doc).unwrap()),
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(MsgDirection) = mgr.try_pop_msg() {
                     self.dir = match self.dir {
                         Direction::Up => Direction::Right,
@@ -327,7 +327,7 @@ fn filter_list() -> Box<dyn SetDisabled> {
                 ScrollBars::new(MyListView::new(filtered))
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(mode) = mgr.try_pop_msg() {
                     *mgr |= self.list.set_selection_mode(mode);
                 } else if let Some(msg) = mgr.try_pop_msg::<SelectionMsg<usize>>() {
@@ -556,7 +556,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .with_title("Confi&g", config(shell.event_config().clone())),
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(msg) = mgr.try_pop_msg::<Menu>() {
                     match msg {
                         Menu::Theme(name) => {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -411,9 +411,9 @@ fn canvas() -> Box<dyn SetDisabled> {
             pixmap.fill_path(&path, &paint, FillRule::Winding, scale, None);
         }
 
-        fn do_redraw_animate(&mut self) -> (bool, bool) {
+        fn need_redraw(&mut self) -> bool {
             // Set false to disable animation
-            (true, true)
+            true
         }
     }
 

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -420,7 +420,7 @@ fn canvas() -> Box<dyn SetDisabled> {
     Box::new(singleton! {
         #[widget{
             layout = column: [
-                Label::new("Animated canvas demo (CPU-rendered, async)."),
+                Label::new("Animated canvas demo (CPU-rendered, async). Note: scheduling is broken on X11."),
                 self.canvas,
             ];
         }]

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -72,7 +72,7 @@ fn widgets() -> Box<dyn SetDisabled> {
     struct Guard;
     impl EditGuard for Guard {
         fn activate(edit: &mut EditField<Self>, mgr: &mut EventMgr) -> Response {
-            mgr.push_msg(Item::Edit(edit.get_string()));
+            mgr.push(Item::Edit(edit.get_string()));
             Response::Used
         }
 
@@ -154,21 +154,21 @@ fn widgets() -> Box<dyn SetDisabled> {
             ]),
             #[widget] cb = CheckButton::new("&Check me")
                 .with_state(true)
-                .on_toggle(|mgr, check| mgr.push_msg(Item::Check(check))),
+                .on_toggle(|mgr, check| mgr.push(Item::Check(check))),
             #[widget] rb = RadioButton::new("radio button &1", radio.clone())
-                .on_select(|mgr| mgr.push_msg(Item::Radio(1))),
+                .on_select(|mgr| mgr.push(Item::Radio(1))),
             #[widget] rb2 = RadioButton::new("radio button &2", radio)
                 .with_state(true)
-                .on_select(|mgr| mgr.push_msg(Item::Radio(2))),
+                .on_select(|mgr| mgr.push(Item::Radio(2))),
             #[widget] cbb = ComboBox::new_vec(vec![
                 MenuEntry::new("&One", Item::Combo(1)),
                 MenuEntry::new("T&wo", Item::Combo(2)),
                 MenuEntry::new("Th&ree", Item::Combo(3)),
             ]),
             #[widget] spin: Spinner<i32> = Spinner::new(0..=10, 1)
-                .on_change(|mgr, value| mgr.push_msg(Item::Spinner(value))),
+                .on_change(|mgr, value| mgr.push(Item::Spinner(value))),
             #[widget] sd: Slider<i32, Right> = Slider::new(0..=10, 1)
-                .on_move(|mgr, value| mgr.push_msg(Item::Slider(value))),
+                .on_move(|mgr, value| mgr.push(Item::Slider(value))),
             #[widget] sc: ScrollBar<Right> = ScrollBar::new().with_limits(100, 20),
             #[widget] pg: ProgressBar<Right> = ProgressBar::new(),
             #[widget] sv = img_rustacean.with_scaling(|s| {
@@ -184,7 +184,7 @@ fn widgets() -> Box<dyn SetDisabled> {
                     if index == widget_index![self.sc] {
                         let ratio = value as f32 / self.sc.max_value() as f32;
                         *mgr |= self.pg.set_value(ratio);
-                        mgr.push_msg(Item::Scroll(value))
+                        mgr.push(Item::Scroll(value))
                     }
                 } else if let Some(Item::Spinner(value)) = mgr.try_observe_msg() {
                     *mgr |= self.sd.set_value(*value);
@@ -214,7 +214,7 @@ fn editor() -> Box<dyn SetDisabled> {
         fn edit(edit: &mut EditField<Self>, mgr: &mut EventMgr) {
             let result = Markdown::new(edit.get_str());
             edit.set_error_state(result.is_err());
-            mgr.push_msg(result.unwrap_or_else(|err| Markdown::new(&format!("{err}")).unwrap()));
+            mgr.push(result.unwrap_or_else(|err| Markdown::new(&format!("{err}")).unwrap()));
         }
     }
 
@@ -532,9 +532,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             })
             .separator()
-            .toggle("&Disabled", |mgr, state| {
-                mgr.push_msg(Menu::Disabled(state))
-            });
+            .toggle("&Disabled", |mgr, state| mgr.push(Menu::Disabled(state)));
         })
         .build();
 

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -420,9 +420,7 @@ fn canvas() -> Box<dyn SetDisabled> {
     Box::new(singleton! {
         #[widget{
             layout = column: [
-                Label::new("Animated canvas demo
-This example uses kas_resvg::Canvas, which is CPU-rendered.
-Embedded GPU-rendered content is also possible (see separate Mandlebrot example)."),
+                Label::new("Animated canvas demo (CPU-rendered, async)."),
                 self.canvas,
             ];
         }]

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -466,7 +466,7 @@ impl_scope! {
         }
     }
     impl Widget for Self {
-        fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+        fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(iter) = mgr.try_pop_msg() {
                 self.mbrot.iter = iter;
                 *mgr |= self.iters.set_string(format!("{iter}"));

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -467,10 +467,10 @@ impl_scope! {
     }
     impl Widget for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
-            if let Some(iter) = mgr.try_pop_msg() {
+            if let Some(iter) = mgr.try_pop() {
                 self.mbrot.iter = iter;
                 *mgr |= self.iters.set_string(format!("{iter}"));
-            } else if let Some(ViewUpdate) = mgr.try_pop_msg() {
+            } else if let Some(ViewUpdate) = mgr.try_pop() {
                 mgr.redraw(self.mbrot.id());
                 *mgr |= self.label.set_string(self.mbrot.loc());
             }

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -382,7 +382,7 @@ impl_scope! {
                             self.delta += self.alpha.complex_mul(delta);
                         }
                     }
-                    mgr.push_msg(ViewUpdate);
+                    mgr.push(ViewUpdate);
                 }
                 Event::Scroll(delta) => {
                     let factor = match delta {
@@ -390,7 +390,7 @@ impl_scope! {
                         event::ScrollDelta::PixelDelta(coord) => -0.01 * coord.1 as f64,
                     };
                     self.alpha = self.alpha * 2f64.powf(factor);
-                    mgr.push_msg(ViewUpdate);
+                    mgr.push(ViewUpdate);
                 }
                 Event::Pan { alpha, delta } => {
                     // Our full transform (from screen coordinates to world coordinates) is:
@@ -407,7 +407,7 @@ impl_scope! {
                         + (self.alpha - new_alpha).complex_mul(self.view_delta);
                     self.alpha = new_alpha;
 
-                    mgr.push_msg(ViewUpdate);
+                    mgr.push(ViewUpdate);
                 }
                 Event::PressStart { source, coord, .. } => {
                     mgr.grab_press(
@@ -452,7 +452,7 @@ impl_scope! {
         fn new() -> MandlebrotWindow {
             let slider = Slider::new(0..=256, 1)
                 .with_value(64)
-                .on_move(|mgr, iter| mgr.push_msg(iter));
+                .on_move(|mgr, iter| mgr.push(iter));
             let mbrot = Mandlebrot::new();
             MandlebrotWindow {
                 core: Default::default(),

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -37,7 +37,7 @@ fn main() -> kas::shell::Result<()> {
             #[widget] panes: RowSplitter<EditField> = panes,
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(msg) = mgr.try_pop_msg::<Message>() {
                     match msg {
                         Message::Decr => {

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -38,7 +38,7 @@ fn main() -> kas::shell::Result<()> {
         }
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
-                if let Some(msg) = mgr.try_pop_msg::<Message>() {
+                if let Some(msg) = mgr.try_pop::<Message>() {
                     match msg {
                         Message::Decr => {
                             mgr.config_mgr(|mgr| self.panes.pop(mgr));

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -53,7 +53,7 @@ fn make_window() -> Box<dyn kas::Window> {
                     _ => Response::Unused,
                 }
             }
-            fn handle_message(&mut self, mgr: &mut EventMgr, _: usize) {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(MsgReset) = mgr.try_pop_msg() {
                     self.saved = Duration::default();
                     self.start = None;

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -54,11 +54,11 @@ fn make_window() -> Box<dyn kas::Window> {
                 }
             }
             fn handle_message(&mut self, mgr: &mut EventMgr) {
-                if let Some(MsgReset) = mgr.try_pop_msg() {
+                if let Some(MsgReset) = mgr.try_pop() {
                     self.saved = Duration::default();
                     self.start = None;
                     *mgr |= self.display.set_str("0.000");
-                } else if let Some(MsgStart) = mgr.try_pop_msg() {
+                } else if let Some(MsgStart) = mgr.try_pop() {
                     if let Some(start) = self.start {
                         self.saved += Instant::now() - start;
                         self.start = None;

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -79,7 +79,7 @@ fn main() -> kas::shell::Result<()> {
             core: widget_core!(),
             #[widget] max: impl Widget + HasString = EditBox::new("12")
                 .on_afl(|mgr, text| match text.parse::<usize>() {
-                    Ok(n) => mgr.push_msg(n),
+                    Ok(n) => mgr.push(n),
                     Err(_) => (),
                 }),
             #[widget] table: ScrollBars<MatrixView<TableData, driver::NavView>> = table,

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -85,8 +85,8 @@ fn main() -> kas::shell::Result<()> {
             #[widget] table: ScrollBars<MatrixView<TableData, driver::NavView>> = table,
         }
         impl Widget for Self {
-            fn handle_message(&mut self, mgr: &mut EventMgr, index: usize) {
-                if index == widget_index![self.max] {
+            fn handle_message(&mut self, mgr: &mut EventMgr) {
+                if mgr.last_child() == Some(widget_index![self.max]) {
                     if let Some(max) = mgr.try_pop_msg::<usize>() {
                         let data = self.table.data_mut();
                         if data.1 != max {

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -87,7 +87,7 @@ fn main() -> kas::shell::Result<()> {
         impl Widget for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if mgr.last_child() == Some(widget_index![self.max]) {
-                    if let Some(max) = mgr.try_pop_msg::<usize>() {
+                    if let Some(max) = mgr.try_pop::<usize>() {
                         let data = self.table.data_mut();
                         if data.1 != max {
                             data.0 += 1;


### PR DESCRIPTION
This renames `EventMgr::push_msg` to `push`, and adds support for futures resolving to a message:
```rust
pub fn push_async<Fut, Out>(&mut self, id: WidgetId, fut: Fut)
    where
        Fut: IntoFuture<Output = Option<Out>> + 'static,
        Out: Debug + 'static,
{ ... }
```

The future is run on the same thread (thus should not have high CPU usage).

Currently, it is required to identify the sending widget (`id`) explicitly and the future is not polled immediately. This might change if the `EventMgr` context tracks the current widget (`WidgetId`).

PR also includes changes to event handling. Most notably, `handle_message` may now be called on the widget which submitted the message (important for async rendering in Canvas using this async impl, but also useful for several other cases).

The `Canvas` widget now uses async rendering. It is possible to observe that a resize initially scales the old result, then re-renders. I'd like to do the same for `Svg`, but `usvg::Tree` is neither `Send` nor `Sync` so we can't push the work to another thread (without unsafe or other ugly workarounds).