### PR TITLE
Window suspend/resume cycle, winit 0.29.1-beta

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -116,6 +116,6 @@ version = "0.5.0" # used in doc links
 
 [dependencies.winit]
 # Provides translations for several winit types
-version = "0.29.0-beta.0"
+version = "0.29.1-beta"
 optional = true
 default-features = false

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -90,7 +90,7 @@ serde = { version = "1.0.123", features = ["derive"], optional = true }
 serde_json = { version = "1.0.61", optional = true }
 serde_yaml = { version = "0.9.9", optional = true }
 ron = { version = "0.8.0", package = "ron", optional = true }
-num_enum = "0.6.1"
+num_enum = "0.7.0"
 dark-light = { version = "1.0", optional = true }
 raw-window-handle = "0.5.0"
 async-global-executor = { version = "2.3.1", optional = true }

--- a/crates/kas-core/src/action.rs
+++ b/crates/kas-core/src/action.rs
@@ -20,7 +20,7 @@ bitflags! {
     /// (`toolkit.run()`) or if the widget in question is not part of a UI these
     /// values can be ignored.
     #[must_use]
-    #[derive(Copy, Clone, Default)]
+    #[derive(Copy, Clone, Debug, Default)]
     pub struct Action: u32 {
         /// The whole window requires redrawing
         ///

--- a/crates/kas-core/src/event/config.rs
+++ b/crates/kas-core/src/event/config.rs
@@ -160,19 +160,19 @@ pub struct WindowConfig {
 
 impl WindowConfig {
     /// Construct
+    ///
+    /// It is required to call [`Self::update`] before usage.
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    pub fn new(config: Rc<RefCell<Config>>, scale_factor: f32, dpem: f32) -> Self {
-        let mut w = WindowConfig {
+    pub fn new(config: Rc<RefCell<Config>>) -> Self {
+        WindowConfig {
             config,
             scroll_flick_sub: f32::NAN,
             scroll_dist: f32::NAN,
             pan_dist_thresh: f32::NAN,
             nav_focus: true,
             frame_dur: Default::default(),
-        };
-        w.update(scale_factor, dpem);
-        w
+        }
     }
 
     /// Update window-specific/cached values

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -788,6 +788,8 @@ impl<'a> EventCx<'a> {
             }
             // TODO: if popup.id is an ancestor of self.nav_focus then clear
             // focus if not setting (currently we cannot test this)
+
+            return;
         }
 
         self.shell.close_window(id);

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -717,10 +717,7 @@ impl<'a> EventCx<'a> {
     ///
     /// A pop-up may be closed by calling [`EventCx::close_window`] with
     /// the [`WindowId`] returned by this method.
-    ///
-    /// Returns `None` if window creation is not currently available (but note
-    /// that `Some` result does not guarantee the operation succeeded).
-    pub fn add_popup(&mut self, popup: crate::Popup) -> Option<WindowId> {
+    pub fn add_popup(&mut self, popup: crate::Popup) -> WindowId {
         log::trace!(target: "kas_core::event", "add_popup: {popup:?}");
         let new_id = &popup.id;
         while let Some((_, popup, _)) = self.popups.last() {
@@ -733,13 +730,11 @@ impl<'a> EventCx<'a> {
             // Don't restore old nav focus: assume new focus will be set by new popup
         }
 
-        let opt_id = self.shell.add_popup(popup.clone());
-        if let Some(id) = opt_id {
-            let nav_focus = self.nav_focus.clone();
-            self.popups.push((id, popup, nav_focus));
-        }
+        let id = self.shell.add_popup(popup.clone());
+        let nav_focus = self.nav_focus.clone();
+        self.popups.push((id, popup, nav_focus));
         self.clear_nav_focus();
-        opt_id
+        id
     }
 
     /// Add a window

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -133,9 +133,8 @@ impl EventState {
         f(&mut cx);
     }
 
-    /// Update, after receiving all events
-    #[inline]
-    pub(crate) fn post_events<A>(
+    /// Handle all pending items before event loop sleeps
+    pub(crate) fn flush_pending<A>(
         &mut self,
         shell: &mut dyn ShellWindow,
         messages: &mut ErasedStack,
@@ -254,31 +253,6 @@ impl EventState {
         }
 
         std::mem::take(&mut self.action)
-    }
-
-    /// Update, after drawing
-    ///
-    /// Returns true if action is non-empty
-    #[inline]
-    pub(crate) fn post_draw(
-        &mut self,
-        shell: &mut dyn ShellWindow,
-        messages: &mut ErasedStack,
-        widget: Node<'_>,
-    ) -> bool {
-        let mut cx = EventCx {
-            state: self,
-            shell,
-            messages,
-            last_child: None,
-            scroll: Scroll::None,
-        };
-
-        // Widget::draw may add futures; we should poll those now.
-        cx.poll_futures(widget);
-
-        drop(cx);
-        !self.action.is_empty()
     }
 }
 

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -75,21 +75,24 @@ impl EventState {
     pub(crate) fn full_configure<A>(
         &mut self,
         shell: &mut dyn ShellWindow,
+        wid: WindowId,
         win: &mut Window<A>,
         data: &A,
     ) {
-        log::debug!(target: "kas_core::event", "full_configure");
+        let id = WidgetId::ROOT.make_child(wid.get().cast());
+
+        log::debug!(target: "kas_core::event", "full_configure of Window{id}");
         self.action.remove(Action::RECONFIGURE);
 
         // These are recreated during configure:
         self.accel_layers.clear();
         self.nav_fallback = None;
 
-        self.new_accel_layer(WidgetId::ROOT, false);
+        self.new_accel_layer(id.clone(), false);
 
         shell.size_and_draw_shared(Box::new(|size, draw_shared| {
             let mut cx = ConfigCx::new(size, draw_shared, self);
-            cx.configure(win.as_node(data), WidgetId::ROOT);
+            cx.configure(win.as_node(data), id);
         }));
 
         let hover = win.find_id(data, self.last_mouse_coord);

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -11,8 +11,10 @@ use std::time::{Duration, Instant};
 
 use super::*;
 use crate::cast::traits::*;
+use crate::draw::DrawShared;
 use crate::geom::{Coord, DVec2};
 use crate::shell::ShellWindow;
+use crate::theme::ThemeSize;
 use crate::{Action, NavAdvance, WidgetId, Window};
 
 // TODO: this should be configurable or derived from the system
@@ -72,7 +74,8 @@ impl EventState {
     /// renamed and removed widgets.
     pub(crate) fn full_configure<A>(
         &mut self,
-        shell: &mut dyn ShellWindow,
+        sizer: &dyn ThemeSize,
+        draw_shared: &mut dyn DrawShared,
         wid: WindowId,
         win: &mut Window<A>,
         data: &A,
@@ -88,10 +91,7 @@ impl EventState {
 
         self.new_accel_layer(id.clone(), false);
 
-        shell.size_and_draw_shared(Box::new(|size, draw_shared| {
-            let mut cx = ConfigCx::new(size, draw_shared, self);
-            cx.configure(win.as_node(data), id);
-        }));
+        ConfigCx::new(sizer, draw_shared, self).configure(win.as_node(data), id);
 
         let hover = win.find_id(data, self.last_mouse_coord);
         self.set_hover(hover);

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -14,8 +14,6 @@ use crate::cast::traits::*;
 use crate::geom::{Coord, DVec2};
 use crate::shell::ShellWindow;
 use crate::{Action, NavAdvance, WidgetId, Window};
-use std::cell::RefCell;
-use std::rc::Rc;
 
 // TODO: this should be configurable or derived from the system
 const DOUBLE_CLICK_TIMEOUT: Duration = Duration::from_secs(1);
@@ -28,9 +26,9 @@ const FAKE_MOUSE_BUTTON: MouseButton = MouseButton::Other(0);
 impl EventState {
     /// Construct per-window event state
     #[inline]
-    pub(crate) fn new(config: Rc<RefCell<Config>>, scale_factor: f32, dpem: f32) -> Self {
+    pub(crate) fn new(config: WindowConfig) -> Self {
         EventState {
-            config: WindowConfig::new(config, scale_factor, dpem),
+            config,
             disabled: vec![],
             window_has_focus: false,
             modifiers: ModifiersState::empty(),

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -87,11 +87,9 @@ impl<'a> EventCx<'a> {
                             grab.depress = grab.cur_id.clone();
                             self.action |= Action::REDRAW;
                         }
-                    } else {
-                        if grab.depress.is_some() {
-                            grab.depress = None;
-                            self.action |= Action::REDRAW;
-                        }
+                    } else if grab.depress.is_some() {
+                        grab.depress = None;
+                        self.action |= Action::REDRAW;
                     }
                 }
                 GrabMode::Grab => {
@@ -131,11 +129,9 @@ impl TouchGrab {
                     self.depress = self.cur_id.clone();
                     return Action::REDRAW;
                 }
-            } else {
-                if self.depress.is_some() {
-                    self.depress = None;
-                    return Action::REDRAW;
-                }
+            } else if self.depress.is_some() {
+                self.depress = None;
+                return Action::REDRAW;
             }
         }
         Action::empty()

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -31,6 +31,10 @@ impl WindowId {
     pub(crate) fn new(n: NonZeroU32) -> WindowId {
         WindowId(n)
     }
+
+    pub(crate) fn get(self) -> u32 {
+        self.0.get()
+    }
 }
 
 /// Commands supported by the [`Window`]

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -280,9 +280,9 @@ impl<Data: 'static> Window<Data> {
         self.title_bar.title()
     }
 
-    /// Take the window's icon, if any
-    pub(crate) fn take_icon(&mut self) -> Option<Icon> {
-        self.icon.take()
+    /// Get the window's icon, if any
+    pub(crate) fn icon(&mut self) -> Option<Icon> {
+        self.icon.clone()
     }
 
     /// Set the window's icon (inline)

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -14,7 +14,6 @@ use crate::{Action, Window, WindowId};
 use raw_window_handle as raw;
 use std::any::TypeId;
 use thiserror::Error;
-#[cfg(winit)] use winit::error::OsError;
 
 /// Possible failures from constructing a [`Shell`](super::Shell)
 ///
@@ -30,13 +29,16 @@ pub enum Error {
     /// Config load/save error
     #[error("config load/save error")]
     Config(#[from] kas::config::Error),
-    #[doc(hidden)]
 
-    /// OS error during window creation
-    #[error("operating system error")]
-    #[cfg(winit)]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "winit")))]
-    Window(#[from] OsError),
+    /// Event loop error
+    #[error("event loop")]
+    EventLoop(#[from] winit::error::EventLoopError),
+}
+
+impl From<winit::error::OsError> for Error {
+    fn from(error: winit::error::OsError) -> Self {
+        Error::EventLoop(winit::error::EventLoopError::Os(error))
+    }
 }
 
 /// A `Result` type representing `T` or [`enum@Error`]

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -242,7 +242,7 @@ pub(crate) trait ShellWindow {
     ///
     /// Returns `None` if window creation is not currently available (but note
     /// that `Some` result does not guarantee the operation succeeded).
-    fn add_popup(&mut self, popup: crate::Popup) -> Option<WindowId>;
+    fn add_popup(&mut self, popup: crate::Popup) -> WindowId;
 
     /// Add a window
     ///

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -299,7 +299,7 @@ pub(crate) trait ShellWindow {
     /// User-code *must not* depend on `f` being called for memory safety.
     fn size_and_draw_shared<'s>(
         &'s mut self,
-        f: Box<dyn FnOnce(&mut dyn ThemeSize, &mut dyn DrawShared) + 's>,
+        f: Box<dyn FnOnce(&dyn ThemeSize, &mut dyn DrawShared) + 's>,
     );
 
     /// Set the mouse cursor

--- a/crates/kas-core/src/shell/event_loop.rs
+++ b/crates/kas-core/src/shell/event_loop.rs
@@ -168,7 +168,7 @@ where
                         }
                         PendingAction::AddWindow(id, widget) => {
                             log::debug!("Pending: adding window {}", widget.title());
-                            let mut window = Window::new(&mut self.shared, id, widget);
+                            let mut window = Window::new(&self.shared, id, widget);
                             if !self.suspended {
                                 match window.resume(&mut self.shared, elwt) {
                                     Ok(winit_id) => {

--- a/crates/kas-core/src/shell/event_loop.rs
+++ b/crates/kas-core/src/shell/event_loop.rs
@@ -42,10 +42,13 @@ where
     pub(super) fn new(mut windows: Vec<Window<A, S, T>>, shared: SharedState<A, S, T>) -> Self {
         let id_map = windows
             .iter()
-            .map(|w| (w.window_id, w.window.id()))
+            .map(|w| (w.window_id, w.winit_window_id()))
             .collect();
         Loop {
-            windows: windows.drain(..).map(|w| (w.window.id(), w)).collect(),
+            windows: windows
+                .drain(..)
+                .map(|w| (w.winit_window_id(), w))
+                .collect(),
             id_map,
             shared,
             resumes: vec![],
@@ -155,7 +158,7 @@ where
                             log::debug!("Pending: adding window {}", widget.title());
                             match Window::new(&mut self.shared, elwt, id, widget) {
                                 Ok(window) => {
-                                    let wid = window.window.id();
+                                    let wid = window.winit_window_id();
                                     self.id_map.insert(id, wid);
                                     self.windows.insert(wid, window);
                                 }

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -11,6 +11,7 @@ mod common;
 #[cfg(winit)] mod shell;
 #[cfg(winit)] mod window;
 
+#[cfg(winit)] use crate::WindowId;
 #[cfg(winit)] use event_loop::Loop as EventLoop;
 #[cfg(winit)] use shared::{SharedState, ShellShared};
 #[cfg(winit)] use shell::PlatformWrapper;
@@ -30,16 +31,16 @@ pub extern crate raw_window_handle;
 #[allow(clippy::large_enum_variant)]
 #[cfg(winit)]
 enum PendingAction<A: 'static> {
-    AddPopup(winit::window::WindowId, kas::WindowId, kas::Popup),
-    AddWindow(kas::WindowId, kas::Window<A>),
-    CloseWindow(kas::WindowId),
+    AddPopup(WindowId, WindowId, kas::Popup),
+    AddWindow(WindowId, kas::Window<A>),
+    CloseWindow(WindowId),
     Action(kas::Action),
 }
 
 #[cfg(winit)]
 enum ProxyAction {
     CloseAll,
-    Close(kas::WindowId),
+    Close(WindowId),
     Message(kas::erased::SendErased),
     WakeAsync,
 }

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -105,9 +105,14 @@ where
 }
 
 impl<Data: AppData, S: kas::draw::DrawSharedImpl, T> ShellShared<Data, S, T> {
+    /// Return the next window identifier
+    ///
+    /// TODO(opt): this should recycle used identifiers since WidgetId does not
+    /// efficiently represent large numbers.
     pub fn next_window_id(&mut self) -> WindowId {
-        self.window_id += 1;
-        WindowId::new(NonZeroU32::new(self.window_id).unwrap())
+        let id = self.window_id + 1;
+        self.window_id = id;
+        WindowId::new(NonZeroU32::new(id).unwrap())
     }
 
     #[inline]

--- a/crates/kas-core/src/shell/shell.rs
+++ b/crates/kas-core/src/shell/shell.rs
@@ -156,7 +156,7 @@ where
     #[inline]
     pub fn add(&mut self, window: Window<Data>) -> WindowId {
         let id = self.shared.shell.next_window_id();
-        let win = super::Window::new(&mut self.shared, id, window);
+        let win = super::Window::new(&self.shared, id, window);
         self.windows.push(win);
         id
     }

--- a/crates/kas-core/src/shell/shell.rs
+++ b/crates/kas-core/src/shell/shell.rs
@@ -154,18 +154,18 @@ where
 
     /// Assume ownership of and display a window
     #[inline]
-    pub fn add(&mut self, window: Window<Data>) -> Result<WindowId> {
+    pub fn add(&mut self, window: Window<Data>) -> WindowId {
         let id = self.shared.shell.next_window_id();
-        let win = super::Window::new(&mut self.shared, &self.el, id, window)?;
+        let win = super::Window::new(&mut self.shared, id, window);
         self.windows.push(win);
-        Ok(id)
+        id
     }
 
     /// Assume ownership of and display a window, inline
     #[inline]
-    pub fn with(mut self, window: Window<Data>) -> Result<Self> {
-        let _ = self.add(window)?;
-        Ok(self)
+    pub fn with(mut self, window: Window<Data>) -> Self {
+        let _ = self.add(window);
+        self
     }
 
     /// Create a proxy which can be used to update the UI from another thread

--- a/crates/kas-core/src/shell/shell.rs
+++ b/crates/kas-core/src/shell/shell.rs
@@ -119,7 +119,7 @@ where
         options: Options,
         config: Rc<RefCell<event::Config>>,
     ) -> Result<Self> {
-        let el = EventLoopBuilder::with_user_event().build();
+        let el = EventLoopBuilder::with_user_event().build()?;
         let windows = vec![];
 
         let mut draw_shared = graphical_shell.into().build()?;
@@ -175,10 +175,11 @@ where
 
     /// Run the main loop.
     #[inline]
-    pub fn run(self) -> ! {
+    pub fn run(self) -> Result<()> {
         let mut el = super::EventLoop::new(self.windows, self.shared);
         self.el
-            .run(move |event, elwt, control_flow| el.handle(event, elwt, control_flow))
+            .run(move |event, elwt, control_flow| el.handle(event, elwt, control_flow))?;
+        Ok(())
     }
 }
 

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -33,6 +33,7 @@ struct WindowData<S: WindowSurface, T: Theme<S::Shared>> {
     surface: S,
 
     // NOTE: cached components could be here or in Window
+    window_id: WindowId,
     solve_cache: SolveCache,
     theme_window: T::Window,
     next_avail_frame_time: Instant,
@@ -152,6 +153,7 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
             wayland_clipboard,
             surface,
 
+            window_id,
             solve_cache,
             theme_window,
             next_avail_frame_time: time,
@@ -478,7 +480,7 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> TkWindow<'a, A, S, T
 
 impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWindow<'a, A, S, T> {
     fn add_popup(&mut self, popup: kas::Popup) -> WindowId {
-        let parent_id = self.window.id();
+        let parent_id = self.window.window_id;
         let id = self.shared.next_window_id();
         self.shared
             .pending

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -53,7 +53,7 @@ pub struct Window<A: AppData, S: WindowSurface, T: Theme<S::Shared>> {
 impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
     /// Construct window state (widget)
     pub(super) fn new(
-        shared: &mut SharedState<A, S, T>,
+        shared: &SharedState<A, S, T>,
         window_id: WindowId,
         widget: kas::Window<A>,
     ) -> Self {
@@ -630,7 +630,7 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWi
     #[cfg(winit)]
     #[inline]
     fn winit_window(&self) -> Option<&winit::window::Window> {
-        Some(&self.window)
+        Some(self.window)
     }
 
     #[inline]

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -9,7 +9,7 @@ use super::{PendingAction, Platform, ProxyAction};
 use super::{SharedState, ShellShared, ShellWindow, WindowSurface};
 use kas::cast::Cast;
 use kas::draw::{color::Rgba, AnimationState, DrawShared};
-use kas::event::{ConfigCx, CursorIcon, EventState};
+use kas::event::{config::WindowConfig, ConfigCx, CursorIcon, EventState};
 use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
 use kas::theme::{DrawCx, SizeCx, ThemeControl, ThemeSize};
@@ -91,9 +91,10 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
         };
 
         let mut theme_window = shared.shell.theme.new_window(scale_factor);
-        let dpem = theme_window.size().dpem();
 
-        let mut ev_state = EventState::new(shared.config.clone(), scale_factor, dpem);
+        let config = WindowConfig::new(shared.config.clone());
+        let mut ev_state = EventState::new(config);
+        ev_state.update_config(scale_factor, theme_window.size().dpem());
         let mut tkw = TkWindow::new(&mut shared.shell, None, &mut theme_window);
         ev_state.full_configure(&mut tkw, window_id, &mut widget, &shared.data);
 

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -95,7 +95,7 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
 
         let mut ev_state = EventState::new(shared.config.clone(), scale_factor, dpem);
         let mut tkw = TkWindow::new(&mut shared.shell, None, &mut theme_window);
-        ev_state.full_configure(&mut tkw, &mut widget, &shared.data);
+        ev_state.full_configure(&mut tkw, window_id, &mut widget, &shared.data);
 
         let sizer = SizeCx::new(theme_window.size());
         let mut solve_cache = SolveCache::find_constraints(widget.as_node(&shared.data), sizer);
@@ -354,7 +354,7 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
             &mut self.theme_window,
         );
         self.ev_state
-            .full_configure(&mut tkw, &mut self.widget, &shared.data);
+            .full_configure(&mut tkw, self.window_id, &mut self.widget, &shared.data);
 
         self.solve_cache.invalidate_rule_cache();
         self.apply_size(shared, false);

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -457,7 +457,7 @@ fn parse_cell_info(input: ParseStream) -> Result<CellInfo> {
             let lit = input.parse::<LitInt>()?;
             let n: u32 = lit.base10_parse()?;
 
-            if let Ok(_) = plus {
+            if plus.is_ok() {
                 Ok(start + n)
             } else if n > start {
                 Ok(n)

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -81,11 +81,11 @@ impl_scope! {
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &A, event: Event) -> Response {
             let open_popup = |s: &mut Self, cx: &mut EventCx, key_focus: bool| {
-                s.popup_id = cx.add_popup(kas::Popup {
+                s.popup_id = Some(cx.add_popup(kas::Popup {
                     id: s.popup.id(),
                     parent: s.id(),
                     direction: Direction::Down,
-                });
+                }));
                 if let Some(w) = s.popup.inner.inner.get_child(s.active) {
                     cx.next_nav_focus(w.id(), false, key_focus);
                 }

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -88,7 +88,9 @@ impl_scope! {
     }]
     /// An editor over a `String`
     ///
-    /// Emits a [`TextEditResult`] message on closure.
+    /// Emits a [`TextEditResult`] message when the "Ok" or "Cancel" button is
+    /// pressed. When used as a pop-up, it is up to the caller to close on this
+    /// message.
     pub struct TextEdit {
         core: widget_core!(),
         #[widget]

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -74,11 +74,11 @@ impl_scope! {
 
         fn open_menu(&mut self, cx: &mut EventCx, set_focus: bool) {
             if self.popup_id.is_none() {
-                self.popup_id = cx.add_popup(kas::Popup {
+                self.popup_id = Some(cx.add_popup(kas::Popup {
                     id: self.list.id(),
                     parent: self.id(),
                     direction: self.direction.as_direction(),
-                });
+                }));
                 if set_focus {
                     cx.next_nav_focus(self.id(), false, true);
                 }

--- a/examples/async-event.rs
+++ b/examples/async-event.rs
@@ -49,7 +49,7 @@ fn main() -> kas::shell::Result<()> {
     let widget = ColourSquare::new();
     let window = Window::new(widget, "Async event demo");
 
-    shell.with(window)?.run()
+    shell.with(window).run()
 }
 
 impl_scope! {

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -72,7 +72,7 @@ fn main() -> kas::shell::Result<()> {
 
     let theme = kas_wgpu::ShadedTheme::new().with_font_size(16.0);
     kas::shell::DefaultShell::new((), theme)?
-        .with(calc_ui())?
+        .with(calc_ui())
         .run()
 }
 

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -179,5 +179,5 @@ fn main() -> kas::shell::Result<()> {
         .with_decorations(kas::Decorations::None)
         .with_transparent(true);
 
-    Shell::new((), Theme::new())?.with(window)?.run()
+    Shell::new((), Theme::new())?.with(window).run()
 }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -29,6 +29,6 @@ fn main() -> kas::shell::Result<()> {
 
     let theme = kas::theme::SimpleTheme::new().with_font_size(24.0);
     kas::shell::DefaultShell::new((), theme)?
-        .with(Window::new(counter(), "Counter"))?
+        .with(Window::new(counter(), "Counter"))
         .run()
 }

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -83,7 +83,5 @@ fn main() -> kas::shell::Result<()> {
 
     let window = Window::new(column, "Cursor gallery");
     let theme = kas::theme::FlatTheme::new();
-    kas::shell::DefaultShell::new((), theme)?
-        .with(window)?
-        .run()
+    kas::shell::DefaultShell::new((), theme)?.with(window).run()
 }

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -242,7 +242,5 @@ fn main() -> kas::shell::Result<()> {
     let window = Window::new(ui, "Dynamic widget demo");
 
     let theme = kas::theme::FlatTheme::new();
-    kas::shell::DefaultShell::new((), theme)?
-        .with(window)?
-        .run()
+    kas::shell::DefaultShell::new((), theme)?.with(window).run()
 }

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -185,7 +185,5 @@ fn main() -> kas::shell::Result<()> {
     let window = Window::new(ui, "Dynamic widget demo");
 
     let theme = kas::theme::FlatTheme::new();
-    kas::shell::DefaultShell::new((), theme)?
-        .with(window)?
-        .run()
+    kas::shell::DefaultShell::new((), theme)?.with(window).run()
 }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -135,6 +135,7 @@ fn widgets() -> Box<dyn SetDisabled<()>> {
         struct {
             core: widget_core!(),
             #[widget(&())] editor: TextEdit = TextEdit::new("", true),
+            popup_id: Option<kas::WindowId>,
         }
         impl Events for Self {
             type Data = Data;
@@ -148,11 +149,11 @@ fn widgets() -> Box<dyn SetDisabled<()>> {
                     // cx.add_window::<()>(ed.into_window("Edit text"));
                     // TODO: cx.add_modal(..)
                     // FIXME: what's with mouse focus here?
-                    cx.add_popup(kas::Popup {
+                    self.popup_id = Some(cx.add_popup(kas::Popup {
                         id: self.editor.id(),
                         parent: self.id(),
                         direction: kas::dir::Direction::Up,
-                    });
+                    }));
                 } else if let Some(result) = cx.try_pop() {
                     match result {
                         TextEditResult::Cancel => (),
@@ -160,6 +161,9 @@ fn widgets() -> Box<dyn SetDisabled<()>> {
                             // Translate from TextEdit's output
                             cx.push(Item::Text(text));
                         }
+                    }
+                    if let Some(id) = self.popup_id.take() {
+                        cx.close_window(id, true);
                     }
                 }
             }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -644,6 +644,6 @@ fn main() -> kas::shell::Result<()> {
         }
     };
 
-    shell.add(Window::new(ui, "Gallery — Widgets"))?;
+    shell.add(Window::new(ui, "Gallery — Widgets"));
     shell.run()
 }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -529,7 +529,7 @@ KAS_CONFIG_MODE=readwrite
     Box::new(Adapt::new(ui, ()))
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> kas::shell::Result<()> {
     env_logger::init();
 
     let theme = kas::theme::MultiTheme::builder()

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -11,7 +11,5 @@ fn main() -> kas::shell::Result<()> {
     let window = MessageBox::new("Message").into_window("Hello world");
 
     let theme = kas::theme::FlatTheme::new();
-    kas::shell::DefaultShell::new((), theme)?
-        .with(window)?
-        .run()
+    kas::shell::DefaultShell::new((), theme)?.with(window).run()
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -7,7 +7,7 @@
 
 use kas::widgets::dialog::MessageBox;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> kas::shell::Result<()> {
     let window = MessageBox::new("Message").into_window("Hello world");
 
     let theme = kas::theme::FlatTheme::new();

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -25,7 +25,5 @@ fn main() -> kas::shell::Result<()> {
     let window = Window::new(ui, "Layout demo");
 
     let theme = kas::theme::FlatTheme::new();
-    kas::shell::DefaultShell::new((), theme)?
-        .with(window)?
-        .run()
+    kas::shell::DefaultShell::new((), theme)?.with(window).run()
 }

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -487,6 +487,6 @@ fn main() -> kas::shell::Result<()> {
     let theme = kas::theme::FlatTheme::new().with_colours("dark");
     let options = kas::config::Options::from_env();
     kas::shell::WgpuShell::new_custom((), PipeBuilder, theme, options)?
-        .with(window)?
+        .with(window)
         .run()
 }

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -38,7 +38,5 @@ fn main() -> kas::shell::Result<()> {
     let window = Window::new(adapt, "Slitter panes");
 
     let theme = kas_wgpu::ShadedTheme::new();
-    kas::shell::DefaultShell::new((), theme)?
-        .with(window)?
-        .run()
+    kas::shell::DefaultShell::new((), theme)?.with(window).run()
 }

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -83,7 +83,5 @@ fn main() -> kas::shell::Result<()> {
     let theme = kas_wgpu::ShadedTheme::new()
         .with_colours("dark")
         .with_font_size(18.0);
-    kas::shell::DefaultShell::new((), theme)?
-        .with(window)?
-        .run()
+    kas::shell::DefaultShell::new((), theme)?.with(window).run()
 }

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -63,7 +63,7 @@ fn main() -> kas::shell::Result<()> {
     let theme = kas_wgpu::ShadedTheme::new().with_font_size(24.0);
 
     kas::shell::DefaultShell::new(count, theme)?
-        .with(counter("Counter 1"))?
-        .with(counter("Counter 2"))?
+        .with(counter("Counter 1"))
+        .with(counter("Counter 2"))
         .run()
 }

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -76,7 +76,5 @@ fn main() -> kas::shell::Result<()> {
     let window = Window::new(ui, "Times-Tables");
 
     let theme = kas::theme::SimpleTheme::new().with_font_size(16.0);
-    kas::shell::DefaultShell::new((), theme)?
-        .with(window)?
-        .run()
+    kas::shell::DefaultShell::new((), theme)?.with(window).run()
 }


### PR DESCRIPTION
Construct windows on on winit's `Event::Resumed`; destroy on `Event::Suspended`. This is needed for Android but recommended by Winit for all platforms.