### PR TITLE
Revise crate features; improve CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,7 @@ jobs:
           cargo test
           cargo test --all-features
       - name: Test examples/mandlebrot
-        run: |
-          cargo test --manifest-path examples/mandlebrot/Cargo.toml
-          cargo test --manifest-path examples/mandlebrot/Cargo.toml --all-features
+        run: cargo test --manifest-path examples/mandlebrot/Cargo.toml
       - name: Clippy
         run: |
           cargo clippy --all --features nightly -- \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,25 +26,42 @@ jobs:
         run: |
           cargo fmt --all -- --check
       - name: Build docs
-        run: cargo doc --all-features --all --no-deps
+        run: |
+          cargo doc --all --no-deps
+          cargo doc --all-features --all --no-deps
       - name: Test kas-macros
-        run: cargo test --manifest-path crates/kas-macros/Cargo.toml --all-features
+        run: |
+          cargo test --manifest-path crates/kas-macros/Cargo.toml
+          cargo test --manifest-path crates/kas-macros/Cargo.toml --all-features
       - name: Test kas-core
-        run: cargo test --manifest-path crates/kas-core/Cargo.toml --all-features
+        run: |
+          cargo test --manifest-path crates/kas-core/Cargo.toml
+          cargo test --manifest-path crates/kas-core/Cargo.toml --all-features
       - name: Test kas-widgets
-        run: cargo test --manifest-path crates/kas-widgets/Cargo.toml --all-features
+        run: |
+          cargo test --manifest-path crates/kas-widgets/Cargo.toml
+          cargo test --manifest-path crates/kas-widgets/Cargo.toml --all-features
       - name: Test kas-resvg
-        run: cargo test --manifest-path crates/kas-resvg/Cargo.toml --all-features
+        run: |
+          cargo test --manifest-path crates/kas-resvg/Cargo.toml
+          cargo test --manifest-path crates/kas-resvg/Cargo.toml --all-features
       - name: Test kas-wgpu
         run: |
+          cargo test --manifest-path crates/kas-wgpu/Cargo.toml
           cargo test --manifest-path crates/kas-wgpu/Cargo.toml --no-default-features --features raster,kas/x11
           cargo test --manifest-path crates/kas-wgpu/Cargo.toml --all-features --features kas/x11
       - name: Test kas-dylib
-        run: cargo test --manifest-path crates/kas-dylib/Cargo.toml --all-features --features kas-core/x11
+        run: |
+          cargo test --manifest-path crates/kas-dylib/Cargo.toml
+          cargo test --manifest-path crates/kas-dylib/Cargo.toml --all-features --features kas-core/x11
       - name: Test kas
-        run: cargo test --all-features
+        run: |
+          cargo test
+          cargo test --all-features
       - name: Test examples/mandlebrot
-        run: cargo test --manifest-path examples/mandlebrot/Cargo.toml --all-features
+        run: |
+          cargo test --manifest-path examples/mandlebrot/Cargo.toml
+          cargo test --manifest-path examples/mandlebrot/Cargo.toml --all-features
       - name: Clippy
         run: |
           cargo clippy --all --features nightly -- \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Test kas-macros
         run: cargo test --manifest-path crates/kas-macros/Cargo.toml --all-features
       - name: Test kas-core
-        run: cargo test --manifest-path crates/kas-core/Cargo.toml
+        run: cargo test --manifest-path crates/kas-core/Cargo.toml --features stable
       - name: Test kas-widgets
         run: cargo test --manifest-path crates/kas-widgets/Cargo.toml
       - name: Test kas-resvg
@@ -110,7 +110,7 @@ jobs:
       - name: Test kas-dylib
         run: cargo test --manifest-path crates/kas-dylib/Cargo.toml --features kas-core/x11
       - name: Test kas
-        run: cargo test
+        run: cargo test --features stable
       - name: Test examples/mandlebrot
         run: cargo test --manifest-path examples/mandlebrot/Cargo.toml
       - name: Clippy (stable)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,9 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 minimal = ["wgpu", "winit", "wayland", "x11"]
 # All recommended features for optimal experience
 default = ["minimal", "view", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light", "spawn"]
-# All features usable on stable rust
-stable = ["default", "dynamic", "serde", "json", "ron", "macros_log"]
+# All standard test target features
+# NOTE: dynamic is excluded due to linker problems on Windows
+stable = ["default", "serde", "json", "ron", "macros_log"]
 # Enables "recommended" unstable features
 nightly = ["min_spec"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 #########  meta / build features  #########
 
 # All recommended features for optimal experience
-default = ["minimal", "view", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light", "spawn", "wayland", "x11"]
+default = ["minimal", "view", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light", "spawn", "winit", "wayland", "x11"]
 
 # Include only "required" features.
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 [features]
 #########  meta / build features  #########
 
-# All recommended features for optimal experience
-default = ["minimal", "view", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light", "spawn", "winit", "wayland", "x11"]
-
 # Include only "required" features.
 #
 #  A shell is required and wgpu is currently the only shell; this shell uses and
@@ -32,13 +29,16 @@ default = ["minimal", "view", "yaml", "image", "resvg", "clipboard", "markdown",
 #
 # Note: only some examples build in this configuration; others need view,
 # markdown, resvg. Recommended also: clipboard, yaml (or some config format).
-minimal = ["wgpu"]
+minimal = ["wgpu", "winit", "wayland", "x11"]
+# All recommended features for optimal experience
+default = ["minimal", "view", "yaml", "image", "resvg", "clipboard", "markdown", "shaping", "dark-light", "spawn"]
+# All features usable on stable rust
+stable = ["default", "dynamic", "serde", "json", "ron", "macros_log"]
+# Enables "recommended" unstable features
+nightly = ["min_spec"]
 
 # Enable dynamic linking (faster linking via an extra run-time dependency):
 dynamic = ["dep:kas-dylib"]
-
-# Enables usage of unstable Rust features
-nightly = ["min_spec"]
 
 # Use min_specialization (enables accelerator underlining for AccelLabel)
 min_spec = ["kas-widgets/min_spec"]
@@ -86,7 +86,7 @@ ron = ["serde", "kas-core/ron"]
 image = ["kas-widgets/image"]
 
 # Enable resvg module (Canvas + Svg widgets)
-resvg = ["dep:kas-resvg", "kas-resvg?/svg"]
+resvg = ["dep:kas-resvg", "kas-resvg?/svg", "kas-dylib?/resvg"]
 # Enable resvg module (Canvas only)
 tiny-skia = ["dep:kas-resvg"]
 

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -13,12 +13,15 @@ repository = "https://github.com/kas-gui/kas"
 exclude = ["/screenshots"]
 
 [package.metadata.docs.rs]
-features = ["winit", "markdown", "yaml", "json", "ron"]
+features = ["stable"]
 rustdoc-args = ["--cfg", "doc_cfg"]
 # To build locally:
-# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --features=internal_doc,winit,markdown,yaml,json,ron --no-deps --open
+# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --features=stable --no-deps --open
 
 [features]
+# All features usable on stable rust
+stable = ["winit", "x11", "wayland", "markdown", "yaml", "json", "ron", "shaping", "clipboard", "spawn", "dark-light", "serde"]
+
 # Use full specialization
 spec = []
 

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -11,6 +11,7 @@ use crate::cast::Cast;
 use crate::geom::{Quad, Rect, Size};
 use crate::shell::Platform;
 use crate::text::{Effect, TextDisplay};
+use crate::theme::RasterConfig;
 use std::any::Any;
 use std::num::NonZeroU32;
 use std::rc::Rc;
@@ -157,6 +158,9 @@ impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 pub trait DrawSharedImpl: Any {
     type Draw: DrawImpl;
+
+    /// Set font raster config
+    fn set_raster_config(&mut self, config: &RasterConfig);
 
     /// Allocate an image
     ///

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -9,7 +9,7 @@ use crate::draw::{color::Rgba, DrawIface, WindowCommon};
 use crate::draw::{DrawImpl, DrawShared, DrawSharedImpl};
 use crate::event::{CursorIcon, UpdateId};
 use crate::geom::Size;
-use crate::theme::{RasterConfig, ThemeControl, ThemeSize};
+use crate::theme::{ThemeControl, ThemeSize};
 use crate::{Action, WindowId};
 use raw_window_handle as raw;
 use thiserror::Error;
@@ -183,7 +183,7 @@ pub trait GraphicalShell {
     type Surface: WindowSurface<Shared = Self::Shared> + 'static;
 
     /// Construct shared state
-    fn build(self, raster_config: &RasterConfig) -> Result<Self::Shared>;
+    fn build(self) -> Result<Self::Shared>;
 }
 
 /// Window graphical surface requirements

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -17,11 +17,9 @@ mod common;
 #[cfg(feature = "winit")] use window::Window;
 
 pub(crate) use common::ShellWindow;
-#[cfg(feature = "winit")] pub use common::WindowSurface;
-pub use common::{Error, GraphicalShell, Platform, Result};
+pub use common::{Error, GraphicalShell, Platform, Result, WindowSurface};
 #[cfg(feature = "winit")]
 pub use shell::{ClosedError, Proxy, Shell, ShellAssoc};
-#[cfg(feature = "winit")]
 pub extern crate raw_window_handle;
 
 #[cfg(feature = "winit")]

--- a/crates/kas-core/src/shell/shell.rs
+++ b/crates/kas-core/src/shell/shell.rs
@@ -112,7 +112,8 @@ where
         let el = EventLoopBuilder::with_user_event().build();
         let windows = vec![];
 
-        let draw_shared = graphical_shell.into().build(theme.config().raster())?;
+        let mut draw_shared = graphical_shell.into().build()?;
+        draw_shared.set_raster_config(theme.config().raster());
         let pw = PlatformWrapper(&el);
         let shared = SharedState::new(pw, draw_shared, theme, options, config)?;
 

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -13,7 +13,8 @@ use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
 use kas::theme::{DrawMgr, SizeMgr, ThemeControl, ThemeSize};
 use kas::theme::{Theme, Window as _};
-#[cfg(wayland_platform)] use kas::util::warn_about_error;
+#[cfg(all(wayland_platform, feature = "clipboard"))]
+use kas::util::warn_about_error;
 use kas::{Action, Layout, WidgetCore, WidgetExt, Window as _, WindowId};
 use std::mem::take;
 use std::time::Instant;
@@ -24,17 +25,17 @@ use winit::window::WindowBuilder;
 #[crate::autoimpl(Deref, DerefMut using self.window)]
 pub(super) struct WindowData {
     window: winit::window::Window,
-    #[cfg(wayland_platform)]
+    #[cfg(all(wayland_platform, feature = "clipboard"))]
     wayland_clipboard: Option<smithay_clipboard::Clipboard>,
 }
 
 impl WindowData {
-    #[cfg(not(wayland_platform))]
+    #[cfg(not(all(wayland_platform, feature = "clipboard")))]
     fn new(window: winit::window::Window) -> Self {
         WindowData { window }
     }
 
-    #[cfg(wayland_platform)]
+    #[cfg(all(wayland_platform, feature = "clipboard"))]
     fn new(window: winit::window::Window) -> Self {
         use winit::platform::wayland::WindowExtWayland;
         let wayland_clipboard = window
@@ -505,7 +506,7 @@ where
 
     #[inline]
     fn get_clipboard(&mut self) -> Option<String> {
-        #[cfg(wayland_platform)]
+        #[cfg(all(wayland_platform, feature = "clipboard"))]
         if let Some(cb) = self
             .window
             .as_ref()
@@ -525,7 +526,7 @@ where
 
     #[inline]
     fn set_clipboard<'c>(&mut self, content: String) {
-        #[cfg(wayland_platform)]
+        #[cfg(all(wayland_platform, feature = "clipboard"))]
         if let Some(cb) = self
             .window
             .as_ref()
@@ -540,7 +541,7 @@ where
 
     #[inline]
     fn get_primary(&mut self) -> Option<String> {
-        #[cfg(wayland_platform)]
+        #[cfg(all(wayland_platform, feature = "clipboard"))]
         if let Some(cb) = self
             .window
             .as_ref()
@@ -560,7 +561,7 @@ where
 
     #[inline]
     fn set_primary<'c>(&mut self, content: String) {
-        #[cfg(wayland_platform)]
+        #[cfg(all(wayland_platform, feature = "clipboard"))]
         if let Some(cb) = self
             .window
             .as_ref()

--- a/crates/kas-dylib/Cargo.toml
+++ b/crates/kas-dylib/Cargo.toml
@@ -15,6 +15,8 @@ repository = "https://github.com/kas-gui/kas"
 crate-type = ["dylib"]
 
 [features]
+default = ["raster"]
+raster = ["kas-wgpu/raster"]
 resvg = ["dep:kas-resvg"]
 
 [dependencies]

--- a/crates/kas-dylib/Cargo.toml
+++ b/crates/kas-dylib/Cargo.toml
@@ -21,4 +21,4 @@ resvg = ["dep:kas-resvg"]
 kas-core = { version = "0.13.0", path = "../kas-core" }
 kas-widgets = { version = "0.13.0", path = "../kas-widgets" }
 kas-resvg = { version = "0.13.0", path = "../kas-resvg", optional = true }
-kas-wgpu = { version = "0.13.0", path = "../kas-wgpu" }
+kas-wgpu = { version = "0.13.0", path = "../kas-wgpu", default-features = false }

--- a/crates/kas-resvg/Cargo.toml
+++ b/crates/kas-resvg/Cargo.toml
@@ -13,10 +13,10 @@ repository = "https://github.com/kas-gui/kas"
 exclude = ["/screenshots"]
 
 [package.metadata.docs.rs]
-features = ["canvas", "svg"]
+all-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
 # To build locally:
-# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --features=canvas,svg --no-deps --open
+# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
 
 [features]
 # Support SVG images

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -39,7 +39,6 @@ rustc-hash = "1.0"
 version = "0.13.0"
 package = "kas-core"
 path = "../kas-core"
-features = ["winit"]
 
 [dependencies.kas-text]
 version = "0.6.0"

--- a/crates/kas-wgpu/README.md
+++ b/crates/kas-wgpu/README.md
@@ -1,10 +1,9 @@
 KAS WGPU
 ======
 
-[KAS] shell interface over [winit] and [wgpu].
+[KAS] shell interface over [wgpu].
 
 [KAS]: https://crates.io/crates/kas
-[winit]: https://github.com/rust-windowing/winit/
 [wgpu]: https://github.com/gfx-rs/wgpu-rs
 
 
@@ -31,7 +30,6 @@ Optional features
 
 This crate has the following feature flags:
 
--   `clipboard` (enabled by default): clipboard integration
 -   `raster` (enabled by default): use [kas-text]'s default backend for glyph
     rastering (alternatively, specify `kas-text/ab_glyph` or `kas-text/fontdue`)
 -   `shaping` (enabled by default): use [kas-text]'s default backend (Rustybuzz)

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -18,6 +18,7 @@ use kas::draw::*;
 use kas::geom::{Quad, Rect, Size, Vec2};
 use kas::shell::Error;
 use kas::text::{Effect, TextDisplay};
+use kas::theme::RasterConfig;
 
 /// Possible failures from constructing a [`Shell`]
 ///
@@ -33,7 +34,6 @@ impl<C: CustomPipe> DrawPipe<C> {
     pub fn new<CB: CustomPipeBuilder<Pipe = C>>(
         mut custom: CB,
         options: &Options,
-        raster_config: &kas::theme::RasterConfig,
     ) -> Result<Self, Error> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: options.backend(),
@@ -105,7 +105,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         let flat_round = flat_round::Pipeline::new(&device, &shaders, &bgl_common);
         let round_2col = round_2col::Pipeline::new(&device, &shaders, &bgl_common);
         let custom = custom.build(&device, &bgl_common, RENDER_TEX_FORMAT);
-        let text = text_pipe::Pipeline::new(&device, &shaders, &bgl_common, raster_config);
+        let text = text_pipe::Pipeline::new(&device, &shaders, &bgl_common);
 
         Ok(DrawPipe {
             instance,
@@ -327,6 +327,10 @@ impl<C: CustomPipe> DrawPipe<C> {
 
 impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
     type Draw = DrawWindow<C::Window>;
+
+    fn set_raster_config(&mut self, config: &RasterConfig) {
+        self.text.set_raster_config(config);
+    }
 
     #[inline]
     fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, AllocError> {

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -87,7 +87,6 @@ impl Pipeline {
         device: &wgpu::Device,
         shaders: &ShaderManager,
         bgl_common: &wgpu::BindGroupLayout,
-        config: &RasterConfig,
     ) -> Self {
         let atlas_pipe = atlases::Pipeline::new(
             device,
@@ -121,16 +120,22 @@ impl Pipeline {
             },
         );
         Pipeline {
-            config: Config::new(
-                config.mode,
-                config.scale_steps,
-                config.subpixel_threshold,
-                config.subpixel_steps,
-            ),
+            config: Config::default(),
             atlas_pipe,
             glyphs: Default::default(),
             prepare: Default::default(),
         }
+    }
+
+    pub fn set_raster_config(&mut self, config: &RasterConfig) {
+        self.config = Config::new(
+            config.mode,
+            config.scale_steps,
+            config.subpixel_threshold,
+            config.subpixel_steps,
+        )
+        // NOTE: possibly this should force re-drawing of all glyphs, but for
+        // now that is out of scope
     }
 
     /// Write to textures

--- a/crates/kas-wgpu/src/lib.rs
+++ b/crates/kas-wgpu/src/lib.rs
@@ -3,11 +3,9 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! KAS shell over [winit] and [WGPU]
+//! KAS shell over [WGPU]
 //!
-//! This crate implements a KAS shell (backend) using [WGPU] for
-//! GPU-accelerated rendering and [winit] for windowing, thus it should be
-//! portable to most desktop and potentially also mobile platforms.
+//! This crate implements a KAS's drawing APIs over [WGPU].
 //!
 //! This crate supports themes via the [`kas::theme`], and provides one
 //! additional theme, [`ShadedTheme`].
@@ -19,8 +17,6 @@
 //! See [`options::Options::from_env`] for documentation.
 //!
 //! [WGPU]: https://github.com/gfx-rs/wgpu
-//! [winit]: https://github.com/rust-windowing/winit
-//! [clipboard]: https://crates.io/crates/clipboard
 
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 
@@ -31,7 +27,7 @@ mod shaded_theme;
 mod surface;
 
 use crate::draw::{CustomPipeBuilder, DrawPipe};
-use kas::shell::{self, GraphicalShell, Result};
+use kas::shell::{GraphicalShell, Result};
 use kas::theme::RasterConfig;
 
 pub use draw_shaded::{DrawShaded, DrawShadedImpl};
@@ -64,5 +60,5 @@ impl<CB: CustomPipeBuilder> From<CB> for WgpuShellBuilder<CB> {
     }
 }
 
-/// A KAS shell over Winit and WGPU
-pub type Shell<C, T> = shell::Shell<WgpuShellBuilder<C>, T>;
+/// The default (unparameterised) implementation of [`GraphicalShell`]
+pub type DefaultGraphicalShell = WgpuShellBuilder<()>;

--- a/crates/kas-wgpu/src/lib.rs
+++ b/crates/kas-wgpu/src/lib.rs
@@ -59,5 +59,5 @@ impl<CB: CustomPipeBuilder> From<CB> for WgpuShellBuilder<CB> {
     }
 }
 
-/// The default (unparameterised) implementation of [`GraphicalShell`]
+/// The default (unparameterised) implementation of [`DrawSharedBuilder`]
 pub type DefaultGraphicalShell = WgpuShellBuilder<()>;

--- a/crates/kas-wgpu/src/lib.rs
+++ b/crates/kas-wgpu/src/lib.rs
@@ -28,7 +28,6 @@ mod surface;
 
 use crate::draw::{CustomPipeBuilder, DrawPipe};
 use kas::shell::{GraphicalShell, Result};
-use kas::theme::RasterConfig;
 
 pub use draw_shaded::{DrawShaded, DrawShadedImpl};
 pub use options::Options;
@@ -43,8 +42,8 @@ impl<CB: CustomPipeBuilder> GraphicalShell for WgpuShellBuilder<CB> {
     type Window = draw::DrawWindow<<CB::Pipe as draw::CustomPipe>::Window>;
     type Surface = surface::Surface<CB::Pipe>;
 
-    fn build(self, raster_config: &RasterConfig) -> Result<Self::Shared> {
-        DrawPipe::new(self.0, &self.1, raster_config)
+    fn build(self) -> Result<Self::Shared> {
+        DrawPipe::new(self.0, &self.1)
     }
 }
 

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -490,7 +490,7 @@ fn main() -> kas::shell::Result<()> {
     let theme = kas::theme::FlatTheme::new().with_colours("dark");
 
     let options = kas::config::Options::from_env();
-    kas_wgpu::Shell::new_custom(PipeBuilder, theme, options)?
+    kas::shell::Shell::<kas_wgpu::WgpuShellBuilder<_>, _>::new_custom(PipeBuilder, theme, options)?
         .with(MandlebrotWindow::new())?
         .run()
 }

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -490,7 +490,7 @@ fn main() -> kas::shell::Result<()> {
     let theme = kas::theme::FlatTheme::new().with_colours("dark");
 
     let options = kas::config::Options::from_env();
-    kas::shell::Shell::<kas_wgpu::WgpuShellBuilder<_>, _>::new_custom(PipeBuilder, theme, options)?
+    kas::shell::WgpuShell::new_custom(PipeBuilder, theme, options)?
         .with(MandlebrotWindow::new())?
         .run()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,10 @@ pub mod shell {
 
     pub use kas_core::shell::*;
 
+    /// The WGPU shell
+    #[cfg(feature = "wgpu")]
+    pub type WgpuShell<CB, T> = kas_core::shell::Shell<kas_wgpu::WgpuShellBuilder<CB>, T>;
+
     /// The default (configuration-specific) shell
     #[cfg(feature = "wgpu")]
     pub type DefaultShell<T> = kas_core::shell::Shell<kas_wgpu::DefaultGraphicalShell, T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub mod shell {
 
     /// The default (configuration-specific) shell
     #[cfg(feature = "wgpu")]
-    pub type DefaultShell<T> = kas_wgpu::Shell<(), T>;
+    pub type DefaultShell<T> = kas_core::shell::Shell<kas_wgpu::DefaultGraphicalShell, T>;
 }
 
 #[cfg(feature = "dynamic")]


### PR DESCRIPTION
Some of the crates released at 0.13.0 don't compile with default features; test those and fix.

Add "stable" feature for kas, kas-core and use in tests and docs.rs.