### PR TITLE
Update winit, wgpu, dark-light, window_clipboard

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -99,7 +99,7 @@ version = "0.5.0" # used in doc links
 
 [dependencies.winit]
 # Provides translations for several winit types
-version = "0.27"
+version = "0.28.1"
 optional = true
 default-features = false
 

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -84,7 +84,6 @@ ron = { version = "0.8.0", package = "ron", optional = true }
 num_enum = "0.5.6"
 dark-light = { version = "1.0", optional = true }
 raw-window-handle = "0.5.0"
-window_clipboard = { version = "0.2.0", optional = true }
 async-global-executor = { version = "2.3.1", optional = true }
 cfg-if = "1.0.0"
 
@@ -103,3 +102,8 @@ version = "0.5.0" # used in doc links
 version = "0.27"
 optional = true
 default-features = false
+
+[dependencies.window_clipboard]
+git = "https://github.com/TobTobXX/window_clipboard.git"
+rev = "1392da8339c8aebb9849d00eb7383a73ed076f1d"
+optional = true

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -82,7 +82,7 @@ serde_json = { version = "1.0.61", optional = true }
 serde_yaml = { version = "0.9.9", optional = true }
 ron = { version = "0.8.0", package = "ron", optional = true }
 num_enum = "0.5.6"
-dark-light = { version = "0.2.2", optional = true }
+dark-light = { version = "1.0", optional = true }
 raw-window-handle = "0.5.0"
 window_clipboard = { version = "0.2.0", optional = true }
 async-global-executor = { version = "2.3.1", optional = true }

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -198,7 +198,9 @@ pub trait WindowSurface {
         shared: &mut Self::Shared,
         size: Size,
         window: W,
-    ) -> Self;
+    ) -> Result<Self>
+    where
+        Self: Sized;
 
     /// Get current surface size
     fn size(&self) -> Size;

--- a/crates/kas-core/src/shell/shell.rs
+++ b/crates/kas-core/src/shell/shell.rs
@@ -217,7 +217,7 @@ impl<'a> PlatformWrapper<'a> {
         {
             cfg_if::cfg_if! {
                 if #[cfg(all(feature = "wayland", feature = "x11"))] {
-                    use winit::platform::unix::EventLoopWindowTargetExtUnix;
+                    use winit::platform::wayland::EventLoopWindowTargetExtWayland;
                     return if self.0.is_wayland() {
                         Platform::Wayland
                     } else {

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -16,7 +16,6 @@ use kas::theme::{Theme, Window as _};
 use kas::{Action, Layout, WidgetCore, WidgetExt, Window as _, WindowId};
 use std::mem::take;
 use std::time::Instant;
-use winit::error::OsError;
 use winit::event::WindowEvent;
 use winit::event_loop::EventLoopWindowTarget;
 use winit::window::WindowBuilder;
@@ -43,7 +42,7 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
         elwt: &EventLoopWindowTarget<ProxyAction>,
         window_id: WindowId,
         widget: Box<dyn kas::Window>,
-    ) -> Result<Self, OsError> {
+    ) -> super::Result<Self> {
         let time = Instant::now();
 
         let mut widget = kas::RootWidget::new(widget);
@@ -114,7 +113,7 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
             solve_cache.invalidate_rule_cache();
         }
 
-        let surface = S::new(&mut shared.draw.draw, size, &window);
+        let surface = S::new(&mut shared.draw.draw, size, &window)?;
 
         let mut r = Window {
             widget,

--- a/crates/kas-core/src/theme/colors.rs
+++ b/crates/kas-core/src/theme/colors.rs
@@ -226,9 +226,10 @@ impl From<ColorsLinear> for ColorsSrgb {
 impl Default for ColorsLinear {
     #[cfg(feature = "dark-light")]
     fn default() -> Self {
+        use dark_light::Mode;
         match dark_light::detect() {
-            dark_light::Mode::Dark => ColorsSrgb::dark().into(),
-            dark_light::Mode::Light => ColorsSrgb::light().into(),
+            Mode::Dark => ColorsSrgb::dark().into(),
+            Mode::Light | Mode::Default => ColorsSrgb::light().into(),
         }
     }
 

--- a/crates/kas-macros/Cargo.toml
+++ b/crates/kas-macros/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro-error = "1.0"
 bitflags = "1.3.1"
 
 [dependencies.impl-tools-lib]
-version = "0.7.0" # version used in doc links
+version = "0.8.0" # version used in doc links
 
 [dependencies.syn]
 version = "1.0.14"

--- a/crates/kas-resvg/Cargo.toml
+++ b/crates/kas-resvg/Cargo.toml
@@ -24,8 +24,8 @@ svg = ["dep:resvg", "dep:usvg"]
 
 [dependencies]
 tiny-skia = { version = "0.8.2" }
-resvg = { version = "0.28.0", optional = true }
-usvg = { version = "0.28.0", optional = true }
+resvg = { version = "0.29.0", optional = true }
+usvg = { version = "0.29.0", optional = true }
 once_cell = "1.17.0"
 thiserror = "1.0.23"
 

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -45,7 +45,6 @@ fn load(data: &[u8], resources_dir: Option<&Path>) -> Result<Tree, usvg::Error> 
         shape_rendering: usvg::ShapeRendering::default(),
         text_rendering: usvg::TextRendering::default(),
         image_rendering: usvg::ImageRendering::default(),
-        keep_named_groups: false,
         default_size: usvg::Size::new(100.0, 100.0).unwrap(),
         image_href_resolver: Default::default(),
     };

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -29,7 +29,7 @@ raster = ["kas-text/raster"]
 bytemuck = "1.7.0"
 futures-lite = "1.12"
 log = "0.4"
-wgpu = { version = "0.14.0", features = ["spirv"] }
+wgpu = { version = "0.15.0", features = ["spirv"] }
 thiserror = "1.0.23"
 guillotiere = "0.6.0"
 rustc-hash = "1.0"

--- a/crates/kas-wgpu/src/draw/atlases.rs
+++ b/crates/kas-wgpu/src/draw/atlases.rs
@@ -52,6 +52,7 @@ impl Atlas {
             dimension: wgpu::TextureDimension::D2,
             format,
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
         });
 
         let view = tex.create_view(&wgpu::TextureViewDescriptor::default());

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -35,7 +35,10 @@ impl<C: CustomPipe> DrawPipe<C> {
         options: &Options,
         raster_config: &kas::theme::RasterConfig,
     ) -> Result<Self, Error> {
-        let instance = wgpu::Instance::new(options.backend());
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: options.backend(),
+            ..Default::default()
+        });
         let adapter_options = options.adapter_options();
         let req = instance.request_adapter(&adapter_options);
         let adapter = match block_on(req) {


### PR DESCRIPTION
Update to use the pending winit release, wgpu 0.15 and dark-light 1.0.

Uses https://github.com/hecrj/window_clipboard/pull/20.