### PR TITLE
Replace clipboard, primary buffer, Press::grab, new 0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.0] — 2023-02-26
 
+### Changed behaviour
+
+-   `Canvas` uses async rendering (#376)
+-   `Svg` uses async rendering (#378)
+-   Improved momentum scrolling (#381)
+-   Support primary buffer (middle-click clipboard) on Linux (#383)
+
 ### Additions
 
 -   Add `EventMgr::push_async`, `push_spawn` (#376)
 -   Support transparent windows (#380)
 -   Support borderless windows and basic toolkit-drawn titlebar (#380)
+-   New `GrabMode::Click` (#383)
+-   Add `PressSource::is_secondary`, `is_tertiary` (#383)
+-   Add `EventMgr::get_primary`, `set_primary` (#383)
 
-### Changes
+### Other changes
 
 -   Move theme traits, `SimpleTheme` and `FlatTheme` to kas-core (#374)
 -   Move `ShadedTheme` to kas-wgpu (#374)
@@ -19,10 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Add `kas::shell::DefaultShell`. (#375)
 -   Rename `ToolkitProxy` → `Proxy`, `TkAction` → `Action` (#375)
 -   `Widget::handle_message` is now called on the widget submitting a message (#376)
--   `Canvas` uses async rendering (#376)
--   `Svg` uses async rendering (#378)
 -   Update to Winit 0.28, Wgpu 0.15, dark-light 1.0 (#379)
--   Improved momentum scrolling (#381)
+-   Switch from window_clipboard to arboard + smithay-clipboard (#383)
+-   Cancel existing mouse grab when requesting a new one (#383)
+-   Change data structure of `Event::PressStart`, `PressMove`, `PressEnd` (#383)
+-   Replace `EventMgr::grab_press` with `Press::grab` builder pattern (#383)
 
 ### Fixes
 

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -46,7 +46,7 @@ json = ["serde", "dep:serde_json"]
 ron = ["serde", "dep:ron"]
 
 # Enables clipboard read/write
-clipboard = ["dep:window_clipboard"]
+clipboard = ["dep:copypasta"]
 
 # Inject logging into macro-generated code.
 # Requires that all crates using these macros depend on the log crate.
@@ -86,6 +86,7 @@ dark-light = { version = "1.0", optional = true }
 raw-window-handle = "0.5.0"
 async-global-executor = { version = "2.3.1", optional = true }
 cfg-if = "1.0.0"
+copypasta = { version = "0.8.2", optional = true }
 
 [dependencies.kas-macros]
 version = "0.13.0"
@@ -102,8 +103,3 @@ version = "0.5.0" # used in doc links
 version = "0.28.1"
 optional = true
 default-features = false
-
-[dependencies.window_clipboard]
-git = "https://github.com/TobTobXX/window_clipboard.git"
-rev = "1392da8339c8aebb9849d00eb7383a73ed076f1d"
-optional = true

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -46,7 +46,7 @@ json = ["serde", "dep:serde_json"]
 ron = ["serde", "dep:ron"]
 
 # Enables clipboard read/write
-clipboard = ["dep:copypasta"]
+clipboard = ["dep:copypasta", "dep:smithay-clipboard"]
 
 # Inject logging into macro-generated code.
 # Requires that all crates using these macros depend on the log crate.
@@ -70,6 +70,9 @@ dark-light = ["dep:dark-light"]
 # Support spawning async tasks
 spawn = ["dep:async-global-executor"]
 
+[build-dependencies]
+cfg_aliases = "0.1.1"
+
 [dependencies]
 log = "0.4"
 smallvec = "1.6.1"
@@ -87,6 +90,7 @@ raw-window-handle = "0.5.0"
 async-global-executor = { version = "2.3.1", optional = true }
 cfg-if = "1.0.0"
 copypasta = { version = "0.8.2", optional = true }
+smithay-clipboard = { version = "0.6.6", optional = true }
 
 [dependencies.kas-macros]
 version = "0.13.0"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -46,7 +46,7 @@ json = ["serde", "dep:serde_json"]
 ron = ["serde", "dep:ron"]
 
 # Enables clipboard read/write
-clipboard = ["dep:copypasta", "dep:smithay-clipboard"]
+clipboard = ["dep:arboard", "dep:smithay-clipboard"]
 
 # Inject logging into macro-generated code.
 # Requires that all crates using these macros depend on the log crate.
@@ -89,7 +89,7 @@ dark-light = { version = "1.0", optional = true }
 raw-window-handle = "0.5.0"
 async-global-executor = { version = "2.3.1", optional = true }
 cfg-if = "1.0.0"
-copypasta = { version = "0.8.2", optional = true }
+arboard = { version = "3.2.0", optional = true }
 smithay-clipboard = { version = "0.6.6", optional = true }
 
 [dependencies.kas-macros]

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -89,8 +89,13 @@ dark-light = { version = "1.0", optional = true }
 raw-window-handle = "0.5.0"
 async-global-executor = { version = "2.3.1", optional = true }
 cfg-if = "1.0.0"
-arboard = { version = "3.2.0", optional = true }
+
+[target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
 smithay-clipboard = { version = "0.6.6", optional = true }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+arboard = { version = "3.2.0", optional = true, default-features = false }
+
 
 [dependencies.kas-macros]
 version = "0.13.0"

--- a/crates/kas-core/build.rs
+++ b/crates/kas-core/build.rs
@@ -1,0 +1,26 @@
+// Script copied from winit
+
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    // The script doesn't depend on our code
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Setup cfg aliases
+    cfg_aliases! {
+        // Systems.
+        android_platform: { target_os = "android" },
+        wasm_platform: { target_arch = "wasm32" },
+        macos_platform: { target_os = "macos" },
+        ios_platform: { target_os = "ios" },
+        windows_platform: { target_os = "windows" },
+        apple: { any(target_os = "ios", target_os = "macos") },
+        free_unix: { all(unix, not(apple), not(android_platform)) },
+        redox: { target_os = "redox" },
+
+        // Native displays.
+        x11_platform: { all(feature = "x11", free_unix, not(wasm), not(redox)) },
+        wayland_platform: { all(feature = "wayland", free_unix, not(wasm), not(redox)) },
+        orbital_platform: { redox },
+    }
+}

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -424,7 +424,7 @@ impl TextInput {
                 self.glide.press_start();
                 action
             }
-            Event::PressMove { press, delta } => {
+            Event::PressMove { press, delta } if press.is_primary() => {
                 self.glide.press_move(delta);
                 match press.source {
                     PressSource::Touch(touch_id) => match self.touch_phase {
@@ -448,7 +448,7 @@ impl TextInput {
                     }
                 }
             }
-            Event::PressEnd { press, .. } => {
+            Event::PressEnd { press, .. } if press.is_primary() => {
                 let timeout = mgr.config().scroll_flick_timeout();
                 let pan_dist_thresh = mgr.config().pan_dist_thresh();
                 if self.glide.press_end(timeout, pan_dist_thresh)

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -306,22 +306,22 @@ impl ScrollComponent {
                 self.glide.stop();
                 moved = self.scroll_by_delta(mgr, delta);
             }
-            Event::PressStart { source, coord, .. }
-                if self.max_offset != Offset::ZERO && mgr.config_enable_pan(source) =>
+            Event::PressStart { press, .. }
+                if self.max_offset != Offset::ZERO && mgr.config_enable_pan(*press) =>
             {
                 let icon = Some(CursorIcon::Grabbing);
-                mgr.grab_press_unique(id, source, coord, icon);
+                mgr.grab_press_unique(id, press.source, press.coord, icon);
                 self.glide.press_start();
             }
-            Event::PressMove { source, delta, .. }
-                if self.max_offset != Offset::ZERO && mgr.config_enable_pan(source) =>
+            Event::PressMove { press, delta, .. }
+                if self.max_offset != Offset::ZERO && mgr.config_enable_pan(*press) =>
             {
                 if self.glide.press_move(delta) {
                     moved = self.scroll_by_delta(mgr, delta);
                 }
             }
-            Event::PressEnd { source, .. }
-                if self.max_offset != Offset::ZERO && mgr.config_enable_pan(source) =>
+            Event::PressEnd { press, .. }
+                if self.max_offset != Offset::ZERO && mgr.config_enable_pan(*press) =>
             {
                 let timeout = mgr.config().scroll_flick_timeout();
                 let pan_dist_thresh = mgr.config().pan_dist_thresh();
@@ -405,10 +405,10 @@ impl TextInput {
     pub fn handle(&mut self, mgr: &mut EventMgr, w_id: WidgetId, event: Event) -> TextInputAction {
         use TextInputAction as Action;
         match event {
-            Event::PressStart { source, coord, .. } if source.is_primary() => {
-                let (action, icon) = match source {
+            Event::PressStart { press } if press.is_primary() => {
+                let (action, icon) = match *press {
                     PressSource::Touch(touch_id) => {
-                        self.touch_phase = TouchPhase::Start(touch_id, coord);
+                        self.touch_phase = TouchPhase::Start(touch_id, press.coord);
                         let delay = mgr.config().touch_select_delay();
                         mgr.request_update(w_id.clone(), PAYLOAD_SELECT, delay, false);
                         (Action::Focus, None)
@@ -417,25 +417,20 @@ impl TextInput {
                         (Action::Focus, Some(CursorIcon::Grabbing))
                     }
                     PressSource::Mouse(_, repeats) => (
-                        Action::Cursor(coord, true, !mgr.modifiers().shift(), repeats),
+                        Action::Cursor(press.coord, true, !mgr.modifiers().shift(), repeats),
                         None,
                     ),
                 };
-                mgr.grab_press_unique(w_id, source, coord, icon);
+                mgr.grab_press_unique(w_id, press.source, press.coord, icon);
                 self.glide.press_start();
                 action
             }
-            Event::PressMove {
-                source,
-                coord,
-                delta,
-                ..
-            } => {
+            Event::PressMove { press, delta } => {
                 self.glide.press_move(delta);
-                match source {
+                match press.source {
                     PressSource::Touch(touch_id) => match self.touch_phase {
                         TouchPhase::Start(id, start_coord) if id == touch_id => {
-                            let delta = coord - start_coord;
+                            let delta = press.coord - start_coord;
                             if mgr.config_test_pan_thresh(delta) {
                                 self.touch_phase = TouchPhase::Pan(id);
                                 Action::Pan(delta)
@@ -444,20 +439,22 @@ impl TextInput {
                             }
                         }
                         TouchPhase::Pan(id) if id == touch_id => Action::Pan(delta),
-                        _ => Action::Cursor(coord, false, false, 1),
+                        _ => Action::Cursor(press.coord, false, false, 1),
                     },
                     PressSource::Mouse(..) if mgr.config_enable_mouse_text_pan() => {
                         Action::Pan(delta)
                     }
-                    PressSource::Mouse(_, repeats) => Action::Cursor(coord, false, false, repeats),
+                    PressSource::Mouse(_, repeats) => {
+                        Action::Cursor(press.coord, false, false, repeats)
+                    }
                 }
             }
-            Event::PressEnd { source, .. } => {
+            Event::PressEnd { press, .. } => {
                 let timeout = mgr.config().scroll_flick_timeout();
                 let pan_dist_thresh = mgr.config().pan_dist_thresh();
                 if self.glide.press_end(timeout, pan_dist_thresh)
-                    && (matches!(source, PressSource::Touch(id) if self.touch_phase == TouchPhase::Pan(id))
-                        || matches!(source, PressSource::Mouse(..) if mgr.config_enable_mouse_text_pan()))
+                    && (matches!(press.source, PressSource::Touch(id) if self.touch_phase == TouchPhase::Pan(id))
+                        || matches!(press.source, PressSource::Mouse(..) if mgr.config_enable_mouse_text_pan()))
                 {
                     self.touch_phase = TouchPhase::None;
                     mgr.request_update(w_id, PAYLOAD_GLIDE, Duration::new(0, 0), true);

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -309,8 +309,7 @@ impl ScrollComponent {
             Event::PressStart { press, .. }
                 if self.max_offset != Offset::ZERO && mgr.config_enable_pan(*press) =>
             {
-                let icon = Some(CursorIcon::Grabbing);
-                mgr.grab_press_unique(id, press.source, press.coord, icon);
+                let _ = press.grab(id).with_icon(CursorIcon::Grabbing).with_mgr(mgr);
                 self.glide.press_start();
             }
             Event::PressMove { press, delta, .. }
@@ -421,7 +420,7 @@ impl TextInput {
                         None,
                     ),
                 };
-                mgr.grab_press_unique(w_id, press.source, press.coord, icon);
+                press.grab(w_id).with_opt_icon(icon).with_mgr(mgr);
                 self.glide.press_start();
                 action
             }

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -259,11 +259,6 @@ impl Event {
                 mgr.grab_press(id, source, coord, GrabMode::Grab, None);
                 Response::Used
             }
-            Event::PressMove { source, cur_id, .. } => {
-                let target = if id == cur_id { cur_id } else { None };
-                mgr.set_grab_depress(source, target);
-                Response::Used
-            }
             Event::PressEnd {
                 end_id, success, ..
             } if success && id == end_id => f(mgr),

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 #[allow(unused)]
 use super::{EventMgr, EventState, GrabMode, Response}; // for doc-links
-use super::{MouseButton, Press, UpdateId, VirtualKeyCode};
+use super::{Press, UpdateId, VirtualKeyCode};
 use crate::geom::{DVec2, Offset};
 #[allow(unused)] use crate::Widget;
 use crate::{dir::Direction, WidgetId, WindowId};
@@ -510,55 +510,6 @@ impl Command {
             Command::Up => Some(Direction::Up),
             Command::Down => Some(Direction::Down),
             _ => None,
-        }
-    }
-}
-
-/// Source of `EventChild::Press`
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum PressSource {
-    /// A mouse click
-    ///
-    /// Arguments: `button, repeats`.
-    ///
-    /// The `repeats` argument is used for double-clicks and similar. For a
-    /// single-click, `repeats == 1`; for a double-click it is 2, for a
-    /// triple-click it is 3, and so on (without upper limit).
-    ///
-    /// For `PressMove` and `PressEnd` events delivered with a mouse-grab,
-    /// both arguments are copied from the initiating `PressStart` event.
-    /// For a `PressMove` delivered without a grab (only possible with pop-ups)
-    /// a fake `button` value is used and `repeats == 0`.
-    Mouse(MouseButton, u32),
-    /// A touch event (with given `id`)
-    Touch(u64),
-}
-
-impl PressSource {
-    /// Returns true if this represents the left mouse button or a touch event
-    #[inline]
-    pub fn is_primary(self) -> bool {
-        match self {
-            PressSource::Mouse(button, _) => button == MouseButton::Left,
-            PressSource::Touch(_) => true,
-        }
-    }
-
-    /// Returns true if this represents a touch event
-    #[inline]
-    pub fn is_touch(self) -> bool {
-        matches!(self, PressSource::Touch(_))
-    }
-
-    /// The `repetitions` value
-    ///
-    /// This is 1 for a single-click and all touch events, 2 for a double-click,
-    /// 3 for a triple-click, etc. For `PressMove` without a grab this is 0.
-    #[inline]
-    pub fn repetitions(self) -> u32 {
-        match self {
-            PressSource::Mouse(_, repetitions) => repetitions,
-            PressSource::Touch(_) => 1,
         }
     }
 }

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -29,7 +29,7 @@ mod mgr_pub;
 mod mgr_shell;
 mod press;
 pub use config_mgr::ConfigMgr;
-pub use press::{GrabBuilder, Press};
+pub use press::{GrabBuilder, Press, PressSource};
 
 /// Controls the types of events delivered by [`EventMgr::grab_press`]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -27,7 +27,9 @@ use crate::{Action, Erased, Widget, WidgetExt, WidgetId, WindowId};
 mod config_mgr;
 mod mgr_pub;
 mod mgr_shell;
+mod press;
 pub use config_mgr::ConfigMgr;
+pub use press::{GrabBuilder, Press};
 
 /// Controls the types of events delivered by [`EventMgr::grab_press`]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -91,12 +91,12 @@ impl<'a> EventMgr<'a> {
                 }
                 GrabMode::Grab => {
                     let target = grab.start_id.clone();
-                    let event = Event::PressMove {
+                    let press = Press {
                         source: PressSource::Mouse(grab.button, grab.repetitions),
-                        cur_id: grab.cur_id.clone(),
+                        id: grab.cur_id.clone(),
                         coord: grab.coord,
-                        delta,
                     };
+                    let event = Event::PressMove { press, delta };
                     self.send_event(widget, target, event);
                 }
                 _ => (),
@@ -140,12 +140,12 @@ impl TouchGrab {
         if self.mode == GrabMode::Grab && self.last_move != self.coord {
             let delta = self.coord - self.last_move;
             let target = self.start_id.clone();
-            let event = Event::PressMove {
+            let press = Press {
                 source: PressSource::Touch(self.id),
-                cur_id: self.cur_id.clone(),
+                id: self.cur_id.clone(),
                 coord: self.coord,
-                delta,
             };
+            let event = Event::PressMove { press, delta };
             self.last_move = self.coord;
             Some((target, event))
         } else {
@@ -559,12 +559,12 @@ impl<'a> EventMgr<'a> {
                 // Pan grabs do not receive Event::PressEnd
                 None
             } else {
-                let event = Event::PressEnd {
+                let press = Press {
                     source: PressSource::Mouse(grab.button, grab.repetitions),
-                    end_id: self.hover.clone(),
+                    id: self.hover.clone(),
                     coord: self.last_mouse_coord,
-                    success,
                 };
+                let event = Event::PressEnd { press, success };
                 Some((grab.start_id, event))
             }
         } else {

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -762,6 +762,24 @@ impl<'a> EventMgr<'a> {
         self.shell.set_clipboard(content)
     }
 
+    /// Get contents of primary buffer
+    ///
+    /// Linux has a "primary buffer" with implicit copy on text selection and
+    /// paste on middle-click. This method does nothing on other platforms.
+    #[inline]
+    pub fn get_primary(&mut self) -> Option<String> {
+        self.shell.get_primary()
+    }
+
+    /// Set contents of primary buffer
+    ///
+    /// Linux has a "primary buffer" with implicit copy on text selection and
+    /// paste on middle-click. This method does nothing on other platforms.
+    #[inline]
+    pub fn set_primary(&mut self, content: String) {
+        self.shell.set_primary(content)
+    }
+
     /// Adjust the theme
     #[inline]
     pub fn adjust_theme<F: FnMut(&mut dyn ThemeControl) -> Action>(&mut self, mut f: F) {

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -399,12 +399,12 @@ impl<'a> EventMgr<'a> {
                     }
                 } else if let Some(id) = self.popups.last().map(|(_, p, _)| p.parent.clone()) {
                     let source = PressSource::Mouse(FAKE_MOUSE_BUTTON, 0);
-                    let event = Event::PressMove {
+                    let press = Press {
                         source,
-                        cur_id,
+                        id: cur_id,
                         coord,
-                        delta,
                     };
+                    let event = Event::PressMove { press, delta };
                     self.send_event(widget, id, event);
                 } else {
                     // We don't forward move events without a grab
@@ -480,11 +480,12 @@ impl<'a> EventMgr<'a> {
                     }
 
                     let source = PressSource::Mouse(button, self.last_click_repetitions);
-                    let event = Event::PressStart {
+                    let press = Press {
                         source,
-                        start_id: self.hover.clone(),
+                        id: self.hover.clone(),
                         coord,
                     };
+                    let event = Event::PressStart { press };
                     let used = self.send_popup_first(widget, self.hover.clone(), event);
 
                     if !used && self.mouse_grab.is_none() && widget.drag_anywhere() {
@@ -509,11 +510,12 @@ impl<'a> EventMgr<'a> {
                                 }
                             }
 
-                            let event = Event::PressStart {
+                            let press = Press {
                                 source,
-                                start_id: start_id.clone(),
+                                id: start_id.clone(),
                                 coord,
                             };
+                            let event = Event::PressStart { press };
                             self.send_popup_first(widget, start_id, event);
                         }
                     }
@@ -553,12 +555,10 @@ impl<'a> EventMgr<'a> {
                             }
 
                             if grab.mode == GrabMode::Grab {
-                                let event = Event::PressEnd {
-                                    source,
-                                    end_id: grab.cur_id.clone(),
-                                    coord,
-                                    success: ev == TouchPhase::Ended,
-                                };
+                                let id = grab.cur_id.clone();
+                                let press = Press { source, id, coord };
+                                let success = ev == TouchPhase::Ended;
+                                let event = Event::PressEnd { press, success };
                                 self.send_event(widget, grab.start_id, event);
                             }
                         }

--- a/crates/kas-core/src/event/manager/press.rs
+++ b/crates/kas-core/src/event/manager/press.rs
@@ -1,0 +1,152 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Event handling: events
+
+#[allow(unused)]
+use super::{EventMgr, EventState, GrabMode, Response}; // for doc-links
+use super::{MouseGrab, Pending, TouchGrab};
+use crate::event::{CursorIcon, PressSource};
+use crate::geom::{Coord, Offset};
+use crate::{Action, WidgetId};
+
+/// Details of press events
+#[crate::autoimpl(Deref using self.source)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Press {
+    /// Source
+    pub source: PressSource,
+    /// Identifier of current widget
+    pub id: Option<WidgetId>,
+    /// Current coordinate
+    pub coord: Coord,
+}
+
+impl Press {
+    /// Grab pan/move/press-end events for widget `id`
+    ///
+    /// There are three types of grab ([`GrabMode`]):
+    ///
+    /// -   `Click`: send the corresponding [`Event::PressEnd`] only
+    /// -   `Grab` (the default): send [`Event::PressMove`] and [`Event::PressEnd`]
+    /// -   Pan modes: send [`Event::Pan`] on motion.
+    ///     Note: this is most useful when grabbing multiple touch events.
+    ///
+    /// Only a single mouse grab is allowed at any one time; requesting a
+    /// second will cancel the first (sending [`Event::PressEnd`] with
+    /// `success: false`).
+    ///
+    /// [`EventState::is_depressed`] will return true for the grabbing widget.
+    /// Call [`EventState::set_grab_depress`] on `PressMove` to update the
+    /// grab's depress target. (This is done automatically for
+    /// [`GrabMode::Click`], and ends automatically when the grab ends.)
+    ///
+    /// This method uses the builder pattern. On completion, [`Response::Used`]
+    /// is returned. It is expected that the requested press/pan events are all
+    /// "used" ([`Response::Used`]).
+    #[inline]
+    pub fn grab(&self, id: WidgetId) -> GrabBuilder {
+        GrabBuilder {
+            id,
+            source: self.source,
+            coord: self.coord,
+            mode: GrabMode::Grab,
+            cursor: None,
+        }
+    }
+}
+
+/// Bulider pattern (see [`Press::grab`])
+///
+/// Conclude by calling [`Self::with_mgr`].
+#[must_use]
+pub struct GrabBuilder {
+    id: WidgetId,
+    source: PressSource,
+    coord: Coord,
+    mode: GrabMode,
+    cursor: Option<CursorIcon>,
+}
+
+impl GrabBuilder {
+    /// Set grab mode (default: [`GrabMode::Grab`])
+    #[inline]
+    pub fn with_mode(mut self, mode: GrabMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Set cursor icon (default: do not set)
+    #[inline]
+    pub fn with_icon(self, icon: CursorIcon) -> Self {
+        self.with_opt_icon(Some(icon))
+    }
+
+    /// Optionally set cursor icon (default: do not set)
+    #[inline]
+    pub fn with_opt_icon(mut self, icon: Option<CursorIcon>) -> Self {
+        self.cursor = icon;
+        self
+    }
+
+    /// Complete the grab, providing the [`EventMgr`]
+    pub fn with_mgr(self, mgr: &mut EventMgr) -> Response {
+        let GrabBuilder {
+            id,
+            source,
+            coord,
+            mode,
+            cursor,
+        } = self;
+        log::trace!(target: "kas_core::event::manager", "grab_press: start_id={id}, source={source:?}");
+        let mut pan_grab = (u16::MAX, 0);
+        match source {
+            PressSource::Mouse(button, repetitions) => {
+                if let Some((id, event)) = mgr.remove_mouse_grab(false) {
+                    mgr.pending.push_back(Pending::Send(id, event));
+                }
+                if mode.is_pan() {
+                    pan_grab = mgr.set_pan_on(id.clone(), mode, false, coord);
+                }
+                mgr.mouse_grab = Some(MouseGrab {
+                    button,
+                    repetitions,
+                    start_id: id.clone(),
+                    cur_id: Some(id.clone()),
+                    depress: Some(id),
+                    mode,
+                    pan_grab,
+                    coord,
+                    delta: Offset::ZERO,
+                });
+                if let Some(icon) = cursor {
+                    mgr.shell.set_cursor_icon(icon);
+                }
+            }
+            PressSource::Touch(touch_id) => {
+                if mgr.remove_touch(touch_id).is_some() {
+                    #[cfg(debug_assertions)]
+                    log::error!(target: "kas_core::event::manager", "grab_press: touch_id conflict!");
+                }
+                if mode.is_pan() {
+                    pan_grab = mgr.set_pan_on(id.clone(), mode, true, coord);
+                }
+                mgr.touch_grab.push(TouchGrab {
+                    id: touch_id,
+                    start_id: id.clone(),
+                    depress: Some(id.clone()),
+                    cur_id: Some(id),
+                    last_move: coord,
+                    coord,
+                    mode,
+                    pan_grab,
+                });
+            }
+        }
+
+        mgr.send_action(Action::REDRAW);
+        Response::Used
+    }
+}

--- a/crates/kas-core/src/event/manager/press.rs
+++ b/crates/kas-core/src/event/manager/press.rs
@@ -45,19 +45,13 @@ impl PressSource {
     /// Returns true if this represents the right mouse button
     #[inline]
     pub fn is_secondary(self) -> bool {
-        match self {
-            PressSource::Mouse(MouseButton::Right, _) => true,
-            _ => false,
-        }
+        matches!(self, PressSource::Mouse(MouseButton::Right, _))
     }
 
     /// Returns true if this represents the middle mouse button
     #[inline]
     pub fn is_tertiary(self) -> bool {
-        match self {
-            PressSource::Mouse(MouseButton::Middle, _) => true,
-            _ => false,
-        }
+        matches!(self, PressSource::Mouse(MouseButton::Middle, _))
     }
 
     /// Returns true if this represents a touch event

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -77,7 +77,7 @@ pub use winit::event::{ModifiersState, MouseButton, VirtualKeyCode};
 #[cfg(not(feature = "winit"))]
 pub use enums::{CursorIcon, ModifiersState, MouseButton, VirtualKeyCode};
 pub use events::*;
-pub use manager::{ConfigMgr, EventMgr, EventState, GrabBuilder, GrabMode, Press};
+pub use manager::*;
 pub use response::{Response, Scroll};
 pub use update::UpdateId;
 

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -77,7 +77,7 @@ pub use winit::event::{ModifiersState, MouseButton, VirtualKeyCode};
 #[cfg(not(feature = "winit"))]
 pub use enums::{CursorIcon, ModifiersState, MouseButton, VirtualKeyCode};
 pub use events::*;
-pub use manager::{ConfigMgr, EventMgr, EventState, GrabMode};
+pub use manager::{ConfigMgr, EventMgr, EventState, GrabBuilder, GrabMode, Press};
 pub use response::{Response, Scroll};
 pub use update::UpdateId;
 

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -273,6 +273,18 @@ pub(crate) trait ShellWindow {
     /// Attempt to set clipboard contents
     fn set_clipboard(&mut self, content: String);
 
+    /// Get contents of primary buffer
+    ///
+    /// Linux has a "primary buffer" with implicit copy on text selection and
+    /// paste on middle-click. This method does nothing on other platforms.
+    fn get_primary(&mut self) -> Option<String>;
+
+    /// Set contents of primary buffer
+    ///
+    /// Linux has a "primary buffer" with implicit copy on text selection and
+    /// paste on middle-click. This method does nothing on other platforms.
+    fn set_primary(&mut self, content: String);
+
     /// Adjust the theme
     ///
     /// Note: theme adjustments apply to all windows, as does the [`Action`]

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -52,10 +52,19 @@ where
         let mut draw = kas::draw::SharedState::new(draw_shared, platform);
         theme.init(&mut draw);
 
+        #[cfg(feature = "clipboard")]
+        let clipboard = match ClipboardContext::new() {
+            Ok(cb) => Some(cb),
+            Err(e) => {
+                warn_about_error("Failed to connect clipboard", e.as_ref());
+                None
+            }
+        };
+
         Ok(SharedState {
             platform,
             #[cfg(feature = "clipboard")]
-            clipboard: None,
+            clipboard,
             draw,
             theme,
             config,
@@ -65,20 +74,6 @@ where
             window_id: 0,
             options,
         })
-    }
-
-    /// Initialise the clipboard context
-    ///
-    /// This requires a window handle (on some platforms), thus is done when the
-    /// first window is constructed.
-    pub fn init_clipboard(&mut self, _window: &winit::window::Window) {
-        #[cfg(feature = "clipboard")]
-        {
-            match ClipboardContext::new() {
-                Ok(cb) => self.clipboard = Some(cb),
-                Err(e) => warn_about_error("Failed to connect clipboard", e.as_ref()),
-            }
-        }
     }
 
     pub fn next_window_id(&mut self) -> WindowId {

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -17,14 +17,13 @@ use kas::theme::Theme;
 use kas::util::warn_about_error;
 use kas::{draw, WindowId};
 
-#[cfg(feature = "clipboard")]
-use copypasta::{ClipboardContext, ClipboardProvider};
+#[cfg(feature = "clipboard")] use arboard::Clipboard;
 
 /// State shared between windows
 pub struct SharedState<S: WindowSurface, T> {
     pub(super) platform: Platform,
     #[cfg(feature = "clipboard")]
-    clipboard: Option<ClipboardContext>,
+    clipboard: Option<Clipboard>,
     pub(super) draw: draw::SharedState<S::Shared>,
     pub(super) theme: T,
     pub(super) config: SharedRc<kas::event::Config>,
@@ -53,10 +52,10 @@ where
         theme.init(&mut draw);
 
         #[cfg(feature = "clipboard")]
-        let clipboard = match ClipboardContext::new() {
+        let clipboard = match Clipboard::new() {
             Ok(cb) => Some(cb),
             Err(e) => {
-                warn_about_error("Failed to connect clipboard", e.as_ref());
+                warn_about_error("Failed to connect clipboard", &e);
                 None
             }
         };
@@ -86,9 +85,9 @@ where
         #[cfg(feature = "clipboard")]
         {
             if let Some(cb) = self.clipboard.as_mut() {
-                match cb.get_contents() {
+                match cb.get_text() {
                     Ok(s) => return Some(s),
-                    Err(e) => warn_about_error("Failed to get clipboard contents", e.as_ref()),
+                    Err(e) => warn_about_error("Failed to get clipboard contents", &e),
                 }
             }
         }
@@ -100,9 +99,9 @@ where
     pub fn set_clipboard(&mut self, _content: String) {
         #[cfg(feature = "clipboard")]
         if let Some(cb) = self.clipboard.as_mut() {
-            match cb.set_contents(_content) {
+            match cb.set_text(_content) {
                 Ok(()) => (),
-                Err(e) => warn_about_error("Failed to set clipboard contents", e.as_ref()),
+                Err(e) => warn_about_error("Failed to set clipboard contents", &e),
             }
         }
     }

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -106,6 +106,46 @@ where
         }
     }
 
+    #[inline]
+    pub fn get_primary(&mut self) -> Option<String> {
+        #[cfg(all(
+            unix,
+            not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
+            feature = "clipboard",
+        ))]
+        {
+            use arboard::{GetExtLinux, LinuxClipboardKind};
+            if let Some(cb) = self.clipboard.as_mut() {
+                match cb.get().clipboard(LinuxClipboardKind::Primary).text() {
+                    Ok(s) => return Some(s),
+                    Err(e) => warn_about_error("Failed to get clipboard contents", &e),
+                }
+            }
+        }
+
+        None
+    }
+
+    #[inline]
+    pub fn set_primary(&mut self, _content: String) {
+        #[cfg(all(
+            unix,
+            not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
+            feature = "clipboard",
+        ))]
+        if let Some(cb) = self.clipboard.as_mut() {
+            use arboard::{LinuxClipboardKind, SetExtLinux};
+            match cb
+                .set()
+                .clipboard(LinuxClipboardKind::Primary)
+                .text(_content)
+            {
+                Ok(()) => (),
+                Err(e) => warn_about_error("Failed to set clipboard contents", &e),
+            }
+        }
+    }
+
     pub fn update_all(&mut self, id: UpdateId, payload: u64) {
         self.pending.push(PendingAction::Update(id, payload));
     }

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -13,6 +13,7 @@ use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
 use kas::theme::{DrawMgr, SizeMgr, ThemeControl, ThemeSize};
 use kas::theme::{Theme, Window as _};
+use kas::util::warn_about_error;
 use kas::{Action, Layout, WidgetCore, WidgetExt, Window as _, WindowId};
 use std::mem::take;
 use std::time::Instant;
@@ -20,14 +21,39 @@ use winit::event::WindowEvent;
 use winit::event_loop::EventLoopWindowTarget;
 use winit::window::WindowBuilder;
 
+#[crate::autoimpl(Deref, DerefMut using self.window)]
+pub(super) struct WindowData {
+    window: winit::window::Window,
+    #[cfg(wayland_platform)]
+    wayland_clipboard: Option<smithay_clipboard::Clipboard>,
+}
+
+impl WindowData {
+    #[cfg(not(wayland_platform))]
+    fn new(window: winit::window::Window) -> Self {
+        WindowData { window }
+    }
+
+    #[cfg(wayland_platform)]
+    fn new(window: winit::window::Window) -> Self {
+        use winit::platform::wayland::WindowExtWayland;
+        let wayland_clipboard = window
+            .wayland_display()
+            .map(|display| unsafe { smithay_clipboard::Clipboard::new(display) });
+        WindowData {
+            window,
+            wayland_clipboard,
+        }
+    }
+}
+
 /// Per-window data
 pub struct Window<S: WindowSurface, T: Theme<S::Shared>> {
     pub(super) widget: kas::RootWidget,
     pub(super) window_id: WindowId,
     ev_state: EventState,
     solve_cache: SolveCache,
-    /// The winit window
-    pub(super) window: winit::window::Window,
+    pub(super) window: WindowData,
     theme_window: T::Window,
     next_avail_frame_time: Instant,
     queued_frame_time: Option<Instant>,
@@ -93,8 +119,6 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
             .with_transparent(widget.transparent())
             .build(elwt)?;
 
-        shared.init_clipboard(&window);
-
         let scale_factor = window.scale_factor();
         shared.scale_factor = scale_factor;
         let size: Size = window.inner_size().cast();
@@ -120,7 +144,7 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
             window_id,
             ev_state,
             solve_cache,
-            window,
+            window: WindowData::new(window),
             theme_window,
             next_avail_frame_time: time,
             queued_frame_time: Some(time),
@@ -414,7 +438,7 @@ where
     T::Window: kas::theme::Window,
 {
     shared: &'a mut SharedState<S, T>,
-    window: Option<&'a winit::window::Window>,
+    window: Option<&'a WindowData>,
     theme_window: &'a mut T::Window,
 }
 
@@ -424,7 +448,7 @@ where
 {
     fn new(
         shared: &'a mut SharedState<S, T>,
-        window: Option<&'a winit::window::Window>,
+        window: Option<&'a WindowData>,
         theme_window: &'a mut T::Window,
     ) -> Self {
         TkWindow {
@@ -481,11 +505,34 @@ where
 
     #[inline]
     fn get_clipboard(&mut self) -> Option<String> {
+        if let Some(cb) = self
+            .window
+            .as_ref()
+            .and_then(|data| data.wayland_clipboard.as_ref())
+        {
+            return match cb.load() {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    warn_about_error("Failed to get clipboard contents", &e);
+                    None
+                }
+            };
+        }
+
         self.shared.get_clipboard()
     }
 
     #[inline]
     fn set_clipboard<'c>(&mut self, content: String) {
+        if let Some(cb) = self
+            .window
+            .as_ref()
+            .and_then(|data| data.wayland_clipboard.as_ref())
+        {
+            cb.store(content);
+            return;
+        }
+
         self.shared.set_clipboard(content);
     }
 

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -13,7 +13,7 @@ use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
 use kas::theme::{DrawMgr, SizeMgr, ThemeControl, ThemeSize};
 use kas::theme::{Theme, Window as _};
-use kas::util::warn_about_error;
+#[cfg(wayland_platform)] use kas::util::warn_about_error;
 use kas::{Action, Layout, WidgetCore, WidgetExt, Window as _, WindowId};
 use std::mem::take;
 use std::time::Instant;
@@ -505,6 +505,7 @@ where
 
     #[inline]
     fn get_clipboard(&mut self) -> Option<String> {
+        #[cfg(wayland_platform)]
         if let Some(cb) = self
             .window
             .as_ref()
@@ -524,6 +525,7 @@ where
 
     #[inline]
     fn set_clipboard<'c>(&mut self, content: String) {
+        #[cfg(wayland_platform)]
         if let Some(cb) = self
             .window
             .as_ref()
@@ -538,6 +540,7 @@ where
 
     #[inline]
     fn get_primary(&mut self) -> Option<String> {
+        #[cfg(wayland_platform)]
         if let Some(cb) = self
             .window
             .as_ref()
@@ -557,6 +560,7 @@ where
 
     #[inline]
     fn set_primary<'c>(&mut self, content: String) {
+        #[cfg(wayland_platform)]
         if let Some(cb) = self
             .window
             .as_ref()

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -536,6 +536,39 @@ where
         self.shared.set_clipboard(content);
     }
 
+    #[inline]
+    fn get_primary(&mut self) -> Option<String> {
+        if let Some(cb) = self
+            .window
+            .as_ref()
+            .and_then(|data| data.wayland_clipboard.as_ref())
+        {
+            return match cb.load_primary() {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    warn_about_error("Failed to get clipboard contents", &e);
+                    None
+                }
+            };
+        }
+
+        self.shared.get_primary()
+    }
+
+    #[inline]
+    fn set_primary<'c>(&mut self, content: String) {
+        if let Some(cb) = self
+            .window
+            .as_ref()
+            .and_then(|data| data.wayland_clipboard.as_ref())
+        {
+            cb.store_primary(content);
+            return;
+        }
+
+        self.shared.set_primary(content);
+    }
+
     fn adjust_theme(&mut self, f: &mut dyn FnMut(&mut dyn ThemeControl) -> Action) {
         let action = f(&mut self.shared.theme);
         self.shared.pending.push(PendingAction::Action(action));

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -746,7 +746,7 @@ impl_scope! {
                         Response::Unused
                     };
                 }
-                Event::PressStart { source, coord, .. } if source.is_primary() && mgr.config().mouse_nav_focus() => {
+                Event::PressStart { ref press } if press.is_primary() && mgr.config().mouse_nav_focus() => {
                     if let Some((index, ref key)) = self.press_target {
                         let w = &mut self.widgets[index];
                         if w.key.as_ref().map(|k| k == key).unwrap_or(false) {
@@ -756,18 +756,18 @@ impl_scope! {
 
                     // Press may also be grabbed by scroll component (replacing
                     // this). Either way we can select on PressEnd.
-                    mgr.grab_press_unique(self.id(), source, coord, None);
+                    mgr.grab_press_unique(self.id(), press.source, press.coord, None);
                     Response::Used
                 }
                 Event::PressMove { .. } => Response::Used,
-                Event::PressEnd { source, coord, success, .. } if source.is_primary() => {
+                Event::PressEnd { ref press, success } if press.is_primary() => {
                     if let Some((index, ref key)) = self.press_target {
                         let w = &mut self.widgets[index];
                         if success
                             && !matches!(self.sel_mode, SelectionMode::None)
                             && !self.scroll.is_gliding()
                             && w.key.as_ref().map(|k| k == key).unwrap_or(false)
-                            && w.widget.rect().contains(coord + self.scroll.offset())
+                            && w.widget.rect().contains(press.coord + self.scroll.offset())
                         {
                             mgr.push(SelectMsg);
                         }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -760,10 +760,11 @@ impl_scope! {
                     Response::Used
                 }
                 Event::PressMove { .. } => Response::Used,
-                Event::PressEnd { source, coord, .. } if source.is_primary() => {
+                Event::PressEnd { source, coord, success, .. } if source.is_primary() => {
                     if let Some((index, ref key)) = self.press_target {
                         let w = &mut self.widgets[index];
-                        if !matches!(self.sel_mode, SelectionMode::None)
+                        if success
+                            && !matches!(self.sel_mode, SelectionMode::None)
                             && !self.scroll.is_gliding()
                             && w.key.as_ref().map(|k| k == key).unwrap_or(false)
                             && w.widget.rect().contains(coord + self.scroll.offset())

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -756,8 +756,7 @@ impl_scope! {
 
                     // Press may also be grabbed by scroll component (replacing
                     // this). Either way we can select on PressEnd.
-                    mgr.grab_press_unique(self.id(), press.source, press.coord, None);
-                    Response::Used
+                    press.grab(self.id()).with_mgr(mgr)
                 }
                 Event::PressMove { .. } => Response::Used,
                 Event::PressEnd { ref press, success } if press.is_primary() => {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -789,10 +789,11 @@ impl_scope! {
                     Response::Used
                 }
                 Event::PressMove { .. } => Response::Used,
-                Event::PressEnd { source, coord, .. } if source.is_primary() => {
+                Event::PressEnd { source, coord, success, .. } if source.is_primary() => {
                     if let Some((index, ref key)) = self.press_target {
                         let w = &mut self.widgets[index];
-                        if !matches!(self.sel_mode, SelectionMode::None)
+                        if success
+                            && !matches!(self.sel_mode, SelectionMode::None)
                             && !self.scroll.is_gliding()
                             && w.key.as_ref().map(|k| k == key).unwrap_or(false)
                             && w.widget.rect().contains(coord + self.scroll.offset())

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -775,7 +775,7 @@ impl_scope! {
                         Response::Unused
                     };
                 }
-                Event::PressStart { source, coord, .. } if source.is_primary() && mgr.config().mouse_nav_focus() => {
+                Event::PressStart { ref press } if press.is_primary() && mgr.config().mouse_nav_focus() => {
                     if let Some((index, ref key)) = self.press_target {
                         let w = &mut self.widgets[index];
                         if w.key.as_ref().map(|k| k == key).unwrap_or(false) {
@@ -785,18 +785,18 @@ impl_scope! {
 
                     // Press may also be grabbed by scroll component (replacing
                     // this). Either way we can select on PressEnd.
-                    mgr.grab_press_unique(self.id(), source, coord, None);
+                    mgr.grab_press_unique(self.id(), press.source, press.coord, None);
                     Response::Used
                 }
                 Event::PressMove { .. } => Response::Used,
-                Event::PressEnd { source, coord, success, .. } if source.is_primary() => {
+                Event::PressEnd { ref press, success } if press.is_primary() => {
                     if let Some((index, ref key)) = self.press_target {
                         let w = &mut self.widgets[index];
                         if success
                             && !matches!(self.sel_mode, SelectionMode::None)
                             && !self.scroll.is_gliding()
                             && w.key.as_ref().map(|k| k == key).unwrap_or(false)
-                            && w.widget.rect().contains(coord + self.scroll.offset())
+                            && w.widget.rect().contains(press.coord + self.scroll.offset())
                         {
                             mgr.push(SelectMsg);
                         }

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -785,8 +785,7 @@ impl_scope! {
 
                     // Press may also be grabbed by scroll component (replacing
                     // this). Either way we can select on PressEnd.
-                    mgr.grab_press_unique(self.id(), press.source, press.coord, None);
-                    Response::Used
+                    press.grab(self.id()).with_mgr(mgr)
                 }
                 Event::PressMove { .. } => Response::Used,
                 Event::PressEnd { ref press, success } if press.is_primary() => {

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -114,7 +114,7 @@ impl_scope! {
                 Event::PressStart { press } => {
                     if press.id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
                         if press.is_primary() {
-                            mgr.grab_press_unique(self.id(), *press, press.coord, None);
+                            press.grab(self.id()).with_mgr(mgr);
                             mgr.set_grab_depress(*press, press.id);
                             self.opening = self.popup_id.is_none();
                         }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -111,15 +111,11 @@ impl_scope! {
                     }
                     Response::Used
                 }
-                Event::PressStart {
-                    source,
-                    start_id,
-                    coord,
-                } => {
-                    if start_id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
-                        if source.is_primary() {
-                            mgr.grab_press_unique(self.id(), source, coord, None);
-                            mgr.set_grab_depress(source, start_id);
+                Event::PressStart { press } => {
+                    if press.id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
+                        if press.is_primary() {
+                            mgr.grab_press_unique(self.id(), *press, press.coord, None);
+                            mgr.set_grab_depress(*press, press.id);
                             self.opening = self.popup_id.is_none();
                         }
                         Response::Used
@@ -130,25 +126,20 @@ impl_scope! {
                         Response::Unused
                     }
                 }
-                Event::PressMove {
-                    source,
-                    cur_id,
-                    coord,
-                    ..
-                } => {
+                Event::PressMove { press, .. } => {
                     if self.popup_id.is_none() {
                         open_popup(self, mgr, false);
                     }
-                    let cond = self.popup.inner.rect().contains(coord);
-                    let target = if cond { cur_id } else { None };
-                    mgr.set_grab_depress(source, target.clone());
+                    let cond = self.popup.inner.rect().contains(press.coord);
+                    let target = if cond { press.id } else { None };
+                    mgr.set_grab_depress(press.source, target.clone());
                     if let Some(id) = target {
                         mgr.set_nav_focus(id, false);
                     }
                     Response::Used
                 }
-                Event::PressEnd { end_id, success, .. } if success => {
-                    if let Some(id) = end_id {
+                Event::PressEnd { press, success } if success => {
+                    if let Some(id) = press.id {
                         if self.eq_id(&id) {
                             if self.opening {
                                 if self.popup_id.is_none() {
@@ -166,7 +157,7 @@ impl_scope! {
                     }
                     Response::Used
                 }
-                Event::PressEnd { .. } =>Response::Used,
+                Event::PressEnd { .. } => Response::Used,
                 Event::PopupRemoved(id) => {
                     debug_assert_eq!(Some(id), self.popup_id);
                     self.popup_id = None;

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -92,16 +92,16 @@ impl_scope! {
     impl Widget for GripPart {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
-                Event::PressStart { source, coord, .. } => {
+                Event::PressStart { press, .. } => {
                     mgr.push(GripMsg::PressStart);
-                    mgr.grab_press_unique(self.id(), source, coord, Some(CursorIcon::Grabbing));
+                    mgr.grab_press_unique(self.id(), *press, press.coord, Some(CursorIcon::Grabbing));
 
                     // Event delivery implies coord is over the grip.
-                    self.press_coord = coord - self.offset();
+                    self.press_coord = press.coord - self.offset();
                     Response::Used
                 }
-                Event::PressMove { coord, .. } => {
-                    let offset = coord - self.press_coord;
+                Event::PressMove { press, .. } => {
+                    let offset = press.coord - self.press_coord;
                     let offset = offset.clamp(Offset::ZERO, self.max_offset());
                     mgr.push(GripMsg::PressMove(offset));
                     Response::Used

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -26,7 +26,9 @@ pub enum GripMsg {
     /// the posision; e.g. `Slider` pins the position to the nearest detent.
     PressMove(Offset),
     /// Widget received [`Event::PressEnd`]
-    PressEnd,
+    ///
+    /// Parameter: `success` (see [`Event::PressEnd`]).
+    PressEnd(bool),
 }
 
 impl_scope! {
@@ -104,8 +106,8 @@ impl_scope! {
                     mgr.push(GripMsg::PressMove(offset));
                     Response::Used
                 }
-                Event::PressEnd { .. } => {
-                    mgr.push(GripMsg::PressEnd);
+                Event::PressEnd { success, .. } => {
+                    mgr.push(GripMsg::PressEnd(success));
                     Response::Used
                 }
                 _ => Response::Unused,

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -142,7 +142,7 @@ impl_scope! {
                             let press_in_the_bar = self.rect().contains(press.coord);
 
                             if !press_in_the_bar || !any_menu_open {
-                                mgr.grab_press_unique(self.id(), *press, press.coord, None);
+                                press.grab(self.id()).with_mgr(mgr);
                             }
                             mgr.set_grab_depress(*press, press.id.clone());
                             if press_in_the_bar {

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -131,31 +131,27 @@ impl_scope! {
                     }
                     Response::Used
                 }
-                Event::PressStart {
-                    source,
-                    start_id,
-                    coord,
-                } => {
-                    if start_id
+                Event::PressStart { press } => {
+                    if press.id
                         .as_ref()
                         .map(|id| self.is_ancestor_of(id))
                         .unwrap_or(false)
                     {
-                        if source.is_primary() {
+                        if press.is_primary() {
                             let any_menu_open = self.widgets.iter().any(|w| w.menu_is_open());
-                            let press_in_the_bar = self.rect().contains(coord);
+                            let press_in_the_bar = self.rect().contains(press.coord);
 
                             if !press_in_the_bar || !any_menu_open {
-                                mgr.grab_press_unique(self.id(), source, coord, None);
+                                mgr.grab_press_unique(self.id(), *press, press.coord, None);
                             }
-                            mgr.set_grab_depress(source, start_id.clone());
+                            mgr.set_grab_depress(*press, press.id.clone());
                             if press_in_the_bar {
                                 if self
                                     .widgets
                                     .iter()
-                                    .any(|w| w.eq_id(&start_id) && !w.menu_is_open())
+                                    .any(|w| w.eq_id(&press.id) && !w.menu_is_open())
                                 {
-                                    self.set_menu_path(mgr, start_id.as_ref(), false);
+                                    self.set_menu_path(mgr, press.id.as_ref(), false);
                                 } else {
                                     self.set_menu_path(mgr, None, false);
                                 }
@@ -169,15 +165,10 @@ impl_scope! {
                         Response::Unused
                     }
                 }
-                Event::PressMove {
-                    source,
-                    cur_id,
-                    coord,
-                    ..
-                } => {
-                    mgr.set_grab_depress(source, cur_id.clone());
+                Event::PressMove { press, .. } => {
+                    mgr.set_grab_depress(*press, press.id.clone());
 
-                    let id = match cur_id {
+                    let id = match press.id {
                         Some(x) => x,
                         None => return Response::Used,
                     };
@@ -185,7 +176,7 @@ impl_scope! {
                     if self.is_strict_ancestor_of(&id) {
                         // We instantly open a sub-menu on motion over the bar,
                         // but delay when over a sub-menu (most intuitive?)
-                        if self.rect().contains(coord) {
+                        if self.rect().contains(press.coord) {
                             mgr.clear_nav_focus();
                             self.delayed_open = None;
                             self.set_menu_path(mgr, Some(&id), false);
@@ -201,17 +192,16 @@ impl_scope! {
                     Response::Used
                 }
                 Event::PressEnd {
-                    coord,
-                    end_id,
+                    press,
                     success,
                     ..
                 } if success => {
-                    let id = match end_id {
+                    let id = match press.id {
                         Some(x) => x,
                         None => return Response::Used,
                     };
 
-                    if !self.rect().contains(coord) {
+                    if !self.rect().contains(press.coord) {
                         // not on the menubar
                         self.delayed_open = None;
                         mgr.send(self, id, Event::Command(Command::Activate));

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -309,8 +309,8 @@ impl_scope! {
                     *mgr |= Action::REDRAW;
                     Response::Used
                 }
-                Event::PressStart { source, coord, .. } => {
-                    let offset = self.handle.handle_press_on_track(mgr, source, coord);
+                Event::PressStart { press } => {
+                    let offset = self.handle.handle_press_on_track(mgr, *press, press.coord);
                     self.apply_grip_offset(mgr, offset);
                     Response::Used
                 }

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -310,7 +310,7 @@ impl_scope! {
                     Response::Used
                 }
                 Event::PressStart { press } => {
-                    let offset = self.handle.handle_press_on_track(mgr, *press, press.coord);
+                    let offset = self.handle.handle_press_on_track(mgr, &press);
                     self.apply_grip_offset(mgr, offset);
                     Response::Used
                 }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -133,6 +133,13 @@ impl_scope! {
             }
         }
 
+        fn set_primary(&self, mgr: &mut EventMgr) {
+            if !self.selection.is_empty() {
+                let range = self.selection.range();
+                mgr.set_primary(String::from(&self.text.as_str()[range]));
+            }
+        }
+
         // Pan by given delta. Return `Response::Scrolled` or `Response::Pan(remaining)`.
         fn pan_delta(&mut self, mgr: &mut EventMgr, mut delta: Offset) -> Response {
             let new_offset = (self.view_offset - delta)
@@ -216,6 +223,7 @@ impl_scope! {
                     Command::SelectAll => {
                         self.selection.set_sel_pos(0);
                         self.selection.set_edit_pos(self.text.str_len());
+                        self.set_primary(mgr);
                         mgr.redraw(self.id());
                         Response::Used
                     }
@@ -255,6 +263,7 @@ impl_scope! {
                             if repeats > 1 {
                                 self.selection.expand(&self.text, repeats);
                             }
+                            self.set_primary(mgr);
                         }
                         Response::Used
                     }

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -333,8 +333,8 @@ impl_scope! {
                         }
                     }
                 }
-                Event::PressStart { source, coord, .. } => {
-                    let offset = self.handle.handle_press_on_track(mgr, source, coord);
+                Event::PressStart { press } => {
+                    let offset = self.handle.handle_press_on_track(mgr, *press, press.coord);
                     self.apply_grip_offset(mgr, offset);
                 }
                 _ => return Response::Unused,

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -334,7 +334,7 @@ impl_scope! {
                     }
                 }
                 Event::PressStart { press } => {
-                    let offset = self.handle.handle_press_on_track(mgr, *press, press.coord);
+                    let offset = self.handle.handle_press_on_track(mgr, &press);
                     self.apply_grip_offset(mgr, offset);
                 }
                 _ => return Response::Unused,

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -409,14 +409,11 @@ impl_scope! {
 
                     mgr.push(ViewUpdate);
                 }
-                Event::PressStart { source, coord, .. } => {
-                    mgr.grab_press(
-                        self.id(),
-                        source,
-                        coord,
-                        event::GrabMode::PanFull,
-                        Some(event::CursorIcon::Grabbing),
-                    );
+                Event::PressStart { press } => {
+                    return press.grab(self.id())
+                        .with_mode(event::GrabMode::PanFull)
+                        .with_icon(event::CursorIcon::Grabbing)
+                        .with_mgr(mgr);
                 }
                 _ => return Response::Unused,
             }


### PR DESCRIPTION
#382 was not released due to the window_clipboard dependency. This PR replaces that with arboard + smithay-clipboard, and:

- supports the primary buffer on Linux
- adds `Press::grab` builder pattern