### PR TITLE
Add trait Node: Widget, trait Visitable

### DIFF
--- a/crates/kas-core/src/core/data.rs
+++ b/crates/kas-core/src/core/data.rs
@@ -69,7 +69,7 @@ impl Clone for CoreData {
 /// visible). The window is responsible for calling these methods.
 //
 // NOTE: it's tempting to include a pointer to the widget here. There are two
-// options: (a) an unsafe aliased pointer or (b) Rc<RefCell<dyn Widget>>.
+// options: (a) an unsafe aliased pointer or (b) Rc<RefCell<dyn Node>>.
 // Option (a) should work but is an unnecessary performance hack; (b) could in
 // theory work but requires adjusting WidgetChildren::get, find etc. to take a
 // closure instead of returning a reference, causing *significant* complication.

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -108,10 +108,7 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// Default impl: `self.id_ref().make_child(index)`
     #[inline]
-    fn make_child_id(&mut self, index: usize) -> WidgetId
-    where
-        Self: Sized,
-    {
+    fn make_child_id(&mut self, index: usize) -> WidgetId {
         self.id_ref().make_child(index)
     }
 }

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -108,7 +108,10 @@ pub trait WidgetChildren: WidgetCore {
     ///
     /// Default impl: `self.id_ref().make_child(index)`
     #[inline]
-    fn make_child_id(&mut self, index: usize) -> WidgetId {
+    fn make_child_id(&mut self, index: usize) -> WidgetId
+    where
+        Self: Sized,
+    {
         self.id_ref().make_child(index)
     }
 }
@@ -583,7 +586,7 @@ pub enum NavAdvance {
 /// All methods are hidden and direct usage is not supported. Instead, use:
 ///
 /// -   [`ConfigMgr::configure`] or [`EventMgr::configure`]
-pub trait Node: Widget {
+pub trait Node: Layout {
     /// Internal method: configure recursively
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -789,12 +789,12 @@ impl<W: Widget> Node for W {
 }
 
 /// Extension trait over widgets
-pub trait WidgetExt: Widget {
+pub trait NodeExt: Node {
     /// Get the widget's identifier
     ///
     /// Note that the default-constructed [`WidgetId`] is *invalid*: any
     /// operations on this value will cause a panic. Valid identifiers are
-    /// assigned by [`Widget::pre_configure`].
+    /// assigned during configure.
     #[inline]
     fn id(&self) -> WidgetId {
         self.id_ref().clone()
@@ -857,4 +857,4 @@ pub trait WidgetExt: Widget {
         }
     }
 }
-impl<W: Widget + ?Sized> WidgetExt for W {}
+impl<W: Node + ?Sized> NodeExt for W {}

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -576,6 +576,13 @@ pub trait Widget: WidgetChildren {
 }
 
 /// Node: dyn-safe widget
+///
+/// This trait is automatically implemented for every [`Widget`].
+/// Directly implementing this trait is not supported.
+///
+/// All methods are hidden and direct usage is not supported. Instead, use:
+///
+/// -   [`ConfigMgr::configure`] or [`EventMgr::configure`]
 pub trait Node: Widget {
     /// Internal method: configure recursively
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -583,9 +583,8 @@ pub enum NavAdvance {
 /// This trait is automatically implemented for every [`Widget`].
 /// Directly implementing this trait is not supported.
 ///
-/// All methods are hidden and direct usage is not supported. Instead, use:
-///
-/// -   [`ConfigMgr::configure`] or [`EventMgr::configure`]
+/// All methods are hidden and direct usage is not supported; instead use the
+/// [`ConfigMgr`] and [`EventMgr`] types which use these methods internally.
 pub trait Node: Layout {
     /// Internal method: configure recursively
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
@@ -762,18 +761,14 @@ impl<W: Widget> Node for W {
             NavAdvance::Reverse(_) => true,
         };
 
-        loop {
-            if let Some(index) = self.nav_next(cx, rev, child) {
-                if let Some(id) = self
-                    .get_child_mut(index)
-                    .and_then(|w| w._nav_next(cx, focus, advance))
-                {
-                    return Some(id);
-                }
-                child = Some(index);
-            } else {
-                break;
+        while let Some(index) = self.nav_next(cx, rev, child) {
+            if let Some(id) = self
+                .get_child_mut(index)
+                .and_then(|w| w._nav_next(cx, focus, advance))
+            {
+                return Some(id);
             }
+            child = Some(index);
         }
 
         let can_match_self = match advance {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -27,7 +27,7 @@ use crate::layout::{self, AlignPair, AutoLayout};
 /// **Directly implementing this trait is not supported**.
 /// See [`Widget`] trait documentation.
 #[autoimpl(for<T: trait + ?Sized> &'_ mut T, Box<T>)]
-pub trait WidgetCore: Layout {
+pub trait WidgetCore {
     /// Get the widget's identifier
     ///
     /// Note that the default-constructed [`WidgetId`] is *invalid*: any
@@ -141,7 +141,7 @@ pub trait WidgetChildren: WidgetCore {
 /// solve layout for a single widget/layout object, it may be useful to use
 /// [`layout::solve_size_rules`] or [`layout::SolveCache`].
 #[autoimpl(for<T: trait + ?Sized> &'_ mut T, Box<T>)]
-pub trait Layout {
+pub trait Layout: WidgetChildren {
     /// Get size rules for the given axis
     ///
     /// Typically, this method is called twice: first for the horizontal axis,
@@ -378,7 +378,7 @@ pub trait Layout {
 /// }
 /// ```
 #[autoimpl(for<T: trait + ?Sized> &'_ mut T, Box<T>)]
-pub trait Widget: WidgetChildren {
+pub trait Widget: Layout {
     /// Pre-configuration
     ///
     /// This method is called before children are configured to assign a

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -188,6 +188,22 @@ pub trait Layout: WidgetChildren {
     /// [`Stretch`]: crate::layout::Stretch
     fn set_rect(&mut self, mgr: &mut ConfigMgr, rect: Rect);
 
+    /// Get translation of children relative to this widget
+    ///
+    /// Usually this is zero; only widgets with scrollable or offset content
+    /// *and* child widgets need to implement this.
+    /// Such widgets must also implement [`Widget::handle_scroll`].
+    ///
+    /// Affects event handling via [`Layout::find_id`] and affects the positioning
+    /// of pop-up menus. [`Layout::draw`] must be implemented directly using
+    /// [`DrawMgr::with_clip_region`] to offset contents.
+    ///
+    /// Default implementation: return [`Offset::ZERO`]
+    #[inline]
+    fn translation(&self) -> Offset {
+        Offset::ZERO
+    }
+
     /// Translate a coordinate to a [`WidgetId`]
     ///
     /// This method is used to determine which widget reacts to the mouse cursor
@@ -261,7 +277,7 @@ pub trait Layout: WidgetChildren {
 /// -   [`WidgetCore`] — base functionality
 /// -   [`WidgetChildren`] — enumerates children
 /// -   [`Layout`] — handles sizing and positioning for self and children
-/// -   [`Widget`] — configuration, some aspects of layout, event handling
+/// -   [`Widget`] — configuration, event handling
 ///
 /// # Implementing Widget
 ///
@@ -416,20 +432,6 @@ pub trait Widget: Layout {
     #[inline]
     fn navigable(&self) -> bool {
         false
-    }
-
-    /// Get translation of children relative to this widget
-    ///
-    /// Usually this is zero; only widgets with scrollable or offset content
-    /// *and* child widgets need to implement this.
-    /// Such widgets must also implement [`Widget::handle_scroll`].
-    ///
-    /// Affects event handling via [`Layout::find_id`] and affects the positioning
-    /// of pop-up menus. [`Layout::draw`] must be implemented directly using
-    /// [`DrawMgr::with_clip_region`] to offset contents.
-    #[inline]
-    fn translation(&self) -> Offset {
-        Offset::ZERO
     }
 
     /// Navigation in spatial order

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -42,9 +42,9 @@ pub trait WidgetCore: Layout {
     fn widget_name(&self) -> &'static str;
 
     /// Erase type
-    fn as_widget(&self) -> &dyn Widget;
+    fn as_node(&self) -> &dyn Node;
     /// Erase type
-    fn as_widget_mut(&mut self) -> &mut dyn Widget;
+    fn as_node_mut(&mut self) -> &mut dyn Node;
 }
 
 /// Listing of a [`Widget`]'s children
@@ -77,7 +77,7 @@ pub trait WidgetChildren: WidgetCore {
     /// Get a reference to a child widget by index, if any
     ///
     /// Required: `index < self.len()`.
-    fn get_child(&self, index: usize) -> Option<&dyn Widget>;
+    fn get_child(&self, index: usize) -> Option<&dyn Node>;
 
     /// Mutable variant of get
     ///
@@ -85,7 +85,7 @@ pub trait WidgetChildren: WidgetCore {
     /// redraw may break the UI. If a widget is replaced, a reconfigure **must**
     /// be requested. This can be done via [`EventState::send_action`].
     /// This method may be removed in the future.
-    fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget>;
+    fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node>;
 
     /// Find the child which is an ancestor of this `id`, if any
     ///
@@ -575,6 +575,10 @@ pub trait Widget: WidgetChildren {
     }
 }
 
+/// Node: dyn-safe widget
+pub trait Node: Widget {}
+impl<W: Widget> Node for W {}
+
 /// Extension trait over widgets
 pub trait WidgetExt: Widget {
     /// Get the widget's identifier
@@ -622,24 +626,23 @@ pub trait WidgetExt: Widget {
     }
 
     /// Find the descendant with this `id`, if any
-    fn find_widget(&self, id: &WidgetId) -> Option<&dyn Widget> {
+    fn find_node(&self, id: &WidgetId) -> Option<&dyn Node> {
         if let Some(index) = self.find_child_index(id) {
-            self.get_child(index)
-                .and_then(|child| child.find_widget(id))
+            self.get_child(index).and_then(|child| child.find_node(id))
         } else if self.eq_id(id) {
-            return Some(self.as_widget());
+            return Some(self.as_node());
         } else {
             None
         }
     }
 
     /// Find the descendant with this `id`, if any
-    fn find_widget_mut(&mut self, id: &WidgetId) -> Option<&mut dyn Widget> {
+    fn find_node_mut(&mut self, id: &WidgetId) -> Option<&mut dyn Node> {
         if let Some(index) = self.find_child_index(id) {
             self.get_child_mut(index)
-                .and_then(|child| child.find_widget_mut(id))
+                .and_then(|child| child.find_node_mut(id))
         } else if self.eq_id(id) {
-            return Some(self.as_widget_mut());
+            return Some(self.as_node_mut());
         } else {
             None
         }

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -622,24 +622,9 @@ impl<'a> EventMgr<'a> {
     // Traverse widget tree by recursive call, broadcasting
     #[inline]
     fn send_update(&mut self, widget: &mut dyn Node, id: UpdateId, payload: u64) -> usize {
-        fn inner(
-            mgr: &mut EventMgr,
-            widget: &mut dyn Node,
-            count: &mut usize,
-            id: UpdateId,
-            payload: u64,
-        ) {
-            widget.handle_event(mgr, Event::Update { id, payload });
-            *count += 1;
-            for index in 0..widget.num_children() {
-                if let Some(w) = widget.get_child_mut(index) {
-                    inner(mgr, w, count, id, payload);
-                }
-            }
-        }
-
         let mut count = 0;
-        inner(self, widget, &mut count, id, payload);
+        let event = Event::Update { id, payload };
+        widget._broadcast(self, &mut count, event);
         if !self.messages.is_empty() {
             log::error!(target: "kas_core::event::manager", "message(s) sent when handling Event::Update");
             self.drop_messages();

--- a/crates/kas-core/src/event/manager.rs
+++ b/crates/kas-core/src/event/manager.rs
@@ -23,7 +23,7 @@ use crate::cast::Cast;
 use crate::geom::{Coord, Offset};
 use crate::shell::ShellWindow;
 use crate::util::WidgetHierarchy;
-use crate::{Action, Erased, NavAdvance, Node, WidgetExt, WidgetId, WindowId};
+use crate::{Action, Erased, NavAdvance, Node, NodeExt, WidgetId, WindowId};
 
 mod config_mgr;
 mod mgr_pub;

--- a/crates/kas-core/src/event/manager/config_mgr.rs
+++ b/crates/kas-core/src/event/manager/config_mgr.rs
@@ -92,18 +92,7 @@ impl<'a> ConfigMgr<'a> {
     /// Pass the `id` to assign to the widget: this should be constructed from
     /// the parent's id via [`WidgetId::make_child`].
     pub fn configure(&mut self, id: WidgetId, widget: &mut dyn Node) {
-        widget.pre_configure(self, id);
-
-        for index in 0..widget.num_children() {
-            let id = widget.make_child_id(index);
-            if id.is_valid() {
-                if let Some(widget) = widget.get_child_mut(index) {
-                    self.configure(id, widget);
-                }
-            }
-        }
-
-        widget.configure(self);
+        widget._configure(self, id);
     }
 
     /// Align a feature's rect

--- a/crates/kas-core/src/event/manager/config_mgr.rs
+++ b/crates/kas-core/src/event/manager/config_mgr.rs
@@ -13,7 +13,7 @@ use crate::layout::AlignPair;
 use crate::shell::Platform;
 use crate::text::TextApi;
 use crate::theme::{Feature, SizeMgr, TextClass, ThemeSize};
-use crate::{Action, Widget, WidgetId};
+use crate::{Action, Node, WidgetId};
 use std::ops::{Deref, DerefMut};
 
 #[allow(unused)] use crate::{event::Event, Layout};
@@ -91,7 +91,7 @@ impl<'a> ConfigMgr<'a> {
     ///
     /// Pass the `id` to assign to the widget: this should be constructed from
     /// the parent's id via [`WidgetId::make_child`].
-    pub fn configure(&mut self, id: WidgetId, widget: &mut dyn Widget) {
+    pub fn configure(&mut self, id: WidgetId, widget: &mut dyn Node) {
         widget.pre_configure(self, id);
 
         for index in 0..widget.num_children() {

--- a/crates/kas-core/src/event/manager/config_mgr.rs
+++ b/crates/kas-core/src/event/manager/config_mgr.rs
@@ -91,7 +91,7 @@ impl<'a> ConfigMgr<'a> {
     ///
     /// Pass the `id` to assign to the widget: this should be constructed from
     /// the parent's id via [`WidgetId::make_child`].
-    pub fn configure(&mut self, id: WidgetId, widget: &mut dyn Node) {
+    pub fn configure(&mut self, widget: &mut dyn Node, id: WidgetId) {
         widget._configure(self, id);
     }
 

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -622,7 +622,7 @@ impl<'a> EventMgr<'a> {
             if self.scroll == Scroll::None {
                 self.scroll = scroll;
             } else {
-                // send_recurse does not call handle_scroll on its target, which
+                // Node::_send does not call handle_scroll on its target, which
                 // is *presumably* the widget calling this method
                 widget.handle_scroll(self, self.scroll);
             }

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -611,7 +611,7 @@ impl<'a> EventMgr<'a> {
     ///     (TODO: do we need another method to find this target?)
     /// -   Some events such as [`Event::PressMove`] contain embedded widget
     ///     identifiers which may affect handling of the event.
-    pub fn send(&mut self, widget: &mut dyn Widget, id: WidgetId, event: Event) {
+    pub fn send(&mut self, widget: &mut dyn Node, id: WidgetId, event: Event) {
         if matches!(self.scroll, Scroll::None | Scroll::Scrolled) && self.messages.is_empty() {
             // Safe to send immediately, except from steal_event when responding
             // Unused (hence noted possible panic in that method)!

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -591,16 +591,9 @@ impl<'a> EventMgr<'a> {
 
     /// Send an event to a widget
     ///
-    /// Sends `event` to widget `id`, where `widget` is either the target `id`
-    /// or any ancestor.
-    /// Ancestors of `id` up to and including `widget` have the usual
-    /// event-handling interactions: the ability to steal events and handle
-    /// unused events, to handle messages and to react to scroll actions.
-    ///
-    /// This method may be called from event handlers. It is implementation
-    /// defined whether the event is sent immediately or later, thus it may
-    /// or may not be observed by the caller that messages are left on the stack
-    /// and scroll state is adjusted.
+    /// Sends `event` to widget `id`. The event is queued to send later, thus
+    /// any actions by the receiving widget will not be immediately visible to
+    /// the caller of this method.
     ///
     /// When calling this method, be aware that:
     ///
@@ -611,26 +604,8 @@ impl<'a> EventMgr<'a> {
     ///     (TODO: do we need another method to find this target?)
     /// -   Some events such as [`Event::PressMove`] contain embedded widget
     ///     identifiers which may affect handling of the event.
-    pub fn send(&mut self, widget: &mut dyn Node, id: WidgetId, event: Event) {
-        if matches!(self.scroll, Scroll::None | Scroll::Scrolled) && self.messages.is_empty() {
-            // Safe to send immediately, except from steal_event when responding
-            // Unused (hence noted possible panic in that method)!
-            let last_child = std::mem::take(&mut self.last_child);
-            let scroll = std::mem::take(&mut self.scroll);
-            self.send_event_impl(widget, id, event);
-            self.last_child = last_child;
-            if self.scroll == Scroll::None {
-                self.scroll = scroll;
-            } else {
-                // Node::_send does not call handle_scroll on its target, which
-                // is *presumably* the widget calling this method
-                widget.handle_scroll(self, self.scroll);
-            }
-        } else {
-            // Possibly not safe: send later.
-            log::debug!("queing event for later sending");
-            self.pending.push_back(Pending::Send(id, event));
-        }
+    pub fn send(&mut self, id: WidgetId, event: Event) {
+        self.pending.push_back(Pending::Send(id, event));
     }
 
     /// Push a message to the stack

--- a/crates/kas-core/src/event/manager/mgr_pub.rs
+++ b/crates/kas-core/src/event/manager/mgr_pub.rs
@@ -898,4 +898,11 @@ impl<'a> EventMgr<'a> {
             }
         }
     }
+
+    /// Configure a widget
+    ///
+    /// This is a shortcut to [`ConfigMgr::configure`].
+    pub fn configure(&mut self, widget: &mut dyn Node, id: WidgetId) {
+        self.config_mgr(|mgr| mgr.configure(widget, id));
+    }
 }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -83,7 +83,7 @@ impl EventState {
 
         shell.size_and_draw_shared(Box::new(|size, draw_shared| {
             let mut mgr = ConfigMgr::new(size, draw_shared, self);
-            mgr.configure(WidgetId::ROOT, widget);
+            mgr.configure(widget, WidgetId::ROOT);
         }));
 
         let hover = widget.find_id(self.last_mouse_coord);
@@ -202,11 +202,9 @@ impl EventState {
             log::trace!(target: "kas_core::event::manager", "update: handling Pending::{item:?}");
             match item {
                 Pending::Configure(id) => {
-                    mgr.config_mgr(|mgr| {
-                        if let Some(w) = widget.find_node_mut(&id) {
-                            mgr.configure(id, w);
-                        }
-                    });
+                    if let Some(w) = widget.find_node_mut(&id) {
+                        mgr.configure(w, id);
+                    }
 
                     let hover = widget.find_id(mgr.state.last_mouse_coord);
                     mgr.state.set_hover(hover);

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -14,7 +14,7 @@ use crate::cast::traits::*;
 use crate::geom::{Coord, DVec2};
 use crate::model::SharedRc;
 use crate::shell::ShellWindow;
-use crate::{Action, Layout, RootWidget, Widget, WidgetId, Window};
+use crate::{Action, Layout, RootWidget, WidgetId, Window};
 
 // TODO: this should be configurable or derived from the system
 const DOUBLE_CLICK_TIMEOUT: Duration = Duration::from_secs(1);
@@ -71,7 +71,7 @@ impl EventState {
     /// [`WidgetId`] identifiers and call widgets' [`Widget::configure`]
     /// method. Additionally, it updates the [`EventState`] to account for
     /// renamed and removed widgets.
-    pub(crate) fn full_configure(&mut self, shell: &mut dyn ShellWindow, widget: &mut dyn Widget) {
+    pub(crate) fn full_configure(&mut self, shell: &mut dyn ShellWindow, widget: &mut dyn Node) {
         log::debug!(target: "kas_core::event::manager", "full_configure");
         self.action.remove(Action::RECONFIGURE);
 
@@ -91,7 +91,7 @@ impl EventState {
     }
 
     /// Update the widgets under the cursor and touch events
-    pub(crate) fn region_moved(&mut self, widget: &mut dyn Widget) {
+    pub(crate) fn region_moved(&mut self, widget: &mut dyn Node) {
         log::trace!(target: "kas_core::event::manager", "region_moved");
         // Note: redraw is already implied.
 
@@ -129,11 +129,7 @@ impl EventState {
 
     /// Update, after receiving all events
     #[inline]
-    pub(crate) fn update(
-        &mut self,
-        shell: &mut dyn ShellWindow,
-        widget: &mut dyn Widget,
-    ) -> Action {
+    pub(crate) fn update(&mut self, shell: &mut dyn ShellWindow, widget: &mut dyn Node) -> Action {
         let old_hover_icon = self.hover_icon;
 
         let mut mgr = EventMgr {
@@ -207,7 +203,7 @@ impl EventState {
             match item {
                 Pending::Configure(id) => {
                     mgr.config_mgr(|mgr| {
-                        if let Some(w) = widget.find_widget_mut(&id) {
+                        if let Some(w) = widget.find_node_mut(&id) {
                             mgr.configure(id, w);
                         }
                     });
@@ -252,11 +248,7 @@ impl EventState {
     ///
     /// Returns true if action is non-empty
     #[inline]
-    pub(crate) fn post_draw(
-        &mut self,
-        shell: &mut dyn ShellWindow,
-        widget: &mut dyn Widget,
-    ) -> bool {
+    pub(crate) fn post_draw(&mut self, shell: &mut dyn ShellWindow, widget: &mut dyn Node) -> bool {
         let mut mgr = EventMgr {
             state: self,
             shell,
@@ -278,7 +270,7 @@ impl EventState {
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 impl<'a> EventMgr<'a> {
     /// Update widgets due to timer
-    pub(crate) fn update_timer(&mut self, widget: &mut dyn Widget) {
+    pub(crate) fn update_timer(&mut self, widget: &mut dyn Node) {
         let now = Instant::now();
 
         // assumption: time_updates are sorted in reverse order
@@ -295,7 +287,7 @@ impl<'a> EventMgr<'a> {
     }
 
     /// Update widgets with an [`UpdateId`]
-    pub(crate) fn update_widgets(&mut self, widget: &mut dyn Widget, id: UpdateId, payload: u64) {
+    pub(crate) fn update_widgets(&mut self, widget: &mut dyn Node, id: UpdateId, payload: u64) {
         if id == self.state.config.config.id() {
             let (sf, dpem) = self.size_mgr(|size| (size.scale_factor(), size.dpem()));
             self.state.config.update(sf, dpem);
@@ -310,7 +302,7 @@ impl<'a> EventMgr<'a> {
         );
     }
 
-    fn poll_futures(&mut self, widget: &mut dyn Widget) {
+    fn poll_futures(&mut self, widget: &mut dyn Node) {
         let mut i = 0;
         while i < self.state.fut_messages.len() {
             let (_, fut) = &mut self.state.fut_messages[i];
@@ -486,7 +478,7 @@ impl<'a> EventMgr<'a> {
                     if let Some(start_id) = self.hover.clone() {
                         // No mouse grab but have a hover target
                         if self.config.mouse_nav_focus() {
-                            if let Some(w) = widget.find_widget(&start_id) {
+                            if let Some(w) = widget.find_node(&start_id) {
                                 if w.navigable() {
                                     self.set_nav_focus(w.id(), false);
                                 }
@@ -518,7 +510,7 @@ impl<'a> EventMgr<'a> {
                         let start_id = widget.find_id(coord);
                         if let Some(id) = start_id.as_ref() {
                             if self.config.touch_nav_focus() {
-                                if let Some(w) = widget.find_widget(id) {
+                                if let Some(w) = widget.find_node(id) {
                                     if w.navigable() {
                                         self.set_nav_focus(w.id(), false);
                                     }

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -14,7 +14,7 @@ use crate::cast::traits::*;
 use crate::geom::{Coord, DVec2};
 use crate::model::SharedRc;
 use crate::shell::ShellWindow;
-use crate::{Action, Layout, RootWidget, WidgetId, Window};
+use crate::{Action, Layout, NavAdvance, RootWidget, WidgetId, Window};
 
 // TODO: this should be configurable or derived from the system
 const DOUBLE_CLICK_TIMEOUT: Duration = Duration::from_secs(1);
@@ -476,10 +476,10 @@ impl<'a> EventMgr<'a> {
                     if let Some(start_id) = self.hover.clone() {
                         // No mouse grab but have a hover target
                         if self.config.mouse_nav_focus() {
-                            if let Some(w) = widget.find_node(&start_id) {
-                                if w.navigable() {
-                                    self.set_nav_focus(w.id(), false);
-                                }
+                            if let Some(id) =
+                                widget._nav_next(self, Some(&start_id), NavAdvance::None)
+                            {
+                                self.set_nav_focus(id, false);
                             }
                         }
                     }
@@ -508,10 +508,10 @@ impl<'a> EventMgr<'a> {
                         let start_id = widget.find_id(coord);
                         if let Some(id) = start_id.as_ref() {
                             if self.config.touch_nav_focus() {
-                                if let Some(w) = widget.find_node(id) {
-                                    if w.navigable() {
-                                        self.set_nav_focus(w.id(), false);
-                                    }
+                                if let Some(id) =
+                                    widget._nav_next(self, Some(&id), NavAdvance::None)
+                                {
+                                    self.set_nav_focus(id, false);
                                 }
                             }
 

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -508,8 +508,7 @@ impl<'a> EventMgr<'a> {
                         let start_id = widget.find_id(coord);
                         if let Some(id) = start_id.as_ref() {
                             if self.config.touch_nav_focus() {
-                                if let Some(id) =
-                                    widget._nav_next(self, Some(&id), NavAdvance::None)
+                                if let Some(id) = widget._nav_next(self, Some(id), NavAdvance::None)
                                 {
                                     self.set_nav_focus(id, false);
                                 }

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -242,7 +242,7 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RulesSetter for RowSetter<D, T, 
 /// layout representation.
 ///
 /// This is only applicable where child widgets are contained in a slice of type
-/// `W: Widget` (which may be `Box<dyn Widget>`). In other cases, the naive
+/// `W: Widget` (which may be `Box<dyn Node>`). In other cases, the naive
 /// implementation (test all items) must be used.
 #[derive(Clone, Copy, Debug)]
 pub struct RowPositionSolver<D: Directional> {

--- a/crates/kas-core/src/layout/sizer.rs
+++ b/crates/kas-core/src/layout/sizer.rs
@@ -11,7 +11,7 @@ use crate::event::ConfigMgr;
 use crate::geom::{Rect, Size};
 use crate::theme::SizeMgr;
 use crate::util::WidgetHierarchy;
-use crate::Widget;
+use crate::{Node, Widget};
 
 /// A [`SizeRules`] solver for layouts
 ///
@@ -134,7 +134,7 @@ impl SolveCache {
     /// Calculate required size of widget
     ///
     /// Assumes no explicit alignment.
-    pub fn find_constraints(widget: &mut dyn Widget, size_mgr: SizeMgr) -> Self {
+    pub fn find_constraints(widget: &mut dyn Node, size_mgr: SizeMgr) -> Self {
         let start = std::time::Instant::now();
 
         let w = widget.size_rules(size_mgr.re(), AxisInfo::new(false, None, None));
@@ -184,7 +184,7 @@ impl SolveCache {
     /// last used).
     pub fn apply_rect(
         &mut self,
-        widget: &mut dyn Widget,
+        widget: &mut dyn Node,
         mgr: &mut ConfigMgr,
         mut rect: Rect,
         inner_margin: bool,
@@ -228,7 +228,7 @@ impl SolveCache {
     /// Print widget heirarchy in the trace log
     ///
     /// This is sometimes called after [`Self::apply_rect`].
-    pub fn print_widget_heirarchy(&mut self, widget: &mut dyn Widget) {
+    pub fn print_widget_heirarchy(&mut self, widget: &mut dyn Node) {
         let rect = widget.rect();
         let hier = WidgetHierarchy::new(widget);
         log::trace!(

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -17,7 +17,7 @@ use crate::event::ConfigMgr;
 use crate::geom::{Coord, Offset, Rect, Size};
 use crate::theme::{Background, DrawMgr, FrameStyle, MarginStyle, SizeMgr};
 use crate::WidgetId;
-use crate::{dir::Directional, dir::Directions, Layout, Widget, WidgetCore};
+use crate::{dir::Directional, dir::Directions, Layout, Widget};
 use std::iter::ExactSizeIterator;
 
 /// A sub-set of [`Layout`] used by [`Visitor`].
@@ -65,9 +65,9 @@ enum LayoutType<'a> {
     /// A boxed component
     BoxComponent(Box<dyn Visitable + 'a>),
     /// A single child widget
-    Single(&'a mut dyn WidgetCore),
+    Single(&'a mut dyn Layout),
     /// A single child widget with alignment
-    AlignSingle(&'a mut dyn WidgetCore, AlignHints),
+    AlignSingle(&'a mut dyn Layout, AlignHints),
     /// Apply alignment hints to some sub-layout
     Align(Box<Visitor<'a>>, AlignHints),
     /// Apply alignment and pack some sub-layout
@@ -82,13 +82,13 @@ enum LayoutType<'a> {
 
 impl<'a> Visitor<'a> {
     /// Construct a single-item layout
-    pub fn single(widget: &'a mut dyn WidgetCore) -> Self {
+    pub fn single(widget: &'a mut dyn Layout) -> Self {
         let layout = LayoutType::Single(widget);
         Visitor { layout }
     }
 
     /// Construct a single-item layout with alignment hints
-    pub fn align_single(widget: &'a mut dyn WidgetCore, hints: AlignHints) -> Self {
+    pub fn align_single(widget: &'a mut dyn Layout, hints: AlignHints) -> Self {
         let layout = LayoutType::AlignSingle(widget, hints);
         Visitor { layout }
     }

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -59,7 +59,7 @@ enum LayoutType<'a> {
 /* unused utility method:
 impl<'a> LayoutType<'a> {
     fn id(&self) -> Option<WidgetId> {
-        use crate::WidgetExt;
+        use crate::NodeExt;
         match self {
             LayoutType::None => None,
             LayoutType::Component(_) => None,

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -29,4 +29,4 @@ pub use crate::{autoimpl, impl_default, impl_scope, singleton, widget, widget_in
 #[doc(no_inline)]
 pub use crate::{HasScrollBars, ScrollBarMode, Scrollable};
 #[doc(no_inline)]
-pub use crate::{Layout, Widget, WidgetChildren, WidgetCore, WidgetExt, Window};
+pub use crate::{Layout, Node, Widget, WidgetChildren, WidgetCore, WidgetExt, Window};

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -29,4 +29,4 @@ pub use crate::{autoimpl, impl_default, impl_scope, singleton, widget, widget_in
 #[doc(no_inline)]
 pub use crate::{HasScrollBars, ScrollBarMode, Scrollable};
 #[doc(no_inline)]
-pub use crate::{Layout, Node, Widget, WidgetChildren, WidgetCore, WidgetExt, Window};
+pub use crate::{Layout, Node, NodeExt, Widget, WidgetChildren, WidgetCore, Window};

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -11,7 +11,7 @@ use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::{self, AxisInfo, SizeRules};
 use crate::theme::{DrawMgr, FrameStyle, SizeMgr};
 use crate::title_bar::TitleBar;
-use crate::{Action, Decorations, Layout, Node, Widget, WidgetExt, WidgetId, Window, WindowId};
+use crate::{Action, Decorations, Layout, Node, NodeExt, Widget, WidgetId, Window, WindowId};
 use kas_macros::impl_scope;
 use smallvec::SmallVec;
 

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -11,7 +11,7 @@ use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::{self, AxisInfo, SizeRules};
 use crate::theme::{DrawMgr, FrameStyle, SizeMgr};
 use crate::title_bar::TitleBar;
-use crate::{Action, Decorations, Layout, Widget, WidgetExt, WidgetId, Window, WindowId};
+use crate::{Action, Decorations, Layout, Node, Widget, WidgetExt, WidgetId, Window, WindowId};
 use kas_macros::impl_scope;
 use smallvec::SmallVec;
 
@@ -80,7 +80,7 @@ impl_scope! {
             for (_, popup, translation) in self.popups.iter_mut().rev() {
                 if let Some(id) = self
                     .w
-                    .find_widget_mut(&popup.id)
+                    .find_node_mut(&popup.id)
                     .and_then(|w| w.find_id(coord + *translation))
                 {
                     return Some(id);
@@ -100,7 +100,7 @@ impl_scope! {
             }
             draw.recurse(&mut self.w);
             for (_, popup, translation) in &self.popups {
-                if let Some(widget) = self.w.find_widget_mut(&popup.id) {
+                if let Some(widget) = self.w.find_node_mut(&popup.id) {
                     let clip_rect = widget.rect() - *translation;
                     draw.with_overlay(clip_rect, *translation, |mut draw| {
                         draw.recurse(widget);
@@ -218,7 +218,7 @@ impl RootWidget {
 
 // Search for a widget by `id`. On success, return that widget's [`Rect`] and
 // the translation of its children.
-fn find_rect(mut widget: &dyn Widget, id: WidgetId) -> Option<(Rect, Offset)> {
+fn find_rect(mut widget: &dyn Node, id: WidgetId) -> Option<(Rect, Offset)> {
     let mut translation = Offset::ZERO;
     loop {
         if let Some(i) = widget.find_child_index(&id) {
@@ -256,7 +256,7 @@ impl RootWidget {
         let (c, t) = find_rect(&self.w, popup.parent.clone()).unwrap();
         *translation = t;
         let r = r + t; // work in translated coordinate space
-        let widget = self.w.find_widget_mut(&popup.id).unwrap();
+        let widget = self.w.find_node_mut(&popup.id).unwrap();
         let mut cache = layout::SolveCache::find_constraints(widget, mgr.size_mgr());
         let ideal = cache.ideal(false);
         let m = cache.margins();

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -261,7 +261,7 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
             self.ev_state.region_moved(&mut *self.widget);
         } else*/
         if action.contains(Action::REGION_MOVED) {
-            self.ev_state.region_moved(&mut self.widget.as_node_mut());
+            self.ev_state.region_moved(self.widget.as_node_mut());
         }
         if !action.is_empty() {
             self.queued_frame_time = Some(self.next_avail_frame_time);

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -88,10 +88,10 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
 
         let mut ev_state = EventState::new(shared.config.clone(), scale_factor, dpem);
         let mut tkw = TkWindow::new(shared, None, &mut theme_window);
-        ev_state.full_configure(&mut tkw, widget.as_widget_mut());
+        ev_state.full_configure(&mut tkw, widget.as_node_mut());
 
         let size_mgr = SizeMgr::new(theme_window.size());
-        let mut solve_cache = SolveCache::find_constraints(widget.as_widget_mut(), size_mgr);
+        let mut solve_cache = SolveCache::find_constraints(widget.as_node_mut(), size_mgr);
 
         // Opening a zero-size window causes a crash, so force at least 1x1:
         let ideal = solve_cache.ideal(true).max(Size(1, 1));
@@ -203,7 +203,7 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
     /// Update, after receiving all events
     pub(super) fn update(&mut self, shared: &mut SharedState<S, T>) -> (Action, Option<Instant>) {
         let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
-        let action = self.ev_state.update(&mut tkw, self.widget.as_widget_mut());
+        let action = self.ev_state.update(&mut tkw, self.widget.as_node_mut());
 
         if action.contains(Action::CLOSE | Action::EXIT) {
             return (action, None);
@@ -229,9 +229,7 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
     /// Returns: time of next scheduled resume.
     pub(super) fn post_draw(&mut self, shared: &mut SharedState<S, T>) -> Option<Instant> {
         let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
-        let has_action = self
-            .ev_state
-            .post_draw(&mut tkw, self.widget.as_widget_mut());
+        let has_action = self.ev_state.post_draw(&mut tkw, self.widget.as_node_mut());
 
         if has_action {
             self.queued_frame_time = Some(self.next_avail_frame_time);
@@ -263,7 +261,7 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
             self.ev_state.region_moved(&mut *self.widget);
         } else*/
         if action.contains(Action::REGION_MOVED) {
-            self.ev_state.region_moved(&mut self.widget.as_widget_mut());
+            self.ev_state.region_moved(&mut self.widget.as_node_mut());
         }
         if !action.is_empty() {
             self.queued_frame_time = Some(self.next_avail_frame_time);
@@ -276,12 +274,12 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
         self.ev_state.with(&mut tkw, |mgr| {
             widget.handle_closure(mgr);
         });
-        self.ev_state.update(&mut tkw, self.widget.as_widget_mut())
+        self.ev_state.update(&mut tkw, self.widget.as_node_mut())
     }
 
     pub(super) fn update_timer(&mut self, shared: &mut SharedState<S, T>) -> Option<Instant> {
         let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
-        let widget = self.widget.as_widget_mut();
+        let widget = self.widget.as_node_mut();
         self.ev_state.with(&mut tkw, |mgr| mgr.update_timer(widget));
         self.next_resume()
     }
@@ -293,7 +291,7 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
         payload: u64,
     ) {
         let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
-        let widget = self.widget.as_widget_mut();
+        let widget = self.widget.as_node_mut();
         self.ev_state
             .with(&mut tkw, |mgr| mgr.update_widgets(widget, id, payload));
     }
@@ -334,7 +332,7 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
 
         let mut tkw = TkWindow::new(shared, Some(&self.window), &mut self.theme_window);
         self.ev_state
-            .full_configure(&mut tkw, self.widget.as_widget_mut());
+            .full_configure(&mut tkw, self.widget.as_node_mut());
 
         self.solve_cache.invalidate_rule_cache();
         self.apply_size(shared, false);
@@ -353,9 +351,9 @@ impl<S: WindowSurface, T: Theme<S::Shared>> Window<S, T> {
             &mut shared.draw,
             &mut self.ev_state,
         );
-        solve_cache.apply_rect(widget.as_widget_mut(), &mut mgr, rect, true);
+        solve_cache.apply_rect(widget.as_node_mut(), &mut mgr, rect, true);
         if first {
-            solve_cache.print_widget_heirarchy(widget.as_widget_mut());
+            solve_cache.print_widget_heirarchy(widget.as_node_mut());
         }
         widget.resize_popups(&mut mgr);
 

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -15,7 +15,7 @@ use kas::theme::{DrawMgr, SizeMgr, ThemeControl, ThemeSize};
 use kas::theme::{Theme, Window as _};
 #[cfg(all(wayland_platform, feature = "clipboard"))]
 use kas::util::warn_about_error;
-use kas::{Action, Layout, WidgetCore, WidgetExt, Window as _, WindowId};
+use kas::{Action, Layout, NodeExt, WidgetCore, Window as _, WindowId};
 use std::mem::take;
 use std::time::Instant;
 use winit::event::WindowEvent;

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -12,7 +12,7 @@ use crate::draw::{Draw, DrawIface, DrawShared, DrawSharedImpl, ImageId, PassType
 use crate::event::{ConfigMgr, EventState};
 use crate::geom::{Offset, Rect};
 use crate::text::{TextApi, TextDisplay};
-use crate::{autoimpl, Action, Widget, WidgetCore, WidgetId};
+use crate::{autoimpl, Action, Layout, Widget, WidgetId};
 use std::convert::AsRef;
 use std::ops::{Bound, Range, RangeBounds};
 use std::time::Instant;
@@ -76,7 +76,7 @@ impl<'a> DrawMgr<'a> {
 
     /// Recurse drawing to a child
     #[inline]
-    pub fn recurse(&mut self, child: &mut (impl WidgetCore + ?Sized)) {
+    pub fn recurse(&mut self, child: &mut (impl Layout + ?Sized)) {
         child.draw(self.re_id(child.id_ref().clone()));
     }
 

--- a/crates/kas-core/src/util.rs
+++ b/crates/kas-core/src/util.rs
@@ -6,12 +6,12 @@
 //! Utilities
 
 use crate::geom::Coord;
-use crate::{Node, WidgetExt, WidgetId};
+use crate::{Node, NodeExt, WidgetId};
 use std::fmt;
 
 /// Helper to display widget identification (e.g. `MyWidget#01`)
 ///
-/// Constructed by [`crate::WidgetExt::identify`].
+/// Constructed by [`crate::NodeExt::identify`].
 pub struct IdentifyWidget(pub(crate) &'static str, pub(crate) WidgetId);
 impl fmt::Display for IdentifyWidget {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/crates/kas-core/src/util.rs
+++ b/crates/kas-core/src/util.rs
@@ -6,7 +6,7 @@
 //! Utilities
 
 use crate::geom::Coord;
-use crate::{Widget, WidgetExt, WidgetId};
+use crate::{Node, WidgetExt, WidgetId};
 use std::fmt;
 
 /// Helper to display widget identification (e.g. `MyWidget#01`)
@@ -23,11 +23,11 @@ impl fmt::Display for IdentifyWidget {
 ///
 /// Note: output starts with a new line.
 pub struct WidgetHierarchy<'a> {
-    widget: &'a dyn Widget,
+    widget: &'a dyn Node,
     indent: usize,
 }
 impl<'a> WidgetHierarchy<'a> {
-    pub fn new(widget: &'a dyn Widget) -> Self {
+    pub fn new(widget: &'a dyn Node) -> Self {
         WidgetHierarchy { widget, indent: 0 }
     }
 }

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -81,7 +81,7 @@ impl Tree {
             }
 
             fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
-                use ::kas::{layout, Widget, WidgetCore, WidgetExt};
+                use ::kas::{layout, Widget, WidgetCore, NodeExt};
                 if !self.rect().contains(coord) {
                     return None;
                 }

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -1124,7 +1124,7 @@ impl Layout {
                 quote! { layout::Visitor::float(#iter) }
             }
             Layout::Label(stor, _) => {
-                quote! { layout::Visitor::component(&mut #core_path.#stor) }
+                quote! { layout::Visitor::single(&mut #core_path.#stor) }
             }
             Layout::NonNavigable(layout) => return layout.generate(core_path),
         })

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -81,7 +81,7 @@ impl Tree {
             }
 
             fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
-                use ::kas::{layout, Widget, WidgetCore, NodeExt};
+                use ::kas::{layout, Layout, WidgetCore, NodeExt};
                 if !self.rect().contains(coord) {
                     return None;
                 }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -569,7 +569,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
 
         let mut set_rect = quote! { self.#core.rect = rect; };
         let mut find_id = quote! {
-            use ::kas::{WidgetCore, WidgetExt};
+            use ::kas::{WidgetCore, NodeExt};
             self.rect().contains(coord).then(|| self.id())
         };
         if let Some((_, layout)) = args.layout.take() {
@@ -696,7 +696,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 mgr: &mut ::kas::event::EventMgr,
                 event: ::kas::event::Event,
             ) -> ::kas::event::Response {
-                use ::kas::{event::{Event, Response}, WidgetExt};
+                use ::kas::{event::{Event, Response}, NodeExt};
                 #pre_handle_event
                 self.handle_event(mgr, event)
             }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -352,6 +352,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
     let widget_name = name.to_string();
 
     let mut fn_size_rules = None;
+    let mut fn_translation = None;
     let (fn_set_rect, fn_find_id);
     let mut fn_draw = None;
     let mut gen_layout = false;
@@ -431,6 +432,12 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 self.#inner.set_rect(mgr, rect);
             }
         };
+        fn_translation = Some(quote! {
+            #[inline]
+            fn translation(&self) -> ::kas::geom::Offset {
+                self.#inner.translation()
+            }
+        });
         fn_find_id = quote! {
             #[inline]
             fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
@@ -463,12 +470,6 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
             #[inline]
             fn configure(&mut self, mgr: &mut ::kas::event::ConfigMgr) {
                 self.#inner.configure(mgr);
-            }
-        };
-        let translation = quote! {
-            #[inline]
-            fn translation(&self) -> ::kas::geom::Offset {
-                self.#inner.translation()
             }
         };
         fn_nav_next = Some(quote! {
@@ -526,7 +527,6 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
         };
         widget_methods = vec![
             ("configure", configure),
-            ("translation", translation),
             ("handle_message", handle_message),
             ("handle_scroll", handle_scroll),
         ];
@@ -729,6 +729,11 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
         }
         if !has_method("set_rect") {
             layout_impl.items.push(parse2(fn_set_rect)?);
+        }
+        if let Some(method) = fn_translation {
+            if !has_method("translation") {
+                layout_impl.items.push(parse2(method)?);
+            }
         }
         if !has_method("find_id") {
             layout_impl.items.push(parse2(fn_find_id)?);

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -383,9 +383,9 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 }
 
                 #[inline]
-                fn as_widget(&self) -> &dyn ::kas::Widget { self }
+                fn as_node(&self) -> &dyn ::kas::Node { self }
                 #[inline]
-                fn as_widget_mut(&mut self) -> &mut dyn ::kas::Widget { self }
+                fn as_node_mut(&mut self) -> &mut dyn ::kas::Node { self }
             }
 
             impl #impl_generics ::kas::WidgetChildren for #impl_target {
@@ -394,11 +394,11 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                     self.#inner.num_children()
                 }
                 #[inline]
-                fn get_child(&self, index: usize) -> Option<&dyn ::kas::Widget> {
+                fn get_child(&self, index: usize) -> Option<&dyn ::kas::Node> {
                     self.#inner.get_child(index)
                 }
                 #[inline]
-                fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn ::kas::Widget> {
+                fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn ::kas::Node> {
                     self.#inner.get_child_mut(index)
                 }
                 #[inline]
@@ -814,9 +814,9 @@ pub fn impl_core(impl_generics: &Toks, impl_target: &Toks, name: &str, core_path
             }
 
             #[inline]
-            fn as_widget(&self) -> &dyn ::kas::Widget { self }
+            fn as_node(&self) -> &dyn ::kas::Node { self }
             #[inline]
-            fn as_widget_mut(&mut self) -> &mut dyn ::kas::Widget { self }
+            fn as_node_mut(&mut self) -> &mut dyn ::kas::Node { self }
         }
     }
 }
@@ -849,13 +849,13 @@ pub fn impl_widget_children(
             fn num_children(&self) -> usize {
                 #count
             }
-            fn get_child(&self, _index: usize) -> Option<&dyn ::kas::Widget> {
+            fn get_child(&self, _index: usize) -> Option<&dyn ::kas::Node> {
                 match _index {
                     #get_rules
                     _ => None
                 }
             }
-            fn get_child_mut(&mut self, _index: usize) -> Option<&mut dyn ::kas::Widget> {
+            fn get_child_mut(&mut self, _index: usize) -> Option<&mut dyn ::kas::Node> {
                 match _index {
                     #get_mut_rules
                     _ => None

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -608,6 +608,11 @@ impl_scope! {
             mgr.request_reconfigure(self.id());
         }
 
+        #[inline]
+        fn translation(&self) -> Offset {
+            self.scroll_offset()
+        }
+
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
             if !self.rect().contains(coord) {
                 return None;
@@ -692,11 +697,6 @@ impl_scope! {
             }
 
             Some(data % usize::conv(self.cur_len))
-        }
-
-        #[inline]
-        fn translation(&self) -> Offset {
-            self.scroll_offset()
         }
 
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -411,7 +411,7 @@ impl_scope! {
                     // Reset widgets to ensure input state such as cursor
                     // position does not bleed over to next data entry
                     w.widget = self.driver.make();
-                    mgr.configure(id, &mut w.widget);
+                    mgr.configure(&mut w.widget, id);
 
                     if let Some(item) = self.data.borrow(&key) {
                         *mgr |= self.driver.set(&mut w.widget, &key, item.borrow());

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -481,15 +481,15 @@ impl_scope! {
             self.cur_len.cast()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
+        fn get_child(&self, index: usize) -> Option<&dyn Node> {
             self.widgets.get(index).and_then(|w| {
-                w.key.is_some().then(|| w.widget.as_widget())
+                w.key.is_some().then(|| w.widget.as_node())
             })
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
             self.widgets.get_mut(index).and_then(|w| {
-                w.key.is_some().then(|| w.widget.as_widget_mut())
+                w.key.is_some().then(|| w.widget.as_node_mut())
             })
         }
         fn find_child_index(&self, id: &WidgetId) -> Option<usize> {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -384,7 +384,7 @@ impl_scope! {
                         // Reset widgets to ensure input state such as cursor
                         // position does not bleed over to next data entry
                         w.widget = self.driver.make();
-                        mgr.configure(id, &mut w.widget);
+                        mgr.configure(&mut w.widget, id);
 
                         if let Some(item) = self.data.borrow(&key) {
                             *mgr |= self.driver.set(&mut w.widget, &key, item.borrow());

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -456,15 +456,15 @@ impl_scope! {
             self.cur_len.cast()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
+        fn get_child(&self, index: usize) -> Option<&dyn Node> {
             self.widgets.get(index).and_then(|w| {
-                w.key.is_some().then(|| w.widget.as_widget())
+                w.key.is_some().then(|| w.widget.as_node())
             })
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
             self.widgets.get_mut(index).and_then(|w| {
-                w.key.is_some().then(|| w.widget.as_widget_mut())
+                w.key.is_some().then(|| w.widget.as_node_mut())
             })
         }
         fn find_child_index(&self, id: &WidgetId) -> Option<usize> {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -577,6 +577,11 @@ impl_scope! {
             mgr.request_reconfigure(self.id());
         }
 
+        #[inline]
+        fn translation(&self) -> Offset {
+            self.scroll_offset()
+        }
+
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
             if !self.rect().contains(coord) {
                 return None;
@@ -680,11 +685,6 @@ impl_scope! {
             }
 
             Some(solver.data_to_child(ci, ri))
-        }
-
-        #[inline]
-        fn translation(&self) -> Offset {
-            self.scroll_offset()
         }
 
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -145,7 +145,7 @@ impl_scope! {
                                 return Response::Used;
                             }
                         } else if self.popup_id.is_some() && self.popup.is_ancestor_of(&id) {
-                            mgr.send(self, id, Event::Command(Command::Activate));
+                            mgr.send(id, Event::Command(Command::Activate));
                             return Response::Used;
                         }
                     }

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -16,7 +16,7 @@ use std::ops::{Index, IndexMut};
 /// This is parameterised over the handler message type.
 ///
 /// See documentation of [`Grid`] type.
-pub type BoxGrid = Grid<Box<dyn Widget>>;
+pub type BoxGrid = Grid<Box<dyn Node>>;
 
 impl_scope! {
     /// A generic grid widget
@@ -67,12 +67,12 @@ impl_scope! {
             self.widgets.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
-            self.widgets.get(index).map(|c| c.1.as_widget())
+        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+            self.widgets.get(index).map(|c| c.1.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
-            self.widgets.get_mut(index).map(|c| c.1.as_widget_mut())
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+            self.widgets.get_mut(index).map(|c| c.1.as_node_mut())
         }
     }
 

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -268,7 +268,7 @@ impl_scope! {
         pub fn push(&mut self, mgr: &mut ConfigMgr, mut widget: W) -> usize {
             let index = self.widgets.len();
             let id = self.make_child_id(index);
-            mgr.configure(id, &mut widget);
+            mgr.configure(&mut widget, id);
             self.widgets.push(widget);
 
             *mgr |= Action::RESIZE;
@@ -305,7 +305,7 @@ impl_scope! {
             }
 
             let id = self.make_child_id(index);
-            mgr.configure(id, &mut widget);
+            mgr.configure(&mut widget, id);
             self.widgets.insert(index, widget);
             *mgr |= Action::RESIZE;
         }
@@ -340,7 +340,7 @@ impl_scope! {
         /// The new child is configured immediately. Triggers [`Action::RESIZE`].
         pub fn replace(&mut self, mgr: &mut ConfigMgr, index: usize, mut w: W) -> W {
             let id = self.make_child_id(index);
-            mgr.configure(id, &mut w);
+            mgr.configure(&mut w, id);
             std::mem::swap(&mut w, &mut self.widgets[index]);
 
             if w.id_ref().is_valid() {
@@ -364,7 +364,7 @@ impl_scope! {
             }
             for mut w in iter {
                 let id = self.make_child_id(self.widgets.len());
-                mgr.configure(id, &mut w);
+                mgr.configure(&mut w, id);
                 self.widgets.push(w);
             }
 
@@ -397,7 +397,7 @@ impl_scope! {
                 for index in old_len..len {
                     let id = self.make_child_id(index);
                     let mut w = f(index);
-                    mgr.configure(id, &mut w);
+                    mgr.configure(&mut w, id);
                     self.widgets.push(w);
                 }
                 *mgr |= Action::RESIZE;

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -35,7 +35,7 @@ pub type BoxColumn = BoxList<Down>;
 /// This is parameterised over directionality.
 ///
 /// See documentation of [`List`] type.
-pub type BoxList<D> = List<D, Box<dyn Widget>>;
+pub type BoxList<D> = List<D, Box<dyn Node>>;
 
 impl_scope! {
     /// A generic row/column widget
@@ -50,7 +50,7 @@ impl_scope! {
     /// Some more specific type-defs are available:
     ///
     /// -   [`Row`] and [`Column`] fix the direction `D`
-    /// -   [`BoxList`] fixes the widget type to `Box<dyn Widget>`
+    /// -   [`BoxList`] fixes the widget type to `Box<dyn Node>`
     /// -   [`BoxRow`] and [`BoxColumn`] fix both type parameters
     ///
     /// ## Performance
@@ -84,12 +84,12 @@ impl_scope! {
             self.widgets.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
-            self.widgets.get(index).map(|w| w.as_widget())
+        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+            self.widgets.get(index).map(|w| w.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
-            self.widgets.get_mut(index).map(|w| w.as_widget_mut())
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+            self.widgets.get_mut(index).map(|w| w.as_node_mut())
         }
 
         fn find_child_index(&self, id: &WidgetId) -> Option<usize> {

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -65,12 +65,12 @@ impl_scope! {
             self.widgets.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
-            self.widgets.get(index).map(|w| w.as_widget())
+        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+            self.widgets.get(index).map(|w| w.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
-            self.widgets.get_mut(index).map(|w| w.as_widget_mut())
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+            self.widgets.get_mut(index).map(|w| w.as_node_mut())
         }
     }
 

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -203,7 +203,7 @@ impl_scope! {
                     if !self.rect().contains(press.coord) {
                         // not on the menubar
                         self.delayed_open = None;
-                        mgr.send(self, id, Event::Command(Command::Activate));
+                        mgr.send(id, Event::Command(Command::Activate));
                     }
                     Response::Used
                 }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -268,12 +268,12 @@ impl_scope! {
             self.list.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
-            self.list.get(index).map(|w| w.as_widget())
+        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+            self.list.get(index).map(|w| w.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
-            self.list.get_mut(index).map(|w| w.as_widget_mut())
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+            self.list.get_mut(index).map(|w| w.as_node_mut())
         }
     }
 

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -37,7 +37,7 @@ impl RadioGroup {
     /// Get the active [`RadioBox`], if any
     ///
     /// Note: this is never equal to a [`RadioButton`]'s [`WidgetId`], but may
-    /// be a descendant (test with [`WidgetExt::is_ancestor_of`]).
+    /// be a descendant (test with [`NodeExt::is_ancestor_of`]).
     pub fn get(&self) -> Option<WidgetId> {
         (self.0).1.borrow().clone()
     }

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -115,6 +115,11 @@ impl_scope! {
                 .set_sizes(rect.size, child_size + self.frame_size);
         }
 
+        #[inline]
+        fn translation(&self) -> Offset {
+            self.scroll_offset()
+        }
+
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
             if !self.rect().contains(coord) {
                 return None;
@@ -132,11 +137,6 @@ impl_scope! {
     impl Widget for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.register_nav_fallback(self.id());
-        }
-
-        #[inline]
-        fn translation(&self) -> Offset {
-            self.scroll_offset()
         }
 
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -43,7 +43,7 @@ pub type BoxColumnSplitter = BoxSplitter<Down>;
 /// This is parameterised over directionality.
 ///
 /// See documentation of [`Splitter`] type.
-pub type BoxSplitter<D> = Splitter<D, Box<dyn Widget>>;
+pub type BoxSplitter<D> = Splitter<D, Box<dyn Node>>;
 
 /// A row of widget references
 ///
@@ -60,7 +60,7 @@ pub type RefColumnSplitter<'a> = RefSplitter<'a, Down>;
 /// This is parameterised over directionality.
 ///
 /// See documentation of [`Splitter`] type.
-pub type RefSplitter<'a, D> = Splitter<D, &'a mut dyn Widget>;
+pub type RefSplitter<'a, D> = Splitter<D, &'a mut dyn Node>;
 
 impl_scope! {
     /// A resizable row/column widget
@@ -113,19 +113,19 @@ impl_scope! {
             self.widgets.len() + self.handles.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
+        fn get_child(&self, index: usize) -> Option<&dyn Node> {
             if (index & 1) != 0 {
-                self.handles.get(index >> 1).map(|w| w.as_widget())
+                self.handles.get(index >> 1).map(|w| w.as_node())
             } else {
-                self.widgets.get(index >> 1).map(|w| w.as_widget())
+                self.widgets.get(index >> 1).map(|w| w.as_node())
             }
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
             if (index & 1) != 0 {
-                self.handles.get_mut(index >> 1).map(|w| w.as_widget_mut())
+                self.handles.get_mut(index >> 1).map(|w| w.as_node_mut())
             } else {
-                self.widgets.get_mut(index >> 1).map(|w| w.as_widget_mut())
+                self.widgets.get_mut(index >> 1).map(|w| w.as_node_mut())
             }
         }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -391,12 +391,12 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
             let len = self.handles.len();
             let id = self.make_next_id(true, len);
             let mut w = GripPart::new();
-            mgr.configure(id, &mut w);
+            mgr.configure(&mut w, id);
             self.handles.push(w);
         }
 
         let id = self.make_next_id(false, index);
-        mgr.configure(id, &mut widget);
+        mgr.configure(&mut widget, id);
         self.widgets.push(widget);
 
         self.size_solved = false;
@@ -445,12 +445,12 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
             let index = index.min(self.handles.len());
             let id = self.make_next_id(true, index);
             let mut w = GripPart::new();
-            mgr.configure(id, &mut w);
+            mgr.configure(&mut w, id);
             self.handles.insert(index, w);
         }
 
         let id = self.make_next_id(false, index);
-        mgr.configure(id, &mut widget);
+        mgr.configure(&mut widget, id);
         self.widgets.insert(index, widget);
 
         self.size_solved = false;
@@ -495,7 +495,7 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
     /// The new child is configured immediately. Triggers [`Action::RESIZE`].
     pub fn replace(&mut self, mgr: &mut ConfigMgr, index: usize, mut w: W) -> W {
         let id = self.make_next_id(false, index);
-        mgr.configure(id, &mut w);
+        mgr.configure(&mut w, id);
         std::mem::swap(&mut w, &mut self.widgets[index]);
 
         if w.id_ref().is_valid() {
@@ -525,12 +525,12 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
             if index > 0 {
                 let id = self.make_next_id(true, self.handles.len());
                 let mut w = GripPart::new();
-                mgr.configure(id, &mut w);
+                mgr.configure(&mut w, id);
                 self.handles.push(w);
             }
 
             let id = self.make_next_id(false, index);
-            mgr.configure(id, &mut widget);
+            mgr.configure(&mut widget, id);
             self.widgets.push(widget);
         }
 
@@ -578,13 +578,13 @@ impl<D: Directional, W: Widget> Splitter<D, W> {
                 if index > 0 {
                     let id = self.make_next_id(true, self.handles.len());
                     let mut w = GripPart::new();
-                    mgr.configure(id, &mut w);
+                    mgr.configure(&mut w, id);
                     self.handles.push(w);
                 }
 
                 let id = self.make_next_id(false, index);
                 let mut widget = f(index);
-                mgr.configure(id, &mut widget);
+                mgr.configure(&mut widget, id);
                 self.widgets.push(widget);
             }
 

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -13,12 +13,12 @@ use std::ops::{Index, IndexMut, Range};
 /// A stack of boxed widgets
 ///
 /// This is a parametrisation of [`Stack`].
-pub type BoxStack = Stack<Box<dyn Widget>>;
+pub type BoxStack = Stack<Box<dyn Node>>;
 
 /// A stack of widget references
 ///
 /// This is a parametrisation of [`Stack`].
-pub type RefStack<'a> = Stack<&'a mut dyn Widget>;
+pub type RefStack<'a> = Stack<&'a mut dyn Node>;
 
 impl_scope! {
     /// A stack of widgets
@@ -52,12 +52,12 @@ impl_scope! {
             self.widgets.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
-            self.widgets.get(index).map(|w| w.as_widget())
+        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+            self.widgets.get(index).map(|w| w.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
-            self.widgets.get_mut(index).map(|w| w.as_widget_mut())
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+            self.widgets.get_mut(index).map(|w| w.as_node_mut())
         }
 
         fn find_child_index(&self, id: &WidgetId) -> Option<usize> {

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -298,7 +298,7 @@ impl<W: Widget> Stack<W> {
     pub fn push(&mut self, mgr: &mut ConfigMgr, mut widget: W) -> usize {
         let index = self.widgets.len();
         let id = self.make_child_id(index);
-        mgr.configure(id, &mut widget);
+        mgr.configure(&mut widget, id);
 
         self.widgets.push(widget);
 
@@ -350,7 +350,7 @@ impl<W: Widget> Stack<W> {
         }
 
         let id = self.make_child_id(index);
-        mgr.configure(id, &mut widget);
+        mgr.configure(&mut widget, id);
 
         self.widgets.insert(index, widget);
 
@@ -406,7 +406,7 @@ impl<W: Widget> Stack<W> {
     /// then [`Action::RESIZE`] is triggered.
     pub fn replace(&mut self, mgr: &mut ConfigMgr, index: usize, mut w: W) -> W {
         let id = self.make_child_id(index);
-        mgr.configure(id, &mut w);
+        mgr.configure(&mut w, id);
         std::mem::swap(&mut w, &mut self.widgets[index]);
 
         if w.id_ref().is_valid() {
@@ -440,7 +440,7 @@ impl<W: Widget> Stack<W> {
         }
         for mut w in iter {
             let id = self.make_child_id(self.widgets.len());
-            mgr.configure(id, &mut w);
+            mgr.configure(&mut w, id);
             self.widgets.push(w);
         }
 
@@ -476,7 +476,7 @@ impl<W: Widget> Stack<W> {
             for index in old_len..len {
                 let id = self.make_child_id(index);
                 let mut w = f(index);
-                mgr.configure(id, &mut w);
+                mgr.configure(&mut w, id);
                 self.widgets.push(w);
             }
 

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -23,7 +23,7 @@ pub type Tab = TextButton;
 /// A tabbed stack of boxed widgets
 ///
 /// This is a parametrisation of [`TabStack`].
-pub type BoxTabStack = TabStack<Box<dyn Widget>>;
+pub type BoxTabStack = TabStack<Box<dyn Node>>;
 
 impl_scope! {
     /// A tabbed stack of widgets

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use kas::class::HasString;
 use kas::event::{ConfigMgr, Event, EventMgr, Response};
 use kas::widget::{Frame, Label, TextButton};
-use kas::{Decorations, Widget, WidgetCore, WidgetExt, Window};
+use kas::{Decorations, NodeExt, Widget, WidgetCore, Window};
 
 #[derive(Clone, Debug)]
 struct MsgReset;


### PR DESCRIPTION
This is the first part of actual trait reform related to #387, though quite different from the design used there and usable without associated data.

The design may be subject to further change before the next Kas release; I have a bunch of notes to organise and add to the new design repo, but trait design is the hardest part of the current revision and I haven't settled on a specific approach yet.

This PR adds:

- `pub trait Node: Widget` as the new dyn-safe widget API. Several methods previously implemented externally using introspection (`WidgetChildren` API) are now implemented on `Node`, and the required methods (including all event-handling methods) are no longer exposed by a dyn-safe widget (now `dyn Node`).
- In the past, `trait Layout` was used both for full widgets and for the "components" used for embedded layout. We no longer have a reason to use the same trait for both, so now `trait Visitable` is used for components allowing `fn Widget::translation` to be moved to `Layout`.