### PR TITLE
Rename Node → Widget, new trait Events, use macro not blanket impl

### DIFF
--- a/crates/kas-core/src/action.rs
+++ b/crates/kas-core/src/action.rs
@@ -52,7 +52,7 @@ bitflags! {
         /// Reconfigure all widgets of the window
         ///
         /// *Configuring* widgets assigns [`WidgetId`] identifiers and calls
-        /// [`crate::Widget::configure`].
+        /// [`crate::Events::configure`].
         ///
         /// [`WidgetId`]: crate::WidgetId
         const RECONFIGURE = 1 << 16;

--- a/crates/kas-core/src/core/data.rs
+++ b/crates/kas-core/src/core/data.rs
@@ -69,7 +69,7 @@ impl Clone for CoreData {
 /// visible). The window is responsible for calling these methods.
 //
 // NOTE: it's tempting to include a pointer to the widget here. There are two
-// options: (a) an unsafe aliased pointer or (b) Rc<RefCell<dyn Node>>.
+// options: (a) an unsafe aliased pointer or (b) Rc<RefCell<dyn Widget>>.
 // Option (a) should work but is an unnecessary performance hack; (b) could in
 // theory work but requires adjusting WidgetChildren::get, find etc. to take a
 // closure instead of returning a reference, causing *significant* complication.

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -1,0 +1,171 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Widget method implementations
+
+use crate::event::{ConfigMgr, Event, EventMgr, Response};
+use crate::{Erased, NavAdvance, NodeExt, Widget, WidgetId};
+
+/// Generic implementation of [`Node::_configure`]
+pub fn _configure<W: Widget>(widget: &mut W, cx: &mut ConfigMgr, id: WidgetId) {
+    widget.pre_configure(cx, id);
+
+    for index in 0..widget.num_children() {
+        let id = widget.make_child_id(index);
+        if id.is_valid() {
+            if let Some(widget) = widget.get_child_mut(index) {
+                widget._configure(cx, id);
+            }
+        }
+    }
+
+    widget.configure(cx);
+}
+
+/// Generic implementation of [`Node::_broadcast`]
+pub fn _broadcast<W: Widget>(widget: &mut W, cx: &mut EventMgr, count: &mut usize, event: Event) {
+    widget.handle_event(cx, event.clone());
+    *count += 1;
+    for index in 0..widget.num_children() {
+        if let Some(w) = widget.get_child_mut(index) {
+            w._broadcast(cx, count, event.clone());
+        }
+    }
+}
+
+/// Generic implementation of [`Node::_send`]
+pub fn _send<W: Widget>(
+    widget: &mut W,
+    cx: &mut EventMgr,
+    id: WidgetId,
+    disabled: bool,
+    event: Event,
+) -> Response {
+    let mut response = Response::Unused;
+    if id == widget.id_ref() {
+        if disabled {
+            return response;
+        }
+
+        response |= widget.pre_handle_event(cx, event);
+    } else if widget.steal_event(cx, &id, &event).is_used() {
+        response = Response::Used;
+    } else {
+        cx.assert_post_steal_unused();
+        if let Some(index) = widget.find_child_index(&id) {
+            let translation = widget.translation();
+            if let Some(w) = widget.get_child_mut(index) {
+                response = w._send(cx, id, disabled, event.clone() + translation);
+                if let Some(scroll) = cx.post_send(index) {
+                    widget.handle_scroll(cx, scroll);
+                }
+            } else {
+                #[cfg(debug_assertions)]
+                log::warn!(
+                    "_send: {} found index {index} for {id} but not child",
+                    widget.identify()
+                );
+            }
+        }
+
+        if response.is_unused() && event.is_reusable() {
+            response = widget.handle_event(cx, event);
+        }
+    }
+
+    if cx.has_msg() {
+        widget.handle_message(cx);
+    }
+
+    response
+}
+
+/// Generic implementation of [`Node::_replay`]
+pub fn _replay<W: Widget>(widget: &mut W, cx: &mut EventMgr, id: WidgetId, msg: Erased) {
+    if let Some(index) = widget.find_child_index(&id) {
+        if let Some(w) = widget.get_child_mut(index) {
+            w._replay(cx, id, msg);
+            if let Some(scroll) = cx.post_send(index) {
+                widget.handle_scroll(cx, scroll);
+            }
+        } else {
+            #[cfg(debug_assertions)]
+            log::warn!(
+                "_replay: {} found index {index} for {id} but not child",
+                widget.identify()
+            );
+        }
+
+        if cx.has_msg() {
+            widget.handle_message(cx);
+        }
+    } else if id == widget.id_ref() {
+        cx.push_erased(msg);
+        widget.handle_message(cx);
+    } else {
+        #[cfg(debug_assertions)]
+        log::debug!("_replay: {} cannot find path to {id}", widget.identify());
+    }
+}
+
+/// Generic implementation of [`Node::_nav_next`]
+pub fn _nav_next<W: Widget>(
+    widget: &mut W,
+    cx: &mut EventMgr,
+    focus: Option<&WidgetId>,
+    advance: NavAdvance,
+) -> Option<WidgetId> {
+    if cx.is_disabled(widget.id_ref()) {
+        return None;
+    }
+
+    let mut child = focus.and_then(|id| widget.find_child_index(id));
+
+    if let Some(index) = child {
+        if let Some(id) = widget
+            .get_child_mut(index)
+            .and_then(|w| w._nav_next(cx, focus, advance))
+        {
+            return Some(id);
+        }
+    }
+
+    let can_match_self = match advance {
+        NavAdvance::None => true,
+        NavAdvance::Forward(true) => true,
+        NavAdvance::Forward(false) => !widget.eq_id(focus),
+        _ => false,
+    };
+    if can_match_self && widget.navigable() {
+        return Some(widget.id());
+    }
+
+    let rev = match advance {
+        NavAdvance::None => return None,
+        NavAdvance::Forward(_) => false,
+        NavAdvance::Reverse(_) => true,
+    };
+
+    while let Some(index) = widget.nav_next(cx, rev, child) {
+        if let Some(id) = widget
+            .get_child_mut(index)
+            .and_then(|w| w._nav_next(cx, focus, advance))
+        {
+            return Some(id);
+        }
+        child = Some(index);
+    }
+
+    let can_match_self = match advance {
+        NavAdvance::Reverse(true) => true,
+        NavAdvance::Reverse(false) => !widget.eq_id(focus),
+        _ => false,
+    };
+    if can_match_self && widget.navigable() {
+        return Some(widget.id());
+    }
+
+    None
+}

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -7,10 +7,10 @@
 
 use crate::event::{ConfigMgr, Event, EventMgr, Response};
 use crate::util::IdentifyWidget;
-use crate::{Erased, NavAdvance, Widget, WidgetId};
+use crate::{Erased, Events, Layout, NavAdvance, WidgetId};
 
-/// Generic implementation of [`Node::_configure`]
-pub fn _configure<W: Widget>(widget: &mut W, cx: &mut ConfigMgr, id: WidgetId) {
+/// Generic implementation of [`Widget::_configure`]
+pub fn _configure<W: Layout + Events>(widget: &mut W, cx: &mut ConfigMgr, id: WidgetId) {
     widget.pre_configure(cx, id);
 
     for index in 0..widget.num_children() {
@@ -25,8 +25,13 @@ pub fn _configure<W: Widget>(widget: &mut W, cx: &mut ConfigMgr, id: WidgetId) {
     widget.configure(cx);
 }
 
-/// Generic implementation of [`Node::_broadcast`]
-pub fn _broadcast<W: Widget>(widget: &mut W, cx: &mut EventMgr, count: &mut usize, event: Event) {
+/// Generic implementation of [`Widget::_broadcast`]
+pub fn _broadcast<W: Layout + Events>(
+    widget: &mut W,
+    cx: &mut EventMgr,
+    count: &mut usize,
+    event: Event,
+) {
     widget.handle_event(cx, event.clone());
     *count += 1;
     for index in 0..widget.num_children() {
@@ -36,8 +41,8 @@ pub fn _broadcast<W: Widget>(widget: &mut W, cx: &mut EventMgr, count: &mut usiz
     }
 }
 
-/// Generic implementation of [`Node::_send`]
-pub fn _send<W: Widget>(
+/// Generic implementation of [`Widget::_send`]
+pub fn _send<W: Layout + Events>(
     widget: &mut W,
     cx: &mut EventMgr,
     id: WidgetId,
@@ -83,8 +88,8 @@ pub fn _send<W: Widget>(
     response
 }
 
-/// Generic implementation of [`Node::_replay`]
-pub fn _replay<W: Widget>(widget: &mut W, cx: &mut EventMgr, id: WidgetId, msg: Erased) {
+/// Generic implementation of [`Widget::_replay`]
+pub fn _replay<W: Layout + Events>(widget: &mut W, cx: &mut EventMgr, id: WidgetId, msg: Erased) {
     if let Some(index) = widget.find_child_index(&id) {
         if let Some(w) = widget.get_child_mut(index) {
             w._replay(cx, id, msg);
@@ -114,8 +119,8 @@ pub fn _replay<W: Widget>(widget: &mut W, cx: &mut EventMgr, id: WidgetId, msg: 
     }
 }
 
-/// Generic implementation of [`Node::_nav_next`]
-pub fn _nav_next<W: Widget>(
+/// Generic implementation of [`Widget::_nav_next`]
+pub fn _nav_next<W: Layout + Events>(
     widget: &mut W,
     cx: &mut EventMgr,
     focus: Option<&WidgetId>,

--- a/crates/kas-core/src/core/mod.rs
+++ b/crates/kas-core/src/core/mod.rs
@@ -11,6 +11,10 @@ mod widget;
 mod widget_id;
 mod window;
 
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+#[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
+pub mod impls;
+
 pub use data::*;
 pub use scroll_traits::*;
 pub use widget::*;

--- a/crates/kas-core/src/core/scroll_traits.rs
+++ b/crates/kas-core/src/core/scroll_traits.rs
@@ -5,7 +5,6 @@
 
 //! Scroll bar traits
 
-use super::Widget;
 use crate::event::EventMgr;
 use crate::geom::{Offset, Size};
 use crate::Action;
@@ -16,7 +15,7 @@ use crate::Action;
 /// a parent to control scrolling.
 ///
 /// If the widget scrolls itself it should set a scroll action via [`EventMgr::set_scroll`].
-pub trait Scrollable: Widget {
+pub trait Scrollable {
     /// Given size `size`, returns whether `(horiz, vert)` scrolling is required
     fn scroll_axes(&self, size: Size) -> (bool, bool);
 

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -675,7 +675,7 @@ pub trait NodeExt: Node {
     /// Display as "StructName#WidgetId"
     #[inline]
     fn identify(&self) -> IdentifyWidget {
-        IdentifyWidget(self.widget_name(), self.id())
+        IdentifyWidget(self.widget_name(), self.id_ref())
     }
 
     /// Check whether `id` is self or a descendant

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::{EventMgr, EventState, GrabMode, Response}; // for doc-links
 use super::{Press, UpdateId, VirtualKeyCode};
 use crate::geom::{DVec2, Offset};
-#[allow(unused)] use crate::Widget;
+#[allow(unused)] use crate::Events;
 use crate::{dir::Direction, WidgetId, WindowId};
 
 /// Events addressed to a widget
@@ -163,9 +163,9 @@ pub enum Event {
     ///
     /// When [`EventMgr::update_all`] is called, this event is broadcast to all
     /// widgets via depth-first traversal of the widget tree. As such,
-    /// [`Widget::steal_event`] is not called with this `Event`,
-    /// nor are [`Widget::handle_message`] or
-    /// [`Widget::handle_scroll`] called after a widget receives this `Event`.
+    /// [`Events::steal_event`] is not called with this `Event`,
+    /// nor are [`Events::handle_message`] or
+    /// [`Events::handle_scroll`] called after a widget receives this `Event`.
     Update { id: UpdateId, payload: u64 },
     /// Notification that a popup has been destroyed
     ///
@@ -278,7 +278,7 @@ impl Event {
         }
     }
 
-    /// Can the event be received by [`Widget::handle_event`] during unwinding?
+    /// Can the event be received by [`Events::handle_event`] during unwinding?
     ///
     /// Events which may be sent to the widget under the mouse or to the
     /// keyboard navigation target may be acted on by an ancestor if unused.

--- a/crates/kas-core/src/event/manager/config_mgr.rs
+++ b/crates/kas-core/src/event/manager/config_mgr.rs
@@ -13,7 +13,7 @@ use crate::layout::AlignPair;
 use crate::shell::Platform;
 use crate::text::TextApi;
 use crate::theme::{Feature, SizeMgr, TextClass, ThemeSize};
-use crate::{Action, Node, WidgetId};
+use crate::{Action, Widget, WidgetId};
 use std::ops::{Deref, DerefMut};
 
 #[allow(unused)] use crate::{event::Event, Layout};
@@ -48,7 +48,7 @@ impl<'a> ConfigMgr<'a> {
     /// Warning: sizes are calculated using the window's current scale factor.
     /// This may change, even without user action, since some platforms
     /// always initialize windows with scale factor 1.
-    /// See also notes on [`Widget::configure`].
+    /// See also notes on [`Events::configure`].
     #[inline]
     pub fn size_mgr(&self) -> SizeMgr<'a> {
         SizeMgr::new(self.sh)
@@ -86,12 +86,12 @@ impl<'a> ConfigMgr<'a> {
     /// Configure a widget
     ///
     /// All widgets must be configured after construction (see
-    /// [`Widget::configure`]). This method may be used to configure a new
+    /// [`Events::configure`]). This method may be used to configure a new
     /// child widget without requiring the whole window to be reconfigured.
     ///
     /// Pass the `id` to assign to the widget: this should be constructed from
     /// the parent's id via [`WidgetId::make_child`].
-    pub fn configure(&mut self, widget: &mut dyn Node, id: WidgetId) {
+    pub fn configure(&mut self, widget: &mut dyn Widget, id: WidgetId) {
         widget._configure(self, id);
     }
 

--- a/crates/kas-core/src/event/manager/mgr_shell.rs
+++ b/crates/kas-core/src/event/manager/mgr_shell.rs
@@ -68,10 +68,10 @@ impl EventState {
     /// is created (before or after resizing).
     ///
     /// This method calls [`ConfigMgr::configure`] in order to assign
-    /// [`WidgetId`] identifiers and call widgets' [`Widget::configure`]
+    /// [`WidgetId`] identifiers and call widgets' [`Events::configure`]
     /// method. Additionally, it updates the [`EventState`] to account for
     /// renamed and removed widgets.
-    pub(crate) fn full_configure(&mut self, shell: &mut dyn ShellWindow, widget: &mut dyn Node) {
+    pub(crate) fn full_configure(&mut self, shell: &mut dyn ShellWindow, widget: &mut dyn Widget) {
         log::debug!(target: "kas_core::event::manager", "full_configure");
         self.action.remove(Action::RECONFIGURE);
 
@@ -91,7 +91,7 @@ impl EventState {
     }
 
     /// Update the widgets under the cursor and touch events
-    pub(crate) fn region_moved(&mut self, widget: &mut dyn Node) {
+    pub(crate) fn region_moved(&mut self, widget: &mut dyn Widget) {
         log::trace!(target: "kas_core::event::manager", "region_moved");
         // Note: redraw is already implied.
 
@@ -129,7 +129,11 @@ impl EventState {
 
     /// Update, after receiving all events
     #[inline]
-    pub(crate) fn update(&mut self, shell: &mut dyn ShellWindow, widget: &mut dyn Node) -> Action {
+    pub(crate) fn update(
+        &mut self,
+        shell: &mut dyn ShellWindow,
+        widget: &mut dyn Widget,
+    ) -> Action {
         let old_hover_icon = self.hover_icon;
 
         let mut mgr = EventMgr {
@@ -246,7 +250,11 @@ impl EventState {
     ///
     /// Returns true if action is non-empty
     #[inline]
-    pub(crate) fn post_draw(&mut self, shell: &mut dyn ShellWindow, widget: &mut dyn Node) -> bool {
+    pub(crate) fn post_draw(
+        &mut self,
+        shell: &mut dyn ShellWindow,
+        widget: &mut dyn Widget,
+    ) -> bool {
         let mut mgr = EventMgr {
             state: self,
             shell,
@@ -268,7 +276,7 @@ impl EventState {
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 impl<'a> EventMgr<'a> {
     /// Update widgets due to timer
-    pub(crate) fn update_timer(&mut self, widget: &mut dyn Node) {
+    pub(crate) fn update_timer(&mut self, widget: &mut dyn Widget) {
         let now = Instant::now();
 
         // assumption: time_updates are sorted in reverse order
@@ -285,7 +293,7 @@ impl<'a> EventMgr<'a> {
     }
 
     /// Update widgets with an [`UpdateId`]
-    pub(crate) fn update_widgets(&mut self, widget: &mut dyn Node, id: UpdateId, payload: u64) {
+    pub(crate) fn update_widgets(&mut self, widget: &mut dyn Widget, id: UpdateId, payload: u64) {
         if id == self.state.config.config.id() {
             let (sf, dpem) = self.size_mgr(|size| (size.scale_factor(), size.dpem()));
             self.state.config.update(sf, dpem);
@@ -300,7 +308,7 @@ impl<'a> EventMgr<'a> {
         );
     }
 
-    fn poll_futures(&mut self, widget: &mut dyn Node) {
+    fn poll_futures(&mut self, widget: &mut dyn Widget) {
         let mut i = 0;
         while i < self.state.fut_messages.len() {
             let (_, fut) = &mut self.state.fut_messages[i];

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -19,26 +19,26 @@
 //!     from mouse/touch coordinates by calling [`find_id`](crate::Layout::find_id).
 //! 2.  If the target is [disabled](EventState::is_disabled), then find the
 //!     top-most ancestor which is disabled and make that the target, but
-//!     inhibit calling of [`Widget::handle_event`] on this widget (but still
-//!     unwind, calling [`Widget::handle_event`] on ancestors)).
+//!     inhibit calling of [`Events::handle_event`] on this widget (but still
+//!     unwind, calling [`Events::handle_event`] on ancestors)).
 //! 3.  Traverse *down* the widget tree from its root to the target according to
 //!     the [`WidgetId`]. On each node (excluding the target),
 //!
-//!     -   Call [`Widget::steal_event`]; if this method "steals" the event,
+//!     -   Call [`Events::steal_event`]; if this method "steals" the event,
 //!         skip to step 5.
 //! 4.  In the normal case (when the target is not disabled and the event is
-//!     not stolen), [`Widget::handle_event`] is called on the target.
-//! 5.  If the message stack is not empty, call [`Widget::handle_message`] on
+//!     not stolen), [`Events::handle_event`] is called on the target.
+//! 5.  If the message stack is not empty, call [`Events::handle_message`] on
 //!     the current node.
 //! 6.  Unwind, traversing back *up* the widget tree (towards the root).
 //!     On each node (excluding the target),
 //!
 //!     -   If a non-empty scroll action is [set](EventMgr::set_scroll),
-//!         call [`Widget::handle_scroll`]
+//!         call [`Events::handle_scroll`]
 //!     -   If the event has not yet been [used](Response::Used),
-//!         call [`Widget::handle_event`]
+//!         call [`Events::handle_event`]
 //!     -   If the message stack is non-empty (see [`EventMgr::push`]),
-//!         call [`Widget::handle_message`].
+//!         call [`Events::handle_message`].
 //! 7.  Clear any messages still on the message stack, printing a warning to the
 //!     log. Messages *should* be handled during unwinding, though not doing so
 //!     is safe (and possibly useful during development).
@@ -71,7 +71,7 @@ use smallvec::SmallVec;
 pub use winit::event::{ModifiersState, MouseButton, VirtualKeyCode};
 #[cfg(feature = "winit")] pub use winit::window::CursorIcon;
 
-#[allow(unused)] use crate::Widget;
+#[allow(unused)] use crate::{Events, Widget};
 #[doc(no_inline)] pub use config::Config;
 #[cfg(not(feature = "winit"))]
 pub use enums::{CursorIcon, ModifiersState, MouseButton, VirtualKeyCode};

--- a/crates/kas-core/src/event/response.rs
+++ b/crates/kas-core/src/event/response.rs
@@ -7,9 +7,9 @@
 
 use crate::geom::{Offset, Rect};
 
-/// Response from [`Widget::handle_event`]
+/// Response from [`Events::handle_event`]
 ///
-/// [`Widget::handle_event`]: crate::Widget::handle_event
+/// [`Events::handle_event`]: crate::Events::handle_event
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Response {
     /// Event was unused

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -242,7 +242,7 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RulesSetter for RowSetter<D, T, 
 /// layout representation.
 ///
 /// This is only applicable where child widgets are contained in a slice of type
-/// `W: Layout` (which may be `Box<dyn Node>`). In other cases, the naive
+/// `W: Layout` (which may be `Box<dyn Widget>`). In other cases, the naive
 /// implementation (test all items) must be used.
 #[derive(Clone, Copy, Debug)]
 pub struct RowPositionSolver<D: Directional> {

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -12,7 +12,7 @@ use super::{AxisInfo, SizeRules};
 use super::{RowStorage, RowTemp, RulesSetter, RulesSolver};
 use crate::dir::{Direction, Directional};
 use crate::geom::{Coord, Rect};
-use crate::Widget;
+use crate::Layout;
 
 /// A [`RulesSolver`] for rows (and, without loss of generality, for columns).
 ///
@@ -242,7 +242,7 @@ impl<D: Directional, T: RowTemp, S: RowStorage> RulesSetter for RowSetter<D, T, 
 /// layout representation.
 ///
 /// This is only applicable where child widgets are contained in a slice of type
-/// `W: Widget` (which may be `Box<dyn Node>`). In other cases, the naive
+/// `W: Layout` (which may be `Box<dyn Node>`). In other cases, the naive
 /// implementation (test all items) must be used.
 #[derive(Clone, Copy, Debug)]
 pub struct RowPositionSolver<D: Directional> {
@@ -255,7 +255,7 @@ impl<D: Directional> RowPositionSolver<D> {
         RowPositionSolver { direction }
     }
 
-    fn binary_search<W: Widget>(self, widgets: &[W], coord: Coord) -> Result<usize, usize> {
+    fn binary_search<W: Layout>(self, widgets: &[W], coord: Coord) -> Result<usize, usize> {
         match self.direction.as_direction() {
             Direction::Right => widgets.binary_search_by_key(&coord.0, |w| w.rect().pos.0),
             Direction::Down => widgets.binary_search_by_key(&coord.1, |w| w.rect().pos.1),
@@ -268,7 +268,7 @@ impl<D: Directional> RowPositionSolver<D> {
     ///
     /// Returns `None` when the coordinates lie within the margin area or
     /// outside of the parent widget.
-    pub fn find_child_index<W: Widget>(self, widgets: &[W], coord: Coord) -> Option<usize> {
+    pub fn find_child_index<W: Layout>(self, widgets: &[W], coord: Coord) -> Option<usize> {
         match self.binary_search(widgets, coord) {
             Ok(i) => Some(i),
             Err(i) if self.direction.is_reversed() => {
@@ -293,7 +293,7 @@ impl<D: Directional> RowPositionSolver<D> {
     /// Returns `None` when the coordinates lie within the margin area or
     /// outside of the parent widget.
     #[inline]
-    pub fn find_child<W: Widget>(self, widgets: &[W], coord: Coord) -> Option<&W> {
+    pub fn find_child<W: Layout>(self, widgets: &[W], coord: Coord) -> Option<&W> {
         self.find_child_index(widgets, coord).map(|i| &widgets[i])
     }
 
@@ -302,13 +302,13 @@ impl<D: Directional> RowPositionSolver<D> {
     /// Returns `None` when the coordinates lie within the margin area or
     /// outside of the parent widget.
     #[inline]
-    pub fn find_child_mut<W: Widget>(self, widgets: &mut [W], coord: Coord) -> Option<&mut W> {
+    pub fn find_child_mut<W: Layout>(self, widgets: &mut [W], coord: Coord) -> Option<&mut W> {
         self.find_child_index(widgets, coord)
             .map(|i| &mut widgets[i])
     }
 
     /// Call `f` on each child intersecting the given `rect`
-    pub fn for_children<W: Widget, F: FnMut(&mut W)>(
+    pub fn for_children<W: Layout, F: FnMut(&mut W)>(
         self,
         widgets: &mut [W],
         rect: Rect,

--- a/crates/kas-core/src/layout/sizer.rs
+++ b/crates/kas-core/src/layout/sizer.rs
@@ -11,7 +11,7 @@ use crate::event::ConfigMgr;
 use crate::geom::{Rect, Size};
 use crate::theme::SizeMgr;
 use crate::util::WidgetHierarchy;
-use crate::{Layout, Node};
+use crate::{Layout, Widget};
 
 /// A [`SizeRules`] solver for layouts
 ///
@@ -134,7 +134,7 @@ impl SolveCache {
     /// Calculate required size of widget
     ///
     /// Assumes no explicit alignment.
-    pub fn find_constraints(widget: &mut dyn Node, size_mgr: SizeMgr) -> Self {
+    pub fn find_constraints(widget: &mut dyn Widget, size_mgr: SizeMgr) -> Self {
         let start = std::time::Instant::now();
 
         let w = widget.size_rules(size_mgr.re(), AxisInfo::new(false, None, None));
@@ -184,7 +184,7 @@ impl SolveCache {
     /// last used).
     pub fn apply_rect(
         &mut self,
-        widget: &mut dyn Node,
+        widget: &mut dyn Widget,
         mgr: &mut ConfigMgr,
         mut rect: Rect,
         inner_margin: bool,
@@ -228,7 +228,7 @@ impl SolveCache {
     /// Print widget heirarchy in the trace log
     ///
     /// This is sometimes called after [`Self::apply_rect`].
-    pub fn print_widget_heirarchy(&mut self, widget: &mut dyn Node) {
+    pub fn print_widget_heirarchy(&mut self, widget: &mut dyn Widget) {
         let rect = widget.rect();
         let hier = WidgetHierarchy::new(widget);
         log::trace!(

--- a/crates/kas-core/src/layout/sizer.rs
+++ b/crates/kas-core/src/layout/sizer.rs
@@ -11,7 +11,7 @@ use crate::event::ConfigMgr;
 use crate::geom::{Rect, Size};
 use crate::theme::SizeMgr;
 use crate::util::WidgetHierarchy;
-use crate::{Node, Widget};
+use crate::{Layout, Node};
 
 /// A [`SizeRules`] solver for layouts
 ///
@@ -71,7 +71,7 @@ pub trait RulesSetter {
 ///
 /// Parameters `x_size` and `y_size` should be passed where this dimension is
 /// fixed and are used e.g. for text wrapping.
-pub fn solve_size_rules<W: Widget + ?Sized>(
+pub fn solve_size_rules<W: Layout + ?Sized>(
     widget: &mut W,
     size_mgr: SizeMgr,
     x_size: Option<i32>,

--- a/crates/kas-core/src/layout/visitor.rs
+++ b/crates/kas-core/src/layout/visitor.rs
@@ -17,7 +17,7 @@ use crate::event::ConfigMgr;
 use crate::geom::{Coord, Offset, Rect, Size};
 use crate::theme::{Background, DrawMgr, FrameStyle, MarginStyle, SizeMgr};
 use crate::WidgetId;
-use crate::{dir::Directional, dir::Directions, Layout, Widget};
+use crate::{dir::Directional, dir::Directions, Layout};
 use std::iter::ExactSizeIterator;
 
 /// A sub-set of [`Layout`] used by [`Visitor`].
@@ -151,7 +151,7 @@ impl<'a> Visitor<'a> {
     /// the optimisations are not (currently) so useful.
     pub fn slice<W, D>(slice: &'a mut [W], direction: D, data: &'a mut DynRowStorage) -> Self
     where
-        W: Widget,
+        W: Layout,
         D: Directional,
     {
         let layout = LayoutType::BoxComponent(Box::new(Slice {
@@ -390,13 +390,13 @@ where
 }
 
 /// A row/column over a slice
-struct Slice<'a, W: Widget, D: Directional> {
+struct Slice<'a, W: Layout, D: Directional> {
     data: &'a mut DynRowStorage,
     direction: D,
     children: &'a mut [W],
 }
 
-impl<'a, W: Widget, D: Directional> Visitable for Slice<'a, W, D> {
+impl<'a, W: Layout, D: Directional> Visitable for Slice<'a, W, D> {
     fn size_rules(&mut self, mgr: SizeMgr, axis: AxisInfo) -> SizeRules {
         let dim = (self.direction, self.children.len());
         let mut solver = RowSolver::new(axis, dim, self.data);

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -27,6 +27,6 @@ pub use crate::text::{EditableTextApi, Text, TextApi, TextApiExt};
 #[doc(no_inline)]
 pub use crate::{autoimpl, impl_default, impl_scope, singleton, widget, widget_index};
 #[doc(no_inline)]
-pub use crate::{HasScrollBars, ScrollBarMode, Scrollable};
+pub use crate::{Events, Layout, Widget, WidgetChildren, WidgetCore, WidgetExt, Window};
 #[doc(no_inline)]
-pub use crate::{Layout, Node, NodeExt, Widget, WidgetChildren, WidgetCore, Window};
+pub use crate::{HasScrollBars, ScrollBarMode, Scrollable};

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -11,7 +11,7 @@ use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::{self, AxisInfo, SizeRules};
 use crate::theme::{DrawMgr, FrameStyle, SizeMgr};
 use crate::title_bar::TitleBar;
-use crate::{Action, Decorations, Layout, Node, NodeExt, Widget, WidgetId, Window, WindowId};
+use crate::{Action, Decorations, Events, Layout, Widget, WidgetExt, WidgetId, Window, WindowId};
 use kas_macros::impl_scope;
 use smallvec::SmallVec;
 
@@ -110,7 +110,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for RootWidget {
+    impl Events for RootWidget {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             self.decorations = self.w.decorations();
             if mgr.platform().is_wayland() && self.decorations == Decorations::Server {
@@ -218,7 +218,7 @@ impl RootWidget {
 
 // Search for a widget by `id`. On success, return that widget's [`Rect`] and
 // the translation of its children.
-fn find_rect(mut widget: &dyn Node, id: WidgetId) -> Option<(Rect, Offset)> {
+fn find_rect(mut widget: &dyn Widget, id: WidgetId) -> Option<(Rect, Offset)> {
     let mut translation = Offset::ZERO;
     loop {
         if let Some(i) = widget.find_child_index(&id) {

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -15,7 +15,7 @@ use kas::theme::{DrawMgr, SizeMgr, ThemeControl, ThemeSize};
 use kas::theme::{Theme, Window as _};
 #[cfg(all(wayland_platform, feature = "clipboard"))]
 use kas::util::warn_about_error;
-use kas::{Action, Layout, NodeExt, WidgetCore, Window as _, WindowId};
+use kas::{Action, Layout, WidgetCore, WidgetExt, Window as _, WindowId};
 use std::mem::take;
 use std::time::Instant;
 use winit::event::WindowEvent;

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -12,7 +12,7 @@ use crate::draw::{Draw, DrawIface, DrawShared, DrawSharedImpl, ImageId, PassType
 use crate::event::{ConfigMgr, EventState};
 use crate::geom::{Offset, Rect};
 use crate::text::{TextApi, TextDisplay};
-use crate::{autoimpl, Action, Layout, Widget, WidgetId};
+use crate::{autoimpl, Action, Layout, WidgetId};
 use std::convert::AsRef;
 use std::ops::{Bound, Range, RangeBounds};
 use std::time::Instant;
@@ -304,13 +304,13 @@ impl<'a> DrawMgr<'a> {
     }
 
     /// Draw UI element: scroll bar
-    pub fn scroll_bar<W: Widget>(&mut self, track_rect: Rect, handle: &W, dir: Direction) {
+    pub fn scroll_bar<W: Layout>(&mut self, track_rect: Rect, handle: &W, dir: Direction) {
         self.h
             .scroll_bar(&self.id, handle.id_ref(), track_rect, handle.rect(), dir);
     }
 
     /// Draw UI element: slider
-    pub fn slider<W: Widget>(&mut self, track_rect: Rect, handle: &W, dir: Direction) {
+    pub fn slider<W: Layout>(&mut self, track_rect: Rect, handle: &W, dir: Direction) {
         self.h
             .slider(&self.id, handle.id_ref(), track_rect, handle.rect(), dir);
     }

--- a/crates/kas-core/src/title_bar.rs
+++ b/crates/kas-core/src/title_bar.rs
@@ -98,7 +98,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             event.on_activate(mgr, self.id(), |mgr| {
                 mgr.push(self.msg.clone());
@@ -144,7 +144,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(msg) = mgr.try_pop() {
                 match msg {

--- a/crates/kas-core/src/util.rs
+++ b/crates/kas-core/src/util.rs
@@ -6,12 +6,12 @@
 //! Utilities
 
 use crate::geom::Coord;
-use crate::{Node, NodeExt, WidgetId};
+use crate::{Widget, WidgetExt, WidgetId};
 use std::fmt;
 
 /// Helper to display widget identification (e.g. `MyWidget#01`)
 ///
-/// Constructed by [`crate::NodeExt::identify`].
+/// Constructed by [`crate::WidgetExt::identify`].
 pub struct IdentifyWidget<'a>(pub(crate) &'static str, pub(crate) &'a WidgetId);
 impl<'a> fmt::Display for IdentifyWidget<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -23,11 +23,11 @@ impl<'a> fmt::Display for IdentifyWidget<'a> {
 ///
 /// Note: output starts with a new line.
 pub struct WidgetHierarchy<'a> {
-    widget: &'a dyn Node,
+    widget: &'a dyn Widget,
     indent: usize,
 }
 impl<'a> WidgetHierarchy<'a> {
-    pub fn new(widget: &'a dyn Node) -> Self {
+    pub fn new(widget: &'a dyn Widget) -> Self {
         WidgetHierarchy { widget, indent: 0 }
     }
 }
@@ -80,7 +80,7 @@ impl<'a, T: fmt::Debug + ?Sized> fmt::Debug for TryFormat<'a, T> {
     }
 }
 
-/// Generic implementation of [`crate::Widget::nav_next`]
+/// Generic implementation of [`crate::Events::nav_next`]
 pub fn nav_next(reverse: bool, from: Option<usize>, len: usize) -> Option<usize> {
     let last = len.wrapping_sub(1);
     if last == usize::MAX {

--- a/crates/kas-core/src/util.rs
+++ b/crates/kas-core/src/util.rs
@@ -12,8 +12,8 @@ use std::fmt;
 /// Helper to display widget identification (e.g. `MyWidget#01`)
 ///
 /// Constructed by [`crate::NodeExt::identify`].
-pub struct IdentifyWidget(pub(crate) &'static str, pub(crate) WidgetId);
-impl fmt::Display for IdentifyWidget {
+pub struct IdentifyWidget<'a>(pub(crate) &'static str, pub(crate) &'a WidgetId);
+impl<'a> fmt::Display for IdentifyWidget<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "{}{}", self.0, self.1)
     }

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -156,11 +156,11 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// This may *only* be used within the [`impl_scope!`] macro.
 ///
 /// Implements the [`WidgetCore`] and [`Widget`] traits for the deriving type.
-/// Implements the [`WidgetChildren`] and [`Layout`]
+/// Implements the [`WidgetChildren`], [`Events`] and [`Layout`]
 /// traits only if not implemented explicitly within the
 /// defining [`impl_scope!`].
 ///
-/// This macro may inject methods into existing [`Layout`] / [`Widget`] implementations.
+/// This macro may inject methods into existing [`Layout`] / [`Events`] / [`Widget`] implementations.
 /// This is used both to provide default implementations which could not be
 /// written on the trait and to implement properties like `navigable`.
 /// (In the case of multiple implementations of the same trait, as used for
@@ -180,7 +180,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 ///     <code><em>field</em></code> is the name (or number) of a field:
 ///     enables "derive mode" ([see below](#derive)) over the given field
 /// -   <code>navigable = <em>bool</em></code> — a quick implementation of
-///     `Widget::navigable`: whether this widget supports keyboard focus via
+///     `Events::navigable`: whether this widget supports keyboard focus via
 ///     the <kbd>Tab</kbd> key (default is `false`)
 /// -   <code>hover_highlight = <em>bool</em></code> — if true, then match
 ///     `Event::MouseHover` and `Event::LostMouseHover`, requesting redraw and
@@ -195,8 +195,8 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// `#[widget]` and used to identify the field used (name may be anything).
 /// This field *may* have type [`CoreData`] or may be a generated
 /// type; either way it has fields `id: WidgetId` (assigned by
-/// `Widget::pre_configure`) and `rect: Rect` (usually assigned by
-/// `Widget::set_rect`). It may contain additional fields for layout data. The
+/// `Events::pre_configure`) and `rect: Rect` (usually assigned by
+/// `Layout::set_rect`). It may contain additional fields for layout data. The
 /// type supports `Default` and `Clone` (although `Clone` actually
 /// default-initializes all fields other than `rect` since clones of widgets
 /// must themselves be configured).
@@ -214,7 +214,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// syntax, where _Layout_ is any of the below.
 ///
 /// Using the `layout = ...;` property will also generate a corresponding
-/// implementation of `Widget::nav_next`, with a couple of exceptions
+/// implementation of `Events::nav_next`, with a couple of exceptions
 /// (where macro-time analysis is insufficient to implement this method).
 ///
 /// > [_Column_](macro@column), [_Row_](macro@row), [_List_](macro@list), [_AlignedColumn_](macro@aligned_column), [_AlignedRow_](macro@aligned_row), [_Grid_](macro@grid), [_Float_](macro@float), [_Align_](macro@align), [_Pack_](macro@pack), [_Margins_](macro@margins) :\
@@ -314,13 +314,14 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// This is a special mode where most features of `#[widget]` are not
 /// available. A few may still be used: `navigable`, `hover_highlight`,
 /// `cursor_icon`. Additionally, it is currently permitted to implement
-/// [`WidgetChildren`], [`Layout`] and [`Widget`] traits manually (this option
+/// [`WidgetChildren`], [`Layout`], [`Events`] and [`Widget`] traits manually (this option
 /// may be removed in the future if not deemed useful).
 ///
 /// [`Widget`]: https://docs.rs/kas/0.11/kas/trait.Widget.html
 /// [`WidgetCore`]: https://docs.rs/kas/0.11/kas/trait.WidgetCore.html
 /// [`WidgetChildren`]: https://docs.rs/kas/0.11/kas/trait.WidgetChildren.html
 /// [`Layout`]: https://docs.rs/kas/0.11/kas/trait.Layout.html
+/// [`Events`]: https://docs.rs/kas/0.11/kas/trait.Events.html
 /// [`CursorIcon`]: https://docs.rs/kas/0.11/kas/event/enum.CursorIcon.html
 /// [`Response`]: https://docs.rs/kas/0.11/kas/event/enum.Response.html
 /// [`CoreData`]: https://docs.rs/kas/0.11/kas/struct.CoreData.html

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -228,7 +228,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// >
 /// > _Slice_ :\
 /// > &nbsp;&nbsp; `slice!` _Storage_? `(` _Direction_ `,` `self` `.` _Member_ `)`\
-/// > &nbsp;&nbsp; A field with type `[W]` for some `W: Widget`
+/// > &nbsp;&nbsp; A field with type `[W]` for some `W: Layout`. (Note: this does not automatically register the slice widgets as children for the purpose of configuration and event-handling. An explicit implementation of `WidgetChildren` will be required.)
 /// >
 /// > _Frame_ :\
 /// > &nbsp;&nbsp; `frame!` _Storage_? `(` _Layout_ ( `,` `style` `=` _Expr_ )? `)`\

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -81,7 +81,7 @@ impl Tree {
             }
 
             fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
-                use ::kas::{layout, Layout, WidgetCore, NodeExt};
+                use ::kas::{layout, Layout, WidgetCore, WidgetExt};
                 if !self.rect().contains(coord) {
                     return None;
                 }
@@ -139,6 +139,7 @@ impl Tree {
             &vec![],
             layout_children,
         );
+        let widget_impl = widget::impl_widget(&impl_generics, &impl_target);
 
         let layout_methods = self.layout_methods(&core_path)?;
 
@@ -156,7 +157,7 @@ impl Tree {
                 #layout_methods
             }
 
-            impl #impl_generics ::kas::Widget for #impl_target {
+            impl #impl_generics ::kas::Events for #impl_target {
                 fn pre_configure(
                     &mut self,
                     _: &mut ::kas::event::ConfigMgr,
@@ -173,6 +174,8 @@ impl Tree {
                     self.handle_event(cx, event)
                 }
             }
+
+            #widget_impl
 
             #name {
                 rect: Default::default(),

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -696,7 +696,10 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 mgr: &mut ::kas::event::EventMgr,
                 event: ::kas::event::Event,
             ) -> ::kas::event::Response {
-                use ::kas::{event::{Event, Response}, NodeExt};
+                use ::kas::{event::{Event, Response, Scroll}, NodeExt, WidgetCore};
+                if event == Event::NavFocus(true) {
+                    mgr.set_scroll(Scroll::Rect(self.rect()));
+                }
                 #pre_handle_event
                 self.handle_event(mgr, event)
             }
@@ -797,7 +800,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
             }
         });
     }
-
+    // println!("{}", scope.to_token_stream());
     Ok(())
 }
 

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -144,7 +144,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
 
     let mut do_impl_widget_children = true;
     let mut layout_impl = None;
-    let mut widget_impl = None;
+    let mut events_impl = None;
 
     let fields = match &mut scope.item {
         ScopeItem::Struct { token, fields } => match fields {
@@ -335,12 +335,12 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 if layout_impl.is_none() {
                     layout_impl = Some(index);
                 }
-            } else if *path == parse_quote! { ::kas::Widget }
-                || *path == parse_quote! { kas::Widget }
-                || *path == parse_quote! { Widget }
+            } else if *path == parse_quote! { ::kas::Events }
+                || *path == parse_quote! { kas::Events }
+                || *path == parse_quote! { Events }
             {
-                if widget_impl.is_none() {
-                    widget_impl = Some(index);
+                if events_impl.is_none() {
+                    events_impl = Some(index);
                 }
             }
         }
@@ -384,9 +384,9 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 }
 
                 #[inline]
-                fn as_node(&self) -> &dyn ::kas::Node { self }
+                fn as_node(&self) -> &dyn ::kas::Widget { self }
                 #[inline]
-                fn as_node_mut(&mut self) -> &mut dyn ::kas::Node { self }
+                fn as_node_mut(&mut self) -> &mut dyn ::kas::Widget { self }
             }
 
             impl #impl_generics ::kas::WidgetChildren for #impl_target {
@@ -395,11 +395,11 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                     self.#inner.num_children()
                 }
                 #[inline]
-                fn get_child(&self, index: usize) -> Option<&dyn ::kas::Node> {
+                fn get_child(&self, index: usize) -> Option<&dyn ::kas::Widget> {
                     self.#inner.get_child(index)
                 }
                 #[inline]
-                fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn ::kas::Node> {
+                fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn ::kas::Widget> {
                     self.#inner.get_child_mut(index)
                 }
                 #[inline]
@@ -569,7 +569,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
 
         let mut set_rect = quote! { self.#core.rect = rect; };
         let mut find_id = quote! {
-            use ::kas::{WidgetCore, NodeExt};
+            use ::kas::{WidgetCore, WidgetExt};
             self.rect().contains(coord).then(|| self.id())
         };
         if let Some((_, layout)) = args.layout.take() {
@@ -696,7 +696,7 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
                 mgr: &mut ::kas::event::EventMgr,
                 event: ::kas::event::Event,
             ) -> ::kas::event::Response {
-                use ::kas::{event::{Event, Response, Scroll}, NodeExt, WidgetCore};
+                use ::kas::{event::{Event, Response, Scroll}, WidgetExt, WidgetCore};
                 if event == Event::NavFocus(true) {
                     mgr.set_scroll(Scroll::Rect(self.rect()));
                 }
@@ -757,41 +757,41 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
         });
     }
 
-    if let Some(index) = widget_impl {
-        let widget_impl = &mut scope.impls[index];
-        let method_idents = collect_idents(widget_impl);
+    if let Some(index) = events_impl {
+        let events_impl = &mut scope.impls[index];
+        let method_idents = collect_idents(events_impl);
         let has_method = |name| method_idents.iter().any(|ident| ident == name);
 
         if opt_derive.is_some() || !has_method("pre_configure") {
-            widget_impl.items.push(parse2(fn_pre_configure)?);
+            events_impl.items.push(parse2(fn_pre_configure)?);
         }
         if let Some(method) = fn_navigable {
-            widget_impl.items.push(parse2(method)?);
+            events_impl.items.push(parse2(method)?);
         }
-        widget_impl.items.push(parse2(fn_pre_handle_event)?);
+        events_impl.items.push(parse2(fn_pre_handle_event)?);
         if let Some(item) = fn_handle_event {
-            widget_impl.items.push(parse2(item)?);
+            events_impl.items.push(parse2(item)?);
         }
 
         if !has_method("nav_next") {
             if let Some(method) = fn_nav_next {
-                widget_impl.items.push(parse2(method)?);
+                events_impl.items.push(parse2(method)?);
             } else if gen_layout {
                 // We emit a warning here only if nav_next is not explicitly defined
                 let (span, msg) = fn_nav_next_err.unwrap();
-                emit_warning!(span, "unable to generate `fn Widget::nav_next`: {}", msg,);
+                emit_warning!(span, "unable to generate `fn Events::nav_next`: {}", msg,);
             }
         }
 
         for (name, method) in widget_methods {
             if !has_method(name) {
-                widget_impl.items.push(parse2(method)?);
+                events_impl.items.push(parse2(method)?);
             }
         }
     } else {
         let other_methods = widget_methods.into_iter().map(|pair| pair.1);
         scope.generated.push(quote! {
-            impl #impl_generics ::kas::Widget for #impl_target {
+            impl #impl_generics ::kas::Events for #impl_target {
                 #fn_pre_configure
                 #fn_navigable
                 #fn_pre_handle_event
@@ -800,6 +800,12 @@ pub fn widget(mut args: WidgetArgs, scope: &mut Scope) -> Result<()> {
             }
         });
     }
+
+    // Note that hidden widget methods are never derived
+    scope
+        .generated
+        .push(impl_widget(&impl_generics, &impl_target));
+
     // println!("{}", scope.to_token_stream());
     Ok(())
 }
@@ -822,9 +828,9 @@ pub fn impl_core(impl_generics: &Toks, impl_target: &Toks, name: &str, core_path
             }
 
             #[inline]
-            fn as_node(&self) -> &dyn ::kas::Node { self }
+            fn as_node(&self) -> &dyn ::kas::Widget { self }
             #[inline]
-            fn as_node_mut(&mut self) -> &mut dyn ::kas::Node { self }
+            fn as_node_mut(&mut self) -> &mut dyn ::kas::Widget { self }
         }
     }
 }
@@ -857,17 +863,68 @@ pub fn impl_widget_children(
             fn num_children(&self) -> usize {
                 #count
             }
-            fn get_child(&self, _index: usize) -> Option<&dyn ::kas::Node> {
+            fn get_child(&self, _index: usize) -> Option<&dyn ::kas::Widget> {
                 match _index {
                     #get_rules
                     _ => None
                 }
             }
-            fn get_child_mut(&mut self, _index: usize) -> Option<&mut dyn ::kas::Node> {
+            fn get_child_mut(&mut self, _index: usize) -> Option<&mut dyn ::kas::Widget> {
                 match _index {
                     #get_mut_rules
                     _ => None
                 }
+            }
+        }
+    }
+}
+
+pub fn impl_widget(impl_generics: &Toks, impl_target: &Toks) -> Toks {
+    quote! {
+        impl #impl_generics ::kas::Widget for #impl_target {
+            fn _configure(
+                &mut self,
+                cx: &mut ::kas::event::ConfigMgr,
+                id: ::kas::WidgetId,
+            ) {
+                ::kas::impls::_configure(self, cx, id);
+            }
+
+            fn _broadcast(
+                &mut self,
+                cx: &mut ::kas::event::EventMgr,
+                count: &mut usize,
+                event: ::kas::event::Event,
+            ) {
+                ::kas::impls::_broadcast(self, cx, count, event);
+            }
+
+            fn _send(
+                &mut self,
+                cx: &mut ::kas::event::EventMgr,
+                id: ::kas::WidgetId,
+                disabled: bool,
+                event: ::kas::event::Event,
+            ) -> ::kas::event::Response {
+                ::kas::impls::_send(self, cx, id, disabled, event)
+            }
+
+            fn _replay(
+                &mut self,
+                cx: &mut ::kas::event::EventMgr,
+                id: ::kas::WidgetId,
+                msg: ::kas::Erased,
+            ) {
+                ::kas::impls::_replay(self, cx, id, msg);
+            }
+
+            fn _nav_next(
+                &mut self,
+                cx: &mut ::kas::event::EventMgr,
+                focus: Option<&::kas::WidgetId>,
+                advance: ::kas::NavAdvance,
+            ) -> Option<::kas::WidgetId> {
+                ::kas::impls::_nav_next(self, cx, focus, advance)
             }
         }
     }

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -184,7 +184,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some((program, mut pixmap)) = mgr.try_pop::<(P, Pixmap)>() {
                 debug_assert!(matches!(self.inner, State::Rendering));

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -251,7 +251,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(pixmap) = mgr.try_pop::<Pixmap>() {
                 let size = (pixmap.width(), pixmap.height());

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -481,13 +481,13 @@ impl_scope! {
             self.cur_len.cast()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
             self.widgets.get(index).and_then(|w| {
                 w.key.is_some().then(|| w.widget.as_node())
             })
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
             self.widgets.get_mut(index).and_then(|w| {
                 w.key.is_some().then(|| w.widget.as_node_mut())
             })
@@ -642,7 +642,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             if self.widgets.is_empty() {
                 // Initial configure: ensure some widgets are loaded to allow

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -456,13 +456,13 @@ impl_scope! {
             self.cur_len.cast()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
             self.widgets.get(index).and_then(|w| {
                 w.key.is_some().then(|| w.widget.as_node())
             })
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
             self.widgets.get_mut(index).and_then(|w| {
                 w.key.is_some().then(|| w.widget.as_node_mut())
             })
@@ -620,7 +620,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             if self.widgets.is_empty() {
                 // Initial configure: ensure some widgets are loaded to allow

--- a/crates/kas-view/src/single_view.rs
+++ b/crates/kas-view/src/single_view.rs
@@ -129,7 +129,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             // We set data now, after child is configured
             let item = self.data.borrow(&()).unwrap();

--- a/crates/kas-widgets/src/adapter/reserve.rs
+++ b/crates/kas-widgets/src/adapter/reserve.rs
@@ -48,8 +48,10 @@ impl_scope! {
     #[autoimpl(Deref, DerefMut using self.inner)]
     #[autoimpl(class_traits using self.inner where W: trait)]
     #[derive(Clone, Default)]
-    #[widget{ derive = self.inner; }]
+    #[widget{ layout = self.inner; }]
     pub struct Reserve<W: Widget, R: FnSizeRules> {
+        core: widget_core!(),
+        #[widget]
         pub inner: W,
         reserve: R,
     }
@@ -84,7 +86,8 @@ impl_scope! {
         /// and the result of the `reserve` closure.
         #[inline]
         pub fn new(inner: W, reserve: R) -> Self {
-            Reserve { inner, reserve }
+            let core = Default::default();
+            Reserve { core, inner, reserve }
         }
     }
 

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -79,7 +79,7 @@ impl_scope! {
         ///
         /// When the button is activated, a clone of `msg` is sent to the
         /// parent widget. The parent (or an ancestor) should handle this using
-        /// [`Widget::handle_message`].
+        /// [`Events::handle_message`].
         #[inline]
         pub fn new_msg<M: Clone + Debug + 'static>(inner: W, msg: M) -> Self {
             Self::new_on(inner, move |mgr| mgr.push(msg.clone()))
@@ -106,7 +106,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.add_accel_keys(self.id_ref(), &self.keys1);
         }
@@ -197,7 +197,7 @@ impl_scope! {
         ///
         /// When the button is activated, a clone of `msg` is sent to the
         /// parent widget. The parent (or an ancestor) should handle this using
-        /// [`Widget::handle_message`].
+        /// [`Events::handle_message`].
         #[inline]
         pub fn new_msg<S: Into<AccelString>, M: Clone + Debug + 'static>(label: S, msg: M) -> Self {
             Self::new_on(label, move |mgr| mgr.push(msg.clone()))
@@ -239,7 +239,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.add_accel_keys(self.id_ref(), &self.keys1);
         }

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -143,7 +143,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             event.on_activate(mgr, self.id(), |mgr| {
                 self.toggle(mgr);
@@ -204,7 +204,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(kas::message::Activate) = mgr.try_pop() {
                 self.inner.toggle(mgr);

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -64,7 +64,7 @@ impl_scope! {
                     parent: s.id(),
                     direction: Direction::Down,
                 });
-                if let Some(w) = s.popup.inner.inner.get_child_mut(s.active) {
+                if let Some(w) = s.popup.inner.inner.get_child(s.active) {
                     mgr.next_nav_focus(w.id(), false, key_focus);
                 }
             };

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -46,7 +46,7 @@ impl_scope! {
         on_select: Option<Box<dyn Fn(&mut EventMgr, M)>>,
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn pre_configure(&mut self, mgr: &mut ConfigMgr, id: WidgetId) {
             self.core.id = id;
             mgr.new_accel_layer(self.id(), true);

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -106,7 +106,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(MessageBoxOk) = mgr.try_pop() {
                 mgr.send_action(Action::CLOSE);
@@ -177,7 +177,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.register_nav_fallback(self.id());
 

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -267,7 +267,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr<'_>) {
             if let Some(ScrollMsg(y)) = mgr.try_pop() {
                 self.inner
@@ -576,7 +576,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             fn request_focus<G: EditGuard + 'static>(s: &mut EditField<G>, mgr: &mut EventMgr) {
                 if !s.has_key_focus && mgr.request_char_focus(s.id()) {

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -16,7 +16,7 @@ use std::ops::{Index, IndexMut};
 /// This is parameterised over the handler message type.
 ///
 /// See documentation of [`Grid`] type.
-pub type BoxGrid = Grid<Box<dyn Node>>;
+pub type BoxGrid = Grid<Box<dyn Widget>>;
 
 impl_scope! {
     /// A generic grid widget
@@ -67,11 +67,11 @@ impl_scope! {
             self.widgets.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
             self.widgets.get(index).map(|c| c.1.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
             self.widgets.get_mut(index).map(|c| c.1.as_node_mut())
         }
     }
@@ -112,7 +112,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(f) = self.on_message {
                 let index = mgr.last_child().expect("message not sent from self");

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -89,7 +89,7 @@ impl_scope! {
         fn draw(&mut self, _: DrawMgr) {}
     }
 
-    impl Widget for GripPart {
+    impl Events for GripPart {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::PressStart { press, .. } => {

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -199,7 +199,7 @@ impl_scope! {
     /// Accelerator keys are not useful on plain labels. To be useful, a parent
     /// widget must do something like:
     /// ```no_test
-    /// impl Widget for Self {
+    /// impl Events for Self {
     ///     fn configure(&mut self, mgr: &mut EventMgr) {
     ///         let target = self.id(); // widget receiving Event::Activate
     ///         mgr.add_accel_keys(target, self.label.keys());
@@ -311,7 +311,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.add_accel_keys(self.id_ref(), self.label.text().keys());
         }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -35,7 +35,7 @@ pub type BoxColumn = BoxList<Down>;
 /// This is parameterised over directionality.
 ///
 /// See documentation of [`List`] type.
-pub type BoxList<D> = List<D, Box<dyn Node>>;
+pub type BoxList<D> = List<D, Box<dyn Widget>>;
 
 impl_scope! {
     /// A generic row/column widget
@@ -50,7 +50,7 @@ impl_scope! {
     /// Some more specific type-defs are available:
     ///
     /// -   [`Row`] and [`Column`] fix the direction `D`
-    /// -   [`BoxList`] fixes the widget type to `Box<dyn Node>`
+    /// -   [`BoxList`] fixes the widget type to `Box<dyn Widget>`
     /// -   [`BoxRow`] and [`BoxColumn`] fix both type parameters
     ///
     /// ## Performance
@@ -84,11 +84,11 @@ impl_scope! {
             self.widgets.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
             self.widgets.get(index).map(|w| w.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
             self.widgets.get_mut(index).map(|w| w.as_node_mut())
         }
 
@@ -122,7 +122,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn pre_configure(&mut self, _: &mut ConfigMgr, id: WidgetId) {
             self.core.id = id;
             self.id_map.clear();

--- a/crates/kas-widgets/src/mark.rs
+++ b/crates/kas-widgets/src/mark.rs
@@ -88,7 +88,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             event.on_activate(mgr, self.id(), |mgr| {
                 mgr.push(self.msg.clone());

--- a/crates/kas-widgets/src/menu.rs
+++ b/crates/kas-widgets/src/menu.rs
@@ -50,7 +50,7 @@ pub struct SubItems<'a> {
 /// Implementations will automatically receive nav focus on mouse-hover, thus
 /// should ensure that [`Layout::find_id`] returns the identifier of the widget
 /// which should be focussed, and that this widget has
-/// [`Widget::navigable`] return true.
+/// [`Events::navigable`] return true.
 #[autoimpl(for<T: trait + ?Sized> Box<T>)]
 pub trait Menu: Widget {
     /// Access row items for aligned layout

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -74,7 +74,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::Command(cmd) if cmd.is_activate() => {

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -65,11 +65,11 @@ impl_scope! {
             self.widgets.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
             self.widgets.get(index).map(|w| w.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
             self.widgets.get_mut(index).map(|w| w.as_node_mut())
         }
     }
@@ -119,7 +119,7 @@ impl_scope! {
         }
     }
 
-    impl<D: Directional> Widget for MenuBar<D> {
+    impl<D: Directional> Events for MenuBar<D> {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::TimerUpdate(id_code) => {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -144,7 +144,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn pre_configure(&mut self, mgr: &mut ConfigMgr, id: WidgetId) {
             self.core.id = id;
             // FIXME: new layer should apply to self.list but not to self.label.
@@ -268,11 +268,11 @@ impl_scope! {
             self.list.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
             self.list.get(index).map(|w| w.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
             self.list.get_mut(index).map(|w| w.as_node_mut())
         }
     }

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -42,7 +42,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::Command(cmd) if cmd.is_activate() => {

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -37,7 +37,7 @@ impl RadioGroup {
     /// Get the active [`RadioBox`], if any
     ///
     /// Note: this is never equal to a [`RadioButton`]'s [`WidgetId`], but may
-    /// be a descendant (test with [`NodeExt::is_ancestor_of`]).
+    /// be a descendant (test with [`WidgetExt::is_ancestor_of`]).
     pub fn get(&self) -> Option<WidgetId> {
         (self.0).1.borrow().clone()
     }
@@ -66,7 +66,7 @@ impl_scope! {
         on_select: Option<Box<dyn Fn(&mut EventMgr)>>,
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::Update { id, .. } if id == self.group.id() => {
@@ -242,7 +242,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(kas::message::Activate) = mgr.try_pop() {
                 self.inner.select(mgr);

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -134,7 +134,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.register_nav_fallback(self.id());
         }

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -301,7 +301,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::TimerUpdate(_) => {
@@ -341,7 +341,7 @@ impl_scope! {
     #[impl_default(where W: trait)]
     #[derive(Clone, Debug)]
     #[widget]
-    pub struct ScrollBars<W: Scrollable + Node> {
+    pub struct ScrollBars<W: Scrollable + Widget> {
         core: widget_core!(),
         mode: ScrollBarMode,
         show_bars: (bool, bool), // set by user (or set_rect when mode == Auto)
@@ -527,7 +527,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             let index = mgr.last_child().expect("message not sent from self");
             if index == widget_index![self.horiz_bar] {

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -341,7 +341,7 @@ impl_scope! {
     #[impl_default(where W: trait)]
     #[derive(Clone, Debug)]
     #[widget]
-    pub struct ScrollBars<W: Scrollable> {
+    pub struct ScrollBars<W: Scrollable + Node> {
         core: widget_core!(),
         mode: ScrollBarMode,
         show_bars: (bool, bool), // set by user (or set_rect when mode == Auto)

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -211,7 +211,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::Command(cmd) => match cmd {

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -315,7 +315,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::Command(cmd) => {

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -345,7 +345,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             *mgr |= self.edit.set_string(self.edit.guard.value.to_string());
         }

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -43,7 +43,7 @@ pub type BoxColumnSplitter = BoxSplitter<Down>;
 /// This is parameterised over directionality.
 ///
 /// See documentation of [`Splitter`] type.
-pub type BoxSplitter<D> = Splitter<D, Box<dyn Node>>;
+pub type BoxSplitter<D> = Splitter<D, Box<dyn Widget>>;
 
 /// A row of widget references
 ///
@@ -60,7 +60,7 @@ pub type RefColumnSplitter<'a> = RefSplitter<'a, Down>;
 /// This is parameterised over directionality.
 ///
 /// See documentation of [`Splitter`] type.
-pub type RefSplitter<'a, D> = Splitter<D, &'a mut dyn Node>;
+pub type RefSplitter<'a, D> = Splitter<D, &'a mut dyn Widget>;
 
 impl_scope! {
     /// A resizable row/column widget
@@ -113,7 +113,7 @@ impl_scope! {
             self.widgets.len() + self.handles.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
             if (index & 1) != 0 {
                 self.handles.get(index >> 1).map(|w| w.as_node())
             } else {
@@ -121,7 +121,7 @@ impl_scope! {
             }
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
             if (index & 1) != 0 {
                 self.handles.get_mut(index >> 1).map(|w| w.as_node_mut())
             } else {
@@ -240,7 +240,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn pre_configure(&mut self, _: &mut ConfigMgr, id: WidgetId) {
             self.core.id = id;
             self.id_map.clear();

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -13,12 +13,12 @@ use std::ops::{Index, IndexMut, Range};
 /// A stack of boxed widgets
 ///
 /// This is a parametrisation of [`Stack`].
-pub type BoxStack = Stack<Box<dyn Node>>;
+pub type BoxStack = Stack<Box<dyn Widget>>;
 
 /// A stack of widget references
 ///
 /// This is a parametrisation of [`Stack`].
-pub type RefStack<'a> = Stack<&'a mut dyn Node>;
+pub type RefStack<'a> = Stack<&'a mut dyn Widget>;
 
 impl_scope! {
     /// A stack of widgets
@@ -52,11 +52,11 @@ impl_scope! {
             self.widgets.len()
         }
         #[inline]
-        fn get_child(&self, index: usize) -> Option<&dyn Node> {
+        fn get_child(&self, index: usize) -> Option<&dyn Widget> {
             self.widgets.get(index).map(|w| w.as_node())
         }
         #[inline]
-        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Node> {
+        fn get_child_mut(&mut self, index: usize) -> Option<&mut dyn Widget> {
             self.widgets.get_mut(index).map(|w| w.as_node_mut())
         }
 
@@ -125,7 +125,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn pre_configure(&mut self, _: &mut ConfigMgr, id: WidgetId) {
             self.core.id = id;
             self.id_map.clear();

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -23,7 +23,7 @@ pub type Tab = TextButton;
 /// A tabbed stack of boxed widgets
 ///
 /// This is a parametrisation of [`TabStack`].
-pub type BoxTabStack = TabStack<Box<dyn Node>>;
+pub type BoxTabStack = TabStack<Box<dyn Widget>>;
 
 impl_scope! {
     /// A tabbed stack of widgets
@@ -82,7 +82,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
+    impl Events for Self {
         fn nav_next(&mut self,
             _: &mut EventMgr,
             reverse: bool,

--- a/examples/async-event.rs
+++ b/examples/async-event.rs
@@ -88,7 +88,7 @@ impl_scope! {
             }
         }
     }
-    impl Widget for ColourSquare {
+    impl Events for ColourSquare {
         fn handle_event(&mut self, mgr: &mut EventMgr, event: Event) -> Response {
             match event {
                 Event::Update { id, .. } if id == self.update_id => {

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -72,7 +72,7 @@ impl_scope! {
             .with_width_em(5.0, 10.0),
         calc: Calculator = Calculator::new(),
     }
-    impl Widget for Self {
+    impl Events for Self {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.disable_nav_focus(true);
 

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -119,7 +119,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Clock {
+    impl Events for Clock {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.request_timer_update(self.id(), 0, Duration::new(0, 0), true);
         }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -36,7 +36,7 @@ impl_scope! {
             }
         }
     }
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(Increment(incr)) = mgr.try_pop() {
                 self.count += incr;

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -226,7 +226,7 @@ fn main() -> kas::shell::Result<()> {
                 }),
             n: usize = 3,
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if mgr.last_child() == Some(widget_index![self.edit]) {
                     if let Some(n) = mgr.try_pop::<usize>() {
@@ -274,7 +274,7 @@ fn main() -> kas::shell::Result<()> {
             #[widget] list: ScrollBars<MyList> =
                 ScrollBars::new(list).with_fixed_bars(false, true),
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(control) = mgr.try_pop::<Control>() {
                     match control {

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -109,7 +109,7 @@ fn main() -> kas::shell::Result<()> {
                 }),
             n: usize = 3,
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if mgr.last_child() == Some(widget_index![self.edit]) {
                     if let Some(n) = mgr.try_pop::<usize>() {
@@ -158,7 +158,7 @@ fn main() -> kas::shell::Result<()> {
                 ScrollBarRegion::new(list).with_fixed_bars(false, true),
             active: usize = 0,
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(control) = mgr.try_pop() {
                     match control {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -98,7 +98,7 @@ fn widgets() -> Box<dyn SetDisabled> {
             #[widget] label: SingleView<SharedRc<String>> =
                 SingleView::new(SharedRc::new("Use button to edit →".to_string())),
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(MsgEdit) = mgr.try_pop() {
                     let text = self.label.data().clone();
@@ -177,7 +177,7 @@ fn widgets() -> Box<dyn SetDisabled> {
             }),
             #[widget] pu = popup_edit_box,
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(ScrollMsg(value)) = mgr.try_pop() {
                     if mgr.last_child() == Some(widget_index![self.sc]) {
@@ -252,7 +252,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
             #[widget] label: ScrollLabel<Markdown> =
                 ScrollLabel::new(Markdown::new(doc).unwrap()),
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(MsgDirection) = mgr.try_pop() {
                     self.dir = match self.dir {
@@ -322,7 +322,7 @@ fn filter_list() -> Box<dyn SetDisabled> {
             #[widget] list: ScrollBars<MyListView> =
                 ScrollBars::new(MyListView::new(filtered))
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(mode) = mgr.try_pop() {
                     *mgr |= self.list.set_selection_mode(mode);
@@ -546,7 +546,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .with_title("Can&vas", canvas())
                 .with_title("Confi&g", config(shell.event_config().clone())),
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(msg) = mgr.try_pop::<Menu>() {
                     match msg {

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -353,7 +353,7 @@ impl_scope! {
         }
     }
 
-    impl Widget for Mandlebrot {
+    impl Events for Mandlebrot {
         fn configure(&mut self, mgr: &mut ConfigMgr) {
             mgr.register_nav_fallback(self.id());
         }
@@ -460,7 +460,7 @@ impl_scope! {
             }
         }
     }
-    impl Widget for Self {
+    impl Events for Self {
         fn handle_message(&mut self, mgr: &mut EventMgr) {
             if let Some(iter) = mgr.try_pop() {
                 self.mbrot.iter = iter;

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -7,7 +7,7 @@
 
 use kas::event::EventMgr;
 use kas::widget::{EditField, RowSplitter, TextButton};
-use kas::{Widget, Window};
+use kas::{Events, Window};
 
 #[derive(Clone, Debug)]
 enum Message {
@@ -35,7 +35,7 @@ fn main() -> kas::shell::Result<()> {
             core: widget_core!(),
             #[widget] panes: RowSplitter<EditField> = panes,
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if let Some(msg) = mgr.try_pop::<Message>() {
                     match msg {

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use kas::class::HasString;
 use kas::event::{ConfigMgr, Event, EventMgr, Response};
 use kas::widget::{Frame, Label, TextButton};
-use kas::{Decorations, NodeExt, Widget, WidgetCore, Window};
+use kas::{Decorations, Events, Widget, WidgetCore, WidgetExt, Window};
 
 #[derive(Clone, Debug)]
 struct MsgReset;
@@ -34,7 +34,7 @@ fn make_window() -> Box<dyn kas::Window> {
             saved: Duration,
             start: Option<Instant>,
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn configure(&mut self, mgr: &mut ConfigMgr) {
                 mgr.enable_alt_bypass(self.id_ref(), true);
             }

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -73,7 +73,7 @@ fn main() -> kas::shell::Result<()> {
                 }),
             #[widget] table: ScrollBars<MatrixView<TableData, driver::NavView>> = table,
         }
-        impl Widget for Self {
+        impl Events for Self {
             fn handle_message(&mut self, mgr: &mut EventMgr) {
                 if mgr.last_child() == Some(widget_index![self.max]) {
                     if let Some(max) = mgr.try_pop::<usize>() {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,4 +16,4 @@
 #[doc(no_inline)]
 pub use kas_core::prelude::*;
 #[doc(no_inline)]
-pub use kas_widgets::adapter::AdaptWidget;
+pub use kas_widgets::adapter::{AdaptDerivable, AdaptWidget};


### PR DESCRIPTION
This is a follow-up on #391, which probably should not have been merged as it was. That PR passed checks despite conflating `Node` vs `Widget` since every `Widget` implemented `Node` (via blanket impl).

Now:

- `Widget` is restored as the "master trait" any widget must implement.
- Event-handling methods are moved to a new trait, `Events`. This is public but with a `Sized` bound to clarify that it is not intended for use in dyn-safe APIs (`Widget` implements a dyn-safe API over `Events + Layout`).
- `Widget` has blanket impls for `&mut T` and `Box<T>` where `T: Widget + ?Sized`. This was not possible with `Node` due to conflict with the other blanket impl.
- This allows user-defined methods to be included in `Widget`.