### PR TITLE
Add widget status tracking; remove pre_configure

### DIFF
--- a/crates/kas-core/src/core/data.rs
+++ b/crates/kas-core/src/core/data.rs
@@ -78,15 +78,18 @@ pub enum WidgetStatus {
 #[cfg(debug_assertions)]
 impl WidgetStatus {
     /// Configure
-    pub fn configure(&mut self) {
+    pub fn configure(&mut self, id: &WidgetId) {
+        if !id.is_valid() {
+            panic!("WidgetStatus: pre_configure must be called before configure!");
+        }
         // re-configure does not require repeating other actions
         *self = (*self).max(WidgetStatus::Configured);
     }
 
     /// Update
-    pub fn update(&self) {
+    pub fn update(&self, id: &WidgetId) {
         if *self < WidgetStatus::Configured {
-            panic!("WidgetStatus: configure must be called before update!");
+            panic!("WidgetStatus of {id}: configure must be called before update!");
         }
 
         // Update-after-configure is already guaranteed (see impls module).
@@ -96,13 +99,13 @@ impl WidgetStatus {
     }
 
     /// Size rules
-    pub fn size_rules(&mut self, axis: crate::layout::AxisInfo) {
+    pub fn size_rules(&mut self, id: &WidgetId, axis: crate::layout::AxisInfo) {
         match self {
             WidgetStatus::New => {
-                panic!("WidgetStatus: configure must be called before size_rules!")
+                panic!("WidgetStatus of {id}: configure must be called before size_rules!")
             }
             WidgetStatus::Configured if axis.is_vertical() => {
-                panic!("WidgetStatus: size_rules(horizontal) must be called before size_rules(vertical)!");
+                panic!("WidgetStatus of {id}: size_rules(horizontal) must be called before size_rules(vertical)!");
             }
             _ => (),
         }
@@ -116,16 +119,16 @@ impl WidgetStatus {
     }
 
     /// Set rect
-    pub fn set_rect(&mut self) {
+    pub fn set_rect(&mut self, id: &WidgetId) {
         if *self < WidgetStatus::SizeRulesY {
-            panic!("WidgetStatus: set_rect called before size_rules(vertical)!");
+            panic!("WidgetStatus of {id}: size_rules(vertical) must be called before set_rect!");
         }
         *self = WidgetStatus::SetRect;
     }
 
-    pub fn require_rect(&self) {
+    pub fn require_rect(&self, id: &WidgetId) {
         if *self < WidgetStatus::SetRect {
-            panic!("WidgetStatus: set_rect must be called before this method!");
+            panic!("WidgetStatus of {id}: set_rect must be called before this method!");
         }
     }
 }

--- a/crates/kas-core/src/core/data.rs
+++ b/crates/kas-core/src/core/data.rs
@@ -78,10 +78,7 @@ pub enum WidgetStatus {
 #[cfg(debug_assertions)]
 impl WidgetStatus {
     /// Configure
-    pub fn configure(&mut self, id: &WidgetId) {
-        if !id.is_valid() {
-            panic!("WidgetStatus: pre_configure must be called before configure!");
-        }
+    pub fn configure(&mut self, _id: &WidgetId) {
         // re-configure does not require repeating other actions
         *self = (*self).max(WidgetStatus::Configured);
     }

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -10,7 +10,7 @@ use crate::event::{ConfigCx, Event, EventCx, FocusSource, IsUsed, Scroll, Unused
 use crate::{Erased, Events, Layout, NavAdvance, Node, Widget, WidgetId};
 
 /// Generic implementation of [`Widget::_configure`]
-pub fn _configure<W: Widget + Events<Data = <W as Widget>::Data>>(
+pub fn _configure<W: Events>(
     widget: &mut W,
     cx: &mut ConfigCx,
     data: &<W as Widget>::Data,
@@ -32,11 +32,7 @@ pub fn _configure<W: Widget + Events<Data = <W as Widget>::Data>>(
 }
 
 /// Generic implementation of [`Widget::_update`]
-pub fn _update<W: Widget + Events<Data = <W as Widget>::Data>>(
-    widget: &mut W,
-    cx: &mut ConfigCx,
-    data: &<W as Widget>::Data,
-) {
+pub fn _update<W: Events>(widget: &mut W, cx: &mut ConfigCx, data: &<W as Widget>::Data) {
     widget.update(cx, data);
     let range = widget.recurse_range();
     let mut node = widget.as_node(data);
@@ -46,7 +42,7 @@ pub fn _update<W: Widget + Events<Data = <W as Widget>::Data>>(
 }
 
 /// Generic implementation of [`Widget::_send`]
-pub fn _send<W: Widget + Events<Data = <W as Widget>::Data>>(
+pub fn _send<W: Events>(
     widget: &mut W,
     cx: &mut EventCx,
     data: &<W as Widget>::Data,
@@ -120,7 +116,7 @@ pub fn _send<W: Widget + Events<Data = <W as Widget>::Data>>(
 }
 
 /// Generic implementation of [`Widget::_replay`]
-pub fn _replay<W: Widget + Events<Data = <W as Widget>::Data>>(
+pub fn _replay<W: Events>(
     widget: &mut W,
     cx: &mut EventCx,
     data: &<W as Widget>::Data,
@@ -166,7 +162,7 @@ pub fn _replay<W: Widget + Events<Data = <W as Widget>::Data>>(
 }
 
 /// Generic implementation of [`Widget::_nav_next`]
-pub fn _nav_next<W: Widget + Events<Data = <W as Widget>::Data>>(
+pub fn _nav_next<W: Events>(
     widget: &mut W,
     cx: &mut EventCx,
     data: &<W as Widget>::Data,

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -5,41 +5,9 @@
 
 //! Widget method implementations
 
-use crate::event::{ConfigCx, Event, EventCx, FocusSource, IsUsed, Scroll, Unused, Used};
+use crate::event::{Event, EventCx, FocusSource, IsUsed, Scroll, Unused, Used};
 #[cfg(debug_assertions)] use crate::util::IdentifyWidget;
 use crate::{Erased, Events, Layout, NavAdvance, Node, Widget, WidgetId};
-
-/// Generic implementation of [`Widget::_configure`]
-pub fn _configure<W: Events>(
-    widget: &mut W,
-    cx: &mut ConfigCx,
-    data: &<W as Widget>::Data,
-    id: WidgetId,
-) {
-    widget.pre_configure(cx, id);
-
-    for index in widget.recurse_range() {
-        let id = widget.make_child_id(index);
-        if id.is_valid() {
-            widget
-                .as_node(data)
-                .for_child(index, |mut node| node._configure(cx, id));
-        }
-    }
-
-    widget.configure(cx);
-    widget.update(cx, data);
-}
-
-/// Generic implementation of [`Widget::_update`]
-pub fn _update<W: Events>(widget: &mut W, cx: &mut ConfigCx, data: &<W as Widget>::Data) {
-    widget.update(cx, data);
-    let range = widget.recurse_range();
-    let mut node = widget.as_node(data);
-    for index in range {
-        node.for_child(index, |mut node| node._update(cx));
-    }
-}
 
 /// Generic implementation of [`Widget::_send`]
 pub fn _send<W: Events>(

--- a/crates/kas-core/src/core/layout.rs
+++ b/crates/kas-core/src/core/layout.rs
@@ -62,8 +62,9 @@ pub trait Layout {
     /// Get the widget's identifier
     ///
     /// Note that the default-constructed [`WidgetId`] is *invalid*: any
-    /// operations on this value will cause a panic. Valid identifiers are
-    /// assigned by [`Events::pre_configure`].
+    /// operations on this value will cause a panic. A valid identifier is
+    /// assigned when the widget is configured (immediately before calling
+    /// [`Events::configure`]).
     ///
     /// This method is implemented by the `#[widget]` macro.
     fn id_ref(&self) -> &WidgetId {

--- a/crates/kas-core/src/core/layout.rs
+++ b/crates/kas-core/src/core/layout.rs
@@ -113,22 +113,10 @@ pub trait Layout {
     ///
     /// The default implementation simply uses [`WidgetId::next_key_after`].
     /// Widgets may choose to assign children custom keys by overriding this
-    /// method and [`Self::make_child_id`].
+    /// method and [`Events::make_child_id`].
     #[inline]
     fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
         id.next_key_after(self.id_ref())
-    }
-
-    /// Make an identifier for a child
-    ///
-    /// This is used to configure children. It may return [`WidgetId::default`]
-    /// in order to avoid configuring the child, but in this case the widget
-    /// must configure via another means.
-    ///
-    /// Default impl: `self.id_ref().make_child(index)`
-    #[inline]
-    fn make_child_id(&mut self, index: usize) -> WidgetId {
-        self.id_ref().make_child(index)
     }
 
     /// Get size rules for the given axis

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -39,17 +39,7 @@ use kas_macros::autoimpl;
 /// visible.
 ///
 /// [`#widget`]: macros::widget
-pub trait Events: Layout + Sized {
-    /// Input data type
-    ///
-    /// This type must match [`Widget::Data`]. When using the `#widget` macro,
-    /// the type must be specified exactly once in one of three places: here,
-    /// in the implementation of [`Widget`], or via the `Data` property of
-    /// [`#widget`].
-    ///
-    /// [`#widget`]: macros::widget
-    type Data;
-
+pub trait Events: Widget + Sized {
     /// Recursion range
     ///
     /// Methods `pre_configure`, `configure` and `update` all recurse over the
@@ -349,9 +339,10 @@ pub trait Widget: Layout {
     /// Widget expects data of this type to be provided by reference when
     /// calling any event-handling operation on this widget.
     ///
-    /// This type must match [`Events::Data`] if `Events` is implemented when
-    /// using the `#[widget]` macro. The type only needs to be specified once,
-    /// here, in the implementation of [`Events`], or via the `Data` property.
+    /// This type may be specified using a [`#widget`] macro property in case
+    /// this trait is not explicitly implemented.
+    ///
+    /// [`#widget`]: macros::widget
     type Data;
 
     /// Erase type

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -40,6 +40,21 @@ use kas_macros::autoimpl;
 ///
 /// [`#widget`]: macros::widget
 pub trait Events: Widget + Sized {
+    /// Make an identifier for a child
+    ///
+    /// This is used to assign children identifiers. It may return
+    /// [`WidgetId::default`] in order to avoid configuring the child, but in
+    /// this case the widget must configure via another means.
+    ///
+    /// If this is implemented explicitly then [`Layout::find_child_index`] must
+    /// be too.
+    ///
+    /// Default impl: `self.id_ref().make_child(index)`
+    #[inline]
+    fn make_child_id(&mut self, index: usize) -> WidgetId {
+        self.id_ref().make_child(index)
+    }
+
     /// Pre-configuration
     ///
     /// This method is called before [`Self::configure_recurse`], therefore
@@ -47,7 +62,7 @@ pub trait Events: Widget + Sized {
     /// (`child.id()` will be invalid the first time this method is called).
     ///
     /// This method must set `self.core.id = id`.
-    /// It may perform preparation for [`Layout::make_child_id`].
+    /// It may perform preparation for [`Events::make_child_id`].
     fn pre_configure(&mut self, cx: &mut ConfigCx, id: WidgetId) {
         let _ = (cx, id);
         unimplemented!() // make rustdoc show that this is a provided method
@@ -61,7 +76,7 @@ pub trait Events: Widget + Sized {
     /// The default implementation suffices except where children should *not*
     /// be configured (for example, to delay configuration of hidden children).
     ///
-    /// Use [`Layout::make_child_id`] and [`ConfigCx::configure`].
+    /// Use [`Events::make_child_id`] and [`ConfigCx::configure`].
     fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
         for index in 0..self.num_children() {
             let id = self.make_child_id(index);
@@ -327,7 +342,7 @@ pub enum NavAdvance {
 ///     in most cases: child widgets embedded within a layout descriptor or
 ///     included as fields marked with `#[widget]` are enumerated.
 /// -   **Introspection** methods [`Layout::find_child_index`] and
-///     [`Layout::make_child_id`] have default implementations which *usually*
+///     [`Events::make_child_id`] have default implementations which *usually*
 ///     suffice.
 /// -   **Layout** is specified either via [layout syntax](macros::widget#layout-1)
 ///     or via implementation of at least [`Layout::size_rules`] and

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -79,9 +79,7 @@ pub trait Events: Layout + Sized {
     /// [`Layout::size_rules`] but not repeated configuration.
     ///
     /// The default implementation does nothing.
-    fn configure(&mut self, cx: &mut ConfigCx) {
-        let _ = cx;
-    }
+    fn configure(&mut self, cx: &mut ConfigCx);
 
     /// Update data
     ///
@@ -97,9 +95,7 @@ pub trait Events: Layout + Sized {
     /// Widgets should be updated even if their data is `()` or is unchanged.
     ///
     /// The default implementation does nothing.
-    fn update(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
-        let _ = (cx, data);
-    }
+    fn update(&mut self, cx: &mut ConfigCx, data: &Self::Data);
 
     /// Is this widget navigable via <kbd>Tab</kbd> key?
     ///
@@ -153,11 +149,7 @@ pub trait Events: Layout + Sized {
     /// [`Unused`].
     ///
     /// Use [`EventCx::send`] instead of calling this method.
-    #[inline]
-    fn handle_event(&mut self, cx: &mut EventCx, data: &Self::Data, event: Event) -> IsUsed {
-        let _ = (cx, data, event);
-        Unused
-    }
+    fn handle_event(&mut self, cx: &mut EventCx, data: &Self::Data, event: Event) -> IsUsed;
 
     /// Potentially steal an event before it reaches a child
     ///
@@ -169,17 +161,13 @@ pub trait Events: Layout + Sized {
     /// This is considered a corner-case and not currently supported.
     ///
     /// Default implementation: return [`Unused`].
-    #[inline]
     fn steal_event(
         &mut self,
         cx: &mut EventCx,
         data: &Self::Data,
         id: &WidgetId,
         event: &Event,
-    ) -> IsUsed {
-        let _ = (cx, data, id, event);
-        Unused
-    }
+    ) -> IsUsed;
 
     /// Handler for messages from children/descendants
     ///

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -547,6 +547,19 @@ impl PartialEq for WidgetId {
 }
 impl Eq for WidgetId {}
 
+impl PartialEq<str> for WidgetId {
+    fn eq(&self, rhs: &str) -> bool {
+        // TODO(opt): we don't have to format to test this
+        let formatted = format!("{self}");
+        formatted == rhs
+    }
+}
+impl PartialEq<&str> for WidgetId {
+    fn eq(&self, rhs: &&str) -> bool {
+        self == *rhs
+    }
+}
+
 impl PartialOrd for WidgetId {
     fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
         Some(self.cmp(rhs))
@@ -661,7 +674,6 @@ mod test {
         let c2 = WidgetId::ROOT.make_child(1).make_child(15);
         let c3 = WidgetId::ROOT.make_child(0).make_child(14);
         let c4 = WidgetId::ROOT.make_child(0).make_child(15);
-        println!("c1: {c1}");
         assert!(c1 != c2);
         assert!(c1 != c3);
         assert!(c2 != c3);
@@ -692,6 +704,17 @@ mod test {
     #[should_panic]
     fn test_partial_eq_invalid_3() {
         let _ = WidgetId::INVALID == WidgetId::ROOT;
+    }
+
+    #[test]
+    fn test_partial_eq_str() {
+        assert_eq!(WidgetId::ROOT, "#");
+        assert!(WidgetId::ROOT != "#0");
+        assert_eq!(WidgetId::ROOT.make_child(0).make_child(15), "#097");
+        assert_eq!(WidgetId::ROOT.make_child(1).make_child(15), "#197");
+        let c3 = WidgetId::ROOT.make_child(0).make_child(14);
+        assert_eq!(c3, "#096");
+        assert!(c3 != "#097");
     }
 
     #[test]

--- a/crates/kas-core/src/decorations.rs
+++ b/crates/kas-core/src/decorations.rs
@@ -80,7 +80,7 @@ impl_scope! {
     }
 
     impl Layout for Self {
-        fn size_rules(&mut self, _: SizeCx, _: AxisInfo) -> SizeRules {
+        fn size_rules(&mut self, _: SizeCx, _axis: AxisInfo) -> SizeRules {
             SizeRules::EMPTY
         }
 

--- a/crates/kas-core/src/erased.rs
+++ b/crates/kas-core/src/erased.rs
@@ -67,6 +67,7 @@ impl std::fmt::Debug for Erased {
 }
 
 /// Like Erased, but supporting Send
+#[derive(Debug)]
 pub(crate) struct SendErased {
     any: Box<dyn Any + Send>,
     #[cfg(debug_assertions)]

--- a/crates/kas-core/src/event/cx/config.rs
+++ b/crates/kas-core/src/event/cx/config.rs
@@ -83,8 +83,7 @@ impl<'a> ConfigCx<'a> {
     /// All widgets must be configured after construction (see
     /// [widget lifecycle](Widget#widget-lifecycle)).
     /// This method performs complete configuration of the widget by calling
-    /// [`Events::pre_configure`], [`Events::configure_recurse`],
-    /// [`Events::configure`] and finally [`Events::update`].
+    /// [`Events::configure`], [`Events::update`], [`Events::configure_recurse`].
     ///
     /// Pass the `id` to assign to the widget. This is usually constructed with
     /// [`Events::make_child_id`].

--- a/crates/kas-core/src/event/cx/config.rs
+++ b/crates/kas-core/src/event/cx/config.rs
@@ -81,8 +81,10 @@ impl<'a> ConfigCx<'a> {
     /// Configure a widget
     ///
     /// All widgets must be configured after construction (see
-    /// [`Events::configure`]). This method may be used to configure a new
-    /// child widget without requiring the whole window to be reconfigured.
+    /// [widget lifecycle](Widget#widget-lifecycle)).
+    /// This method performs complete configuration of the widget by calling
+    /// [`Events::pre_configure`], [`Events::configure_recurse`],
+    /// [`Events::configure`] and finally [`Events::update`].
     ///
     /// Pass the `id` to assign to the widget. This is usually constructed with
     /// [`Layout::make_child_id`].
@@ -93,9 +95,9 @@ impl<'a> ConfigCx<'a> {
 
     /// Update a widget
     ///
-    /// [`Events::update`] will be called recursively on each child and finally
-    /// `self`. If a widget stores state which it passes to children as input
-    /// data, it should call this after mutating the state.
+    /// All widgets must be updated after input data changes.
+    /// This method recursively updates the widget by calling
+    /// [`Events::update`] and [`Events::update_recurse`].
     #[inline]
     pub fn update(&mut self, mut widget: Node<'_>) {
         widget._update(self);

--- a/crates/kas-core/src/event/cx/config.rs
+++ b/crates/kas-core/src/event/cx/config.rs
@@ -87,7 +87,7 @@ impl<'a> ConfigCx<'a> {
     /// [`Events::configure`] and finally [`Events::update`].
     ///
     /// Pass the `id` to assign to the widget. This is usually constructed with
-    /// [`Layout::make_child_id`].
+    /// [`Events::make_child_id`].
     #[inline]
     pub fn configure(&mut self, mut widget: Node<'_>, id: WidgetId) {
         widget._configure(self, id);

--- a/crates/kas-core/src/hidden.rs
+++ b/crates/kas-core/src/hidden.rs
@@ -128,11 +128,6 @@ impl_scope! {
         }
 
         #[inline]
-        fn make_child_id(&mut self, index: usize) -> WidgetId {
-            self.inner.make_child_id(index)
-        }
-
-        #[inline]
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             self.inner.size_rules(sizer, axis)
         }

--- a/crates/kas-core/src/popup.rs
+++ b/crates/kas-core/src/popup.rs
@@ -49,8 +49,7 @@ impl_scope! {
     impl Events for Self {
         type Data = W::Data;
 
-        fn pre_configure(&mut self, cx: &mut ConfigCx, id: WidgetId) {
-            self.core.id = id;
+        fn configure(&mut self, cx: &mut ConfigCx) {
             cx.new_access_layer(self.id(), true);
         }
 

--- a/crates/kas-core/src/popup.rs
+++ b/crates/kas-core/src/popup.rs
@@ -7,7 +7,7 @@
 
 use crate::dir::Direction;
 use crate::event::{ConfigCx, Event, EventCx, IsUsed, Unused, Used};
-use crate::{Events, Layout, LayoutExt, Widget, WidgetId, WindowId};
+use crate::{Events, LayoutExt, Widget, WidgetId, WindowId};
 use kas_macros::{autoimpl, impl_scope, widget_index};
 
 #[allow(unused)] use crate::event::EventState;

--- a/crates/kas-core/src/popup.rs
+++ b/crates/kas-core/src/popup.rs
@@ -49,13 +49,22 @@ impl_scope! {
     impl Events for Self {
         type Data = W::Data;
 
-        fn recurse_range(&self) -> std::ops::Range<usize> {
-            if self.win_id.is_none() { 0..0 } else { 0..1 }
-        }
-
         fn pre_configure(&mut self, cx: &mut ConfigCx, id: WidgetId) {
             self.core.id = id;
             cx.new_access_layer(self.id(), true);
+        }
+
+        fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+            if self.win_id.is_some() {
+                let id = self.make_child_id(widget_index!(self.inner));
+                cx.configure(self.inner.as_node(data), id)
+            }
+        }
+
+        fn update_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+            if self.win_id.is_some() {
+                cx.update(self.inner.as_node(data))
+            }
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &W::Data, event: Event) -> IsUsed {

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -96,8 +96,18 @@ impl_scope! {
                     self.bar_h = bar.min_size();
                 }
             }
+
+            // These methods don't return anything useful, but we are required to call them:
+            let _ = self.b_w.size_rules(sizer.re(), axis);
+            let _ = self.b_e.size_rules(sizer.re(), axis);
+            let _ = self.b_n.size_rules(sizer.re(), axis);
+            let _ = self.b_s.size_rules(sizer.re(), axis);
+            let _ = self.b_nw.size_rules(sizer.re(), axis);
+            let _ = self.b_ne.size_rules(sizer.re(), axis);
+            let _ = self.b_se.size_rules(sizer.re(), axis);
+            let _ = self.b_sw.size_rules(sizer.re(), axis);
+
             if matches!(self.decorations, Decorations::Border | Decorations::Toolkit) {
-                // We would call size_rules on Border widgets here if it did anything
                 let frame = sizer.frame(FrameStyle::Window, axis);
                 let (rules, offset, size) = frame.surround(inner);
                 self.dec_offset.set_component(axis, offset);

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -30,7 +30,7 @@ pub extern crate raw_window_handle;
 // around (also applies when constructing a shell::Window).
 #[allow(clippy::large_enum_variant)]
 #[cfg(winit)]
-enum PendingAction<A: 'static> {
+enum PendingAction<A: crate::AppData> {
     AddPopup(WindowId, WindowId, kas::PopupDescriptor),
     AddWindow(WindowId, kas::Window<A>),
     CloseWindow(WindowId),
@@ -38,6 +38,24 @@ enum PendingAction<A: 'static> {
 }
 
 #[cfg(winit)]
+impl<A: crate::AppData> std::fmt::Debug for PendingAction<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PendingAction::AddPopup(parent_id, id, popup) => f
+                .debug_tuple("AddPopup")
+                .field(&parent_id)
+                .field(&id)
+                .field(&popup)
+                .finish(),
+            PendingAction::AddWindow(id, _) => f.debug_tuple("AddWindow").field(&id).finish(),
+            PendingAction::CloseWindow(id) => f.debug_tuple("CloseWindow").field(&id).finish(),
+            PendingAction::Action(action) => f.debug_tuple("Action").field(&action).finish(),
+        }
+    }
+}
+
+#[cfg(winit)]
+#[derive(Debug)]
 enum ProxyAction {
     CloseAll,
     Close(WindowId),

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -319,6 +319,16 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// available. Only [`Layout`] methods may be specified (overriding those from
 /// the derived widget); everything else is derived.
 ///
+/// ## Debugging
+///
+/// To inspect the output of this macro, set the environment variable
+/// `KAS_DEBUG_WIDGET` to the name of the widget concerned, dump the output to
+/// a temporary file and format. For example:
+/// ```sh
+/// KAS_DEBUG_WIDGET=Border cargo build > temp.rs
+/// rustfmt temp.rs
+/// ```
+///
 /// [`Widget`]: https://docs.rs/kas/latest/kas/trait.Widget.html
 /// [`Widget::get_child`]: https://docs.rs/kas/latest/kas/trait.Widget.html#method.get_child
 /// [`Layout`]: https://docs.rs/kas/latest/kas/trait.Layout.html

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -192,10 +192,10 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 ///
 /// The struct must contain a field of type `widget_core!()` (usually named
 /// `core`). The macro `widget_core!()` is a placeholder, expanded by
-/// `#[widget]` and used to identify the field used (name may be anything).
-/// This field *may* have type [`CoreData`] or may be a generated
-/// type; either way it has fields `id: WidgetId` (assigned by
-/// `Events::pre_configure`) and `rect: Rect` (usually assigned by
+/// `#[widget]` and used to identify the field used (any name may be used).
+/// This field *might* have type [`CoreData`] or might use a special generated
+/// type; either way it has fields `id: WidgetId` (assigned by during configure)
+/// and `rect: Rect` (usually assigned by
 /// `Layout::set_rect`). It may contain additional fields for layout data. The
 /// type supports `Default` and `Clone` (although `Clone` actually
 /// default-initializes all fields other than `rect` since clones of widgets

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -79,7 +79,7 @@ impl Tree {
                 use ::kas::{Layout, layout};
 
                 #[cfg(debug_assertions)]
-                #core_path.status.size_rules(axis);
+                #core_path.status.size_rules(&#core_path.id, axis);
 
                 (#layout).size_rules(sizer, axis)
             }
@@ -92,7 +92,7 @@ impl Tree {
                 use ::kas::{Layout, layout};
 
                 #[cfg(debug_assertions)]
-                #core_path.status.set_rect();
+                #core_path.status.set_rect(&#core_path.id);
 
                 #core_path.rect = rect;
                 (#layout).set_rect(cx, rect);
@@ -102,7 +102,7 @@ impl Tree {
                 use ::kas::{layout, Layout, LayoutExt};
 
                 #[cfg(debug_assertions)]
-                #core_path.status.require_rect();
+                #core_path.status.require_rect(&#core_path.id);
 
                 if !self.rect().contains(coord) {
                     return None;
@@ -115,7 +115,7 @@ impl Tree {
                 use ::kas::{Layout, layout};
 
                 #[cfg(debug_assertions)]
-                #core_path.status.require_rect();
+                #core_path.status.require_rect(&#core_path.id);
 
                 (#layout).draw(draw);
             }
@@ -251,12 +251,12 @@ impl Tree {
 
                 fn configure(&mut self, cx: &mut ::kas::event::ConfigCx) {
                     #[cfg(debug_assertions)]
-                    #core_path.status.configure();
+                    #core_path.status.configure(&#core_path.id);
                 }
 
                 fn update(&mut self, cx: &mut ::kas::event::ConfigCx, data: &Self::Data) {
                     #[cfg(debug_assertions)]
-                    #core_path.status.update();
+                    #core_path.status.update(&#core_path.id);
                 }
 
                 fn steal_event(
@@ -267,7 +267,7 @@ impl Tree {
                     _: &::kas::event::Event,
                 ) -> ::kas::event::IsUsed {
                     #[cfg(debug_assertions)]
-                    #core_path.status.require_rect();
+                    #core_path.status.require_rect(&#core_path.id);
                     ::kas::event::Unused
                 }
 
@@ -278,7 +278,7 @@ impl Tree {
                     _: ::kas::event::Event,
                 ) -> ::kas::event::IsUsed {
                     #[cfg(debug_assertions)]
-                    #core_path.status.require_rect();
+                    #core_path.status.require_rect(&#core_path.id);
                     ::kas::event::Unused
                 }
             }

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -239,24 +239,6 @@ impl Tree {
             }
 
             impl #impl_generics ::kas::Events for #impl_target {
-                fn pre_configure(
-                    &mut self,
-                    _: &mut ::kas::event::ConfigCx,
-                    id: ::kas::WidgetId,
-                ) {
-                    self.id = id;
-                }
-
-                fn configure(&mut self, cx: &mut ::kas::event::ConfigCx) {
-                    #[cfg(debug_assertions)]
-                    #core_path.status.configure(&#core_path.id);
-                }
-
-                fn update(&mut self, cx: &mut ::kas::event::ConfigCx, data: &Self::Data) {
-                    #[cfg(debug_assertions)]
-                    #core_path.status.update(&#core_path.id);
-                }
-
                 fn steal_event(
                     &mut self,
                     _: &mut ::kas::event::EventCx,

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -239,8 +239,6 @@ impl Tree {
             }
 
             impl #impl_generics ::kas::Events for #impl_target {
-                type Data = #data_ty;
-
                 fn pre_configure(
                     &mut self,
                     _: &mut ::kas::event::ConfigCx,

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -77,6 +77,10 @@ impl Tree {
                 axis: ::kas::layout::AxisInfo,
             ) -> ::kas::layout::SizeRules {
                 use ::kas::{Layout, layout};
+
+                #[cfg(debug_assertions)]
+                #core_path.status.size_rules(axis);
+
                 (#layout).size_rules(sizer, axis)
             }
 
@@ -86,12 +90,20 @@ impl Tree {
                 rect: ::kas::geom::Rect,
             ) {
                 use ::kas::{Layout, layout};
+
+                #[cfg(debug_assertions)]
+                #core_path.status.set_rect();
+
                 #core_path.rect = rect;
                 (#layout).set_rect(cx, rect);
             }
 
             fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
                 use ::kas::{layout, Layout, LayoutExt};
+
+                #[cfg(debug_assertions)]
+                #core_path.status.require_rect();
+
                 if !self.rect().contains(coord) {
                     return None;
                 }
@@ -101,6 +113,10 @@ impl Tree {
 
             fn draw(&mut self, draw: ::kas::theme::DrawCx) {
                 use ::kas::{Layout, layout};
+
+                #[cfg(debug_assertions)]
+                #core_path.status.require_rect();
+
                 (#layout).draw(draw);
             }
         })
@@ -202,6 +218,8 @@ impl Tree {
             struct #name #impl_generics {
                 rect: ::kas::geom::Rect,
                 id: ::kas::WidgetId,
+                #[cfg(debug_assertions)]
+                status: ::kas::WidgetStatus,
                 #stor_ty
             }
 
@@ -230,6 +248,39 @@ impl Tree {
                 ) {
                     self.id = id;
                 }
+
+                fn configure(&mut self, cx: &mut ::kas::event::ConfigCx) {
+                    #[cfg(debug_assertions)]
+                    #core_path.status.configure();
+                }
+
+                fn update(&mut self, cx: &mut ::kas::event::ConfigCx, data: &Self::Data) {
+                    #[cfg(debug_assertions)]
+                    #core_path.status.update();
+                }
+
+                fn steal_event(
+                    &mut self,
+                    _: &mut ::kas::event::EventCx,
+                    _: &Self::Data,
+                    _: &::kas::WidgetId,
+                    _: &::kas::event::Event,
+                ) -> ::kas::event::IsUsed {
+                    #[cfg(debug_assertions)]
+                    #core_path.status.require_rect();
+                    ::kas::event::Unused
+                }
+
+                fn handle_event(
+                    &mut self,
+                    _: &mut ::kas::event::EventCx,
+                    _: &Self::Data,
+                    _: ::kas::event::Event,
+                ) -> ::kas::event::IsUsed {
+                    #[cfg(debug_assertions)]
+                    #core_path.status.require_rect();
+                    ::kas::event::Unused
+                }
             }
 
             #widget_impl
@@ -237,6 +288,8 @@ impl Tree {
             #name {
                 rect: Default::default(),
                 id: Default::default(),
+                #[cfg(debug_assertions)]
+                status: Default::default(),
                 #stor_def
             }
         }};

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -931,14 +931,18 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
         if let Some((index, _)) = item_idents.iter().find(|(_, ident)| *ident == "size_rules") {
             if let Some(ref core) = core_data {
                 if let ImplItem::Fn(f) = &mut layout_impl.items[*index] {
-                    if let Some(FnArg::Typed(arg)) = f.sig.inputs.iter().nth(3) {
+                    if let Some(FnArg::Typed(arg)) = f.sig.inputs.iter().nth(2) {
                         if let Pat::Ident(ref pat_ident) = *arg.pat {
                             let axis = &pat_ident.ident;
                             f.block.stmts.insert(0, parse_quote! {
                                 #[cfg(debug_assertions)]
                                 self.#core.status.size_rules(&self.#core.id, #axis);
                             });
+                        } else {
+                            emit_error!(arg.pat, "hidden shenanigans require this parameter to have a name; suggestion: `_axis`");
                         }
+                    } else {
+                        panic!("size_rules misses args!");
                     }
                 }
             }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -1023,7 +1023,11 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
         });
     }
 
-    // println!("{}", scope.to_token_stream());
+    if let Ok(val) = std::env::var("KAS_DEBUG_WIDGET") {
+        if name == val.as_str() {
+            println!("{}", scope.to_token_stream());
+        }
+    }
     Ok(())
 }
 

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -631,15 +631,15 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
 
         let configure_status = parse_quote! {
             #[cfg(debug_assertions)]
-            #core_path.status.configure();
+            #core_path.status.configure(&#core_path.id);
         };
         let update_status = parse_quote! {
             #[cfg(debug_assertions)]
-            #core_path.status.update();
+            #core_path.status.update(&#core_path.id);
         };
         let require_rect: syn::Stmt = parse_quote! {
             #[cfg(debug_assertions)]
-            #core_path.status.require_rect();
+            #core_path.status.require_rect(&#core_path.id);
         };
 
         required_layout_methods = impl_core_methods(&widget_name, &core_path);
@@ -728,7 +728,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                     axis: ::kas::layout::AxisInfo,
                 ) -> ::kas::layout::SizeRules {
                     #[cfg(debug_assertions)]
-                    #core_path.status.size_rules(axis);
+                    #core_path.status.size_rules(&#core_path.id, axis);
                     <Self as ::kas::layout::AutoLayout>::size_rules(self, sizer, axis)
                 }
             });
@@ -739,7 +739,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
             fn_draw = Some(quote! {
                 fn draw(&mut self, draw: ::kas::theme::DrawCx) {
                     #[cfg(debug_assertions)]
-                    #core_path.status.require_rect();
+                    #core_path.status.require_rect(&#core_path.id);
 
                     <Self as ::kas::layout::AutoLayout>::draw(self, draw);
                 }
@@ -758,14 +758,14 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                 rect: ::kas::geom::Rect,
             ) {
                 #[cfg(debug_assertions)]
-                #core_path.status.set_rect();
+                #core_path.status.set_rect(&#core_path.id);
                 #set_rect
             }
         };
         fn_find_id = quote! {
             fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::WidgetId> {
                 #[cfg(debug_assertions)]
-                #core_path.status.require_rect();
+                #core_path.status.require_rect(&#core_path.id);
 
                 #find_id
             }
@@ -936,7 +936,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                             let axis = &pat_ident.ident;
                             f.block.stmts.insert(0, parse_quote! {
                                 #[cfg(debug_assertions)]
-                                self.#core.status.size_rules(#axis);
+                                self.#core.status.size_rules(&self.#core.id, #axis);
                             });
                         }
                     }
@@ -951,7 +951,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                 if let ImplItem::Fn(f) = &mut layout_impl.items[*index] {
                     f.block.stmts.insert(0, parse_quote! {
                         #[cfg(debug_assertions)]
-                        self.#core.status.set_rect();
+                        self.#core.status.set_rect(&self.#core.id);
                     });
                 }
             }
@@ -985,7 +985,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                 if let ImplItem::Fn(f) = &mut layout_impl.items[*index] {
                     f.block.stmts.insert(0, parse_quote! {
                         #[cfg(debug_assertions)]
-                        self.#core.status.require_rect();
+                        self.#core.status.require_rect(&self.#core.id);
                     });
                 }
             }
@@ -998,7 +998,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                 if let ImplItem::Fn(f) = &mut layout_impl.items[*index] {
                     f.block.stmts.insert(0, parse_quote! {
                         #[cfg(debug_assertions)]
-                        self.#core.status.require_rect();
+                        self.#core.status.require_rect(&self.#core.id);
                     });
                 }
             }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -419,11 +419,6 @@ impl_scope! {
                 None
             }
         }
-        #[inline]
-        fn make_child_id(&mut self, _: usize) -> WidgetId {
-            // We configure children in update_widgets and do not want this method to be called
-            unimplemented!()
-        }
 
         fn size_rules(&mut self, sizer: SizeCx, mut axis: AxisInfo) -> SizeRules {
             // We use an invisible frame for highlighting selections, drawing into the margin
@@ -564,6 +559,12 @@ impl_scope! {
     }
 
     impl Events for Self {
+        #[inline]
+        fn make_child_id(&mut self, _: usize) -> WidgetId {
+            // We configure children in update_widgets and do not want this method to be called
+            unimplemented!()
+        }
+
         fn configure(&mut self, cx: &mut ConfigCx) {
             if self.widgets.is_empty() {
                 // Initial configure: ensure some widgets are loaded to allow

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -324,6 +324,7 @@ impl_scope! {
             cur_len = cur_len.min(data_len - first_data);
             first_data = first_data.min(data_len - cur_len);
             self.cur_len = cur_len.cast();
+            debug_assert!(self.num_children() <= self.widgets.len());
             self.first_data = first_data.cast();
 
             let solver = self.position_solver();
@@ -520,8 +521,10 @@ impl_scope! {
                 // Free memory (rarely useful?)
                 self.widgets.truncate(req_widgets);
             }
+            debug_assert!(self.widgets.len() >= req_widgets);
 
             // Widgets need configuring and updating: do so by updating self.
+            self.cur_len = 0; // hack: prevent drawing in the mean-time
             cx.request_update(self.id());
         }
 

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -564,10 +564,6 @@ impl_scope! {
     }
 
     impl Events for Self {
-        fn recurse_range(&self) -> std::ops::Range<usize> {
-            0..0
-        }
-
         fn configure(&mut self, cx: &mut ConfigCx) {
             if self.widgets.is_empty() {
                 // Initial configure: ensure some widgets are loaded to allow
@@ -586,6 +582,8 @@ impl_scope! {
 
             cx.register_nav_fallback(self.id());
         }
+
+        fn configure_recurse(&mut self, _: &mut ConfigCx, _: &Self::Data) {}
 
         fn update(&mut self, cx: &mut ConfigCx, data: &A) {
             self.selection.retain(|key| data.contains_key(key));
@@ -606,6 +604,8 @@ impl_scope! {
 
             self.update_widgets(cx, data);
         }
+
+        fn update_recurse(&mut self, _: &mut ConfigCx, _: &Self::Data) {}
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &A, event: Event) -> IsUsed {
             let is_used = match event {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -764,10 +764,10 @@ impl_scope! {
         }
 
         fn _configure(&mut self, cx: &mut ConfigCx, data: &A, id: WidgetId) {
+            self.core.id = id;
             #[cfg(debug_assertions)]
             self.core.status.configure(&self.core.id);
 
-            self.pre_configure(cx, id);
             self.configure(cx);
             self.update(cx, data);
         }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -55,9 +55,6 @@ impl_scope! {
         frame_offset: Offset,
         frame_size: Size,
         driver: V,
-        /// Empty widget used for sizing; this must be stored between horiz and vert size rule
-        /// calculations for correct line wrapping/layout.
-        default_widget: V::Widget,
         widgets: Vec<WidgetData<A::Key, V::Widget>>,
         data_len: u32,
         /// The number of widgets in use (cur_len ≤ widgets.len())
@@ -123,14 +120,12 @@ impl_scope! {
 
     impl Self {
         /// Construct a new instance
-        pub fn new_dir(mut driver: V, direction: D) -> Self {
-            let default_widget = driver.make(&A::Key::default());
+        pub fn new_dir(driver: V, direction: D) -> Self {
             ListView {
                 core: Default::default(),
                 frame_offset: Default::default(),
                 frame_size: Default::default(),
                 driver,
-                default_widget,
                 widgets: Default::default(),
                 data_len: 0,
                 cur_len: 0,
@@ -452,15 +447,19 @@ impl_scope! {
             });
             axis = AxisInfo::new(axis.is_vertical(), other, axis.align());
 
-            let mut rules = self.default_widget.size_rules(sizer.re(), axis);
-            if axis.is_vertical() == self.direction.is_vertical() {
-                self.child_size_min = rules.min_size();
-            }
-
-            if !self.widgets.is_empty() {
-                for w in self.widgets.iter_mut() {
-                    rules = rules.max(w.widget.size_rules(sizer.re(), axis));
+            self.child_size_min = i32::MAX;
+            let mut rules = SizeRules::EMPTY;
+            for w in self.widgets.iter_mut() {
+                if w.key.is_some() {
+                    let child_rules = w.widget.size_rules(sizer.re(), axis);
+                    if axis.is_vertical() == self.direction.is_vertical() {
+                        self.child_size_min = self.child_size_min.min(child_rules.min_size());
+                    }
+                    rules = rules.max(child_rules);
                 }
+            }
+            if self.child_size_min == i32::MAX {
+                self.child_size_min = 0;
             }
 
             if axis.is_vertical() == self.direction.is_vertical() {
@@ -843,6 +842,7 @@ impl_scope! {
     }
 }
 
+#[derive(Debug)]
 struct PositionSolver {
     pos_start: Coord,
     skip: Offset,

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -737,10 +737,10 @@ impl_scope! {
         }
 
         fn _configure(&mut self, cx: &mut ConfigCx, data: &A, id: WidgetId) {
+            self.core.id = id;
             #[cfg(debug_assertions)]
             self.core.status.configure(&self.core.id);
 
-            self.pre_configure(cx, id);
             self.configure(cx);
             self.update(cx, data);
         }

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -518,10 +518,6 @@ impl_scope! {
     }
 
     impl Events for Self {
-        fn recurse_range(&self) -> std::ops::Range<usize> {
-            0..0
-        }
-
         fn configure(&mut self, cx: &mut ConfigCx) {
             if self.widgets.is_empty() {
                 // Initial configure: ensure some widgets are loaded to allow
@@ -541,6 +537,8 @@ impl_scope! {
             cx.register_nav_fallback(self.id());
         }
 
+        fn configure_recurse(&mut self, _: &mut ConfigCx, _: &Self::Data) {}
+
         fn update(&mut self, cx: &mut ConfigCx, data: &A) {
             self.selection.retain(|key| data.contains_key(key));
 
@@ -558,6 +556,8 @@ impl_scope! {
 
             self.update_widgets(cx, data);
         }
+
+        fn update_recurse(&mut self, _: &mut ConfigCx, _: &Self::Data) {}
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &A, event: Event) -> IsUsed {
             let is_used = match event {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -264,7 +264,8 @@ impl_scope! {
             let row_len = (data_len.1 - first_row).min(self.alloc_len.rows.cast());
             first_col = first_col.min(data_len.0 - col_len);
             first_row = first_row.min(data_len.1 - row_len);
-            self.cur_len = (u32::conv(col_len), row_len.cast());
+            self.cur_len = (col_len.cast(), row_len.cast());
+            debug_assert!(self.num_children() <= self.widgets.len());
             self.first_data = (first_row.cast(), first_col.cast());
 
             let solver = self.position_solver();
@@ -470,8 +471,10 @@ impl_scope! {
                 // Free memory (rarely useful?)
                 self.widgets.truncate(req_widgets);
             }
+            debug_assert!(self.widgets.len() >= req_widgets);
 
             // Widgets need configuring and updating: do so by updating self.
+            self.cur_len = (0, 0); // hack: prevent drawing in the mean-time
             cx.request_update(self.id());
         }
 

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -374,11 +374,6 @@ impl_scope! {
                 None
             }
         }
-        #[inline]
-        fn make_child_id(&mut self, _: usize) -> WidgetId {
-            // We configure children in update_widgets and do not want this method to be called
-            unimplemented!()
-        }
 
         fn size_rules(&mut self, sizer: SizeCx, mut axis: AxisInfo) -> SizeRules {
             // We use an invisible frame for highlighting selections, drawing into the margin
@@ -518,6 +513,12 @@ impl_scope! {
     }
 
     impl Events for Self {
+        #[inline]
+        fn make_child_id(&mut self, _: usize) -> WidgetId {
+            // We configure children in update_widgets and do not want this method to be called
+            unimplemented!()
+        }
+
         fn configure(&mut self, cx: &mut ConfigCx) {
             if self.widgets.is_empty() {
                 // Initial configure: ensure some widgets are loaded to allow

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -285,8 +285,8 @@ impl_scope! {
             axis.sub_other(self.frame_size.extract(axis.flipped()));
 
             let mut rules = self.inner.size_rules(sizer.re(), axis);
+            let bar_rules = self.bar.size_rules(sizer.re(), axis);
             if axis.is_horizontal() && self.multi_line() {
-                let bar_rules = self.bar.size_rules(sizer.re(), axis);
                 self.inner_margin = rules.margins_i32().1.max(bar_rules.margins_i32().0);
                 rules.append(bar_rules);
             }
@@ -303,14 +303,17 @@ impl_scope! {
             let mut rect = outer_rect;
             rect.pos += self.frame_offset;
             rect.size -= self.frame_size;
+
+            let mut bar_rect = Rect::ZERO;
             if self.multi_line() {
                 let bar_width = cx.size_cx().scroll_bar_width();
                 let x1 = rect.pos.0 + rect.size.0;
                 let x0 = x1 - bar_width;
-                let bar_rect = Rect::new(Coord(x0, rect.pos.1), Size(bar_width, rect.size.1));
-                self.bar.set_rect(cx, bar_rect);
+                bar_rect = Rect::new(Coord(x0, rect.pos.1), Size(bar_width, rect.size.1));
                 rect.size.0 = (rect.size.0 - bar_width - self.inner_margin).max(0);
             }
+            self.bar.set_rect(cx, bar_rect);
+
             self.inner.set_rect(cx, rect);
             self.inner.set_outer_rect(outer_rect, FrameStyle::EditBox);
             self.update_scroll_bar(cx);

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -44,7 +44,8 @@ impl_scope! {
     /// This widget is unusual in several ways:
     ///
     /// 1.  [`Layout::size_rules`] does not request any size; the parent is expected
-    ///     to do this.
+    ///     to do this. (Calling this method is still required to comply with
+    ///     widget model.)
     /// 2.  [`Layout::set_rect`] sets the *track* within which this grip may move;
     ///     the parent should always call [`GripPart::set_size_and_offset`]
     ///     afterwards to set the grip position.

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -78,7 +78,7 @@ impl_scope! {
     ///     `set_rect` (otherwise the grip's position will not be updated)
     /// 3.  `draw` does nothing: the parent is expected to do all drawing
     impl Layout for GripPart {
-        fn size_rules(&mut self, _: SizeCx, _: AxisInfo) -> SizeRules {
+        fn size_rules(&mut self, _: SizeCx, _axis: AxisInfo) -> SizeRules {
             SizeRules::EMPTY
         }
 

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -132,8 +132,7 @@ impl_scope! {
             }
         }
 
-        fn pre_configure(&mut self, _: &mut ConfigCx, id: WidgetId) {
-            self.core.id = id;
+        fn configure(&mut self, _: &mut ConfigCx) {
             self.id_map.clear();
         }
 

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -90,7 +90,24 @@ impl_scope! {
             id.next_key_after(self.id_ref())
                 .and_then(|k| self.id_map.get(&k).cloned())
         }
+    }
 
+    impl Widget for Self {
+        type Data = W::Data;
+
+        fn for_child_node(
+            &mut self,
+            data: &W::Data,
+            index: usize,
+            closure: Box<dyn FnOnce(Node<'_>) + '_>,
+        ) {
+            if let Some(w) = self.widgets.get_mut(index) {
+                closure(w.as_node(data));
+            }
+        }
+    }
+
+    impl Events for Self {
         /// Make a fresh id based on `self.next` then insert into `self.id_map`
         fn make_child_id(&mut self, index: usize) -> WidgetId {
             if let Some(child) = self.widgets.get(index) {
@@ -114,24 +131,7 @@ impl_scope! {
                 }
             }
         }
-    }
 
-    impl Widget for Self {
-        type Data = W::Data;
-
-        fn for_child_node(
-            &mut self,
-            data: &W::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            if let Some(w) = self.widgets.get_mut(index) {
-                closure(w.as_node(data));
-            }
-        }
-    }
-
-    impl Events for Self {
         fn pre_configure(&mut self, _: &mut ConfigCx, id: WidgetId) {
             self.core.id = id;
             self.id_map.clear();

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -61,20 +61,6 @@ impl_scope! {
             }
         }
     }
-
-    impl Widget for Self {
-        fn for_child_node(
-            &mut self,
-            data: &Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            if let Some(w) = self.widgets.get_mut(index) {
-                closure(w.as_node(data));
-            }
-        }
-    }
-
     impl Layout for Self {
         #[inline]
         fn num_children(&self) -> usize {
@@ -128,9 +114,22 @@ impl_scope! {
         }
     }
 
-    impl<Data, D: Directional> Events for MenuBar<Data, D> {
+    impl Widget for Self {
         type Data = Data;
 
+        fn for_child_node(
+            &mut self,
+            data: &Data,
+            index: usize,
+            closure: Box<dyn FnOnce(Node<'_>) + '_>,
+        ) {
+            if let Some(w) = self.widgets.get_mut(index) {
+                closure(w.as_node(data));
+            }
+        }
+    }
+
+    impl<Data, D: Directional> Events for MenuBar<Data, D> {
         fn handle_event(&mut self, cx: &mut EventCx, data: &Data, event: Event) -> IsUsed {
             match event {
                 Event::TimerUpdate(id_code) => {

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -282,6 +282,7 @@ impl_scope! {
                     true => axis.align_or_stretch(),
                 },
             );
+            let _ = self.grip.size_rules(sizer.re(), axis);
             sizer.feature(Feature::ScrollBar(self.direction()), axis)
         }
 
@@ -461,15 +462,17 @@ impl_scope! {
     impl Layout for Self {
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             let mut rules = self.inner.size_rules(sizer.re(), axis);
+            let vert_rules = self.vert_bar.size_rules(sizer.re(), axis);
+            let horiz_rules = self.horiz_bar.size_rules(sizer.re(), axis);
             let (use_horiz, use_vert) = match self.mode {
                 ScrollBarMode::Fixed => self.show_bars,
                 ScrollBarMode::Auto => (true, true),
                 ScrollBarMode::Invisible => (false, false),
             };
             if axis.is_horizontal() && use_horiz {
-                rules.append(self.vert_bar.size_rules(sizer.re(), axis));
+                rules.append(vert_rules);
             } else if axis.is_vertical() && use_vert {
-                rules.append(self.horiz_bar.size_rules(sizer.re(), axis));
+                rules.append(horiz_rules);
             }
             rules
         }
@@ -499,12 +502,17 @@ impl_scope! {
                 let size = Size::new(child_size.0, bar_width);
                 self.horiz_bar.set_rect(cx, Rect { pos, size });
                 let _ = self.horiz_bar.set_limits(max_scroll_offset.0, rect.size.0);
+            } else {
+                self.horiz_bar.set_rect(cx, Rect::ZERO);
             }
+
             if self.show_bars.1 {
                 let pos = Coord(rect.pos2().0 - bar_width, pos.1);
                 let size = Size::new(bar_width, self.core.rect.size.1);
                 self.vert_bar.set_rect(cx, Rect { pos, size });
                 let _ = self.vert_bar.set_limits(max_scroll_offset.1, rect.size.1);
+            } else {
+                self.vert_bar.set_rect(cx, Rect::ZERO);
             }
         }
 

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -38,6 +38,7 @@ impl_scope! {
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             let class = TextClass::LabelScroll;
             let mut rules = sizer.text_rules(&mut self.text, class, axis);
+            let _ = self.bar.size_rules(sizer.re(), axis);
             if axis.is_vertical() {
                 rules.reduce_min_to(sizer.line_height(class) * 4);
             }

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -303,6 +303,7 @@ impl_scope! {
                     true => axis.align_or_stretch(),
                 },
             );
+            let _ = self.grip.size_rules(sizer.re(), axis);
             sizer.feature(Feature::Slider(self.direction()), axis)
         }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -101,25 +101,6 @@ impl_scope! {
         }
     }
 
-    impl Widget for Self {
-        fn for_child_node(
-            &mut self,
-            data: &W::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            if (index & 1) != 0 {
-                if let Some(w) = self.handles.get_mut(index >> 1) {
-                    closure(w.as_node(&()));
-                }
-            } else {
-                if let Some(w) = self.widgets.get_mut(index >> 1) {
-                    closure(w.as_node(data));
-                }
-            }
-        }
-    }
-
     impl Layout for Self {
         #[inline]
         fn num_children(&self) -> usize {
@@ -246,9 +227,28 @@ impl_scope! {
         }
     }
 
-    impl Events for Self {
+    impl Widget for Self {
         type Data = W::Data;
 
+        fn for_child_node(
+            &mut self,
+            data: &W::Data,
+            index: usize,
+            closure: Box<dyn FnOnce(Node<'_>) + '_>,
+        ) {
+            if (index & 1) != 0 {
+                if let Some(w) = self.handles.get_mut(index >> 1) {
+                    closure(w.as_node(&()));
+                }
+            } else {
+                if let Some(w) = self.widgets.get_mut(index >> 1) {
+                    closure(w.as_node(data));
+                }
+            }
+        }
+    }
+
+    impl Events for Self {
         fn pre_configure(&mut self, _: &mut ConfigCx, id: WidgetId) {
             self.core.id = id;
             self.id_map.clear();

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -119,11 +119,6 @@ impl_scope! {
                 .and_then(|k| self.id_map.get(&k).cloned())
         }
 
-        fn make_child_id(&mut self, child_index: usize) -> WidgetId {
-            let is_handle = (child_index & 1) != 0;
-            self.make_next_id(is_handle, child_index / 2)
-        }
-
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             if self.widgets.is_empty() {
                 return SizeRules::EMPTY;
@@ -249,6 +244,11 @@ impl_scope! {
     }
 
     impl Events for Self {
+        fn make_child_id(&mut self, child_index: usize) -> WidgetId {
+            let is_handle = (child_index & 1) != 0;
+            self.make_next_id(is_handle, child_index / 2)
+        }
+
         fn pre_configure(&mut self, _: &mut ConfigCx, id: WidgetId) {
             self.core.id = id;
             self.id_map.clear();

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -249,8 +249,7 @@ impl_scope! {
             self.make_next_id(is_handle, child_index / 2)
         }
 
-        fn pre_configure(&mut self, _: &mut ConfigCx, id: WidgetId) {
-            self.core.id = id;
+        fn configure(&mut self, _: &mut ConfigCx) {
             self.id_map.clear();
         }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -165,7 +165,11 @@ impl_scope! {
                 if n >= self.handles.len() {
                     break;
                 }
-                solver.for_child(&mut self.data, (n << 1) + 1, |_axis| handle_rules);
+                let handles = &mut self.handles;
+                solver.for_child(&mut self.data, (n << 1) + 1, |axis| {
+                    handles[n].size_rules(sizer.re(), axis);
+                    handle_rules
+                });
                 n += 1;
             }
             solver.finish(&mut self.data)

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -173,8 +173,7 @@ impl_scope! {
             }
         }
 
-        fn pre_configure(&mut self, _: &mut ConfigCx, id: WidgetId) {
-            self.core.id = id;
+        fn configure(&mut self, _: &mut ConfigCx) {
             self.id_map.clear();
         }
 

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -137,13 +137,22 @@ impl_scope! {
     }
 
     impl Events for Self {
-        fn recurse_range(&self) -> std::ops::Range<usize> {
-            self.active..(self.active + 1)
-        }
-
         fn pre_configure(&mut self, _: &mut ConfigCx, id: WidgetId) {
             self.core.id = id;
             self.id_map.clear();
+        }
+
+        fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+            let id = self.make_child_id(self.active);
+            if let Some(w) = self.widgets.get_mut(self.active) {
+                cx.configure(w.as_node(data), id)
+            }
+        }
+
+        fn update_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+            if let Some(w) = self.widgets.get_mut(self.active) {
+                cx.update(w.as_node(data))
+            }
         }
     }
 

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -70,27 +70,6 @@ impl_scope! {
                 .and_then(|k| self.id_map.get(&k).cloned())
         }
 
-        fn make_child_id(&mut self, index: usize) -> WidgetId {
-            if let Some(child) = self.widgets.get(index) {
-                // Use the widget's existing identifier, if any
-                if child.id_ref().is_valid() {
-                    if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
-                        self.id_map.insert(key, index);
-                        return child.id();
-                    }
-                }
-            }
-
-            loop {
-                let key = self.next;
-                self.next += 1;
-                if let Entry::Vacant(entry) = self.id_map.entry(key) {
-                    entry.insert(index);
-                    return self.id_ref().make_child(key);
-                }
-            }
-        }
-
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             let mut rules = SizeRules::EMPTY;
             let end = self
@@ -137,6 +116,27 @@ impl_scope! {
     }
 
     impl Events for Self {
+        fn make_child_id(&mut self, index: usize) -> WidgetId {
+            if let Some(child) = self.widgets.get(index) {
+                // Use the widget's existing identifier, if any
+                if child.id_ref().is_valid() {
+                    if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
+                        self.id_map.insert(key, index);
+                        return child.id();
+                    }
+                }
+            }
+
+            loop {
+                let key = self.next;
+                self.next += 1;
+                if let Entry::Vacant(entry) = self.id_map.entry(key) {
+                    entry.insert(index);
+                    return self.id_ref().make_child(key);
+                }
+            }
+        }
+
         fn pre_configure(&mut self, _: &mut ConfigCx, id: WidgetId) {
             self.core.id = id;
             self.id_map.clear();

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -5,15 +5,29 @@
 
 //! A stack
 
+use kas::layout::solve_size_rules;
 use kas::prelude::*;
 use std::collections::hash_map::{Entry, HashMap};
 use std::fmt::Debug;
-use std::ops::{Index, IndexMut, Range};
+use std::ops::{Index, IndexMut};
 
 /// A stack of boxed widgets
 ///
 /// This is a parametrisation of [`Stack`].
 pub type BoxStack<Data> = Stack<Box<dyn Widget<Data = Data>>>;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum State {
+    #[default]
+    None,
+    Configured,
+    Sized,
+}
+impl State {
+    fn is_configured(self) -> bool {
+        self != State::None
+    }
+}
 
 impl_scope! {
     /// A stack of widgets
@@ -25,16 +39,15 @@ impl_scope! {
     /// This may only be parametrised with a single widget type, thus usually
     /// it will be necessary to box children (this is what [`BoxStack`] is).
     ///
-    /// Configuring is `O(n)` in the number of pages `n`. Resizing may be `O(n)`
-    /// or may be limited: see [`Self::set_size_limit`]. Drawing is `O(1)`, and
-    /// so is event handling in the expected case.
+    /// By default, all pages are configured and sized. To avoid configuring
+    /// hidden pages (thus preventing these pages from affecting size)
+    /// call [`Self::set_size_limit`] or [`Self::with_size_limit`].
     #[autoimpl(Default)]
     #[derive(Clone, Debug)]
     #[widget]
     pub struct Stack<W: Widget> {
         core: widget_core!(),
-        widgets: Vec<W>,
-        sized_range: Range<usize>, // range of pages for which size rules are solved
+        widgets: Vec<(W, State)>,
         active: usize,
         size_limit: usize,
         next: usize,
@@ -50,7 +63,7 @@ impl_scope! {
             index: usize,
             closure: Box<dyn FnOnce(Node<'_>) + '_>,
         ) {
-            if let Some(w) = self.widgets.get_mut(index) {
+            if let Some((w, _)) = self.widgets.get_mut(index) {
                 closure(w.as_node(data));
             }
         }
@@ -62,7 +75,7 @@ impl_scope! {
             self.widgets.len()
         }
         fn get_child(&self, index: usize) -> Option<&dyn Layout> {
-            self.widgets.get(index).map(|w| w.as_layout())
+            self.widgets.get(index).map(|(w, _)| w.as_layout())
         }
 
         fn find_child_index(&self, id: &WidgetId) -> Option<usize> {
@@ -72,23 +85,35 @@ impl_scope! {
 
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             let mut rules = SizeRules::EMPTY;
-            let end = self
-                .active
-                .saturating_add(self.size_limit)
-                .min(self.widgets.len());
-            let start = end.saturating_sub(self.size_limit);
-            self.sized_range = start..end;
-            debug_assert!(self.sized_range.contains(&self.active));
-            for index in start..end {
-                rules = rules.max(self.widgets[index].size_rules(sizer.re(), axis));
+            let mut index = 0;
+            let end = self.widgets.len().min(self.size_limit);
+            loop {
+                if index == end {
+                    if self.active >= end {
+                        index = self.active;
+                    } else {
+                        break rules;
+                    }
+                } else if index > end {
+                    break rules;
+                }
+
+                if let Some(entry) = self.widgets.get_mut(index) {
+                    if entry.1.is_configured() {
+                        rules = rules.max(entry.0.size_rules(sizer.re(), axis));
+                        entry.1 = State::Sized;
+                    }
+                }
+
+                index += 1;
             }
-            rules
         }
 
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect) {
             self.core.rect = rect;
-            if let Some(child) = self.widgets.get_mut(self.active) {
-                child.set_rect(cx, rect);
+            if let Some(entry) = self.widgets.get_mut(self.active) {
+                debug_assert_eq!(entry.1, State::Sized);
+                entry.0.set_rect(cx, rect);
             }
         }
 
@@ -101,23 +126,34 @@ impl_scope! {
         }
 
         fn find_id(&mut self, coord: Coord) -> Option<WidgetId> {
-            // Latter condition is implied, but compiler doesn't know this:
-            if self.sized_range.contains(&self.active) && self.active < self.widgets.len() {
-                return self.widgets[self.active].find_id(coord);
+            if let Some(entry) = self.widgets.get_mut(self.active) {
+                debug_assert_eq!(entry.1, State::Sized);
+                return entry.0.find_id(coord);
             }
             None
         }
 
         fn draw(&mut self, mut draw: DrawCx) {
-            if self.sized_range.contains(&self.active) && self.active < self.widgets.len() {
-                draw.recurse(&mut self.widgets[self.active]);
+            if let Some(entry) = self.widgets.get_mut(self.active) {
+                debug_assert_eq!(entry.1, State::Sized);
+                draw.recurse(&mut entry.0);
             }
         }
     }
 
     impl Events for Self {
         fn make_child_id(&mut self, index: usize) -> WidgetId {
-            if let Some(child) = self.widgets.get(index) {
+            if let Some((child, state)) = self.widgets.get(index) {
+                if state.is_configured() {
+                    debug_assert!(child.id_ref().is_valid());
+                    if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
+                        debug_assert_eq!(self.id_map.get(&key), Some(&index));
+                    } else {
+                        debug_assert!(false);
+                    }
+                    return child.id();
+                }
+
                 // Use the widget's existing identifier, if any
                 if child.id_ref().is_valid() {
                     if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
@@ -143,15 +179,34 @@ impl_scope! {
         }
 
         fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
-            let id = self.make_child_id(self.active);
-            if let Some(w) = self.widgets.get_mut(self.active) {
-                cx.configure(w.as_node(data), id)
+            let mut index = 0;
+            let end = self.widgets.len().min(self.size_limit);
+            loop {
+                if index == end {
+                    if self.active >= end {
+                        index = self.active;
+                    } else {
+                        break;
+                    }
+                } else if index > end {
+                    break;
+                }
+
+                let id = self.make_child_id(index);
+                if let Some(entry) = self.widgets.get_mut(index) {
+                    cx.configure(entry.0.as_node(data), id);
+                    if entry.1 == State::None {
+                        entry.1 = State::Configured;
+                    }
+                }
+
+                index += 1;
             }
         }
 
         fn update_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
-            if let Some(w) = self.widgets.get_mut(self.active) {
-                cx.update(w.as_node(data))
+            if let Some((w, _)) = self.widgets.get_mut(self.active) {
+                cx.update(w.as_node(data));
             }
         }
     }
@@ -160,58 +215,46 @@ impl_scope! {
         type Output = W;
 
         fn index(&self, index: usize) -> &Self::Output {
-            &self.widgets[index]
+            &self.widgets[index].0
         }
     }
 
     impl IndexMut<usize> for Self {
         fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-            &mut self.widgets[index]
+            &mut self.widgets[index].0
         }
     }
 }
 
 impl<W: Widget> Stack<W> {
-    /// Construct a new instance
+    /// Construct a new, empty instance
     ///
-    /// Initially, the first page (if any) will be shown. Use
-    /// [`Self::with_active`] to change this.
-    pub fn new(widgets: impl Into<Vec<W>>) -> Self {
-        Stack {
-            core: Default::default(),
-            widgets: widgets.into(),
-            sized_range: 0..0,
-            active: 0,
-            size_limit: usize::MAX,
-            next: 0,
-            id_map: Default::default(),
-        }
+    /// See also [`Stack::from`].
+    pub fn new() -> Self {
+        Stack::default()
     }
 
-    /// Edit the list of children directly
+    /// Limit the number of pages considered and sized
     ///
-    /// This may be used to edit pages before window construction. It may
-    /// also be used from a running UI, but in this case a full reconfigure
-    /// of the window's widgets is required (triggered by the the return
-    /// value, [`Action::RECONFIGURE`]).
-    #[inline]
-    pub fn edit<F: FnOnce(&mut Vec<W>)>(&mut self, f: F) -> Action {
-        f(&mut self.widgets);
-        Action::RECONFIGURE
-    }
-
-    /// Limit the number of pages considered by [`Layout::size_rules`]
+    /// By default, this is `usize::MAX`: all pages are configured and affect
+    /// the stack's size requirements.
     ///
-    /// By default, this is `usize::MAX`: all pages affect the result. If
-    /// this is set to 1 then only the active page will affect the result. If
-    /// this is `n > 1`, then `min(n, num_pages)` pages (including active)
-    /// will be used. (If this is set to 0 it is silently replaced with 1.)
-    ///
-    /// Using a limit lower than the number of pages has two effects:
-    /// (1) resizing is faster and (2) calling [`Self::set_active`] may cause a
-    /// full-window resize.
+    /// Set this to 0 to avoid configuring all hidden pages.
+    /// Set this to `n` to configure the active page *and* the first `n` pages.
     pub fn set_size_limit(&mut self, limit: usize) {
-        self.size_limit = limit.max(1);
+        self.size_limit = limit;
+    }
+
+    /// Limit the number of pages configured and sized (inline)
+    ///
+    /// By default, this is `usize::MAX`: all pages are configured and affect
+    /// the stack's size requirements.
+    ///
+    /// Set this to 0 to avoid configuring all hidden pages.
+    /// Set this to `n` to configure the active page *and* the first `n` pages.
+    pub fn with_size_limit(mut self, limit: usize) -> Self {
+        self.size_limit = limit;
+        self
     }
 
     /// Get the index of the active widget
@@ -231,43 +274,42 @@ impl<W: Widget> Stack<W> {
     }
 
     /// Set the active page
-    ///
-    /// Behaviour depends on whether [`SizeRules`] were already solved for
-    /// `index` (see [`Self::set_size_limit`] and note that methods like
-    /// [`Self::push`] do not solve rules for new pages). Case:
-    ///
-    /// -   `index >= num_pages`: no page displayed
-    /// -   `index == active` and `SizeRules` were solved: nothing happens
-    /// -   `SizeRules` were solved: set layout ([`Layout::set_rect`]) and
-    ///     update mouse-cursor target ([`Action::REGION_MOVED`])
-    /// -   Otherwise: resize the whole window ([`Action::RESIZE`])
     pub fn set_active(&mut self, cx: &mut ConfigCx, data: &W::Data, index: usize) {
         let old_index = self.active;
-        self.active = index;
-        if index >= self.widgets.len() {
-            if old_index < self.widgets.len() {
-                *cx |= Action::REGION_MOVED;
-            }
+        if old_index == index {
             return;
         }
+        self.active = index;
 
         let id = self.make_child_id(index);
-        cx.configure(self.widgets[index].as_node(data), id);
+        if let Some(entry) = self.widgets.get_mut(index) {
+            let node = entry.0.as_node(data);
 
-        if self.sized_range.contains(&index) {
-            if old_index != index {
-                self.widgets[index].set_rect(cx, self.core.rect);
+            if entry.1 == State::None {
+                cx.configure(node, id);
+                entry.1 = State::Configured;
+            } else {
+                cx.update(node);
+            }
+
+            if entry.1 == State::Configured {
+                *cx |= Action::RESIZE;
+            } else {
+                debug_assert_eq!(entry.1, State::Sized);
+                entry.0.set_rect(cx, self.core.rect);
                 *cx |= Action::REGION_MOVED;
             }
         } else {
-            *cx |= Action::RESIZE;
+            if old_index < self.widgets.len() {
+                *cx |= Action::REGION_MOVED;
+            }
         }
     }
 
     /// Get a direct reference to the active child widget, if any
     pub fn get_active(&self) -> Option<&W> {
         if self.active < self.widgets.len() {
-            Some(&self.widgets[self.active])
+            Some(&self.widgets[self.active].0)
         } else {
             None
         }
@@ -288,38 +330,45 @@ impl<W: Widget> Stack<W> {
     /// This does not change the activen page index.
     pub fn clear(&mut self) {
         self.widgets.clear();
-        self.sized_range = 0..0;
     }
 
     /// Returns a reference to the page, if any
     pub fn get(&self, index: usize) -> Option<&W> {
-        self.widgets.get(index)
+        self.widgets.get(index).map(|e| &e.0)
     }
 
     /// Returns a mutable reference to the page, if any
     pub fn get_mut(&mut self, index: usize) -> Option<&mut W> {
-        self.widgets.get_mut(index)
+        self.widgets.get_mut(index).map(|e| &mut e.0)
+    }
+
+    /// Configure and size the page at index
+    fn configure_and_size(&mut self, cx: &mut ConfigCx, data: &W::Data, index: usize) {
+        let id = self.make_child_id(index);
+        if let Some(entry) = self.widgets.get_mut(index) {
+            cx.configure(entry.0.as_node(data), id);
+            let Size(w, h) = self.core.rect.size;
+            solve_size_rules(&mut entry.0, cx.size_cx(), Some(w), Some(h), None, None);
+            entry.1 = State::Sized;
+        }
     }
 
     /// Append a page
     ///
-    /// The new page is configured immediately.
     /// The new page is not made active (the active index may be changed to
     /// avoid this). Consider calling [`Self::set_active`].
     ///
     /// Returns the new page's index.
-    pub fn push(&mut self, cx: &mut ConfigCx, data: &W::Data, mut widget: W) -> usize {
+    pub fn push(&mut self, cx: &mut ConfigCx, data: &W::Data, widget: W) -> usize {
         let index = self.widgets.len();
-        let id = self.make_child_id(index);
-        cx.configure(widget.as_node(data), id);
-
-        self.widgets.push(widget);
-
         if index == self.active {
             self.active = usize::MAX;
         }
+        self.widgets.push((widget, State::None));
 
-        self.sized_range.end = self.sized_range.end.min(index);
+        if index < self.size_limit {
+            self.configure_and_size(cx, data, index);
+        }
         index
     }
 
@@ -328,7 +377,7 @@ impl<W: Widget> Stack<W> {
     /// If this page was active then no page will be left active.
     /// Consider also calling [`Self::set_active`].
     pub fn pop(&mut self, cx: &mut EventState) -> Option<W> {
-        let result = self.widgets.pop();
+        let result = self.widgets.pop().map(|(w, _)| w);
         if let Some(w) = result.as_ref() {
             if self.active > 0 && self.active == self.widgets.len() {
                 *cx |= Action::REGION_MOVED;
@@ -347,26 +396,22 @@ impl<W: Widget> Stack<W> {
     ///
     /// Panics if `index > len`.
     ///
-    /// The new child is configured immediately. The active page does not
-    /// change (the index of the active page may change instead).
-    pub fn insert(&mut self, cx: &mut ConfigCx, data: &W::Data, index: usize, mut widget: W) {
-        if self.active < index {
-            self.sized_range.end = self.sized_range.end.min(index);
-        } else {
-            self.sized_range.start = (self.sized_range.start + 1).max(index + 1);
-            self.sized_range.end += 1;
+    /// The active page does not change (the index of the active page may change instead).
+    pub fn insert(&mut self, cx: &mut ConfigCx, data: &W::Data, index: usize, widget: W) {
+        if self.active >= index {
             self.active = self.active.saturating_add(1);
         }
 
-        let id = self.make_child_id(index);
-        cx.configure(widget.as_node(data), id);
-
-        self.widgets.insert(index, widget);
+        self.widgets.insert(index, (widget, State::None));
 
         for v in self.id_map.values_mut() {
             if *v >= index {
                 *v += 1;
             }
+        }
+
+        if index < self.size_limit {
+            self.configure_and_size(cx, data, index);
         }
     }
 
@@ -377,7 +422,7 @@ impl<W: Widget> Stack<W> {
     /// If this page was active then no page will be left active.
     /// Consider also calling [`Self::set_active`].
     pub fn remove(&mut self, cx: &mut EventState, index: usize) -> W {
-        let w = self.widgets.remove(index);
+        let (w, _) = self.widgets.remove(index);
         if w.id_ref().is_valid() {
             if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
                 self.id_map.remove(&key);
@@ -387,12 +432,6 @@ impl<W: Widget> Stack<W> {
         if self.active == index {
             self.active = usize::MAX;
             *cx |= Action::REGION_MOVED;
-        }
-        if index < self.sized_range.end {
-            self.sized_range.end -= 1;
-            if index < self.sized_range.start {
-                self.sized_range.start -= 1;
-            }
         }
 
         for v in self.id_map.values_mut() {
@@ -407,12 +446,11 @@ impl<W: Widget> Stack<W> {
     ///
     /// Panics if `index` is out of bounds.
     ///
-    /// The new child is configured immediately. If it replaces the active page,
-    /// then [`Action::RESIZE`] is triggered.
+    /// If the new child replaces the active page then [`Action::RESIZE`] is triggered.
     pub fn replace(&mut self, cx: &mut ConfigCx, data: &W::Data, index: usize, mut widget: W) -> W {
-        let id = self.make_child_id(index);
-        cx.configure(widget.as_node(data), id);
-        std::mem::swap(&mut widget, &mut self.widgets[index]);
+        let entry = &mut self.widgets[index];
+        std::mem::swap(&mut widget, &mut entry.0);
+        entry.1 = State::None;
 
         if widget.id_ref().is_valid() {
             if let Some(key) = widget.id_ref().next_key_after(self.id_ref()) {
@@ -420,11 +458,11 @@ impl<W: Widget> Stack<W> {
             }
         }
 
-        if self.active < index {
-            self.sized_range.end = self.sized_range.end.min(index);
-        } else {
-            self.sized_range.start = (self.sized_range.start + 1).max(index + 1);
-            self.sized_range.end += 1;
+        if index < self.size_limit || index == self.active {
+            self.configure_and_size(cx, data, index);
+        }
+
+        if self.active >= index {
             if index == self.active {
                 *cx |= Action::RESIZE;
             }
@@ -435,7 +473,6 @@ impl<W: Widget> Stack<W> {
 
     /// Append child widgets from an iterator
     ///
-    /// New children are configured immediately.
     /// The new pages are not made active (the active index may be changed to
     /// avoid this). Consider calling [`Self::set_active`].
     pub fn extend<T: IntoIterator<Item = W>>(
@@ -449,10 +486,12 @@ impl<W: Widget> Stack<W> {
         if let Some(ub) = iter.size_hint().1 {
             self.widgets.reserve(ub);
         }
-        for mut w in iter {
-            let id = self.make_child_id(self.widgets.len());
-            cx.configure(w.as_node(data), id);
-            self.widgets.push(w);
+        for w in iter {
+            let index = self.widgets.len();
+            self.widgets.push((w, State::None));
+            if index < self.size_limit {
+                self.configure_and_size(cx, data, index);
+            }
         }
 
         if (old_len..self.widgets.len()).contains(&self.active) {
@@ -462,7 +501,6 @@ impl<W: Widget> Stack<W> {
 
     /// Resize, using the given closure to construct new widgets
     ///
-    /// New children are configured immediately.
     /// The new pages are not made active (the active index may be changed to
     /// avoid this). Consider calling [`Self::set_active`].
     pub fn resize_with<F: Fn(usize) -> W>(
@@ -475,9 +513,8 @@ impl<W: Widget> Stack<W> {
         let old_len = self.widgets.len();
 
         if len < old_len {
-            self.sized_range.end = self.sized_range.end.min(len);
             loop {
-                let w = self.widgets.pop().unwrap();
+                let (w, _) = self.widgets.pop().unwrap();
                 if w.id_ref().is_valid() {
                     if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
                         self.id_map.remove(&key);
@@ -492,10 +529,10 @@ impl<W: Widget> Stack<W> {
         if len > old_len {
             self.widgets.reserve(len - old_len);
             for index in old_len..len {
-                let id = self.make_child_id(index);
-                let mut w = f(index);
-                cx.configure(w.as_node(data), id);
-                self.widgets.push(w);
+                self.widgets.push((f(index), State::None));
+                if index < self.size_limit {
+                    self.configure_and_size(cx, data, index);
+                }
             }
 
             if (old_len..len).contains(&self.active) {
@@ -505,12 +542,15 @@ impl<W: Widget> Stack<W> {
     }
 }
 
-impl<W: Widget> FromIterator<W> for Stack<W> {
+impl<W: Widget, I> From<I> for Stack<W>
+where
+    I: IntoIterator<Item = W>,
+{
     #[inline]
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = W>,
-    {
-        Self::new(iter.into_iter().collect::<Vec<W>>())
+    fn from(iter: I) -> Self {
+        Self {
+            widgets: iter.into_iter().map(|w| (w, State::None)).collect(),
+            ..Default::default()
+        }
     }
 }

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -132,6 +132,8 @@ impl_scope! {
 
     impl Self {
         /// Construct a new, empty instance
+        ///
+        /// See also [`TabStack::from`].
         pub fn new() -> Self {
             Self {
                 core: Default::default(),

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -308,8 +308,8 @@ impl<W: Widget> TabStack<W> {
 
     /// Append a page
     ///
-    /// The new page is configured immediately. If it becomes the active page
-    /// and then [`Action::RESIZE`] will be triggered.
+    /// The new page is not made active (the active index may be changed to
+    /// avoid this). Consider calling [`Self::set_active`].
     ///
     /// Returns the new page's index.
     pub fn push(&mut self, cx: &mut ConfigCx, data: &W::Data, tab: Tab, widget: W) -> usize {
@@ -321,7 +321,8 @@ impl<W: Widget> TabStack<W> {
 
     /// Remove the last child widget (if any) and return
     ///
-    /// If this page was active then the previous page becomes active.
+    /// If this page was active then no page will be left active.
+    /// Consider also calling [`Self::set_active`].
     pub fn pop(&mut self, cx: &mut EventState) -> Option<(Tab, W)> {
         let tab = self.tabs.pop(cx);
         let w = self.stack.pop(cx);
@@ -333,8 +334,7 @@ impl<W: Widget> TabStack<W> {
     ///
     /// Panics if `index > len`.
     ///
-    /// The new child is configured immediately. The active page does not
-    /// change.
+    /// The active page does not change (the index of the active page may change instead).
     pub fn insert(&mut self, cx: &mut ConfigCx, data: &W::Data, index: usize, tab: Tab, widget: W) {
         self.tabs.insert(cx, &(), index, tab);
         self.stack.insert(cx, data, index, widget);
@@ -344,8 +344,8 @@ impl<W: Widget> TabStack<W> {
     ///
     /// Panics if `index` is out of bounds.
     ///
-    /// If the active page is removed then the previous page (if any) becomes
-    /// active.
+    /// If this page was active then no page will be left active.
+    /// Consider also calling [`Self::set_active`].
     pub fn remove(&mut self, cx: &mut EventState, index: usize) -> (Tab, W) {
         let tab = self.tabs.remove(cx, index);
         let stack = self.stack.remove(cx, index);
@@ -356,16 +356,15 @@ impl<W: Widget> TabStack<W> {
     ///
     /// Panics if `index` is out of bounds.
     ///
-    /// The new child is configured immediately. If it replaces the active page,
-    /// then [`Action::RESIZE`] is triggered.
+    /// If the new child replaces the active page then [`Action::RESIZE`] is triggered.
     pub fn replace(&mut self, cx: &mut ConfigCx, data: &W::Data, index: usize, w: W) -> W {
         self.stack.replace(cx, data, index, w)
     }
 
     /// Append child widgets from an iterator
     ///
-    /// New children are configured immediately. If a new page becomes active,
-    /// then [`Action::RESIZE`] is triggered.
+    /// The new pages are not made active (the active index may be changed to
+    /// avoid this). Consider calling [`Self::set_active`].
     pub fn extend<T: IntoIterator<Item = (Tab, W)>>(
         &mut self,
         cx: &mut ConfigCx,

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -70,7 +70,7 @@ impl_scope! {
         }
     }
     impl Layout for ColourSquare {
-        fn size_rules(&mut self, sizer: SizeCx, _: AxisInfo) -> SizeRules {
+        fn size_rules(&mut self, sizer: SizeCx, _axis: AxisInfo) -> SizeRules {
             SizeRules::fixed_scaled(100.0, 10.0, sizer.scale_factor())
         }
 


### PR DESCRIPTION
The main part of this PR is to add (hidden, debug-only) status tracking for widgets and fix the resulting failures. Closes #408. (Uses solution 9 of #407, limiting function modifications to avoid observable side-effects besides panic-on-check-failure.)

Also:

- Compare a `WidgetId` to an `&str` according to display repr. This is useful when debugging a specific widget.
- Dump expansion of `#[widget]` macro for a specific widget easily:
  ```sh
  KAS_DEBUG_WIDGET=Border cargo build > temp.rs
  rustfmt temp.rs
  ```
- Most methods adding pages to `Stack` do not change the active page
- `ListView` / `MatrixView` no longer use a default (unconfigured) widget for sizing. This means that if no data was available, the child size might be calculated as zero. Fixes added to handle that and the later addition of data.
- Remove `pre_configure`; call `configure` and `update` *before* recursion.
- Remove `Events::recurse_range`; add `configure_recurse` and `update_recurse`