### PR TITLE
New layout macro syntax incl. stand-alone mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
           -A clippy::module-inception \
           -A clippy::too-many-arguments \
           -A clippy::comparison_chain \
+          -A clippy::redundant_pattern_matching \
           -A clippy::unit_arg
 
   test:
@@ -120,4 +121,5 @@ jobs:
           -A clippy::module-inception \
           -A clippy::too-many-arguments \
           -A clippy::comparison_chain \
+          -A clippy::redundant_pattern_matching \
           -A clippy::unit_arg

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -361,7 +361,7 @@ pub trait Layout {
 /// impl_scope! {
 ///     /// A push-button with a text label
 ///     #[widget {
-///         layout = button: self.label;
+///         layout = button!(self.label);
 ///         navigable = true;
 ///         hover_highlight = true;
 ///     }]

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -177,7 +177,7 @@ impl<'a> Visitor<'a> {
     /// Construct a grid layout over an iterator of `(cell, layout)` items
     pub fn grid<I, S>(iter: I, dim: GridDimensions, data: &'a mut S) -> Self
     where
-        I: Iterator<Item = (GridChildInfo, Visitor<'a>)> + 'a,
+        I: DoubleEndedIterator<Item = (GridChildInfo, Visitor<'a>)> + 'a,
         S: GridStorage,
     {
         let layout = LayoutType::BoxComponent(Box::new(Grid {
@@ -457,7 +457,7 @@ struct Grid<'a, S, I> {
 
 impl<'a, S: GridStorage, I> Layout for Grid<'a, S, I>
 where
-    I: Iterator<Item = (GridChildInfo, Visitor<'a>)>,
+    I: DoubleEndedIterator<Item = (GridChildInfo, Visitor<'a>)>,
 {
     fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
         let mut solver = GridSolver::<Vec<_>, Vec<_>, _>::new(axis, self.dim, self.data);
@@ -480,7 +480,7 @@ where
     }
 
     fn draw(&mut self, mut draw: DrawMgr) {
-        for (_, child) in &mut self.children {
+        for (_, child) in (&mut self.children).rev() {
             child.draw(draw.re_clone());
         }
     }

--- a/crates/kas-core/src/title_bar.rs
+++ b/crates/kas-core/src/title_bar.rs
@@ -119,7 +119,7 @@ impl_scope! {
     /// A window's title bar (part of decoration)
     #[derive(Clone, Default)]
     #[widget{
-        layout = row: [
+        layout = row! [
             // self.icon,
             self.title,
             MarkButton::new(MarkStyle::Point(Direction::Down), TitleBarButton::Minimize),

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -254,11 +254,11 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; As `align`, this applies some alignment to content, but also restricts the size of that content to its ideal size (i.e. no stretching).
 /// >
 /// > _Frame_ :\
-/// > &nbsp;&nbsp; `frame` ( `(` _Expr_ `)` )? _Storage_? `:` _Layout_\
+/// > &nbsp;&nbsp; `frame!` _Storage_? `(` _Layout_ ( `,` `style` `=` _Expr_ )? `)`\
 /// > &nbsp;&nbsp; Adds a frame of type _Expr_ around content, defaulting to `FrameStyle::Frame`.
 /// >
 /// > _Button_ :\
-/// > &nbsp;&nbsp; `button` ( `(` _Expr_ `)` )? _Storage_? `:` _Layout_\
+/// > &nbsp;&nbsp; `button!` _Storage_? `(` _Layout_ ( `,` `color` `=` _Expr_ )? `)`\
 /// > &nbsp;&nbsp; Adds a button frame (optionally with color _Expr_) around content.
 /// >
 /// > _Widget_ :\
@@ -320,7 +320,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 ///     #[autoimpl(class_traits using self.inner where W: trait)]
 ///     #[derive(Clone, Default)]
 ///     #[widget{
-///         layout = frame(kas::theme::FrameStyle::Frame): self.inner;
+///         layout = frame!(self.inner, style = kas::theme::FrameStyle::Frame);
 ///     }]
 ///     pub struct Frame<W: Widget> {
 ///         core: widget_core!(),

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -262,8 +262,8 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; Adds a button frame (optionally with color _Expr_) around content.
 /// >
 /// > _Widget_ :\
-/// > &nbsp;&nbsp; _ExprStartingUpperCase_\
-/// > &nbsp;&nbsp; An expression yielding a widget, e.g. `Label::new("Hello world")`. The result must be an object of some type `W: Widget`. Since the expression must start with an upper case letter it is necessary to bring the type into scope first, e.g. `use kas::widget::Label;`.
+/// > &nbsp;&nbsp; _Expr_\
+/// > &nbsp;&nbsp; An expression yielding a widget, e.g. `Label::new("Hello world")`. The result must be an object of some type `W: Widget`.
 /// >
 /// > _Label_ :\
 /// > &nbsp;&nbsp; _StrLit_\

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -528,6 +528,68 @@ pub fn list(input: TokenStream) -> TokenStream {
     parse_macro_input!(input with make_layout::Tree::list).expand_layout("_List")
 }
 
+/// Make a float widget
+///
+/// Widgets overlap with the first being on top. Most widgets stretch to fill
+/// all available space by default which will hide those below; to counteract
+/// this use [`pack`].
+///
+/// Items support [widget layout syntax](macro@widget#layout-1).
+///
+/// # Example
+///
+/// ```
+/// let my_widget = float! [
+///     pack!(top, button("one")),
+///     "two"
+/// ];
+/// ```
+#[proc_macro_error]
+#[proc_macro]
+pub fn float(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input with make_layout::Tree::float).expand_layout("_Float")
+}
+
+/// Make an align widget
+///
+/// This is a small wrapper which adjusts the alignment of its contents.
+///
+/// The alignment specifier may be one or two keywords (space-separated,
+/// horizontal component first): `default`, `center`, `stretch`, `left`,
+/// `right`, `top`, `bottom`.
+///
+/// # Example
+///
+/// ```
+/// let a = align!(right, "132");
+/// let b = align!(left top, "abc");
+/// ```
+#[proc_macro_error]
+#[proc_macro]
+pub fn align(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input with make_layout::Tree::align).expand_layout("_Align")
+}
+
+/// Make a pack widget
+///
+/// This is a small wrapper which adjusts the alignment of its contents and
+/// prevents its contents from stretching.
+///
+/// The alignment specifier may be one or two keywords (space-separated,
+/// horizontal component first): `default`, `center`, `stretch`, `left`,
+/// `right`, `top`, `bottom`.
+///
+/// # Example
+///
+/// ```
+/// let my_widget = pack!(right top, "132");
+/// ```
+#[proc_macro_error]
+#[proc_macro]
+pub fn pack(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input with make_layout::Tree::pack).expand_layout("_Pack")
+}
+
 /// A trait implementation is an extension over some base
 ///
 /// Usage as follows:

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -630,6 +630,51 @@ pub fn pack(input: TokenStream) -> TokenStream {
     parse_macro_input!(input with make_layout::Tree::pack).expand_layout("_Pack")
 }
 
+/// Make a margin-adjustment widget wrapper
+///
+/// This is a small wrapper which adjusts the margins of its contents.
+///
+/// The alignment specifier may be one or two keywords (space-separated,
+/// horizontal component first): `default`, `center`, `stretch`, `left`,
+/// `right`, `top`, `bottom`.
+///
+/// # Example
+///
+/// ```
+/// let a = margins!(1em, "abc");
+/// let b = margins!(vert = none, "abc");
+/// ```
+///
+/// # Syntax
+///
+/// The macro takes one of two forms:
+///
+/// > _Margins_:\
+/// > &nbsp;&nbsp; `margins!` `(` _MarginSpec_ `,` _Layout_ `)`\
+/// > &nbsp;&nbsp; `margins!` `(` _MarginDirection_ `=` _MarginSpec_ `,` _Layout_ `)`\
+/// >
+/// > _MarginDirection_ :\
+/// > &nbsp;&nbsp; `horiz` | `horizontal` | `vert` | `vertical` | `left` | `right` | `top` | `bottom`
+/// >
+/// > _MarginSpec_ :\
+/// > &nbsp;&nbsp; ( _LitFloat_ `px` ) | ( _LitFloat_ `em` ) | `none` | `inner` | `tiny` | `small` | `large` | `text`
+///
+/// | _MarginSpec_ | Description (guide size; theme-specified sizes may vary and may not scale linearly) |
+/// | --- | --- |
+/// | `none` | No margin (`0px`) |
+/// | `inner` | A very tiny theme-specified margin sometimes used to draw selection outlines (`1px`) |
+/// | `tiny` | A very small theme-specified margin (`2px`) |
+/// | `small` | A small theme-specified margin (`4px`) |
+/// | `large`| A large theme-specified margin (`7px`) |
+/// | `text` | Text-specific margins; often asymmetric |
+/// | _LitFloat_ `em` (e.g. `1.2 em`) | Using the typographic unit Em (`1Em` is the text height, excluding ascender and descender) |
+/// | _LitFloat_ `px` (e.g. `5.0 px`) | Using virtual pixels (affected by the scale factor) |
+#[proc_macro_error]
+#[proc_macro]
+pub fn margins(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input with make_layout::Tree::margins).expand_layout("_Margins")
+}
+
 /// A trait implementation is an extension over some base
 ///
 /// Usage as follows:

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -274,7 +274,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; Replaces margins of a layout item.
 /// >
 /// > _NonNavigable_ :\
-/// > &nbsp;&nbsp; `non_navigable` `:` _Layout_ \
+/// > &nbsp;&nbsp; `non_navigable!` `(` _Layout_ `)` \
 /// > &nbsp;&nbsp; Does not affect layout. Specifies that the content is excluded from tab-navigation order.
 ///
 /// Additional syntax rules (not layout items):

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -226,15 +226,15 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; A list of children, e.g. `row! ["Foo", self.foo]`.
 /// >
 /// > _List_ :\
-/// > &nbsp;&nbsp; `list` `(` _Direction_ `)` _Storage_? `:` `[` ( _Layout_ `,`? ) * `]`\
-/// > &nbsp;&nbsp; A list of children, e.g. ``list(up): ..` or `list(self.direction()): ..`
+/// > &nbsp;&nbsp; `list!` _Storage_? `(` _Direction_ `,` `[` ( _Layout_ `,`? ) * `]` `)`\
+/// > &nbsp;&nbsp; A list of children, e.g. `list!(up, [..])` or `list!(self.direction(), [..])`
 /// >
 /// > _AlignedList_ :\
 /// > &nbsp;&nbsp; ( `aligned_column!` | `aligned_row!` ) _Storage_? `[` ( _Layout_ `,`? ) * `]`\
 /// > &nbsp;&nbsp; Inner component must be `row` or `column`, e.g.: `aligned_column! [row! ["One", "Two"], row! ["Three", "Four"]]`. This is syntactic sugar for a grid layout.
 /// >
 /// > _Slice_ :\
-/// > &nbsp;&nbsp; `slice` `(` _Direction_ `)` _Storage_? `:` `self` `.` _Member_\
+/// > &nbsp;&nbsp; `slice!` _Storage_? `(` _Direction_ `,` `self` `.` _Member_ `)`\
 /// > &nbsp;&nbsp; A field with type `[W]` for some `W: Widget`
 /// >
 /// > _Grid_ :\

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -463,6 +463,31 @@ pub fn widget_index(input: TokenStream) -> TokenStream {
     input
 }
 
+/// Make a column widget
+///
+/// Items support [widget layout syntax](macro@widget#layout-1).
+///
+/// # Example
+///
+/// ```
+/// let my_widget = column! [
+///     "one",
+///     "two",
+/// ];
+/// ```
+#[proc_macro_error]
+#[proc_macro]
+pub fn column(input: TokenStream) -> TokenStream {
+    let layout = parse_macro_input!(input with make_layout::Tree::column);
+    match layout.expand_as_widget("_Column") {
+        Ok(toks) => toks.into(),
+        Err(err) => {
+            emit_call_site_error!(err);
+            TokenStream::default()
+        }
+    }
+}
+
 /// A trait implementation is an extension over some base
 ///
 /// Usage as follows:

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -590,6 +590,42 @@ pub fn grid(input: TokenStream) -> TokenStream {
     parse_macro_input!(input with make_layout::Tree::grid).expand_layout("_Grid")
 }
 
+/// Make an aligned column widget
+///
+/// Items support [widget layout syntax](macro@widget#layout-1).
+///
+/// # Example
+///
+/// ```
+/// let my_widget = aligned_column! [
+///     row!["one", "two"],
+///     row!["three", "four"],
+/// ];
+/// ```
+#[proc_macro_error]
+#[proc_macro]
+pub fn aligned_column(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input with make_layout::Tree::aligned_column).expand_layout("_AlignedColumn")
+}
+
+/// Make an aligned row widget
+///
+/// Items support [widget layout syntax](macro@widget#layout-1).
+///
+/// # Example
+///
+/// ```
+/// let my_widget = aligned_row! [
+///     row!["one", "two"],
+///     row!["three", "four"],
+/// ];
+/// ```
+#[proc_macro_error]
+#[proc_macro]
+pub fn aligned_row(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input with make_layout::Tree::aligned_row).expand_layout("_AlignedRow")
+}
+
 /// Make an align widget
 ///
 /// This is a small wrapper which adjusts the alignment of its contents.

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -221,13 +221,17 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; `self` `.` _Member_\
 /// > &nbsp;&nbsp; A named child: `self.foo` (more precisely, this matches any expression starting `self`, and uses `&mut (#expr)`)
 /// >
+/// > _SimpleList_ :\
+/// > &nbsp;&nbsp; ( `column!` | `row!` ) _Storage_? `[` ( _Layout_ `,`? ) * `]`\
+/// > &nbsp;&nbsp; A list of children, e.g. `row! ["Foo", self.foo]`.
+/// >
 /// > _List_ :\
-/// > &nbsp;&nbsp; ( `column` | `row` | `list` `(` _Direction_ `)` ) _Storage_? `:` `[` ( _Layout_ `,`? ) * `]`\
-/// > &nbsp;&nbsp; A list of children, e.g. `row: ["Foo", self.foo]` or `list(up): ..` or `list(self.direction()): ..`
+/// > &nbsp;&nbsp; `list` `(` _Direction_ `)` _Storage_? `:` `[` ( _Layout_ `,`? ) * `]`\
+/// > &nbsp;&nbsp; A list of children, e.g. ``list(up): ..` or `list(self.direction()): ..`
 /// >
 /// > _AlignedList_ :\
-/// > &nbsp;&nbsp; ( `aligned_column` | `aligned_row` ) _Storage_? `:` `[` ( _Layout_ `,`? ) * `]`\
-/// > &nbsp;&nbsp; Inner component must be `row` or `column`, e.g.: `aligned_column: [row: ["One", "Two"], row: ["Three", "Four"]]`. This is syntactic sugar for a grid layout.
+/// > &nbsp;&nbsp; ( `aligned_column!` | `aligned_row!` ) _Storage_? `[` ( _Layout_ `,`? ) * `]`\
+/// > &nbsp;&nbsp; Inner component must be `row` or `column`, e.g.: `aligned_column! [row! ["One", "Two"], row! ["Three", "Four"]]`. This is syntactic sugar for a grid layout.
 /// >
 /// > _Slice_ :\
 /// > &nbsp;&nbsp; `slice` `(` _Direction_ `)` _Storage_? `:` `self` `.` _Member_\
@@ -238,7 +242,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; A two-dimensional layout, supporting cell spans, defined via a list of cells (see _GridCell_ below).
 ///
 /// > _Float_ :\
-/// > &nbsp;&nbsp; `float` `:` `[` ( _Layout_ `,`? ) * `]`\
+/// > &nbsp;&nbsp; `float!` `[` ( _Layout_ `,`? ) * `]`\
 /// > &nbsp;&nbsp; A stack of overlapping elements, top-most first.
 ///
 /// > _Align_ :\
@@ -337,7 +341,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// A simple row layout: `layout = row: [self.a, self.b];`
+/// A simple row layout: `layout = row! [self.a, self.b];`
 ///
 /// Grid cells are defined by `row, column` ranges, where the ranges are either
 /// a half-open range or a single number (who's end is implicitly `start + 1`).

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -515,6 +515,8 @@ pub fn row(input: TokenStream) -> TokenStream {
 ///
 /// This is a more generic variant of [`column`] and [`row`].
 ///
+/// Children are navigated in visual order.
+///
 /// Items support [widget layout syntax](macro@widget#layout-1).
 ///
 /// # Example
@@ -530,9 +532,16 @@ pub fn list(input: TokenStream) -> TokenStream {
 
 /// Make a float widget
 ///
-/// Widgets overlap with the first being on top. Most widgets stretch to fill
-/// all available space by default which will hide those below; to counteract
-/// this use [`pack`].
+/// All children occupy the same space with the first child on top.
+///
+/// Size is determined as the maximum required by any child for each axis.
+/// All children are assigned this size. It is usually necessary to use [`pack`]
+/// or a similar mechanism to constrain a child to avoid it hiding the content
+/// underneath (note that even if an unconstrained child does not *visually*
+/// hide everything beneath, it may still "occupy" the assigned area, preventing
+/// mouse clicks from reaching the widget beneath).
+///
+/// Children are navigated in order of declaration.
 ///
 /// Items support [widget layout syntax](macro@widget#layout-1).
 ///
@@ -540,14 +549,45 @@ pub fn list(input: TokenStream) -> TokenStream {
 ///
 /// ```
 /// let my_widget = float! [
-///     pack!(top, button("one")),
-///     "two"
+///     pack!(left top, "one"),
+///     pack!(right bottom, "two"),
+///     "some text\nin the\nbackground"
 /// ];
 /// ```
 #[proc_macro_error]
 #[proc_macro]
 pub fn float(input: TokenStream) -> TokenStream {
     parse_macro_input!(input with make_layout::Tree::float).expand_layout("_Float")
+}
+
+/// Make a grid widget
+///
+/// Constructs a table with auto-determined number of rows and columns.
+/// Each child is assigned a cell using match-like syntax.
+///
+/// A child may be stretched across multiple cells using range-like syntax:
+/// `3..5`, `3..=4` and `3..+2` are all equivalent.
+///
+/// Behaviour of overlapping widgets is identical to [`float`]: the first
+/// declared item is on top.
+///
+/// Children are navigated in order of declaration.
+///
+/// Items support [widget layout syntax](macro@widget#layout-1).
+///
+/// # Example
+///
+/// ```
+/// let my_widget = grid! {
+///     (0, 0) => "top left",
+///     (1, 0) => "top right",
+///     (0..2, 1) => "bottom row (merged)",
+/// };
+/// ```
+#[proc_macro_error]
+#[proc_macro]
+pub fn grid(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input with make_layout::Tree::grid).expand_layout("_Grid")
 }
 
 /// Make an align widget

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -246,11 +246,11 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; A stack of overlapping elements, top-most first.
 ///
 /// > _Align_ :\
-/// > &nbsp;&nbsp; `align` `(` _AlignType_ ( `,` _AlignType_ )? `)` `:` _Layout_\
-/// > &nbsp;&nbsp; Applies some alignment to a sub-layout, e.g. `align(top): self.foo`. Two-dimensional alignment is possible but must be horizontal first, e.g. `align(left, top): ..`. Note: this does not constrain the size of the widget but merely adjusts content alignment; see also _Pack_.
+/// > &nbsp;&nbsp; `align!` `(` _AlignType_ _AlignType_? `,` _Layout_ `)`\
+/// > &nbsp;&nbsp; Applies some alignment to a sub-layout, e.g. `align!(top, self.foo)`. Two-dimensional alignment is possible but must be horizontal first, e.g. `align!(left top, "content")`. Note: this does not constrain the size of the widget but merely adjusts content alignment; see also _Pack_.
 /// >
 /// > _Pack_ :\
-/// > &nbsp;&nbsp; `pack` `(` _AlignType_ ( `,` _AlignType_ )? `)` _Storage_? `:` _Layout_\
+/// > &nbsp;&nbsp; `pack!` _Storage_? `(` _AlignType_ _AlignType_ ? `,` _Layout_ `)`\
 /// > &nbsp;&nbsp; As `align`, this applies some alignment to content, but also restricts the size of that content to its ideal size (i.e. no stretching).
 /// >
 /// > _Frame_ :\

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -257,7 +257,8 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; The name of a struct field or an index into a tuple struct.
 /// >
 /// > _Direction_ :\
-/// > &nbsp;&nbsp; `left` | `right` | `up` | `down` | _Expr_
+/// > &nbsp;&nbsp; `left` | `right` | `up` | `down` | _Expr_:\
+/// > &nbsp;&nbsp; Note that an _Expr_ must start with `self`
 /// >
 /// > _Storage_ :\
 /// > &nbsp;&nbsp; `'` _Ident_\
@@ -337,10 +338,11 @@ pub fn widget(_: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Example:
 /// ```
+/// # use kas_macros as kas;
 /// use std::fmt;
 /// fn main() {
 ///     let world = "world";
-///     let says_hello_world = kas_macros::singleton! {
+///     let says_hello_world = kas::singleton! {
 ///         struct(&'static str = world);
 ///         impl fmt::Display for Self {
 ///             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -427,8 +429,8 @@ impl ExpandLayout for make_layout::Tree {
 ///
 /// # Example
 ///
-/// ```
-/// let my_widget = column! [
+/// ```ignore
+/// let my_widget = kas::column! [
 ///     "one",
 ///     "two",
 /// ];
@@ -445,8 +447,8 @@ pub fn column(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```
-/// let my_widget = row! ["one", "two"];
+/// ```ignore
+/// let my_widget = kas::row! ["one", "two"];
 /// ```
 #[proc_macro_error]
 #[proc_macro]
@@ -464,9 +466,18 @@ pub fn row(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
+/// ```ignore
+/// let my_widget = kas::list!(left, ["one", "two"]);
 /// ```
-/// let my_widget = list!(kas::Direction::Left, ["one", "two"]);
-/// ```
+///
+/// # Syntax
+///
+/// > _List_ :\
+/// > &nbsp;&nbsp; `list!` `(` _Direction_ `,` `[` ( _Layout_ `,` )* ( _Layout_ `,`? )? `]` `}`
+/// >
+/// > _Direction_ :\
+/// > &nbsp;&nbsp; `left` | `right` | `up` | `down`
+
 #[proc_macro_error]
 #[proc_macro]
 pub fn list(input: TokenStream) -> TokenStream {
@@ -490,8 +501,8 @@ pub fn list(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```
-/// let my_widget = float! [
+/// ```ignore
+/// let my_widget = kas::float! [
 ///     pack!(left top, "one"),
 ///     pack!(right bottom, "two"),
 ///     "some text\nin the\nbackground"
@@ -520,8 +531,8 @@ pub fn float(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```
-/// let my_widget = grid! {
+/// ```ignore
+/// let my_widget = kas::grid! {
 ///     (0, 0) => "top left",
 ///     (1, 0) => "top right",
 ///     (0..2, 1) => "bottom row (merged)",
@@ -554,8 +565,8 @@ pub fn grid(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```
-/// let my_widget = aligned_column! [
+/// ```ignore
+/// let my_widget = kas::aligned_column! [
 ///     row!["one", "two"],
 ///     row!["three", "four"],
 /// ];
@@ -572,10 +583,10 @@ pub fn aligned_column(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```
-/// let my_widget = aligned_row! [
-///     row!["one", "two"],
-///     row!["three", "four"],
+/// ```ignore
+/// let my_widget = kas::aligned_row! [
+///     column!["one", "two"],
+///     column!["three", "four"],
 /// ];
 /// ```
 #[proc_macro_error]
@@ -594,9 +605,9 @@ pub fn aligned_row(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```
-/// let a = align!(right, "132");
-/// let b = align!(left top, "abc");
+/// ```ignore
+/// let a = kas::align!(right, "132");
+/// let b = kas::align!(left top, "abc");
 /// ```
 #[proc_macro_error]
 #[proc_macro]
@@ -615,8 +626,8 @@ pub fn align(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```
-/// let my_widget = pack!(right top, "132");
+/// ```ignore
+/// let my_widget = kas::pack!(right top, "132");
 /// ```
 #[proc_macro_error]
 #[proc_macro]
@@ -631,8 +642,8 @@ pub fn pack(input: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```ignore
-/// let a = margins!(1.0 em, "abc");
-/// let b = margins!(vert = none, "abc");
+/// let a = kas::margins!(1.0 em, "abc");
+/// let b = kas::margins!(vert = none, "abc");
 /// ```
 ///
 /// # Syntax

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -217,41 +217,18 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// implementation of `Widget::nav_next`, with a couple of exceptions
 /// (where macro-time analysis is insufficient to implement this method).
 ///
+/// > [_Column_](macro@column), [_Row_](macro@row), [_List_](macro@list), [_AlignedColumn_](macro@aligned_column), [_AlignedRow_](macro@aligned_row), [_Grid_](macro@grid), [_Float_](macro@float), [_Align_](macro@align), [_Pack_](macro@pack), [_Margins_](macro@margins) :\
+/// > &nbsp;&nbsp; These stand-alone macros are explicitly supported in this position.\
+/// > &nbsp;&nbsp; Optionally, a _Storage_ specifier is supported immediately after the macro name, e.g.\
+/// > &nbsp;&nbsp; `column! 'storage_name ["one", "two"]`
+///
 /// > _Single_ :\
 /// > &nbsp;&nbsp; `self` `.` _Member_\
 /// > &nbsp;&nbsp; A named child: `self.foo` (more precisely, this matches any expression starting `self`, and uses `&mut (#expr)`)
 /// >
-/// > _SimpleList_ :\
-/// > &nbsp;&nbsp; ( `column!` | `row!` ) _Storage_? `[` ( _Layout_ `,`? ) * `]`\
-/// > &nbsp;&nbsp; A list of children, e.g. `row! ["Foo", self.foo]`.
-/// >
-/// > _List_ :\
-/// > &nbsp;&nbsp; `list!` _Storage_? `(` _Direction_ `,` `[` ( _Layout_ `,`? ) * `]` `)`\
-/// > &nbsp;&nbsp; A list of children, e.g. `list!(up, [..])` or `list!(self.direction(), [..])`
-/// >
-/// > _AlignedList_ :\
-/// > &nbsp;&nbsp; ( `aligned_column!` | `aligned_row!` ) _Storage_? `[` ( _Layout_ `,`? ) * `]`\
-/// > &nbsp;&nbsp; Inner component must be `row` or `column`, e.g.: `aligned_column! [row! ["One", "Two"], row! ["Three", "Four"]]`. This is syntactic sugar for a grid layout.
-/// >
 /// > _Slice_ :\
 /// > &nbsp;&nbsp; `slice!` _Storage_? `(` _Direction_ `,` `self` `.` _Member_ `)`\
 /// > &nbsp;&nbsp; A field with type `[W]` for some `W: Widget`
-/// >
-/// > _Grid_ :\
-/// > &nbsp;&nbsp; `grid!` _Storage_? `{` _GridCell_* `}`\
-/// > &nbsp;&nbsp; A two-dimensional layout, supporting cell spans, defined via a list of cells (see _GridCell_ below).
-///
-/// > _Float_ :\
-/// > &nbsp;&nbsp; `float!` `[` ( _Layout_ `,`? ) * `]`\
-/// > &nbsp;&nbsp; A stack of overlapping elements, top-most first.
-///
-/// > _Align_ :\
-/// > &nbsp;&nbsp; `align!` `(` _AlignType_ _AlignType_? `,` _Layout_ `)`\
-/// > &nbsp;&nbsp; Applies some alignment to a sub-layout, e.g. `align!(top, self.foo)`. Two-dimensional alignment is possible but must be horizontal first, e.g. `align!(left top, "content")`. Note: this does not constrain the size of the widget but merely adjusts content alignment; see also _Pack_.
-/// >
-/// > _Pack_ :\
-/// > &nbsp;&nbsp; `pack!` _Storage_? `(` _AlignType_ _AlignType_ ? `,` _Layout_ `)`\
-/// > &nbsp;&nbsp; As `align`, this applies some alignment to content, but also restricts the size of that content to its ideal size (i.e. no stretching).
 /// >
 /// > _Frame_ :\
 /// > &nbsp;&nbsp; `frame!` _Storage_? `(` _Layout_ ( `,` `style` `=` _Expr_ )? `)`\
@@ -268,10 +245,6 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > _Label_ :\
 /// > &nbsp;&nbsp; _StrLit_\
 /// > &nbsp;&nbsp; A string literal generates a label widget, e.g. "Hello world". This is an internal type without text wrapping.
-/// >
-/// > _Margins:\
-/// > &nbsp;&nbsp; `margins!` `(` ( _MarginDirection_ `=` )? _MarginSpec_ `,` _Layout_ `)`\
-/// > &nbsp;&nbsp; Replaces margins of a layout item.
 /// >
 /// > _NonNavigable_ :\
 /// > &nbsp;&nbsp; `non_navigable!` `(` _Layout_ `)` \

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -270,7 +270,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; A string literal generates a label widget, e.g. "Hello world". This is an internal type without text wrapping.
 /// >
 /// > _Margins:\
-/// > &nbsp;&nbsp; `margins` `(` ( _MarginDirection_ `=` )? _MarginSpec_ `)` `:` _Layout_\
+/// > &nbsp;&nbsp; `margins!` `(` ( _MarginDirection_ `=` )? _MarginSpec_ `,` _Layout_ `)`\
 /// > &nbsp;&nbsp; Replaces margins of a layout item.
 /// >
 /// > _NonNavigable_ :\

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -238,11 +238,11 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; `button!` _Storage_? `(` _Layout_ ( `,` `color` `=` _Expr_ )? `)`\
 /// > &nbsp;&nbsp; Adds a button frame (optionally with color _Expr_) around content.
 /// >
-/// > _Widget_ :\
+/// > _WidgetConstructor_ :\
 /// > &nbsp;&nbsp; _Expr_\
 /// > &nbsp;&nbsp; An expression yielding a widget, e.g. `Label::new("Hello world")`. The result must be an object of some type `W: Widget`.
 /// >
-/// > _Label_ :\
+/// > _LabelLit_ :\
 /// > &nbsp;&nbsp; _StrLit_\
 /// > &nbsp;&nbsp; A string literal generates a label widget, e.g. "Hello world". This is an internal type without text wrapping.
 /// >
@@ -258,24 +258,6 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// >
 /// > _Direction_ :\
 /// > &nbsp;&nbsp; `left` | `right` | `up` | `down` | _Expr_
-/// >
-/// > _MarginDirection_ :\
-/// > &nbsp;&nbsp; `horiz` | `horizontal` | `vert` | `vertical` | `left` | `right` | `top` | `bottom`\
-/// > &nbsp;&nbsp; Restricts margin replacement to this axis / side.
-/// >
-/// > _MarginSpec_ :\
-/// > &nbsp;&nbsp; ( _LitFloat_ `px` ) | ( _LitFloat_ `em` ) | `none` | `inner` | `tiny` | `small` | `large` | `text`\
-/// > &nbsp;&nbsp; Margin size in pixels (scaled) or Em (font unit) or a set size (see `MarginStyle`).
-/// >
-/// > _GridCell_ :\
-/// > &nbsp;&nbsp; `(` _CellRange_ `,` _CellRange_ `)` `=>` ( _Layout_ | `{` _Layout_ `}` )\
-/// > &nbsp;&nbsp; Cells are specified using `match`-like syntax from `(col_spec, row_spec)` to a layout, e.g.: `(1, 0) => self.foo`. Spans are specified via range syntax, e.g. `(0..2, 1) => self.bar`.
-/// >
-/// > _CellRange_ :\
-/// > &nbsp;&nbsp; _LitInt_ ( `..` `+`? _LitInt_ )?
-/// >
-/// > _AlignType_ :\
-/// > &nbsp;&nbsp; `default` | `center` | `stretch` | `top` | `bottom` | `left` | `right`
 /// >
 /// > _Storage_ :\
 /// > &nbsp;&nbsp; `'` _Ident_\
@@ -315,18 +297,6 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// A simple row layout: `layout = row! [self.a, self.b];`
-///
-/// Grid cells are defined by `row, column` ranges, where the ranges are either
-/// a half-open range or a single number (who's end is implicitly `start + 1`).
-///
-/// ```ignore
-/// layout = grid! {
-///     (0..2, 0) => self.merged_title,
-///     (0, 1) => self.a,
-///     (1, 1) => self.b,
-///     (1, 2) => self.c,
-/// };
-/// ```
 ///
 /// ## Derive
 ///
@@ -486,7 +456,7 @@ pub fn row(input: TokenStream) -> TokenStream {
 
 /// Make a list widget
 ///
-/// This is a more generic variant of [`column`] and [`row`].
+/// This is a more generic variant of [`column!`] and [`row!`].
 ///
 /// Children are navigated in visual order.
 ///
@@ -508,7 +478,7 @@ pub fn list(input: TokenStream) -> TokenStream {
 /// All children occupy the same space with the first child on top.
 ///
 /// Size is determined as the maximum required by any child for each axis.
-/// All children are assigned this size. It is usually necessary to use [`pack`]
+/// All children are assigned this size. It is usually necessary to use [`pack!`]
 /// or a similar mechanism to constrain a child to avoid it hiding the content
 /// underneath (note that even if an unconstrained child does not *visually*
 /// hide everything beneath, it may still "occupy" the assigned area, preventing
@@ -541,7 +511,7 @@ pub fn float(input: TokenStream) -> TokenStream {
 /// A child may be stretched across multiple cells using range-like syntax:
 /// `3..5`, `3..=4` and `3..+2` are all equivalent.
 ///
-/// Behaviour of overlapping widgets is identical to [`float`]: the first
+/// Behaviour of overlapping widgets is identical to [`float!`]: the first
 /// declared item is on top.
 ///
 /// Children are navigated in order of declaration.
@@ -557,6 +527,21 @@ pub fn float(input: TokenStream) -> TokenStream {
 ///     (0..2, 1) => "bottom row (merged)",
 /// };
 /// ```
+///
+/// # Syntax
+///
+/// > _Grid_ :\
+/// > &nbsp;&nbsp; `grid!` `{` _GridCell_* `}`
+/// >
+/// > _GridCell_ :\
+/// > &nbsp;&nbsp; `(` _CellRange_ `,` _CellRange_ `)` `=>` ( _Layout_ | `{` _Layout_ `}` )
+/// >
+/// > _CellRange_ :\
+/// > &nbsp;&nbsp; _LitInt_ ( `..` `+`? _LitInt_ )?
+///
+/// Cells are specified using `match`-like syntax from `(col_spec, row_spec)` to
+/// a layout, e.g.: `(1, 0) => self.foo`. Spans are specified via range syntax,
+/// e.g. `(0..2, 1) => self.bar`.
 #[proc_macro_error]
 #[proc_macro]
 pub fn grid(input: TokenStream) -> TokenStream {
@@ -643,14 +628,10 @@ pub fn pack(input: TokenStream) -> TokenStream {
 ///
 /// This is a small wrapper which adjusts the margins of its contents.
 ///
-/// The alignment specifier may be one or two keywords (space-separated,
-/// horizontal component first): `default`, `center`, `stretch`, `left`,
-/// `right`, `top`, `bottom`.
-///
 /// # Example
 ///
-/// ```
-/// let a = margins!(1em, "abc");
+/// ```ignore
+/// let a = margins!(1.0 em, "abc");
 /// let b = margins!(vert = none, "abc");
 /// ```
 ///

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -238,7 +238,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; A field with type `[W]` for some `W: Widget`
 /// >
 /// > _Grid_ :\
-/// > &nbsp;&nbsp; `grid` _Storage_? `:` `{` _GridCell_* `}`\
+/// > &nbsp;&nbsp; `grid!` _Storage_? `{` _GridCell_* `}`\
 /// > &nbsp;&nbsp; A two-dimensional layout, supporting cell spans, defined via a list of cells (see _GridCell_ below).
 ///
 /// > _Float_ :\
@@ -295,8 +295,8 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; Margin size in pixels (scaled) or Em (font unit) or a set size (see `MarginStyle`).
 /// >
 /// > _GridCell_ :\
-/// > &nbsp;&nbsp; _CellRange_ `,` _CellRange_ `:` _Layout_\
-/// > &nbsp;&nbsp; Cell location in the order `(col, row)`, e.g.: `1, 0: self.foo`. Spans are specified via range syntax, e.g. `0..2, 1: self.bar`.
+/// > &nbsp;&nbsp; `(` _CellRange_ `,` _CellRange_ `)` `=>` ( _Layout_ | `{` _Layout_ `}` )\
+/// > &nbsp;&nbsp; Cells are specified using `match`-like syntax from `(col_spec, row_spec)` to a layout, e.g.: `(1, 0) => self.foo`. Spans are specified via range syntax, e.g. `(0..2, 1) => self.bar`.
 /// >
 /// > _CellRange_ :\
 /// > &nbsp;&nbsp; _LitInt_ ( `..` `+`? _LitInt_ )?
@@ -347,11 +347,11 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// a half-open range or a single number (who's end is implicitly `start + 1`).
 ///
 /// ```ignore
-/// layout = grid: {
-///     0..2, 0: self.merged_title;
-///     0, 1: self.a;
-///     1, 1: self.b;
-///     1, 2: self.c;
+/// layout = grid! {
+///     (0..2, 0) => self.merged_title,
+///     (0, 1) => self.a,
+///     (1, 1) => self.b,
+///     (1, 2) => self.c,
 /// };
 /// ```
 ///

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -209,6 +209,41 @@ impl Tree {
         let list = parse_layout_list(&input, &mut gen)?;
         Ok(Tree(Layout::List(stor, dir, list)))
     }
+
+    /// Parse a float (contents only)
+    pub fn float(input: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+        let list = parse_layout_items(input, &mut gen)?;
+        Ok(Tree(Layout::Float(list)))
+    }
+
+    /// Parse align (contents only)
+    // TODO: use WithAlign adapter?
+    pub fn align(inner: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+
+        let align = parse_align(&inner)?;
+        let _: Token![,] = inner.parse()?;
+
+        Ok(Tree(if inner.peek(Token![self]) {
+            Layout::AlignSingle(inner.parse()?, align)
+        } else {
+            let layout = Layout::parse(&inner, &mut gen)?;
+            Layout::Align(Box::new(layout), align)
+        }))
+    }
+
+    /// Parse pack (contents only)
+    pub fn pack(inner: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+        let stor = gen.next();
+
+        let align = parse_align(&inner)?;
+        let _: Token![,] = inner.parse()?;
+
+        let layout = Layout::parse(&inner, &mut gen)?;
+        Ok(Tree(Layout::Pack(stor, Box::new(layout), align)))
+    }
 }
 
 #[derive(Debug)]

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -489,8 +489,10 @@ impl Layout {
             let _: kw::slice = input.parse()?;
             let _: Token![!] = input.parse()?;
             let stor = gen.parse_or_next(input)?;
+
             let inner;
             let _ = parenthesized!(inner in input);
+
             let dir: Direction = inner.parse()?;
             let _: Token![,] = inner.parse()?;
             if inner.peek(Token![self]) {
@@ -505,8 +507,11 @@ impl Layout {
             Ok(parse_grid(stor, input, gen)?)
         } else if lookahead.peek(kw::non_navigable) {
             let _: kw::non_navigable = input.parse()?;
-            let _: Token![:] = input.parse()?;
-            let layout = Layout::parse(input, gen)?;
+            let _: Token![!] = input.parse()?;
+
+            let inner;
+            let _ = parenthesized!(inner in input);
+            let layout = Layout::parse(&inner, gen)?;
             Ok(Layout::NonNavigable(Box::new(layout)))
         } else if lookahead.peek(LitStr) {
             let stor = gen.next();

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -368,16 +368,16 @@ impl Layout {
             Ok(Layout::Button(stor, Box::new(layout), color))
         } else if lookahead.peek(kw::column) {
             let _: kw::column = input.parse()?;
+            let _: Token![!] = input.parse()?;
             let dir = Direction::Down;
             let stor = gen.parse_or_next(input)?;
-            let _: Token![:] = input.parse()?;
             let list = parse_layout_list(input, gen)?;
             Ok(Layout::List(stor, dir, list))
         } else if lookahead.peek(kw::row) {
             let _: kw::row = input.parse()?;
+            let _: Token![!] = input.parse()?;
             let dir = Direction::Right;
             let stor = gen.parse_or_next(input)?;
-            let _: Token![:] = input.parse()?;
             let list = parse_layout_list(input, gen)?;
             Ok(Layout::List(stor, dir, list))
         } else if lookahead.peek(kw::list) {
@@ -391,20 +391,20 @@ impl Layout {
             Ok(Layout::List(stor, dir, list))
         } else if lookahead.peek(kw::float) {
             let _: kw::float = input.parse()?;
-            let _: Token![:] = input.parse()?;
+            let _: Token![!] = input.parse()?;
             let list = parse_layout_list(input, gen)?;
             Ok(Layout::Float(list))
         } else if lookahead.peek(kw::aligned_column) {
             let _: kw::aligned_column = input.parse()?;
+            let _: Token![!] = input.parse()?;
             let stor = gen.parse_or_next(input)?;
-            let _: Token![:] = input.parse()?;
             Ok(parse_grid_as_list_of_lists::<kw::row>(
                 stor, input, gen, true,
             )?)
         } else if lookahead.peek(kw::aligned_row) {
             let _: kw::aligned_row = input.parse()?;
+            let _: Token![!] = input.parse()?;
             let stor = gen.parse_or_next(input)?;
-            let _: Token![:] = input.parse()?;
             Ok(parse_grid_as_list_of_lists::<kw::column>(
                 stor, input, gen, false,
             )?)
@@ -544,7 +544,7 @@ fn parse_grid_as_list_of_lists<KW: Parse>(
 
     while !inner.is_empty() {
         let _ = inner.parse::<KW>()?;
-        let _ = inner.parse::<Token![:]>()?;
+        let _ = inner.parse::<Token![!]>()?;
 
         let inner2;
         let _ = bracketed!(inner2 in inner);

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -200,6 +200,24 @@ impl Tree {
         Ok(Tree(Layout::List(stor, Direction::Right, list)))
     }
 
+    /// Parse an aligned column (contents only)
+    pub fn aligned_column(input: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+        let stor = gen.next();
+        Ok(Tree(parse_grid_as_list_of_lists::<kw::row>(
+            stor, input, &mut gen, true,
+        )?))
+    }
+
+    /// Parse an aligned row (contents only)
+    pub fn aligned_row(input: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+        let stor = gen.next();
+        Ok(Tree(parse_grid_as_list_of_lists::<kw::column>(
+            stor, input, &mut gen, false,
+        )?))
+    }
+
     /// Parse direction, list
     pub fn list(input: ParseStream) -> Result<Self> {
         let mut gen = NameGenerator::default();

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -38,6 +38,8 @@ mod kw {
     custom_keyword!(non_navigable);
     custom_keyword!(px);
     custom_keyword!(em);
+    custom_keyword!(style);
+    custom_keyword!(color);
 }
 
 #[derive(Debug)]
@@ -402,28 +404,43 @@ impl Layout {
             Ok(Layout::Single(input.parse()?))
         } else if lookahead.peek(kw::frame) {
             let _: kw::frame = input.parse()?;
-            let style: Expr = if input.peek(syn::token::Paren) {
-                let inner;
-                let _ = parenthesized!(inner in input);
-                inner.parse()?
-            } else {
-                syn::parse_quote! { ::kas::theme::FrameStyle::Frame }
-            };
+            let _: Token![!] = input.parse()?;
             let stor = gen.parse_or_next(input)?;
-            let _: Token![:] = input.parse()?;
-            let layout = Layout::parse(input, gen)?;
+
+            let inner;
+            let _ = parenthesized!(inner in input);
+            let layout = Layout::parse(&inner, gen)?;
+
+            let style: Expr;
+            if !inner.is_empty() {
+                let _: Token![,] = inner.parse()?;
+                let _: kw::style = inner.parse()?;
+                let _: Token![=] = inner.parse()?;
+                style = inner.parse()?;
+            } else {
+                style = syn::parse_quote! { ::kas::theme::FrameStyle::Frame };
+            }
+
             Ok(Layout::Frame(stor, Box::new(layout), style))
         } else if lookahead.peek(kw::button) {
             let _: kw::button = input.parse()?;
-            let mut color: Expr = syn::parse_quote! { None };
-            if input.peek(syn::token::Paren) {
-                let inner;
-                let _ = parenthesized!(inner in input);
-                color = inner.parse()?;
-            }
+            let _: Token![!] = input.parse()?;
             let stor = gen.parse_or_next(input)?;
-            let _: Token![:] = input.parse()?;
-            let layout = Layout::parse(input, gen)?;
+
+            let inner;
+            let _ = parenthesized!(inner in input);
+            let layout = Layout::parse(&inner, gen)?;
+
+            let color: Expr;
+            if !inner.is_empty() {
+                let _: Token![,] = inner.parse()?;
+                let _: kw::color = inner.parse()?;
+                let _: Token![=] = inner.parse()?;
+                color = inner.parse()?;
+            } else {
+                color = syn::parse_quote! { None };
+            }
+
             Ok(Layout::Button(stor, Box::new(layout), color))
         } else if lookahead.peek(kw::column) {
             let _: kw::column = input.parse()?;

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -345,6 +345,8 @@ impl Layout {
             Ok(Layout::Pack(stor, Box::new(layout), align))
         } else if lookahead.peek(kw::margins) {
             let _ = input.parse::<kw::margins>()?;
+            let _: Token![!] = input.parse()?;
+
             let inner;
             let _ = parenthesized!(inner in input);
 
@@ -392,8 +394,9 @@ impl Layout {
                 return Err(lookahead.error());
             };
 
-            let _ = input.parse::<Token![:]>()?;
-            let layout = Layout::parse(input, gen)?;
+            let _ = inner.parse::<Token![,]>()?;
+            let layout = Layout::parse(&inner, gen)?;
+
             Ok(Layout::Margins(Box::new(layout), dirs, margins))
         } else if lookahead.peek(Token![self]) {
             Ok(Layout::Single(input.parse()?))

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -55,8 +55,42 @@ impl Tree {
         }
     }
 
-    pub fn generate(&self, core: &Member) -> Result<Toks> {
-        self.0.generate(core)
+    pub fn layout_methods(&self, core_path: &Toks) -> Result<Toks> {
+        let layout = self.0.generate(core_path)?;
+        Ok(quote! {
+            fn size_rules(
+                &mut self,
+                size_mgr: ::kas::theme::SizeMgr,
+                axis: ::kas::layout::AxisInfo,
+            ) -> ::kas::layout::SizeRules {
+                use ::kas::{WidgetCore, layout};
+                (#layout).size_rules(size_mgr, axis)
+            }
+
+            fn set_rect(
+                &mut self,
+                mgr: &mut ::kas::event::ConfigMgr,
+                rect: ::kas::geom::Rect,
+            ) {
+                use ::kas::{WidgetCore, layout};
+                #core_path.rect = rect;
+                (#layout).set_rect(mgr, rect);
+            }
+
+            fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
+                use ::kas::{layout, Widget, WidgetCore, WidgetExt};
+                if !self.rect().contains(coord) {
+                    return None;
+                }
+                let coord = coord + self.translation();
+                (#layout).find_id(coord).or_else(|| Some(self.id()))
+            }
+
+            fn draw(&mut self, draw: ::kas::theme::DrawMgr) {
+                use ::kas::{WidgetCore, layout};
+                (#layout).draw(draw);
+            }
+        })
     }
 
     pub fn nav_next<'a, I: Clone + ExactSizeIterator<Item = &'a Member>>(
@@ -800,21 +834,21 @@ impl Layout {
     // multi-element layout (list/slice/grid).
     //
     // Required: `::kas::layout` must be in scope.
-    fn generate(&self, core: &Member) -> Result<Toks> {
+    fn generate(&self, core_path: &Toks) -> Result<Toks> {
         Ok(match self {
             Layout::Align(layout, align) => {
-                let inner = layout.generate(core)?;
+                let inner = layout.generate(core_path)?;
                 quote! { layout::Visitor::align(#inner, #align) }
             }
             Layout::AlignSingle(expr, align) => {
                 quote! { layout::Visitor::align_single(&mut #expr, #align) }
             }
             Layout::Pack(stor, layout, align) => {
-                let inner = layout.generate(core)?;
-                quote! { layout::Visitor::pack(&mut self.#core.#stor, #inner, #align) }
+                let inner = layout.generate(core_path)?;
+                quote! { layout::Visitor::pack(&mut #core_path.#stor, #inner, #align) }
             }
             Layout::Margins(layout, dirs, selector) => {
-                let inner = layout.generate(core)?;
+                let inner = layout.generate(core_path)?;
                 quote! { layout::Visitor::margins(
                     #inner,
                     ::kas::dir::Directions::from_bits(#dirs).unwrap(),
@@ -825,36 +859,36 @@ impl Layout {
                 layout::Visitor::single(&mut #expr)
             },
             Layout::Widget(stor, _) => quote! {
-                layout::Visitor::single(&mut self.#core.#stor)
+                layout::Visitor::single(&mut #core_path.#stor)
             },
             Layout::Frame(stor, layout, style) => {
-                let inner = layout.generate(core)?;
+                let inner = layout.generate(core_path)?;
                 quote! {
-                    layout::Visitor::frame(&mut self.#core.#stor, #inner, #style)
+                    layout::Visitor::frame(&mut #core_path.#stor, #inner, #style)
                 }
             }
             Layout::Button(stor, layout, color) => {
-                let inner = layout.generate(core)?;
+                let inner = layout.generate(core_path)?;
                 quote! {
-                    layout::Visitor::button(&mut self.#core.#stor, #inner, #color)
+                    layout::Visitor::button(&mut #core_path.#stor, #inner, #color)
                 }
             }
             Layout::List(stor, dir, list) => {
                 let mut items = Toks::new();
                 for item in list {
-                    let item = item.generate(core)?;
+                    let item = item.generate(core_path)?;
                     items.append_all(quote! {{ #item },});
                 }
                 let iter = quote! { { let arr = [#items]; arr.into_iter() } };
                 quote! {{
                     let dir = #dir;
-                    layout::Visitor::list(#iter, dir, &mut self.#core.#stor)
+                    layout::Visitor::list(#iter, dir, &mut #core_path.#stor)
                 }}
             }
             Layout::Slice(stor, dir, expr) => {
                 quote! {{
                     let dir = #dir;
-                    layout::Visitor::slice(&mut #expr, dir, &mut self.#core.#stor)
+                    layout::Visitor::slice(&mut #expr, dir, &mut #core_path.#stor)
                 }}
             }
             Layout::Grid(stor, dim, cells) => {
@@ -862,7 +896,7 @@ impl Layout {
                 for item in cells {
                     let (col, col_end) = (item.0.col, item.0.col_end);
                     let (row, row_end) = (item.0.row, item.0.row_end);
-                    let layout = item.1.generate(core)?;
+                    let layout = item.1.generate(core_path)?;
                     items.append_all(quote! {
                         (
                             layout::GridChildInfo {
@@ -877,21 +911,21 @@ impl Layout {
                 }
                 let iter = quote! { { let arr = [#items]; arr.into_iter() } };
 
-                quote! { layout::Visitor::grid(#iter, #dim, &mut self.#core.#stor) }
+                quote! { layout::Visitor::grid(#iter, #dim, &mut #core_path.#stor) }
             }
             Layout::Float(list) => {
                 let mut items = Toks::new();
                 for item in list {
-                    let item = item.generate(core)?;
+                    let item = item.generate(core_path)?;
                     items.append_all(quote! {{ #item },});
                 }
                 let iter = quote! { { let arr = [#items]; arr.into_iter() } };
                 quote! { layout::Visitor::float(#iter) }
             }
             Layout::Label(stor, _) => {
-                quote! { layout::Visitor::component(&mut self.#core.#stor) }
+                quote! { layout::Visitor::component(&mut #core_path.#stor) }
             }
-            Layout::NonNavigable(layout) => return layout.generate(core),
+            Layout::NonNavigable(layout) => return layout.generate(core_path),
         })
     }
 

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -191,6 +191,24 @@ impl Tree {
         let list = parse_layout_items(input, &mut gen)?;
         Ok(Tree(Layout::List(stor, Direction::Down, list)))
     }
+
+    /// Parse a row (contents only)
+    pub fn row(input: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+        let stor = gen.next();
+        let list = parse_layout_items(input, &mut gen)?;
+        Ok(Tree(Layout::List(stor, Direction::Right, list)))
+    }
+
+    /// Parse direction, list
+    pub fn list(input: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+        let stor = gen.next();
+        let dir: Direction = input.parse()?;
+        let _: Token![,] = input.parse()?;
+        let list = parse_layout_list(&input, &mut gen)?;
+        Ok(Tree(Layout::List(stor, dir, list)))
+    }
 }
 
 #[derive(Debug)]
@@ -540,9 +558,8 @@ impl Layout {
             let _: kw::row = input.parse()?;
             let _: Token![!] = input.parse()?;
             let stor = gen.parse_or_next(input)?;
-            let dir = Direction::Right;
             let list = parse_layout_list(input, gen)?;
-            Ok(Layout::List(stor, dir, list))
+            Ok(Layout::List(stor, Direction::Right, list))
         } else if lookahead.peek(kw::list) {
             let _: kw::list = input.parse()?;
             let _: Token![!] = input.parse()?;

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -217,6 +217,13 @@ impl Tree {
         Ok(Tree(Layout::Float(list)))
     }
 
+    /// Parse a grid (contents only)
+    pub fn grid(input: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+        let stor = gen.next();
+        Ok(Tree(parse_grid(stor, input, &mut gen)?))
+    }
+
     /// Parse align (contents only)
     // TODO: use WithAlign adapter?
     pub fn align(inner: ParseStream) -> Result<Self> {
@@ -643,7 +650,10 @@ impl Layout {
             let _: kw::grid = input.parse()?;
             let _: Token![!] = input.parse()?;
             let stor = gen.parse_or_next(input)?;
-            Ok(parse_grid(stor, input, gen)?)
+
+            let inner;
+            let _ = braced!(inner in input);
+            Ok(parse_grid(stor, &inner, gen)?)
         } else if lookahead.peek(kw::non_navigable) {
             let _: kw::non_navigable = input.parse()?;
             let _: Token![!] = input.parse()?;
@@ -789,10 +799,7 @@ fn parse_grid_as_list_of_lists<KW: Parse>(
     Ok(Layout::Grid(stor, dim, cells))
 }
 
-fn parse_grid(stor: StorIdent, input: ParseStream, gen: &mut NameGenerator) -> Result<Layout> {
-    let inner;
-    let _ = braced!(inner in input);
-
+fn parse_grid(stor: StorIdent, inner: ParseStream, gen: &mut NameGenerator) -> Result<Layout> {
     let mut dim = GridDimensions::default();
     let mut cells = vec![];
     while !inner.is_empty() {

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -315,6 +315,21 @@ impl Parse for Tree {
 
 impl Layout {
     fn parse(input: ParseStream, gen: &mut NameGenerator) -> Result<Self> {
+        if input.peek2(Token![!]) {
+            Self::parse_macro_like(input, gen)
+        } else if input.peek(Token![self]) {
+            Ok(Layout::Single(input.parse()?))
+        } else if input.peek(LitStr) {
+            let stor = gen.next();
+            Ok(Layout::Label(stor, input.parse()?))
+        } else {
+            let stor = gen.next();
+            let expr = input.parse()?;
+            Ok(Layout::Widget(stor, expr))
+        }
+    }
+
+    fn parse_macro_like(input: ParseStream, gen: &mut NameGenerator) -> Result<Self> {
         let lookahead = input.lookahead1();
         if lookahead.peek(kw::align) {
             let _: kw::align = input.parse()?;
@@ -400,8 +415,6 @@ impl Layout {
             let layout = Layout::parse(&inner, gen)?;
 
             Ok(Layout::Margins(Box::new(layout), dirs, margins))
-        } else if lookahead.peek(Token![self]) {
-            Ok(Layout::Single(input.parse()?))
         } else if lookahead.peek(kw::frame) {
             let _: kw::frame = input.parse()?;
             let _: Token![!] = input.parse()?;
@@ -513,24 +526,10 @@ impl Layout {
             let _ = parenthesized!(inner in input);
             let layout = Layout::parse(&inner, gen)?;
             Ok(Layout::NonNavigable(Box::new(layout)))
-        } else if lookahead.peek(LitStr) {
-            let stor = gen.next();
-            Ok(Layout::Label(stor, input.parse()?))
         } else {
-            if let Ok(ident) = input.fork().parse::<Ident>() {
-                if ident
-                    .to_string()
-                    .chars()
-                    .next()
-                    .map(|c| c.is_ascii_uppercase())
-                    .unwrap_or(false)
-                {
-                    let stor = gen.next();
-                    let expr = input.parse()?;
-                    return Ok(Layout::Widget(stor, expr));
-                }
-            }
-            Err(lookahead.error())
+            let stor = gen.next();
+            let expr = input.parse()?;
+            Ok(Layout::Widget(stor, expr))
         }
     }
 }

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -251,6 +251,12 @@ impl Tree {
         let layout = Layout::parse(&inner, &mut gen)?;
         Ok(Tree(Layout::Pack(stor, Box::new(layout), align)))
     }
+
+    /// Parse margins (contents only)
+    pub fn margins(inner: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+        Layout::margins_inner(inner, &mut gen).map(Tree)
+    }
 }
 
 #[derive(Debug)]
@@ -501,55 +507,7 @@ impl Layout {
 
             let inner;
             let _ = parenthesized!(inner in input);
-
-            let mut dirs = Directions::all();
-            if inner.peek2(Token![=]) {
-                let ident = inner.parse::<Ident>()?;
-                dirs = match ident {
-                    id if id == "horiz" || id == "horizontal" => Directions::LEFT | Directions::RIGHT,
-                    id if id == "vert" || id == "vertical" => Directions::UP | Directions::DOWN,
-                    id if id == "left" => Directions::LEFT,
-                    id if id == "right" => Directions::RIGHT,
-                    id if id == "top" => Directions::UP,
-                    id if id == "bottom" => Directions::DOWN,
-                    _ => return Err(Error::new(ident.span(), "expected one of: horiz, horizontal, vert, vertical, left, right, top, bottom")),
-                };
-                let _ = inner.parse::<Token![=]>()?;
-            }
-
-            let lookahead = inner.lookahead1();
-            let margins = if lookahead.peek(syn::LitFloat) {
-                let val = inner.parse::<syn::LitFloat>()?;
-                let digits = val.base10_digits();
-                match val.suffix() {
-                    "px" => quote! { Px(#digits) },
-                    "em" => quote! { Em(#digits) },
-                    _ => return Err(Error::new(val.span(), "expected suffix `px` or `em`")),
-                }
-            } else if lookahead.peek(Ident) {
-                let ident = inner.parse::<Ident>()?;
-                match ident {
-                    id if id == "none" => quote! { None },
-                    id if id == "inner" => quote! { Inner },
-                    id if id == "tiny" => quote! { Tiny },
-                    id if id == "small" => quote! { Small },
-                    id if id == "large" => quote! { Large },
-                    id if id == "text" => quote! { Text },
-                    _ => {
-                        return Err(Error::new(
-                            ident.span(),
-                            "expected one of: `none`, `inner`, `tiny`, `small`, `large`, `text` or a numeric value",
-                        ))
-                    }
-                }
-            } else {
-                return Err(lookahead.error());
-            };
-
-            let _ = inner.parse::<Token![,]>()?;
-            let layout = Layout::parse(&inner, gen)?;
-
-            Ok(Layout::Margins(Box::new(layout), dirs, margins))
+            Self::margins_inner(&inner, gen)
         } else if lookahead.peek(kw::frame) {
             let _: kw::frame = input.parse()?;
             let _: Token![!] = input.parse()?;
@@ -667,6 +625,64 @@ impl Layout {
             let expr = input.parse()?;
             Ok(Layout::Widget(stor, expr))
         }
+    }
+
+    fn margins_inner(inner: ParseStream, gen: &mut NameGenerator) -> Result<Self> {
+        let mut dirs = Directions::all();
+        if inner.peek2(Token![=]) {
+            let ident = inner.parse::<Ident>()?;
+            dirs = match ident {
+                id if id == "horiz" || id == "horizontal" => Directions::LEFT | Directions::RIGHT,
+                id if id == "vert" || id == "vertical" => Directions::UP | Directions::DOWN,
+                id if id == "left" => Directions::LEFT,
+                id if id == "right" => Directions::RIGHT,
+                id if id == "top" => Directions::UP,
+                id if id == "bottom" => Directions::DOWN,
+                _ => return Err(Error::new(
+                    ident.span(),
+                    "expected one of: horiz, horizontal, vert, vertical, left, right, top, bottom",
+                )),
+            };
+            let _ = inner.parse::<Token![=]>()?;
+        }
+
+        let lookahead = inner.lookahead1();
+        let margins = if lookahead.peek(syn::LitFloat) {
+            let val = inner.parse::<syn::LitFloat>()?;
+            let lookahead = inner.lookahead1();
+            if lookahead.peek(kw::px) {
+                let _ = inner.parse::<kw::px>()?;
+                quote! { Px(#val) }
+            } else if lookahead.peek(kw::em) {
+                let _ = inner.parse::<kw::em>()?;
+                quote! { Em(#val) }
+            } else {
+                return Err(lookahead.error());
+            }
+        } else if lookahead.peek(Ident) {
+            let ident = inner.parse::<Ident>()?;
+            match ident {
+                id if id == "none" => quote! { None },
+                id if id == "inner" => quote! { Inner },
+                id if id == "tiny" => quote! { Tiny },
+                id if id == "small" => quote! { Small },
+                id if id == "large" => quote! { Large },
+                id if id == "text" => quote! { Text },
+                _ => {
+                    return Err(Error::new(
+                        ident.span(),
+                        "expected one of: `none`, `inner`, `tiny`, `small`, `large`, `text` or a numeric value",
+                    ))
+                }
+            }
+        } else {
+            return Err(lookahead.error());
+        };
+
+        let _ = inner.parse::<Token![,]>()?;
+        let layout = Layout::parse(&inner, gen)?;
+
+        Ok(Layout::Margins(Box::new(layout), dirs, margins))
     }
 }
 
@@ -931,10 +947,12 @@ impl ToTokens for GridDimensions {
 impl Layout {
     fn append_fields(&self, ty_toks: &mut Toks, def_toks: &mut Toks, children: &mut Vec<Toks>) {
         match self {
-            Layout::Align(layout, _) | Layout::NonNavigable(layout) => {
+            Layout::Align(layout, _)
+            | Layout::Margins(layout, ..)
+            | Layout::NonNavigable(layout) => {
                 layout.append_fields(ty_toks, def_toks, children);
             }
-            Layout::AlignSingle(..) | Layout::Margins(..) | Layout::Single(_) => (),
+            Layout::AlignSingle(..) | Layout::Single(_) => (),
             Layout::Pack(stor, layout, _) => {
                 ty_toks.append_all(quote! { #stor: ::kas::layout::PackStorage, });
                 def_toks.append_all(quote! { #stor: Default::default(), });

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -140,7 +140,7 @@ enum Direction {
     Right,
     Up,
     Down,
-    Expr(Toks),
+    Expr(Expr),
 }
 
 bitflags::bitflags! {
@@ -369,25 +369,26 @@ impl Layout {
         } else if lookahead.peek(kw::column) {
             let _: kw::column = input.parse()?;
             let _: Token![!] = input.parse()?;
-            let dir = Direction::Down;
             let stor = gen.parse_or_next(input)?;
+            let dir = Direction::Down;
             let list = parse_layout_list(input, gen)?;
             Ok(Layout::List(stor, dir, list))
         } else if lookahead.peek(kw::row) {
             let _: kw::row = input.parse()?;
             let _: Token![!] = input.parse()?;
-            let dir = Direction::Right;
             let stor = gen.parse_or_next(input)?;
+            let dir = Direction::Right;
             let list = parse_layout_list(input, gen)?;
             Ok(Layout::List(stor, dir, list))
         } else if lookahead.peek(kw::list) {
             let _: kw::list = input.parse()?;
+            let _: Token![!] = input.parse()?;
+            let stor = gen.parse_or_next(input)?;
             let inner;
             let _ = parenthesized!(inner in input);
             let dir: Direction = inner.parse()?;
-            let stor = gen.parse_or_next(input)?;
-            let _: Token![:] = input.parse()?;
-            let list = parse_layout_list(input, gen)?;
+            let _: Token![,] = inner.parse()?;
+            let list = parse_layout_list(&inner, gen)?;
             Ok(Layout::List(stor, dir, list))
         } else if lookahead.peek(kw::float) {
             let _: kw::float = input.parse()?;
@@ -410,15 +411,16 @@ impl Layout {
             )?)
         } else if lookahead.peek(kw::slice) {
             let _: kw::slice = input.parse()?;
+            let _: Token![!] = input.parse()?;
+            let stor = gen.parse_or_next(input)?;
             let inner;
             let _ = parenthesized!(inner in input);
             let dir: Direction = inner.parse()?;
-            let stor = gen.parse_or_next(input)?;
-            let _: Token![:] = input.parse()?;
-            if input.peek(Token![self]) {
-                Ok(Layout::Slice(stor, dir, input.parse()?))
+            let _: Token![,] = inner.parse()?;
+            if inner.peek(Token![self]) {
+                Ok(Layout::Slice(stor, dir, inner.parse()?))
             } else {
-                Err(Error::new(input.span(), "expected `self`"))
+                Err(Error::new(inner.span(), "expected `self`"))
             }
         } else if lookahead.peek(kw::grid) {
             let _: kw::grid = input.parse()?;

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -796,7 +796,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
     Ok(())
 }
 
-fn impl_core(impl_generics: &Toks, impl_target: &Toks, name: &str, core_path: &Toks) -> Toks {
+pub fn impl_core(impl_generics: &Toks, impl_target: &Toks, name: &str, core_path: &Toks) -> Toks {
     quote! {
         impl #impl_generics ::kas::WidgetCore for #impl_target {
             #[inline]
@@ -821,7 +821,7 @@ fn impl_core(impl_generics: &Toks, impl_target: &Toks, name: &str, core_path: &T
     }
 }
 
-fn impl_widget_children(
+pub fn impl_widget_children(
     impl_generics: &Toks,
     impl_target: &Toks,
     core_path: &Toks,

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -265,7 +265,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
         }
     }
 
-    crate::widget_index::visit_impls(&children, &mut scope.impls);
+    crate::widget_index::visit_impls(children.iter(), &mut scope.impls);
 
     for (index, impl_) in scope.impls.iter().enumerate() {
         if let Some((_, ref path, _)) = impl_.trait_ {
@@ -623,7 +623,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
         };
         if let Some((_, layout)) = args.layout.take() {
             gen_layout = true;
-            fn_nav_next = match layout.nav_next(&children) {
+            fn_nav_next = match layout.nav_next(children.iter()) {
                 NavNextResult::Err(span, msg) => {
                     fn_nav_next_err = Some((span, msg));
                     None

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -6,9 +6,9 @@
 use crate::make_layout::{self, NavNextResult};
 use impl_tools_lib::fields::{Fields, FieldsNamed, FieldsUnnamed};
 use impl_tools_lib::{Scope, ScopeAttr, ScopeItem, SimplePath};
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::{Span, TokenStream as Toks};
 use proc_macro_error::{emit_error, emit_warning};
-use quote::{quote, quote_spanned, TokenStreamExt};
+use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::spanned::Spanned;
 use syn::{parse2, parse_quote, token::Eq, Ident, ImplItem, Index, ItemImpl, Member, Token, Type};
@@ -40,7 +40,7 @@ pub struct ExprToken {
 
 #[derive(Debug, Default)]
 pub struct WidgetArgs {
-    pub navigable: Option<TokenStream>,
+    pub navigable: Option<Toks>,
     pub hover_highlight: Option<BoolToken>,
     pub cursor_icon: Option<ExprToken>,
     pub derive: Option<Member>,
@@ -142,7 +142,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
     let name = &scope.ident;
     let opt_derive = &args.derive;
 
-    let mut impl_widget_children = true;
+    let mut do_impl_widget_children = true;
     let mut layout_impl = None;
     let mut widget_impl = None;
 
@@ -287,7 +287,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                         "custom `WidgetChildren` implementation when using layout-defined children"
                     );
                 }
-                impl_widget_children = false;
+                do_impl_widget_children = false;
 
                 let mut num_children = None;
                 let mut get_child = None;
@@ -347,6 +347,8 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
     }
 
     let (impl_generics, ty_generics, where_clause) = scope.generics.split_for_impl();
+    let impl_generics = impl_generics.to_token_stream();
+    let impl_target = quote! { #name #ty_generics #where_clause };
     let widget_name = name.to_string();
 
     let mut fn_size_rules = None;
@@ -364,8 +366,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
 
     if let Some(inner) = opt_derive {
         scope.generated.push(quote! {
-            impl #impl_generics ::kas::WidgetCore
-                for #name #ty_generics #where_clause
+            impl #impl_generics ::kas::WidgetCore for #impl_target
             {
                 #[inline]
                 fn id_ref(&self) -> &::kas::WidgetId {
@@ -387,9 +388,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 fn as_widget_mut(&mut self) -> &mut dyn ::kas::Widget { self }
             }
 
-            impl #impl_generics ::kas::WidgetChildren
-                for #name #ty_generics #where_clause
-            {
+            impl #impl_generics ::kas::WidgetChildren for #impl_target {
                 #[inline]
                 fn num_children(&self) -> usize {
                     self.#inner.num_children()
@@ -549,71 +548,23 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 "expected: a field with type `widget_core!()`",
             ));
         };
-        widget_methods = vec![];
+        let core_path = quote! { self.#core };
 
-        scope.generated.push(quote! {
-            impl #impl_generics ::kas::WidgetCore
-                for #name #ty_generics #where_clause
-            {
-                #[inline]
-                fn id_ref(&self) -> &::kas::WidgetId {
-                    &self.#core.id
-                }
-                #[inline]
-                fn rect(&self) -> ::kas::geom::Rect {
-                    self.#core.rect
-                }
+        scope.generated.push(impl_core(
+            &impl_generics,
+            &impl_target,
+            &widget_name,
+            &core_path,
+        ));
 
-                #[inline]
-                fn widget_name(&self) -> &'static str {
-                    #widget_name
-                }
-
-                #[inline]
-                fn as_widget(&self) -> &dyn ::kas::Widget { self }
-                #[inline]
-                fn as_widget_mut(&mut self) -> &mut dyn ::kas::Widget { self }
-            }
-        });
-
-        if impl_widget_children {
-            let mut count = children.len();
-
-            let mut get_rules = quote! {};
-            let mut get_mut_rules = quote! {};
-            for (i, child) in children.iter().enumerate() {
-                let ident = child;
-                get_rules.append_all(quote! { #i => Some(&self.#ident), });
-                get_mut_rules.append_all(quote! { #i => Some(&mut self.#ident), });
-            }
-            for (i, path) in layout_children.iter().enumerate() {
-                let index = count + i;
-                get_rules.append_all(quote! { #index => Some(&self.#core.#path), });
-                get_mut_rules.append_all(quote! { #index => Some(&mut self.#core.#path), });
-            }
-            count += layout_children.len();
-
-            scope.generated.push(quote! {
-                impl #impl_generics ::kas::WidgetChildren
-                    for #name #ty_generics #where_clause
-                {
-                    fn num_children(&self) -> usize {
-                        #count
-                    }
-                    fn get_child(&self, _index: usize) -> Option<&dyn ::kas::Widget> {
-                        match _index {
-                            #get_rules
-                            _ => None
-                        }
-                    }
-                    fn get_child_mut(&mut self, _index: usize) -> Option<&mut dyn ::kas::Widget> {
-                        match _index {
-                            #get_mut_rules
-                            _ => None
-                        }
-                    }
-                }
-            });
+        if do_impl_widget_children {
+            scope.generated.push(impl_widget_children(
+                &impl_generics,
+                &impl_target,
+                &core_path,
+                &children,
+                layout_children,
+            ));
         }
 
         let mut set_rect = quote! { self.#core.rect = rect; };
@@ -663,43 +614,10 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 }),
             };
 
-            let layout = layout.generate(&core)?;
+            let layout_methods = layout.layout_methods(&quote! { self.#core })?;
             scope.generated.push(quote! {
-                impl #impl_generics ::kas::layout::AutoLayout
-                        for #name #ty_generics #where_clause
-                {
-                    fn size_rules(
-                        &mut self,
-                        size_mgr: ::kas::theme::SizeMgr,
-                        axis: ::kas::layout::AxisInfo,
-                    ) -> ::kas::layout::SizeRules {
-                        use ::kas::{WidgetCore, layout};
-                        (#layout).size_rules(size_mgr, axis)
-                    }
-
-                    fn set_rect(
-                        &mut self,
-                        mgr: &mut ::kas::event::ConfigMgr,
-                        rect: ::kas::geom::Rect,
-                    ) {
-                        use ::kas::{WidgetCore, layout};
-                        self.#core.rect = rect;
-                        (#layout).set_rect(mgr, rect);
-                    }
-
-                    fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
-                        use ::kas::{layout, Widget, WidgetCore, WidgetExt};
-                        if !self.rect().contains(coord) {
-                            return None;
-                        }
-                        let coord = coord + self.translation();
-                        (#layout).find_id(coord).or_else(|| Some(self.id()))
-                    }
-
-                    fn draw(&mut self, draw: ::kas::theme::DrawMgr) {
-                        use ::kas::{WidgetCore, layout};
-                        (#layout).draw(draw);
-                    }
+                impl #impl_generics ::kas::layout::AutoLayout for #impl_target {
+                    #layout_methods
                 }
             });
 
@@ -784,6 +702,8 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
             }
         };
         fn_handle_event = None;
+
+        widget_methods = vec![];
     }
 
     fn collect_idents(item_impl: &ItemImpl) -> Vec<Ident> {
@@ -820,7 +740,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
         }
     } else if let Some(fn_size_rules) = fn_size_rules {
         scope.generated.push(quote! {
-            impl #impl_generics ::kas::Layout for #name #ty_generics #where_clause {
+            impl #impl_generics ::kas::Layout for #impl_target {
                 #fn_size_rules
                 #fn_set_rect
                 #fn_find_id
@@ -863,9 +783,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
     } else {
         let other_methods = widget_methods.into_iter().map(|pair| pair.1);
         scope.generated.push(quote! {
-            impl #impl_generics ::kas::Widget
-                    for #name #ty_generics #where_clause
-            {
+            impl #impl_generics ::kas::Widget for #impl_target {
                 #fn_pre_configure
                 #fn_navigable
                 #fn_pre_handle_event
@@ -876,4 +794,73 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn impl_core(impl_generics: &Toks, impl_target: &Toks, name: &str, core_path: &Toks) -> Toks {
+    quote! {
+        impl #impl_generics ::kas::WidgetCore for #impl_target {
+            #[inline]
+            fn id_ref(&self) -> &::kas::WidgetId {
+                &#core_path.id
+            }
+            #[inline]
+            fn rect(&self) -> ::kas::geom::Rect {
+                #core_path.rect
+            }
+
+            #[inline]
+            fn widget_name(&self) -> &'static str {
+                #name
+            }
+
+            #[inline]
+            fn as_widget(&self) -> &dyn ::kas::Widget { self }
+            #[inline]
+            fn as_widget_mut(&mut self) -> &mut dyn ::kas::Widget { self }
+        }
+    }
+}
+
+fn impl_widget_children(
+    impl_generics: &Toks,
+    impl_target: &Toks,
+    core_path: &Toks,
+    children: &Vec<Member>,
+    layout_children: Vec<Toks>,
+) -> Toks {
+    let mut count = children.len();
+
+    let mut get_rules = quote! {};
+    let mut get_mut_rules = quote! {};
+    for (i, child) in children.iter().enumerate() {
+        let ident = child;
+        get_rules.append_all(quote! { #i => Some(&self.#ident), });
+        get_mut_rules.append_all(quote! { #i => Some(&mut self.#ident), });
+    }
+    for (i, path) in layout_children.iter().enumerate() {
+        let index = count + i;
+        get_rules.append_all(quote! { #index => Some(&#core_path.#path), });
+        get_mut_rules.append_all(quote! { #index => Some(&mut #core_path.#path), });
+    }
+    count += layout_children.len();
+
+    quote! {
+        impl #impl_generics ::kas::WidgetChildren for #impl_target {
+            fn num_children(&self) -> usize {
+                #count
+            }
+            fn get_child(&self, _index: usize) -> Option<&dyn ::kas::Widget> {
+                match _index {
+                    #get_rules
+                    _ => None
+                }
+            }
+            fn get_child_mut(&mut self, _index: usize) -> Option<&mut dyn ::kas::Widget> {
+                match _index {
+                    #get_mut_rules
+                    _ => None
+                }
+            }
+        }
+    }
 }

--- a/crates/kas-view/src/driver/config.rs
+++ b/crates/kas-view/src/driver/config.rs
@@ -31,19 +31,43 @@ enum Msg {
 impl_scope! {
     /// A widget for viewing event config
     #[widget{
-        layout = grid: {
-            0, 0: "Menu delay:"; 1, 0: self.menu_delay; 2, 0: "ms";
-            0, 1: "Touch-selection delay:"; 1, 1: self.touch_select_delay; 2, 1: "ms";
-            0, 2: "Scroll flick timeout:"; 1, 2: self.scroll_flick_timeout; 2, 2: "ms";
-            0, 3: "Scroll flick multiply:"; 1, 3: self.scroll_flick_mul;
-            0, 4: "Scroll flick subtract:"; 1, 4: self.scroll_flick_sub;
-            0, 5: "Scroll wheel distance:"; 1, 5: self.scroll_dist_em; 2, 5: "em";
-            0, 6: "Pan distance threshold:"; 1, 6: self.pan_dist_thresh;
-            0, 7: "Mouse pan:"; 1..3, 7: self.mouse_pan;
-            0, 8: "Mouse text pan:"; 1..3, 8: self.mouse_text_pan;
-            1..3, 9: self.mouse_nav_focus;
-            1..3, 10: self.touch_nav_focus;
-            0, 11: "Restore default values:"; 1..3, 11: TextButton::new_msg("&Reset", Msg::Reset);
+        layout = grid! {
+            (0, 0) => "Menu delay:",
+            (1, 0) => self.menu_delay,
+            (2, 0) => "ms",
+
+            (0, 1) => "Touch-selection delay:",
+            (1, 1) => self.touch_select_delay,
+            (2, 1) => "ms",
+
+            (0, 2) => "Scroll flick timeout:",
+            (1, 2) => self.scroll_flick_timeout,
+            (2, 2) => "ms",
+
+            (0, 3) => "Scroll flick multiply:",
+            (1, 3) => self.scroll_flick_mul,
+
+            (0, 4) => "Scroll flick subtract:",
+            (1, 4) => self.scroll_flick_sub,
+
+            (0, 5) => "Scroll wheel distance:",
+            (1, 5) => self.scroll_dist_em, (2, 5) => "em",
+
+            (0, 6) => "Pan distance threshold:",
+            (1, 6) => self.pan_dist_thresh,
+
+            (0, 7) => "Mouse pan:",
+            (1..3, 7) => self.mouse_pan,
+
+            (0, 8) => "Mouse text pan:",
+            (1..3, 8) => self.mouse_text_pan,
+
+            (1..3, 9) => self.mouse_nav_focus,
+
+            (1..3, 10) => self.touch_nav_focus,
+
+            (0, 11) => "Restore default values:",
+            (1..3, 11) => TextButton::new_msg("&Reset", Msg::Reset),
         };
     }]
     pub struct EventConfigWidget {

--- a/crates/kas-widgets/src/adapter/with_label.rs
+++ b/crates/kas-widgets/src/adapter/with_label.rs
@@ -18,7 +18,7 @@ impl_scope! {
     #[autoimpl(Deref, DerefMut using self.inner)]
     #[derive(Clone, Default)]
     #[widget {
-        layout = list! 'row (self.dir, [self.inner, non_navigable: self.label]);
+        layout = list! 'row (self.dir, [self.inner, non_navigable!(self.label)]);
     }]
     pub struct WithLabel<W: Widget, D: Directional> {
         core: widget_core!(),

--- a/crates/kas-widgets/src/adapter/with_label.rs
+++ b/crates/kas-widgets/src/adapter/with_label.rs
@@ -18,7 +18,7 @@ impl_scope! {
     #[autoimpl(Deref, DerefMut using self.inner)]
     #[derive(Clone, Default)]
     #[widget {
-        layout = list(self.dir) 'row: [self.inner, non_navigable: self.label];
+        layout = list! 'row (self.dir, [self.inner, non_navigable: self.label]);
     }]
     pub struct WithLabel<W: Widget, D: Directional> {
         core: widget_core!(),

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -18,7 +18,7 @@ impl_scope! {
     /// Default alignment of content is centered.
     #[autoimpl(class_traits using self.inner where W: trait)]
     #[widget {
-        layout = button(self.color): self.inner;
+        layout = button!(self.inner, color = self.color);
         navigable = true;
         hover_highlight = true;
     }]
@@ -138,7 +138,7 @@ impl_scope! {
     ///
     /// Default alignment of content is centered.
     #[widget {
-        layout = button(self.color): self.label;
+        layout = button!(self.label, color = self.color);
         navigable = true;
         hover_highlight = true;
     }]

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -182,7 +182,7 @@ impl_scope! {
     #[autoimpl(HasBool using self.inner)]
     #[derive(Default)]
     #[widget{
-        layout = list(self.direction()): [self.inner, non_navigable: self.label];
+        layout = list!(self.direction(), [self.inner, non_navigable: self.label]);
     }]
     pub struct CheckButton {
         core: widget_core!(),

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -182,7 +182,7 @@ impl_scope! {
     #[autoimpl(HasBool using self.inner)]
     #[derive(Default)]
     #[widget{
-        layout = list!(self.direction(), [self.inner, non_navigable: self.label]);
+        layout = list!(self.direction(), [self.inner, non_navigable!(self.label)]);
     }]
     pub struct CheckButton {
         core: widget_core!(),

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -28,7 +28,7 @@ impl_scope! {
     /// this message is passed to the handler and not emitted.
     #[impl_default]
     #[widget {
-        layout = button 'frame: row! [self.label, self.mark];
+        layout = button! 'frame(row! [self.label, self.mark]);
         navigable = true;
         hover_highlight = true;
     }]

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -28,7 +28,7 @@ impl_scope! {
     /// this message is passed to the handler and not emitted.
     #[impl_default]
     #[widget {
-        layout = button 'frame: row: [self.label, self.mark];
+        layout = button 'frame: row! [self.label, self.mark];
         navigable = true;
         hover_highlight = true;
     }]

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -138,11 +138,11 @@ struct MsgClose(bool);
 
 impl_scope! {
     #[widget{
-        layout = grid: {
-            0..3, 0: self.edit;
-            0, 1: Filler::maximize();
-            1, 1: TextButton::new_msg("&Cancel", MsgClose(false));
-            2, 1: TextButton::new_msg("&Save", MsgClose(true));
+        layout = grid! {
+            (0..3, 0) => self.edit,
+            (0, 1) => Filler::maximize(),
+            (1, 1) => TextButton::new_msg("&Cancel", MsgClose(false)),
+            (2, 1) => TextButton::new_msg("&Save", MsgClose(true)),
         };
     }]
     /// An editor over a shared `String`

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -80,7 +80,7 @@ struct MessageBoxOk;
 impl_scope! {
     /// A simple message box.
     #[widget{
-        layout = column: [self.label, self.button];
+        layout = column! [self.label, self.button];
     }]
     pub struct MessageBox<T: FormattableText + 'static> {
         core: widget_core!(),

--- a/crates/kas-widgets/src/frame.rs
+++ b/crates/kas-widgets/src/frame.rs
@@ -16,7 +16,7 @@ impl_scope! {
     #[autoimpl(class_traits using self.inner where W: trait)]
     #[derive(Clone, Default)]
     #[widget{
-        layout = frame(kas::theme::FrameStyle::Frame): self.inner;
+        layout = frame!(self.inner);
     }]
     pub struct Frame<W: Widget> {
         core: widget_core!(),
@@ -44,7 +44,7 @@ impl_scope! {
     #[autoimpl(class_traits using self.inner where W: trait)]
     #[derive(Clone, Default)]
     #[widget{
-        layout = frame(kas::theme::FrameStyle::Popup): self.inner;
+        layout = frame!(self.inner, style = kas::theme::FrameStyle::Popup);
     }]
     pub struct PopupFrame<W: Widget> {
         core: widget_core!(),

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -67,7 +67,7 @@ impl_scope! {
     #[autoimpl(Clone where W: Clone)]
     #[autoimpl(Default where D: Default)]
     #[widget {
-        layout = slice(self.direction) 'layout: self.widgets;
+        layout = slice! 'layout (self.direction, self.widgets);
     }]
     pub struct List<D: Directional, W: Widget> {
         core: widget_core!(),

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -107,7 +107,7 @@ impl_scope! {
     #[autoimpl(HasBool using self.checkbox)]
     #[derive(Default)]
     #[widget {
-        layout = row: [self.checkbox, self.label];
+        layout = row! [self.checkbox, self.label];
     }]
     pub struct MenuToggle {
         core: widget_core!(),

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -23,7 +23,7 @@ impl_scope! {
     #[derive(Clone, Default)]
     #[widget{
         navigable = true;
-        layout = frame(kas::theme::FrameStyle::NavFocus): self.inner;
+        layout = frame!(self.inner, style = kas::theme::FrameStyle::NavFocus);
     }]
     pub struct NavFrame<W: Widget> {
         core: widget_core!(),

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -220,7 +220,7 @@ impl_scope! {
     /// See also [`RadioBox`] which excludes the label.
     #[autoimpl(HasBool using self.inner)]
     #[widget{
-        layout = list(self.direction()): [self.inner, non_navigable: self.label];
+        layout = list!(self.direction(), [self.inner, non_navigable: self.label]);
     }]
     pub struct RadioButton {
         core: widget_core!(),

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -220,7 +220,7 @@ impl_scope! {
     /// See also [`RadioBox`] which excludes the label.
     #[autoimpl(HasBool using self.inner)]
     #[widget{
-        layout = list!(self.direction(), [self.inner, non_navigable: self.label]);
+        layout = list!(self.direction(), [self.inner, non_navigable!(self.label)]);
     }]
     pub struct RadioButton {
         core: widget_core!(),

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -164,10 +164,10 @@ impl_scope! {
     /// -   With floating-point types, ensure that `step` is exactly
     ///     representable, e.g. an integer or a power of 2.
     #[widget {
-        layout = frame(FrameStyle::EditBox): row! [
+        layout = frame!(row! [
             self.edit,
             column! [self.b_up, self.b_down],
-        ];
+        ], style = FrameStyle::EditBox);
     }]
     pub struct Spinner<T: SpinnerValue> {
         core: widget_core!(),

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -164,9 +164,9 @@ impl_scope! {
     /// -   With floating-point types, ensure that `step` is exactly
     ///     representable, e.g. an integer or a power of 2.
     #[widget {
-        layout = frame(FrameStyle::EditBox): row: [
+        layout = frame(FrameStyle::EditBox): row! [
             self.edit,
-            column: [self.b_up, self.b_down],
+            column! [self.b_up, self.b_down],
         ];
     }]
     pub struct Spinner<T: SpinnerValue> {

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -43,10 +43,10 @@ impl_scope! {
     /// See also the main implementing widget: [`Stack`].
     #[impl_default]
     #[widget {
-        layout = list(self.direction): [
+        layout = list!(self.direction, [
             self.stack,
             self.tabs,
-        ];
+        ]);
     }]
     pub struct TabStack<W: Widget> {
         core: widget_core!(),

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -28,25 +28,27 @@ impl_scope! {
     // Buttons get keyboard bindings through the "&" item (e.g. "&1"
     // binds both main and numpad 1 key) and via `with_keys`.
     #[widget{
-        layout = grid: {
-            0, 0: TextButton::new_msg("&clear", Key::Clear).with_keys(&[VK::Delete]);
-            1, 0: TextButton::new_msg("&÷", Key::Divide).with_keys(&[VK::Slash]);
-            2, 0: TextButton::new_msg("&×", Key::Multiply).with_keys(&[VK::Asterisk]);
-            3, 0: TextButton::new_msg("&−", Key::Subtract);
-            0, 1: TextButton::new_msg("&7", Key::Char('7'));
-            1, 1: TextButton::new_msg("&8", Key::Char('8'));
-            2, 1: TextButton::new_msg("&9", Key::Char('9'));
-            3, 1..3: TextButton::new_msg("&+", Key::Add);
-            0, 2: TextButton::new_msg("&4", Key::Char('4'));
-            1, 2: TextButton::new_msg("&5", Key::Char('5'));
-            2, 2: TextButton::new_msg("&6", Key::Char('6'));
-            0, 3: TextButton::new_msg("&1", Key::Char('1'));
-            1, 3: TextButton::new_msg("&2", Key::Char('2'));
-            2, 3: TextButton::new_msg("&3", Key::Char('3'));
-            3, 3..5:  TextButton::new_msg("&=", Key::Equals)
-                .with_keys(&[VK::Return, VK::NumpadEnter]);
-            0..2, 4: TextButton::new_msg("&0", Key::Char('0'));
-            2, 4: TextButton::new_msg("&.", Key::Char('.'));
+        layout = grid! {
+            (0, 0) => TextButton::new_msg("&clear", Key::Clear).with_keys(&[VK::Delete]),
+            (1, 0) => TextButton::new_msg("&÷", Key::Divide).with_keys(&[VK::Slash]),
+            (2, 0) => TextButton::new_msg("&×", Key::Multiply).with_keys(&[VK::Asterisk]),
+            (3, 0) => TextButton::new_msg("&−", Key::Subtract),
+            (0, 1) => TextButton::new_msg("&7", Key::Char('7')),
+            (1, 1) => TextButton::new_msg("&8", Key::Char('8')),
+            (2, 1) => TextButton::new_msg("&9", Key::Char('9')),
+            (3, 1..3) => TextButton::new_msg("&+", Key::Add),
+            (0, 2) => TextButton::new_msg("&4", Key::Char('4')),
+            (1, 2) => TextButton::new_msg("&5", Key::Char('5')),
+            (2, 2) => TextButton::new_msg("&6", Key::Char('6')),
+            (0, 3) => TextButton::new_msg("&1", Key::Char('1')),
+            (1, 3) => TextButton::new_msg("&2", Key::Char('2')),
+            (2, 3) => TextButton::new_msg("&3", Key::Char('3')),
+            (3, 3..5) => {
+                TextButton::new_msg("&=", Key::Equals)
+                    .with_keys(&[VK::Return, VK::NumpadEnter])
+            }
+            (0..2, 4) => TextButton::new_msg("&0", Key::Char('0')),
+            (2, 4) => TextButton::new_msg("&.", Key::Char('.')),
         };
     }]
     #[derive(Default)]

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -56,7 +56,7 @@ impl_scope! {
 impl_scope! {
     #[impl_default]
     #[widget{
-        layout = column: [
+        layout = column! [
             self.display,
             Buttons::default(),
         ];

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -14,7 +14,7 @@ struct Increment(i32);
 impl_scope! {
     #[widget{
         layout = column! [
-            align(center): self.display,
+            align!(center, self.display),
             row! [
                 TextButton::new_msg("−", Increment(-1)),
                 TextButton::new_msg("+", Increment(1)),

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -13,9 +13,9 @@ struct Increment(i32);
 
 impl_scope! {
     #[widget{
-        layout = column: [
+        layout = column! [
             align(center): self.display,
-            row: [
+            row! [
                 TextButton::new_msg("−", Increment(-1)),
                 TextButton::new_msg("+", Increment(1)),
             ],

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -133,8 +133,8 @@ impl EditGuard for ListEntryGuard {
 impl_scope! {
     // The list entry
     #[widget{
-        layout = column: [
-            row: [self.label, self.radio],
+        layout = column! [
+            row! [self.label, self.radio],
             self.edit,
         ];
     }]
@@ -208,7 +208,7 @@ fn main() -> kas::shell::Result<()> {
 
     let controls = singleton! {
         #[widget{
-            layout = row: [
+            layout = row! [
                 "Number of rows:",
                 self.edit,
                 TextButton::new_msg("Set", Button::Set),
@@ -258,7 +258,7 @@ fn main() -> kas::shell::Result<()> {
 
     let window = singleton! {
         #[widget{
-            layout = column: [
+            layout = column! [
                 "Demonstration of dynamic widget creation / deletion",
                 self.controls,
                 "Contents of selected entry:",

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -55,8 +55,8 @@ impl EditGuard for ListEntryGuard {
 impl_scope! {
     // The list entry
     #[widget{
-        layout = column: [
-            row: [self.label, self.radio],
+        layout = column! [
+            row! [self.label, self.radio],
             self.edit,
         ];
     }]
@@ -91,7 +91,7 @@ fn main() -> kas::shell::Result<()> {
 
     let controls = singleton! {
         #[widget{
-            layout = row: [
+            layout = row! [
                 "Number of rows:",
                 self.edit,
                 TextButton::new_msg("Set", Button::Set),
@@ -141,7 +141,7 @@ fn main() -> kas::shell::Result<()> {
 
     let window = singleton! {
         #[widget{
-            layout = column: [
+            layout = column! [
                 "Demonstration of dynamic widget creation / deletion",
                 self.controls,
                 "Contents of selected entry:",

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -88,7 +88,7 @@ fn widgets() -> Box<dyn SetDisabled> {
 
     let popup_edit_box = singleton! {
         #[widget{
-            layout = row: [
+            layout = row! [
                 self.label,
                 TextButton::new_msg("&Edit", MsgEdit),
             ];
@@ -118,21 +118,21 @@ fn widgets() -> Box<dyn SetDisabled> {
 
     let widgets = singleton! {
         #[widget{
-            layout = aligned_column: [
-                row: ["ScrollLabel", self.sl],
-                row: ["EditBox", self.eb],
-                row: ["TextButton", self.tb],
-                row: ["Button<Image>", pack(center): self.bi],
-                row: ["CheckButton", self.cb],
-                row: ["RadioButton", self.rb],
-                row: ["RadioButton", self.rb2],
-                row: ["ComboBox", self.cbb],
-                row: ["Spinner", self.spin],
-                row: ["Slider", self.sd],
-                row: ["ScrollBar", self.sc],
-                row: ["ProgressBar", self.pg],
-                row: ["SVG", self.sv],
-                row: ["Child window", self.pu],
+            layout = aligned_column! [
+                row! ["ScrollLabel", self.sl],
+                row! ["EditBox", self.eb],
+                row! ["TextButton", self.tb],
+                row! ["Button<Image>", pack(center): self.bi],
+                row! ["CheckButton", self.cb],
+                row! ["RadioButton", self.rb],
+                row! ["RadioButton", self.rb2],
+                row! ["ComboBox", self.cbb],
+                row! ["Spinner", self.spin],
+                row! ["Slider", self.sd],
+                row! ["ScrollBar", self.sc],
+                row! ["ProgressBar", self.pg],
+                row! ["SVG", self.sv],
+                row! ["Child window", self.pu],
             ];
         }]
         struct {
@@ -236,7 +236,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
 
     Box::new(singleton! {
         #[widget{
-            layout = float: [
+            layout = float! [
                 pack(right, top): TextButton::new_msg("↻", MsgDirection),
                 list(self.dir): [self.editor, non_navigable: self.label],
             ];
@@ -306,9 +306,9 @@ fn filter_list() -> Box<dyn SetDisabled> {
 
     Box::new(singleton! {
         #[widget{
-            layout = column: [
-                row: ["Selection:", self.r0, self.r1, self.r2],
-                row: ["Filter:", self.filter],
+            layout = column! [
+                row! ["Selection:", self.r0, self.r1, self.r2],
+                row! ["Filter:", self.filter],
                 self.list,
             ];
         }]
@@ -415,7 +415,7 @@ fn canvas() -> Box<dyn SetDisabled> {
 
     Box::new(singleton! {
         #[widget{
-            layout = column: [
+            layout = column! [
                 Label::new("Animated canvas demo (CPU-rendered, async). Note: scheduling is broken on X11."),
                 self.canvas,
             ];
@@ -448,7 +448,7 @@ KAS_CONFIG_MODE=readwrite
 
     Box::new(ScrollBarRegion::new(singleton! {
         #[widget{
-            layout = column: [
+            layout = column! [
                 ScrollLabel::new(Markdown::new(DESC).unwrap()),
                 Separator::new(),
                 self.view,
@@ -530,7 +530,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let window = singleton! {
         #[widget{
-            layout = column: [
+            layout = column! [
                 self.menubar,
                 Separator::new(),
                 self.stack,

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -122,7 +122,7 @@ fn widgets() -> Box<dyn SetDisabled> {
                 row! ["ScrollLabel", self.sl],
                 row! ["EditBox", self.eb],
                 row! ["TextButton", self.tb],
-                row! ["Button<Image>", pack(center): self.bi],
+                row! ["Button<Image>", pack!(center, self.bi)],
                 row! ["CheckButton", self.cb],
                 row! ["RadioButton", self.rb],
                 row! ["RadioButton", self.rb2],
@@ -237,7 +237,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
     Box::new(singleton! {
         #[widget{
             layout = float! [
-                pack(right, top): TextButton::new_msg("↻", MsgDirection),
+                pack!(right top, TextButton::new_msg("↻", MsgDirection)),
                 list!(self.dir, [self.editor, non_navigable: self.label]),
             ];
         }]

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -238,7 +238,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
         #[widget{
             layout = float! [
                 pack!(right top, TextButton::new_msg("↻", MsgDirection)),
-                list!(self.dir, [self.editor, non_navigable: self.label]),
+                list!(self.dir, [self.editor, non_navigable!(self.label)]),
             ];
         }]
         struct {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -238,7 +238,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
         #[widget{
             layout = float! [
                 pack(right, top): TextButton::new_msg("↻", MsgDirection),
-                list(self.dir): [self.editor, non_navigable: self.label],
+                list!(self.dir, [self.editor, non_navigable: self.label]),
             ];
         }]
         struct {

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -19,8 +19,8 @@ fn main() -> kas::shell::Result<()> {
                 (1, 0) => "Layout demo",
                 (2, 0) => self.check,
                 (0..3, 1) => ScrollLabel::new(LIPSUM),
-                (0, 2) => align(center): "abc אבג def",
-                (1..3, 3) => align(stretch): ScrollLabel::new(CRASIT),
+                (0, 2) => align!(center, "abc אבג def"),
+                (1..3, 3) => align!(stretch, ScrollLabel::new(CRASIT)),
                 (0, 3) => self.edit,
             };
         }]

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -15,13 +15,13 @@ fn main() -> kas::shell::Result<()> {
 
     let window = kas::singleton! {
         #[widget{
-            layout = grid: {
-                1, 0: "Layout demo";
-                2, 0: self.check;
-                0..3, 1: ScrollLabel::new(LIPSUM);
-                0, 2: align(center): "abc אבג def";
-                1..3, 3: align(stretch): ScrollLabel::new(CRASIT);
-                0, 3: self.edit;
+            layout = grid! {
+                (1, 0) => "Layout demo",
+                (2, 0) => self.check,
+                (0..3, 1) => ScrollLabel::new(LIPSUM),
+                (0, 2) => align(center): "abc אבג def",
+                (1..3, 3) => align(stretch): ScrollLabel::new(CRASIT),
+                (0, 3) => self.edit,
             };
         }]
         struct {

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -5,7 +5,7 @@
 
 //! Demonstration of widget and text layouts
 
-use kas::widget::{CheckBox, EditBox, ScrollLabel};
+use kas::widget::{dialog, CheckBox, EditBox, ScrollLabel};
 
 const LIPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nunc mi, consequat eget urna ut, auctor luctus mi. Sed molestie mi est. Sed non ligula ante. Curabitur ac molestie ante, nec sodales eros. In non arcu at turpis euismod bibendum ut tincidunt eros. Suspendisse blandit maximus nisi, viverra hendrerit elit efficitur et. Morbi ut facilisis eros. Vivamus dignissim, sapien sed mattis consectetur, libero leo imperdiet turpis, ac pulvinar libero purus eu lorem. Etiam quis sollicitudin urna. Integer vitae erat vel neque gravida blandit ac non quam.";
 const CRASIT: &str = "Cras sit amet justo ipsum. Aliquam in nunc posuere leo egestas laoreet convallis eu libero. Nullam ut massa ante. Cras vitae velit pharetra, euismod nisl suscipit, feugiat nulla. Aenean consectetur, diam non tristique iaculis, nisl lectus hendrerit sapien, nec rhoncus mi sem non odio. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla a lorem eu ipsum faucibus placerat ac quis quam. Curabitur justo ligula, laoreet nec ultrices eu, scelerisque non metus. Mauris sit amet est enim. Mauris risus eros, accumsan ut iaculis sit amet, sagittis facilisis neque. Nunc venenatis risus nec purus malesuada, a tristique arcu efficitur. Nulla suscipit arcu nibh. Cras facilisis nibh a gravida aliquet. Praesent fringilla felis a tristique luctus.";
@@ -13,27 +13,16 @@ const CRASIT: &str = "Cras sit amet justo ipsum. Aliquam in nunc posuere leo ege
 fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
-    let window = kas::singleton! {
-        #[widget{
-            layout = grid! {
-                (1, 0) => "Layout demo",
-                (2, 0) => self.check,
-                (0..3, 1) => ScrollLabel::new(LIPSUM),
-                (0, 2) => align!(center, "abc אבג def"),
-                (1..3, 3) => align!(stretch, ScrollLabel::new(CRASIT)),
-                (0, 3) => self.edit,
-            };
-        }]
-        struct {
-            core: widget_core!(),
-            #[widget] edit = EditBox::new("A small\nsample\nof text")
-                .with_multi_line(true),
-            #[widget] check: CheckBox,
-        }
-        impl kas::Window for Self {
-            fn title(&self) -> &str { "Layout demo" }
-        }
+    let ui = kas::grid! {
+        (1, 0) => "Layout demo",
+        (2, 0) => CheckBox::default(),
+        (0..3, 1) => ScrollLabel::new(LIPSUM),
+        (0, 2) => align!(center, "abc אבג def"),
+        (1..3, 3) => align!(stretch, ScrollLabel::new(CRASIT)),
+        (0, 3) => EditBox::new("A small\nsample\nof text")
+            .with_multi_line(true),
     };
+    let window = dialog::Window::new("Layout demo", ui);
 
     let theme = kas::theme::FlatTheme::new();
     kas::shell::DefaultShell::new(theme)?.with(window)?.run()

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -425,7 +425,7 @@ impl_scope! {
     #[widget{
         layout = grid! {
             (1, 0) => self.label,
-            (0, 1) => align(center): self.iters,
+            (0, 1) => align!(center, self.iters),
             (0, 2) => self.slider,
             (1..3, 1..4) => self.mbrot,
         };

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -423,11 +423,11 @@ impl_scope! {
 
 impl_scope! {
     #[widget{
-        layout = grid: {
-            1, 0: self.label;
-            0, 1: align(center): self.iters;
-            0, 2: self.slider;
-            1..3, 1..4: self.mbrot;
+        layout = grid! {
+            (1, 0) => self.label,
+            (0, 1) => align(center): self.iters,
+            (0, 2) => self.slider,
+            (1..3, 1..4) => self.mbrot,
         };
     }]
     struct MandlebrotWindow {

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -23,8 +23,8 @@ fn main() -> kas::shell::Result<()> {
 
     let window = kas::singleton! {
         #[widget{
-            layout = column: [
-                row: [
+            layout = column! [
+                row! [
                     TextButton::new_msg("−", Message::Decr),
                     TextButton::new_msg("+", Message::Incr),
                 ],

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -22,7 +22,7 @@ struct MsgStart;
 fn make_window() -> Box<dyn kas::Window> {
     Box::new(kas::singleton! {
         #[widget{
-            layout = row: [
+            layout = row! [
                 self.display,
                 TextButton::new_msg("&reset", MsgReset),
                 TextButton::new_msg("&start / &stop", MsgStart),

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -61,7 +61,7 @@ fn main() -> kas::shell::Result<()> {
         #[widget{
             layout = column! [
                 row! ["From 1 to", self.max],
-                align(right): self.table,
+                align!(right, self.table),
             ];
         }]
         struct {

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -59,8 +59,8 @@ fn main() -> kas::shell::Result<()> {
 
     let window = singleton! {
         #[widget{
-            layout = column: [
-                row: ["From 1 to", self.max],
+            layout = column! [
+                row! ["From 1 to", self.max],
                 align(right): self.table,
             ];
         }]

--- a/tests/layout_macros.rs
+++ b/tests/layout_macros.rs
@@ -1,0 +1,59 @@
+#[test]
+fn column() {
+    let _widget = kas::column!["one", "two",];
+}
+
+#[test]
+fn row() {
+    let _widget = kas::row!["one", "two"];
+}
+
+#[test]
+fn list() {
+    let _widget = kas::list!(left, ["one", "two"]);
+}
+
+#[test]
+fn float() {
+    let _widget = kas::float![
+        pack!(left top, "one"),
+        pack!(right bottom, "two"),
+        "some text\nin the\nbackground"
+    ];
+}
+
+#[test]
+fn grid() {
+    let _widget = kas::grid! {
+        (0, 0) => "top left",
+        (1, 0) => "top right",
+        (0..2, 1) => "bottom row (merged)",
+    };
+}
+
+#[test]
+fn aligned_column() {
+    let _widget = kas::aligned_column![row!["one", "two"], row!["three", "four"],];
+}
+
+#[test]
+fn aligned_row() {
+    let _widget = kas::aligned_row![column!["one", "two"], column!["three", "four"],];
+}
+
+#[test]
+fn align() {
+    let _a = kas::align!(right, "132");
+    let _b = kas::align!(left top, "abc");
+}
+
+#[test]
+fn pack() {
+    let _widget = kas::pack!(right top, "132");
+}
+
+#[test]
+fn margins() {
+    let _a = kas::margins!(1.0 em, "abc");
+    let _b = kas::margins!(vert = none, "abc");
+}


### PR DESCRIPTION
Another extract from #387: new layout syntax (`row![a, b, c]` instead of `row: [a, b, c]`), including support as stand-alone macros.

Stand-alone usage is mostly useless for now since there's currently no way to integrate event handling, but it is used in `examples/layout.rs`:
```rust
    let ui = kas::grid! {
        (1, 0) => "Layout demo",
        (2, 0) => CheckBox::default(),
        (0..3, 1) => ScrollLabel::new(LIPSUM),
        (0, 2) => align!(center, "abc אבג def"),
        (1..3, 3) => align!(stretch, ScrollLabel::new(CRASIT)),
        (0, 3) => EditBox::new("A small\nsample\nof text")
            .with_multi_line(true),
    };
```