### PR TITLE
Prepare 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] — 2023-02-26
+
+### Additions
+
+-   Add `EventMgr::push_async`, `push_spawn` (#376)
+-   Support transparent windows (#380)
+-   Support borderless windows and basic toolkit-drawn titlebar (#380)
+
+### Changes
+
+-   Move theme traits, `SimpleTheme` and `FlatTheme` to kas-core (#374)
+-   Move `ShadedTheme` to kas-wgpu (#374)
+-   Move `Shell` to kas-core. Add `WindowSurface`, `GraphicalShell`,
+    `ShellAssoc` traits for better abstraction of shell implementation.
+    Add `kas::shell::DefaultShell`. (#375)
+-   Rename `ToolkitProxy` → `Proxy`, `TkAction` → `Action` (#375)
+-   `Widget::handle_message` is now called on the widget submitting a message (#376)
+-   `Canvas` uses async rendering (#376)
+-   `Svg` uses async rendering (#378)
+-   Update to Winit 0.28, Wgpu 0.15, dark-light 1.0 (#379)
+-   Improved momentum scrolling (#381)
+
+### Fixes
+
+-   Translate pop-up menus inside scroll regions (#373)
+
 ## [0.12.1] — 2022-12-22
 
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -111,14 +111,14 @@ wayland = ["kas-core/wayland"]
 x11 = ["kas-core/x11"]
 
 [dependencies]
-kas-core = { version = "0.12.1", path = "crates/kas-core" }
-kas-dylib = { version = "0.12.0", path = "crates/kas-dylib", optional = true }
-kas-widgets = { version = "0.12.1", path = "crates/kas-widgets" }
-kas-view = { version = "0.12.0", path = "crates/kas-view", optional = true }
-kas-resvg = { version = "0.12.0", path = "crates/kas-resvg", optional = true }
+kas-core = { version = "0.13.0", path = "crates/kas-core" }
+kas-dylib = { version = "0.13.0", path = "crates/kas-dylib", optional = true }
+kas-widgets = { version = "0.13.0", path = "crates/kas-widgets" }
+kas-view = { version = "0.13.0", path = "crates/kas-view", optional = true }
+kas-resvg = { version = "0.13.0", path = "crates/kas-resvg", optional = true }
 
 [dependencies.kas-wgpu]
-version = "0.12.1"
+version = "0.13.0"
 path = "crates/kas-wgpu"
 optional = true
 default-features = false

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-core"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -88,7 +88,7 @@ async-global-executor = { version = "2.3.1", optional = true }
 cfg-if = "1.0.0"
 
 [dependencies.kas-macros]
-version = "0.12.0"
+version = "0.13.0"
 path = "../kas-macros"
 
 [dependencies.kas-text]

--- a/crates/kas-core/src/theme/style.rs
+++ b/crates/kas-core/src/theme/style.rs
@@ -110,7 +110,7 @@ pub enum SelectionStyle {
 impl SelectionStyle {
     /// True if an external margin is required
     ///
-    /// Margin size: [`SizeMgr::inner_margins`]
+    /// Margin size is [`SizeMgr::inner_margins`](super::SizeMgr::inner_margins)
     pub fn is_external(self) -> bool {
         matches!(self, SelectionStyle::Frame | SelectionStyle::Both)
     }

--- a/crates/kas-dylib/Cargo.toml
+++ b/crates/kas-dylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-dylib"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ crate-type = ["dylib"]
 resvg = ["dep:kas-resvg"]
 
 [dependencies]
-kas-core = { version = "0.12.0", path = "../kas-core" }
-kas-widgets = { version = "0.12.0", path = "../kas-widgets" }
-kas-resvg = { version = "0.12.0", path = "../kas-resvg", optional = true }
-kas-wgpu = { version = "0.12.0", path = "../kas-wgpu" }
+kas-core = { version = "0.13.0", path = "../kas-core" }
+kas-widgets = { version = "0.13.0", path = "../kas-widgets" }
+kas-resvg = { version = "0.13.0", path = "../kas-resvg", optional = true }
+kas-wgpu = { version = "0.13.0", path = "../kas-wgpu" }

--- a/crates/kas-macros/Cargo.toml
+++ b/crates/kas-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-macros"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/kas-resvg/Cargo.toml
+++ b/crates/kas-resvg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-resvg"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -31,7 +31,7 @@ thiserror = "1.0.23"
 
 [dependencies.kas]
 # We must rename this package since macros expect kas to be in scope:
-version = "0.12.0"
+version = "0.13.0"
 package = "kas-core"
 path = "../kas-core"
 features = ["spawn"]

--- a/crates/kas-view/Cargo.toml
+++ b/crates/kas-view/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-view"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -19,11 +19,11 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 # RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --no-deps --open
 
 [dependencies]
-kas-widgets = { version = "0.12.0", path = "../kas-widgets" }
+kas-widgets = { version = "0.13.0", path = "../kas-widgets" }
 log = "0.4"
 linear-map = "1.2.0"
 thiserror = "1.0.23"
 maybe-owned = "0.3.4"
 
 # We must rename this package since macros expect kas to be in scope:
-kas = { version = "0.12.0", package = "kas-core", path = "../kas-core" }
+kas = { version = "0.13.0", package = "kas-core", path = "../kas-core" }

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-wgpu"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ rustc-hash = "1.0"
 
 [dependencies.kas]
 # Rename package purely for convenience:
-version = "0.12.0"
+version = "0.13.0"
 package = "kas-core"
 path = "../kas-core"
 features = ["winit"]

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-widgets"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ smallvec = "1.6.1"
 unicode-segmentation = "1.7"
 thiserror = "1.0.23"
 image = { version = "0.24.1", optional = true }
-kas-macros = { version = "0.12.0", path = "../kas-macros" }
+kas-macros = { version = "0.13.0", path = "../kas-macros" }
 
 # We must rename this package since macros expect kas to be in scope:
-kas = { version = "0.12.0", package = "kas-core", path = "../kas-core" }
+kas = { version = "0.13.0", package = "kas-core", path = "../kas-core" }

--- a/examples/mandlebrot/Cargo.toml
+++ b/examples/mandlebrot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-mandlebrot"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -8,8 +8,8 @@ description = "KAS GUI / Mandlebrot example"
 publish = false
 
 [dependencies]
-kas = { version = "0.12.0", features = ["wgpu"], path = "../.." }
-kas-wgpu = { version = "0.12.0", path = "../../crates/kas-wgpu" }
+kas = { version = "0.13.0", features = ["wgpu"], path = "../.." }
+kas-wgpu = { version = "0.13.0", path = "../../crates/kas-wgpu" }
 chrono = "0.4"
 env_logger = "0.10"
 log = "0.4"


### PR DESCRIPTION
### Additions

-   Add `EventMgr::push_async`, `push_spawn` (#376)
-   Support transparent windows (#380)
-   Support borderless windows and basic toolkit-drawn titlebar (#380)

### Changes

-   Move theme traits, `SimpleTheme` and `FlatTheme` to kas-core (#374)
-   Move `ShadedTheme` to kas-wgpu (#374)
-   Move `Shell` to kas-core. Add `WindowSurface`, `GraphicalShell`,  `ShellAssoc` traits for better abstraction of shell implementation. Add `kas::shell::DefaultShell`. (#375)
-   Rename `ToolkitProxy` → `Proxy`, `TkAction` → `Action` (#375)
-   `Widget::handle_message` is now called on the widget submitting a message (#376)
-   `Canvas` uses async rendering (#376)
-   `Svg` uses async rendering (#378)
-   Update to Winit 0.28, Wgpu 0.15, dark-light 1.0 (#379)
-   Improved momentum scrolling (#381)
