### PR TITLE
Cleaner handling of pendling events; update Winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,3 +146,7 @@ members = [
     "crates/kas-view",
     "examples/mandlebrot",
 ]
+
+[patch.crates-io.winit]
+git = "https://github.com/rust-windowing/winit.git"
+rev = "cb58c49a90f17734e0405627130674d47c0b8f40"

--- a/crates/kas-core/src/action.rs
+++ b/crates/kas-core/src/action.rs
@@ -35,10 +35,6 @@ bitflags! {
         ///
         /// Implies window redraw.
         const REGION_MOVED = 1 << 4;
-        /*
-        /// A pop-up opened/closed/needs resizing
-        Popup,
-        */
         /// Reset size of all widgets without recalculating requirements
         const SET_RECT = 1 << 8;
         /// Resize all widgets in the window

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -149,7 +149,7 @@ pub trait Events: Widget + Sized {
     ///
     /// Note: to implement `hover_highlight`, simply request a redraw on
     /// focus gain and loss. To implement `cursor_icon`, call
-    /// `cx.set_cursor_icon(EXPR);` on focus gain.
+    /// `cx.set_hover_cursor(EXPR);` on focus gain.
     ///
     /// [`#widget`]: macros::widget
     #[inline]

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -9,7 +9,6 @@ use super::color::Rgba;
 use super::{DrawImpl, PassId};
 use crate::cast::Cast;
 use crate::geom::{Quad, Rect, Size};
-use crate::shell::Platform;
 use crate::text::{Effect, TextDisplay};
 use crate::theme::RasterConfig;
 use std::any::Any;
@@ -76,15 +75,14 @@ pub struct AllocError;
 pub struct SharedState<DS: DrawSharedImpl> {
     /// The shell's [`DrawSharedImpl`] object
     pub draw: DS,
-    platform: Platform,
 }
 
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 impl<DS: DrawSharedImpl> SharedState<DS> {
     /// Construct (this is only called by the shell)
-    pub fn new(draw: DS, platform: Platform) -> Self {
-        SharedState { draw, platform }
+    pub fn new(draw: DS) -> Self {
+        SharedState { draw }
     }
 }
 
@@ -92,9 +90,6 @@ impl<DS: DrawSharedImpl> SharedState<DS> {
 ///
 /// All methods concern management of resources for drawing.
 pub trait DrawShared {
-    /// Get the platform
-    fn platform(&self) -> Platform;
-
     /// Allocate an image
     ///
     /// Use [`SharedState::image_upload`] to set contents of the new image.
@@ -121,11 +116,6 @@ pub trait DrawShared {
 }
 
 impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
-    #[inline]
-    fn platform(&self) -> Platform {
-        self.platform
-    }
-
     #[inline]
     fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageHandle, AllocError> {
         self.draw

--- a/crates/kas-core/src/event/cx/config.rs
+++ b/crates/kas-core/src/event/cx/config.rs
@@ -6,11 +6,9 @@
 //! Configuration context
 
 use super::Pending;
-use crate::draw::DrawShared;
 use crate::event::EventState;
 use crate::geom::{Rect, Size};
 use crate::layout::AlignPair;
-use crate::shell::Platform;
 use crate::text::TextApi;
 use crate::theme::{Feature, SizeCx, TextClass, ThemeSize};
 use crate::{Action, Node, WidgetId};
@@ -26,7 +24,6 @@ use std::ops::{Deref, DerefMut};
 #[must_use]
 pub struct ConfigCx<'a> {
     sh: &'a dyn ThemeSize,
-    ds: &'a mut dyn DrawShared,
     pub(crate) ev: &'a mut EventState,
 }
 
@@ -34,25 +31,14 @@ impl<'a> ConfigCx<'a> {
     /// Construct
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    pub fn new(sh: &'a dyn ThemeSize, ds: &'a mut dyn DrawShared, ev: &'a mut EventState) -> Self {
-        ConfigCx { sh, ds, ev }
-    }
-
-    /// Get the platform
-    pub fn platform(&self) -> Platform {
-        self.ds.platform()
+    pub fn new(sh: &'a dyn ThemeSize, ev: &'a mut EventState) -> Self {
+        ConfigCx { sh, ev }
     }
 
     /// Access a [`SizeCx`]
     #[inline]
     pub fn size_cx(&self) -> SizeCx<'a> {
         SizeCx::new(self.sh)
-    }
-
-    /// Access [`DrawShared`]
-    #[inline]
-    pub fn draw_shared(&mut self) -> &mut dyn DrawShared {
-        self.ds
     }
 
     /// Access [`EventState`]

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -855,21 +855,19 @@ impl<'a> EventCx<'a> {
     /// This may change, even without user action, since some platforms
     /// always initialize windows with scale factor 1.
     /// See also notes on [`Events::configure`].
-    //
-    // NOTE: we could implement this using only &self if required.
-    pub fn size_cx(&mut self) -> SizeCx<'_> {
-        SizeCx::new(self.shell.size_and_draw_shared().0)
+    pub fn size_cx(&self) -> SizeCx<'_> {
+        SizeCx::new(self.shell.theme_size())
     }
 
     /// Get a [`ConfigCx`]
     pub fn config_cx(&mut self) -> ConfigCx<'_> {
-        let (size, _) = self.shell.size_and_draw_shared();
+        let size = self.shell.theme_size();
         ConfigCx::new(size, self.state)
     }
 
     /// Get a [`DrawShared`]
     pub fn draw_shared(&mut self) -> &mut dyn DrawShared {
-        self.shell.size_and_draw_shared().1
+        self.shell.draw_shared()
     }
 
     /// Directly access Winit Window

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -533,8 +533,9 @@ impl EventState {
     /// cases, calling this method may be ineffective. The cursor is
     /// automatically "unset" when the widget is no longer hovered.
     ///
-    /// If a mouse grab ([`Press::grab`]) is active, its icon takes precedence.
-    pub fn set_cursor_icon(&mut self, icon: CursorIcon) {
+    /// See also [`Self::update_grab_cursor`]: if a mouse grab
+    /// ([`Press::grab`]) is active, its icon takes precedence.
+    pub fn set_hover_cursor(&mut self, icon: CursorIcon) {
         // Note: this is acted on by EventState::update
         self.hover_icon = icon;
     }
@@ -920,9 +921,9 @@ impl<'a> EventCx<'a> {
     /// This only succeeds if widget `id` has an active mouse-grab (see
     /// [`Press::grab`]). The cursor will be reset when the mouse-grab
     /// ends.
-    pub fn update_grab_cursor(&mut self, id: WidgetId, icon: CursorIcon) {
+    pub fn set_grab_cursor(&mut self, id: &WidgetId, icon: CursorIcon) {
         if let Some(ref grab) = self.mouse_grab {
-            if grab.start_id == id {
+            if grab.start_id == *id {
                 self.window.set_cursor_icon(icon);
             }
         }

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -606,11 +606,6 @@ impl EventState {
     pub fn request_update(&mut self, id: WidgetId) {
         self.pending.push_back(Pending::Update(id));
     }
-
-    /// Request set_rect of the given path
-    pub fn request_set_rect(&mut self, id: WidgetId) {
-        self.pending.push_back(Pending::SetRect(id));
-    }
 }
 
 /// Public API

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -34,6 +34,11 @@ impl std::ops::BitOrAssign<Action> for EventState {
 
 /// Public API
 impl EventState {
+    /// Get the platform
+    pub fn platform(&self) -> Platform {
+        self.platform
+    }
+
     /// True when the window has focus
     #[inline]
     pub fn window_has_focus(&self) -> bool {
@@ -863,8 +868,8 @@ impl<'a> EventCx<'a> {
 
     /// Get a [`ConfigCx`]
     pub fn config_cx(&mut self) -> ConfigCx<'_> {
-        let (size, draw_shared) = self.shell.size_and_draw_shared();
-        ConfigCx::new(size, draw_shared, self.state)
+        let (size, _) = self.shell.size_and_draw_shared();
+        ConfigCx::new(size, self.state)
     }
 
     /// Get a [`DrawShared`]

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -228,10 +228,6 @@ impl EventState {
                     }
                     cx.send_event(win.as_node(data), id, event);
                 }
-                Pending::SetRect(_id) => {
-                    // TODO(opt): set only this child
-                    cx.send_action(Action::SET_RECT);
-                }
                 Pending::NextNavFocus {
                     target,
                     reverse,

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -12,7 +12,6 @@ use std::time::{Duration, Instant};
 use super::*;
 use crate::cast::traits::*;
 use crate::geom::{Coord, DVec2};
-use crate::shell::ShellWindow;
 use crate::theme::ThemeSize;
 use crate::{Action, NavAdvance, WidgetId, Window};
 
@@ -119,13 +118,17 @@ impl EventState {
     ///
     /// Invokes the given closure on this [`EventCx`].
     #[inline]
-    pub(crate) fn with<F>(&mut self, shell: &mut dyn ShellWindow, messages: &mut ErasedStack, f: F)
-    where
-        F: FnOnce(&mut EventCx),
-    {
+    pub(crate) fn with<'a, F: FnOnce(&mut EventCx)>(
+        &'a mut self,
+        shell: &'a mut dyn ShellSharedErased,
+        window: &'a dyn WindowDataErased,
+        messages: &'a mut ErasedStack,
+        f: F,
+    ) {
         let mut cx = EventCx {
             state: self,
             shell,
+            window,
             messages,
             last_child: None,
             scroll: Scroll::None,
@@ -134,118 +137,113 @@ impl EventState {
     }
 
     /// Handle all pending items before event loop sleeps
-    pub(crate) fn flush_pending<A>(
-        &mut self,
-        shell: &mut dyn ShellWindow,
-        messages: &mut ErasedStack,
+    pub(crate) fn flush_pending<'a, A>(
+        &'a mut self,
+        shell: &'a mut dyn ShellSharedErased,
+        window: &'a dyn WindowDataErased,
+        messages: &'a mut ErasedStack,
         win: &mut Window<A>,
         data: &A,
     ) -> Action {
         let old_hover_icon = self.hover_icon;
 
-        let mut cx = EventCx {
-            state: self,
-            shell,
-            messages,
-            last_child: None,
-            scroll: Scroll::None,
-        };
-
-        while let Some((id, wid)) = cx.popup_removed.pop() {
-            cx.send_event(win.as_node(data), id, Event::PopupClosed(wid));
-        }
-
-        cx.flush_mouse_grab_motion(win.as_node(data));
-        for i in 0..cx.touch_grab.len() {
-            let action = cx.touch_grab[i].flush_click_move();
-            cx.state.action |= action;
-            if let Some((id, event)) = cx.touch_grab[i].flush_grab_move() {
-                cx.send_event(win.as_node(data), id, event);
-            }
-        }
-
-        for gi in 0..cx.pan_grab.len() {
-            let grab = &mut cx.pan_grab[gi];
-            debug_assert!(grab.mode != GrabMode::Grab);
-            assert!(grab.n > 0);
-
-            // Terminology: pi are old coordinates, qi are new coords
-            let (p1, q1) = (DVec2::conv(grab.coords[0].0), DVec2::conv(grab.coords[0].1));
-            grab.coords[0].0 = grab.coords[0].1;
-
-            let alpha;
-            let delta;
-
-            if grab.mode == GrabMode::PanOnly || grab.n == 1 {
-                alpha = DVec2(1.0, 0.0);
-                delta = q1 - p1;
-            } else {
-                // We don't use more than two touches: information would be
-                // redundant (although it could be averaged).
-                let (p2, q2) = (DVec2::conv(grab.coords[1].0), DVec2::conv(grab.coords[1].1));
-                grab.coords[1].0 = grab.coords[1].1;
-                let (pd, qd) = (p2 - p1, q2 - q1);
-
-                alpha = match grab.mode {
-                    GrabMode::PanFull => qd.complex_div(pd),
-                    GrabMode::PanScale => DVec2((qd.sum_square() / pd.sum_square()).sqrt(), 0.0),
-                    GrabMode::PanRotate => {
-                        let a = qd.complex_div(pd);
-                        a / a.sum_square().sqrt()
-                    }
-                    _ => unreachable!(),
-                };
-
-                // Average delta from both movements:
-                delta = (q1 - alpha.complex_mul(p1) + q2 - alpha.complex_mul(p2)) * 0.5;
+        self.with(shell, window, messages, |cx| {
+            while let Some((id, wid)) = cx.popup_removed.pop() {
+                cx.send_event(win.as_node(data), id, Event::PopupClosed(wid));
             }
 
-            let id = grab.id.clone();
-            if alpha != DVec2(1.0, 0.0) || delta != DVec2::ZERO {
-                let event = Event::Pan { alpha, delta };
-                cx.send_event(win.as_node(data), id, event);
-            }
-        }
-
-        // Warning: infinite loops are possible here if widgets always queue a
-        // new pending event when evaluating one of these:
-        while let Some(item) = cx.pending.pop_front() {
-            log::trace!(target: "kas_core::event", "update: handling Pending::{item:?}");
-            match item {
-                Pending::Configure(id) => {
-                    win.as_node(data)
-                        .find_node(&id, |node| cx.configure(node, id.clone()));
-
-                    let hover = win.find_id(data, cx.state.last_mouse_coord);
-                    cx.state.set_hover(hover);
-                }
-                Pending::Update(id) => {
-                    win.as_node(data).find_node(&id, |node| cx.update(node));
-                }
-                Pending::Send(id, event) => {
-                    if matches!(&event, &Event::MouseHover(false)) {
-                        cx.hover_icon = Default::default();
-                    }
+            cx.flush_mouse_grab_motion(win.as_node(data));
+            for i in 0..cx.touch_grab.len() {
+                let action = cx.touch_grab[i].flush_click_move();
+                cx.state.action |= action;
+                if let Some((id, event)) = cx.touch_grab[i].flush_grab_move() {
                     cx.send_event(win.as_node(data), id, event);
                 }
-                Pending::NextNavFocus {
-                    target,
-                    reverse,
-                    source,
-                } => {
-                    cx.next_nav_focus_impl(win.as_node(data), target, reverse, source);
+            }
+
+            for gi in 0..cx.pan_grab.len() {
+                let grab = &mut cx.pan_grab[gi];
+                debug_assert!(grab.mode != GrabMode::Grab);
+                assert!(grab.n > 0);
+
+                // Terminology: pi are old coordinates, qi are new coords
+                let (p1, q1) = (DVec2::conv(grab.coords[0].0), DVec2::conv(grab.coords[0].1));
+                grab.coords[0].0 = grab.coords[0].1;
+
+                let alpha;
+                let delta;
+
+                if grab.mode == GrabMode::PanOnly || grab.n == 1 {
+                    alpha = DVec2(1.0, 0.0);
+                    delta = q1 - p1;
+                } else {
+                    // We don't use more than two touches: information would be
+                    // redundant (although it could be averaged).
+                    let (p2, q2) = (DVec2::conv(grab.coords[1].0), DVec2::conv(grab.coords[1].1));
+                    grab.coords[1].0 = grab.coords[1].1;
+                    let (pd, qd) = (p2 - p1, q2 - q1);
+
+                    alpha = match grab.mode {
+                        GrabMode::PanFull => qd.complex_div(pd),
+                        GrabMode::PanScale => {
+                            DVec2((qd.sum_square() / pd.sum_square()).sqrt(), 0.0)
+                        }
+                        GrabMode::PanRotate => {
+                            let a = qd.complex_div(pd);
+                            a / a.sum_square().sqrt()
+                        }
+                        _ => unreachable!(),
+                    };
+
+                    // Average delta from both movements:
+                    delta = (q1 - alpha.complex_mul(p1) + q2 - alpha.complex_mul(p2)) * 0.5;
+                }
+
+                let id = grab.id.clone();
+                if alpha != DVec2(1.0, 0.0) || delta != DVec2::ZERO {
+                    let event = Event::Pan { alpha, delta };
+                    cx.send_event(win.as_node(data), id, event);
                 }
             }
-        }
 
-        // Poll futures last. This means that any newly pushed future should
-        // get polled from the same update() call.
-        cx.poll_futures(win.as_node(data));
+            // Warning: infinite loops are possible here if widgets always queue a
+            // new pending event when evaluating one of these:
+            while let Some(item) = cx.pending.pop_front() {
+                log::trace!(target: "kas_core::event", "update: handling Pending::{item:?}");
+                match item {
+                    Pending::Configure(id) => {
+                        win.as_node(data)
+                            .find_node(&id, |node| cx.configure(node, id.clone()));
 
-        drop(cx);
+                        let hover = win.find_id(data, cx.state.last_mouse_coord);
+                        cx.state.set_hover(hover);
+                    }
+                    Pending::Update(id) => {
+                        win.as_node(data).find_node(&id, |node| cx.update(node));
+                    }
+                    Pending::Send(id, event) => {
+                        if matches!(&event, &Event::MouseHover(false)) {
+                            cx.hover_icon = Default::default();
+                        }
+                        cx.send_event(win.as_node(data), id, event);
+                    }
+                    Pending::NextNavFocus {
+                        target,
+                        reverse,
+                        source,
+                    } => {
+                        cx.next_nav_focus_impl(win.as_node(data), target, reverse, source);
+                    }
+                }
+            }
+
+            // Poll futures last. This means that any newly pushed future should
+            // get polled from the same update() call.
+            cx.poll_futures(win.as_node(data));
+        });
 
         if self.hover_icon != old_hover_icon && self.mouse_grab.is_none() {
-            shell.set_cursor_icon(self.hover_icon);
+            window.set_cursor_icon(self.hover_icon);
         }
 
         std::mem::take(&mut self.action)

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -381,14 +381,17 @@ impl<'a> EventCx<'a> {
                 self.set_hover(cur_id.clone());
 
                 if let Some(grab) = self.state.mouse_grab.as_mut() {
-                    if !grab.mode.is_pan() {
-                        grab.cur_id = cur_id;
-                        grab.coord = coord;
-                        grab.delta += delta;
-                    } else if let Some(pan) =
-                        self.state.pan_grab.get_mut(usize::conv(grab.pan_grab.0))
-                    {
-                        pan.coords[usize::conv(grab.pan_grab.1)].1 = coord;
+                    match grab.details {
+                        GrabDetails::Click | GrabDetails::Grab => {
+                            grab.cur_id = cur_id;
+                            grab.coord = coord;
+                            grab.delta += delta;
+                        }
+                        GrabDetails::Pan(g) => {
+                            if let Some(pan) = self.state.pan_grab.get_mut(usize::conv(g.0)) {
+                                pan.coords[usize::conv(g.1)].1 = coord;
+                            }
+                        }
                     }
                 } else if let Some(id) = self.popups.last().map(|(_, p, _)| p.id.clone()) {
                     let press = Press {

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -11,7 +11,6 @@ use std::time::{Duration, Instant};
 
 use super::*;
 use crate::cast::traits::*;
-use crate::draw::DrawShared;
 use crate::geom::{Coord, DVec2};
 use crate::shell::ShellWindow;
 use crate::theme::ThemeSize;
@@ -28,9 +27,10 @@ const FAKE_MOUSE_BUTTON: MouseButton = MouseButton::Other(0);
 impl EventState {
     /// Construct per-window event state
     #[inline]
-    pub(crate) fn new(config: WindowConfig) -> Self {
+    pub(crate) fn new(config: WindowConfig, platform: Platform) -> Self {
         EventState {
             config,
+            platform,
             disabled: vec![],
             window_has_focus: false,
             modifiers: ModifiersState::empty(),
@@ -75,7 +75,6 @@ impl EventState {
     pub(crate) fn full_configure<A>(
         &mut self,
         sizer: &dyn ThemeSize,
-        draw_shared: &mut dyn DrawShared,
         wid: WindowId,
         win: &mut Window<A>,
         data: &A,
@@ -91,7 +90,7 @@ impl EventState {
 
         self.new_access_layer(id.clone(), false);
 
-        ConfigCx::new(sizer, draw_shared, self).configure(win.as_node(data), id);
+        ConfigCx::new(sizer, self).configure(win.as_node(data), id);
 
         let hover = win.find_id(data, self.last_mouse_coord);
         self.set_hover(hover);

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -123,23 +123,6 @@ impl TouchGrab {
         }
         Action::empty()
     }
-
-    fn flush_grab_move(&mut self) -> Option<(WidgetId, Event)> {
-        if self.mode == GrabMode::Grab && self.last_move != self.coord {
-            let delta = self.coord - self.last_move;
-            let target = self.start_id.clone();
-            let press = Press {
-                source: PressSource::Touch(self.id),
-                id: self.cur_id.clone(),
-                coord: self.coord,
-            };
-            let event = Event::PressMove { press, delta };
-            self.last_move = self.coord;
-            Some((target, event))
-        } else {
-            None
-        }
-    }
 }
 
 const MAX_PAN_GRABS: usize = 2;

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -21,7 +21,7 @@ use super::config::WindowConfig;
 use super::*;
 use crate::cast::Cast;
 use crate::geom::{Coord, Offset};
-use crate::shell::ShellWindow;
+use crate::shell::{Platform, ShellWindow};
 use crate::util::WidgetHierarchy;
 use crate::LayoutExt;
 use crate::{Action, Erased, ErasedStack, NavAdvance, Node, Widget, WidgetId, WindowId};
@@ -201,6 +201,7 @@ type AccessLayer = (bool, HashMap<Key, WidgetId>);
 // `SmallVec` is used to keep contents in local memory.
 pub struct EventState {
     config: WindowConfig,
+    platform: Platform,
     disabled: Vec<WidgetId>,
     window_has_focus: bool,
     modifiers: ModifiersState,

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -172,7 +172,6 @@ enum Pending {
     Configure(WidgetId),
     Update(WidgetId),
     Send(WidgetId, Event),
-    SetRect(WidgetId),
     NextNavFocus {
         target: Option<WidgetId>,
         reverse: bool,

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -35,20 +35,20 @@ pub use config::ConfigCx;
 pub use press::{GrabBuilder, Press, PressSource};
 
 /// Controls the types of events delivered by [`Press::grab`]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum GrabMode {
     /// Deliver [`Event::PressEnd`] only for each grabbed press
     Click,
     /// Deliver [`Event::PressMove`] and [`Event::PressEnd`] for each grabbed press
     Grab,
-    /// Deliver [`Event::Pan`] events, with scaling and rotation
-    PanFull,
-    /// Deliver [`Event::Pan`] events, with scaling
-    PanScale,
-    /// Deliver [`Event::Pan`] events, with rotation
-    PanRotate,
     /// Deliver [`Event::Pan`] events, without scaling or rotation
     PanOnly,
+    /// Deliver [`Event::Pan`] events, with rotation
+    PanRotate,
+    /// Deliver [`Event::Pan`] events, with scaling
+    PanScale,
+    /// Deliver [`Event::Pan`] events, with scaling and rotation
+    PanFull,
 }
 
 impl GrabMode {
@@ -63,6 +63,12 @@ enum GrabDetails {
     Click { cur_id: Option<WidgetId> },
     Grab,
     Pan((u16, u16)),
+}
+
+impl GrabDetails {
+    fn is_pan(&self) -> bool {
+        matches!(self, GrabDetails::Pan(_))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -227,6 +233,8 @@ impl EventState {
                     self.remove_pan(gi);
                     break;
                 }
+
+                debug_assert_eq!(grab.mode, mode);
 
                 let index = grab.n;
                 if usize::from(index) < MAX_PAN_GRABS {

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -21,7 +21,7 @@ use super::config::WindowConfig;
 use super::*;
 use crate::cast::Cast;
 use crate::geom::{Coord, Offset};
-use crate::shell::{Platform, ShellWindow};
+use crate::shell::{Platform, ShellSharedErased, WindowDataErased};
 use crate::util::WidgetHierarchy;
 use crate::LayoutExt;
 use crate::{Action, Erased, ErasedStack, NavAdvance, Node, Widget, WidgetId, WindowId};
@@ -418,7 +418,8 @@ impl EventState {
 #[must_use]
 pub struct EventCx<'a> {
     state: &'a mut EventState,
-    shell: &'a mut dyn ShellWindow,
+    shell: &'a mut dyn ShellSharedErased,
+    window: &'a dyn WindowDataErased,
     messages: &'a mut ErasedStack,
     last_child: Option<usize>,
     scroll: Scroll,
@@ -543,7 +544,7 @@ impl<'a> EventCx<'a> {
     fn remove_mouse_grab(&mut self, success: bool) -> Option<(WidgetId, Event)> {
         if let Some(grab) = self.mouse_grab.take() {
             log::trace!("remove_mouse_grab: start_id={}", grab.start_id);
-            self.shell.set_cursor_icon(self.hover_icon);
+            self.window.set_cursor_icon(self.hover_icon);
             self.send_action(Action::REDRAW); // redraw(..)
             if grab.mode.is_pan() {
                 self.remove_pan_grab(grab.pan_grab);

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -9,7 +9,7 @@
 use super::{EventCx, GrabMode, IsUsed, MouseGrab, Pending, TouchGrab};
 use crate::event::cx::GrabDetails;
 use crate::event::{CursorIcon, MouseButton, Used};
-use crate::geom::{Coord, Offset};
+use crate::geom::Coord;
 use crate::{Action, WidgetId};
 
 /// Source of `EventChild::Press`
@@ -169,7 +169,9 @@ impl GrabBuilder {
                     cx.pending.push_back(Pending::Send(id, event));
                 }
                 let details = match mode {
-                    GrabMode::Click => GrabDetails::Click,
+                    GrabMode::Click => GrabDetails::Click {
+                        cur_id: Some(id.clone()),
+                    },
                     GrabMode::Grab => GrabDetails::Grab,
                     mode => {
                         assert!(mode.is_pan());
@@ -181,11 +183,8 @@ impl GrabBuilder {
                     button,
                     repetitions,
                     start_id: id.clone(),
-                    cur_id: Some(id.clone()),
                     depress: Some(id),
                     details,
-                    coord,
-                    delta: Offset::ZERO,
                 });
                 if let Some(icon) = cursor {
                     cx.window.set_cursor_icon(icon);

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -182,7 +182,7 @@ impl GrabBuilder {
                     delta: Offset::ZERO,
                 });
                 if let Some(icon) = cursor {
-                    cx.shell.set_cursor_icon(icon);
+                    cx.window.set_cursor_icon(icon);
                 }
             }
             PressSource::Touch(touch_id) => {

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -6,9 +6,9 @@
 //! Event handling: events
 
 #[allow(unused)] use super::{Event, EventState}; // for doc-links
-use super::{EventCx, GrabMode, IsUsed, MouseGrab, Pending, TouchGrab};
+use super::{EventCx, GrabMode, IsUsed, MouseGrab, TouchGrab};
 use crate::event::cx::GrabDetails;
-use crate::event::{CursorIcon, MouseButton, Used};
+use crate::event::{CursorIcon, MouseButton, Unused, Used};
 use crate::geom::Coord;
 use crate::{Action, WidgetId};
 
@@ -153,6 +153,21 @@ impl GrabBuilder {
     }
 
     /// Complete the grab, providing the [`EventCx`]
+    ///
+    /// In case of an existing grab for the same [`source`](Press::source),
+    /// - If the [`WidgetId`] differs this fails (returns [`Unused`])
+    /// - If the [`MouseButton`] differs this fails (technically this is a
+    ///   different `source`, but simultaneous grabs of multiple mouse buttons
+    ///   are not supported).
+    /// - If one grab is a [pan](GrabMode::is_pan) and the other is not, this fails
+    /// - [`GrabMode::Click`] may be upgraded to [`GrabMode::Grab`]
+    /// - Changing from one pan mode to another is an error
+    /// - Mouse button repetitions may be increased; decreasing is an error
+    /// - A [`CursorIcon`] may be set
+    /// - The depress target is re-set to the grabbing widget
+    ///
+    /// Note: error conditions are only checked in debug builds. These cases
+    /// may need revision.
     pub fn with_cx(self, cx: &mut EventCx) -> IsUsed {
         let GrabBuilder {
             id,
@@ -162,12 +177,8 @@ impl GrabBuilder {
             cursor,
         } = self;
         log::trace!(target: "kas_core::event", "grab_press: start_id={id}, source={source:?}");
-        let mut pan_grab = (u16::MAX, 0);
         match source {
             PressSource::Mouse(button, repetitions) => {
-                if let Some((id, event)) = cx.remove_mouse_grab(false) {
-                    cx.pending.push_back(Pending::Send(id, event));
-                }
                 let details = match mode {
                     GrabMode::Click => GrabDetails::Click {
                         cur_id: Some(id.clone()),
@@ -179,35 +190,58 @@ impl GrabBuilder {
                         GrabDetails::Pan(g)
                     }
                 };
-                cx.mouse_grab = Some(MouseGrab {
-                    button,
-                    repetitions,
-                    start_id: id.clone(),
-                    depress: Some(id),
-                    details,
-                });
+                if let Some(ref mut grab) = cx.mouse_grab {
+                    if grab.start_id != id
+                        || grab.button != button
+                        || grab.details.is_pan() != mode.is_pan()
+                    {
+                        return Unused;
+                    }
+
+                    debug_assert!(repetitions >= grab.repetitions);
+                    grab.repetitions = repetitions;
+                    grab.depress = Some(id);
+                    grab.details = details;
+                } else {
+                    cx.mouse_grab = Some(MouseGrab {
+                        button,
+                        repetitions,
+                        start_id: id.clone(),
+                        depress: Some(id),
+                        details,
+                    });
+                }
                 if let Some(icon) = cursor {
                     cx.window.set_cursor_icon(icon);
                 }
             }
             PressSource::Touch(touch_id) => {
-                if cx.remove_touch(touch_id).is_some() {
-                    #[cfg(debug_assertions)]
-                    log::error!(target: "kas_core::event", "grab_press: touch_id conflict!");
+                if let Some(grab) = cx.get_touch(touch_id) {
+                    if grab.mode.is_pan() != mode.is_pan() {
+                        return Unused;
+                    }
+
+                    grab.depress = Some(id.clone());
+                    grab.cur_id = Some(id);
+                    grab.last_move = coord;
+                    grab.coord = coord;
+                    grab.mode = grab.mode.max(mode);
+                } else {
+                    let mut pan_grab = (u16::MAX, 0);
+                    if mode.is_pan() {
+                        pan_grab = cx.set_pan_on(id.clone(), mode, true, coord);
+                    }
+                    cx.touch_grab.push(TouchGrab {
+                        id: touch_id,
+                        start_id: id.clone(),
+                        depress: Some(id.clone()),
+                        cur_id: Some(id),
+                        last_move: coord,
+                        coord,
+                        mode,
+                        pan_grab,
+                    });
                 }
-                if mode.is_pan() {
-                    pan_grab = cx.set_pan_on(id.clone(), mode, true, coord);
-                }
-                cx.touch_grab.push(TouchGrab {
-                    id: touch_id,
-                    start_id: id.clone(),
-                    depress: Some(id.clone()),
-                    cur_id: Some(id),
-                    last_move: coord,
-                    coord,
-                    mode,
-                    pan_grab,
-                });
             }
         }
 

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -252,7 +252,7 @@ impl_scope! {
 
         fn handle_scroll(&mut self, cx: &mut EventCx, data: &Data, _: Scroll) {
             // Something was scrolled; update pop-up translations
-            cx.config_cx(|cx| self.resize_popups(cx, data));
+            self.resize_popups(&mut cx.config_cx(), data);
         }
     }
 }
@@ -403,7 +403,7 @@ impl<Data: 'static> Window<Data> {
     ) {
         let index = self.popups.len();
         self.popups.push((id, popup, Offset::ZERO));
-        cx.config_cx(|cx| self.resize_popup(cx, data, index));
+        self.resize_popup(&mut cx.config_cx(), data, index);
         cx.send_action(Action::REDRAW);
     }
 

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -255,6 +255,15 @@ impl_scope! {
             self.resize_popups(&mut cx.config_cx(), data);
         }
     }
+
+    impl std::fmt::Debug for Self {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Window")
+                .field("core", &self.core)
+                .field("title", &self.title_bar.title())
+                .finish()
+        }
+    }
 }
 
 impl<Data: 'static> Window<Data> {

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -293,14 +293,7 @@ pub(crate) trait ShellWindow {
     fn adjust_theme<'s>(&'s mut self, f: Box<dyn FnOnce(&mut dyn ThemeControl) -> Action + 's>);
 
     /// Access [`ThemeSize`] and [`DrawShared`] objects
-    ///
-    /// Implementations should call the given function argument once; not doing
-    /// so is memory-safe but will cause panics in `EventCx` methods.
-    /// User-code *must not* depend on `f` being called for memory safety.
-    fn size_and_draw_shared<'s>(
-        &'s mut self,
-        f: Box<dyn FnOnce(&dyn ThemeSize, &mut dyn DrawShared) + 's>,
-    );
+    fn size_and_draw_shared<'s>(&'s mut self) -> (&'s dyn ThemeSize, &'s mut dyn DrawShared);
 
     /// Set the mouse cursor
     fn set_cursor_icon(&mut self, icon: CursorIcon);

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -292,14 +292,14 @@ pub(crate) trait ShellWindow {
     // TODO(opt): pass f by value, not boxed
     fn adjust_theme<'s>(&'s mut self, f: Box<dyn FnOnce(&mut dyn ThemeControl) -> Action + 's>);
 
-    /// Access [`ThemeSize`] and [`DrawShared`] objects
-    fn size_and_draw_shared<'s>(&'s mut self) -> (&'s dyn ThemeSize, &'s mut dyn DrawShared);
+    /// Access the [`ThemeSize`] object
+    fn theme_size(&self) -> &dyn ThemeSize;
+
+    /// Access the [`DrawShared`] object
+    fn draw_shared(&mut self) -> &mut dyn DrawShared;
 
     /// Set the mouse cursor
     fn set_cursor_icon(&mut self, icon: CursorIcon);
-
-    /// Get the platform
-    fn platform(&self) -> Platform;
 
     /// Directly access Winit Window
     ///

--- a/crates/kas-core/src/shell/event_loop.rs
+++ b/crates/kas-core/src/shell/event_loop.rs
@@ -12,7 +12,7 @@ use winit::event::{Event, StartCause};
 use winit::event_loop::{ControlFlow, EventLoopWindowTarget};
 use winit::window as ww;
 
-use super::{PendingAction, SharedState};
+use super::{Pending, SharedState};
 use super::{ProxyAction, Window, WindowSurface};
 use kas::theme::Theme;
 use kas::{Action, AppData, WindowId};
@@ -206,7 +206,7 @@ where
     ) {
         while let Some(pending) = self.shared.shell.pending.pop_front() {
             match pending {
-                PendingAction::AddPopup(parent_id, id, popup) => {
+                Pending::AddPopup(parent_id, id, popup) => {
                     log::debug!("Pending: adding overlay");
                     // TODO: support pop-ups as a special window, where available
                     self.windows.get_mut(&parent_id).unwrap().add_popup(
@@ -216,7 +216,7 @@ where
                     );
                     self.popups.insert(id, parent_id);
                 }
-                PendingAction::AddWindow(id, widget) => {
+                Pending::AddWindow(id, widget) => {
                     log::debug!("Pending: adding window {}", widget.title());
                     let mut window = Window::new(&self.shared, id, widget);
                     if !self.suspended {
@@ -231,7 +231,7 @@ where
                     }
                     self.windows.insert(id, window);
                 }
-                PendingAction::CloseWindow(target) => {
+                Pending::CloseWindow(target) => {
                     let mut win_id = target;
                     if let Some(id) = self.popups.remove(&target) {
                         win_id = id;
@@ -240,7 +240,7 @@ where
                         window.send_close(&mut self.shared, target);
                     }
                 }
-                PendingAction::Action(action) => {
+                Pending::Action(action) => {
                     if action.contains(Action::CLOSE | Action::EXIT) {
                         self.windows.clear();
                         self.id_map.clear();

--- a/crates/kas-core/src/shell/event_loop.rs
+++ b/crates/kas-core/src/shell/event_loop.rs
@@ -204,7 +204,7 @@ where
         elwt: &EventLoopWindowTarget<ProxyAction>,
         control_flow: &mut ControlFlow,
     ) {
-        while let Some(pending) = self.shared.shell.pending.pop() {
+        while let Some(pending) = self.shared.shell.pending.pop_front() {
             match pending {
                 PendingAction::AddPopup(parent_id, id, popup) => {
                     log::debug!("Pending: adding overlay");

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -49,3 +49,221 @@ enum ProxyAction {
     Message(kas::erased::SendErased),
     WakeAsync,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct Draw;
+    impl crate::draw::DrawImpl for Draw {
+        fn common_mut(&mut self) -> &mut crate::draw::WindowCommon {
+            todo!()
+        }
+
+        fn new_pass(
+            &mut self,
+            _: crate::draw::PassId,
+            _: crate::prelude::Rect,
+            _: crate::prelude::Offset,
+            _: crate::draw::PassType,
+        ) -> crate::draw::PassId {
+            todo!()
+        }
+
+        fn get_clip_rect(&self, _: crate::draw::PassId) -> crate::prelude::Rect {
+            todo!()
+        }
+
+        fn rect(
+            &mut self,
+            _: crate::draw::PassId,
+            _: crate::geom::Quad,
+            _: crate::draw::color::Rgba,
+        ) {
+            todo!()
+        }
+
+        fn frame(
+            &mut self,
+            _: crate::draw::PassId,
+            _: crate::geom::Quad,
+            _: crate::geom::Quad,
+            _: crate::draw::color::Rgba,
+        ) {
+            todo!()
+        }
+    }
+    impl crate::draw::DrawRoundedImpl for Draw {
+        fn rounded_line(
+            &mut self,
+            _: crate::draw::PassId,
+            _: crate::geom::Vec2,
+            _: crate::geom::Vec2,
+            _: f32,
+            _: crate::draw::color::Rgba,
+        ) {
+            todo!()
+        }
+
+        fn circle(
+            &mut self,
+            _: crate::draw::PassId,
+            _: crate::geom::Quad,
+            _: f32,
+            _: crate::draw::color::Rgba,
+        ) {
+            todo!()
+        }
+
+        fn circle_2col(
+            &mut self,
+            _: crate::draw::PassId,
+            _: crate::geom::Quad,
+            _: crate::draw::color::Rgba,
+            _: crate::draw::color::Rgba,
+        ) {
+            todo!()
+        }
+
+        fn rounded_frame(
+            &mut self,
+            _: crate::draw::PassId,
+            _: crate::geom::Quad,
+            _: crate::geom::Quad,
+            _: f32,
+            _: crate::draw::color::Rgba,
+        ) {
+            todo!()
+        }
+
+        fn rounded_frame_2col(
+            &mut self,
+            _: crate::draw::PassId,
+            _: crate::geom::Quad,
+            _: crate::geom::Quad,
+            _: crate::draw::color::Rgba,
+            _: crate::draw::color::Rgba,
+        ) {
+            todo!()
+        }
+    }
+
+    struct DrawShared;
+    impl crate::draw::DrawSharedImpl for DrawShared {
+        type Draw = Draw;
+
+        fn set_raster_config(&mut self, _: &crate::theme::RasterConfig) {
+            todo!()
+        }
+
+        fn image_alloc(
+            &mut self,
+            _: (u32, u32),
+        ) -> std::result::Result<crate::draw::ImageId, crate::draw::AllocError> {
+            todo!()
+        }
+
+        fn image_upload(&mut self, _: crate::draw::ImageId, _: &[u8], _: crate::draw::ImageFormat) {
+            todo!()
+        }
+
+        fn image_free(&mut self, _: crate::draw::ImageId) {
+            todo!()
+        }
+
+        fn image_size(&self, _: crate::draw::ImageId) -> Option<(u32, u32)> {
+            todo!()
+        }
+
+        fn draw_image(
+            &self,
+            _: &mut Self::Draw,
+            _: crate::draw::PassId,
+            _: crate::draw::ImageId,
+            _: crate::geom::Quad,
+        ) {
+            todo!()
+        }
+
+        fn draw_text(
+            &mut self,
+            _: &mut Self::Draw,
+            _: crate::draw::PassId,
+            _: crate::prelude::Rect,
+            _: &kas_text::TextDisplay,
+            _: crate::draw::color::Rgba,
+        ) {
+            todo!()
+        }
+
+        fn draw_text_effects(
+            &mut self,
+            _: &mut Self::Draw,
+            _: crate::draw::PassId,
+            _: crate::prelude::Rect,
+            _: &kas_text::TextDisplay,
+            _: crate::draw::color::Rgba,
+            _: &[kas_text::Effect<()>],
+        ) {
+            todo!()
+        }
+
+        fn draw_text_effects_rgba(
+            &mut self,
+            _: &mut Self::Draw,
+            _: crate::draw::PassId,
+            _: crate::prelude::Rect,
+            _: &kas_text::TextDisplay,
+            _: &[kas_text::Effect<crate::draw::color::Rgba>],
+        ) {
+            todo!()
+        }
+    }
+
+    struct Surface;
+    impl WindowSurface for Surface {
+        type Shared = DrawShared;
+
+        fn new<W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRawDisplayHandle>(
+            _: &mut Self::Shared,
+            _: crate::prelude::Size,
+            _: W,
+        ) -> Result<Self>
+        where
+            Self: Sized,
+        {
+            todo!()
+        }
+
+        fn size(&self) -> crate::prelude::Size {
+            todo!()
+        }
+
+        fn do_resize(&mut self, _: &mut Self::Shared, _: crate::prelude::Size) -> bool {
+            todo!()
+        }
+
+        fn draw_iface<'iface>(
+            &'iface mut self,
+            _: &'iface mut crate::draw::SharedState<Self::Shared>,
+        ) -> crate::draw::DrawIface<'iface, Self::Shared> {
+            todo!()
+        }
+
+        fn common_mut(&mut self) -> &mut crate::draw::WindowCommon {
+            todo!()
+        }
+
+        fn present(&mut self, _: &mut Self::Shared, _: crate::draw::color::Rgba) {
+            todo!()
+        }
+    }
+
+    #[test]
+    fn size_of_pending() {
+        assert_eq!(
+            std::mem::size_of::<Pending<(), Surface, crate::theme::SimpleTheme>>(),
+            32
+        );
+    }
+}

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -13,11 +13,12 @@ mod common;
 
 #[cfg(winit)] use crate::WindowId;
 #[cfg(winit)] use event_loop::Loop as EventLoop;
-#[cfg(winit)] use shared::{SharedState, ShellSharedErased};
+#[cfg(winit)]
+pub(crate) use shared::{SharedState, ShellSharedErased};
 #[cfg(winit)] use shell::PlatformWrapper;
-#[cfg(winit)] use window::Window;
+#[cfg(winit)]
+pub(crate) use window::{Window, WindowDataErased};
 
-pub(crate) use common::ShellWindow;
 pub use common::{Error, Platform, Result};
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 pub use common::{GraphicalShell, WindowSurface};

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -30,7 +30,7 @@ pub extern crate raw_window_handle;
 // around (also applies when constructing a shell::Window).
 #[allow(clippy::large_enum_variant)]
 #[cfg(winit)]
-enum PendingAction<A: crate::AppData> {
+enum Pending<A: crate::AppData> {
     AddPopup(WindowId, WindowId, kas::PopupDescriptor),
     AddWindow(WindowId, kas::Window<A>),
     CloseWindow(WindowId),
@@ -38,18 +38,18 @@ enum PendingAction<A: crate::AppData> {
 }
 
 #[cfg(winit)]
-impl<A: crate::AppData> std::fmt::Debug for PendingAction<A> {
+impl<A: crate::AppData> std::fmt::Debug for Pending<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PendingAction::AddPopup(parent_id, id, popup) => f
+            Pending::AddPopup(parent_id, id, popup) => f
                 .debug_tuple("AddPopup")
                 .field(&parent_id)
                 .field(&id)
                 .field(&popup)
                 .finish(),
-            PendingAction::AddWindow(id, _) => f.debug_tuple("AddWindow").field(&id).finish(),
-            PendingAction::CloseWindow(id) => f.debug_tuple("CloseWindow").field(&id).finish(),
-            PendingAction::Action(action) => f.debug_tuple("Action").field(&action).finish(),
+            Pending::AddWindow(id, _) => f.debug_tuple("AddWindow").field(&id).finish(),
+            Pending::CloseWindow(id) => f.debug_tuple("CloseWindow").field(&id).finish(),
+            Pending::Action(action) => f.debug_tuple("Action").field(&action).finish(),
         }
     }
 }

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -13,7 +13,7 @@ mod common;
 
 #[cfg(winit)] use crate::WindowId;
 #[cfg(winit)] use event_loop::Loop as EventLoop;
-#[cfg(winit)] use shared::{SharedState, ShellShared};
+#[cfg(winit)] use shared::{SharedState, ShellSharedErased};
 #[cfg(winit)] use shell::PlatformWrapper;
 #[cfg(winit)] use window::Window;
 

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -32,9 +32,11 @@ pub extern crate raw_window_handle;
 #[allow(clippy::large_enum_variant)]
 #[crate::autoimpl(Debug)]
 #[cfg(winit)]
-enum Pending<A: crate::AppData> {
+enum Pending<A: kas::AppData, S: WindowSurface, T: kas::theme::Theme<S::Shared>> {
     AddPopup(WindowId, WindowId, kas::PopupDescriptor),
-    AddWindow(WindowId, kas::Window<A>),
+    // NOTE: we don't need S, T here if we construct the Window later.
+    // But this way we can pass a single boxed value.
+    AddWindow(WindowId, Box<Window<A, S, T>>),
     CloseWindow(WindowId),
     Action(kas::Action),
 }

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -29,29 +29,13 @@ pub extern crate raw_window_handle;
 // TODO(opt): Clippy is probably right that we shouldn't copy a large value
 // around (also applies when constructing a shell::Window).
 #[allow(clippy::large_enum_variant)]
+#[crate::autoimpl(Debug)]
 #[cfg(winit)]
 enum Pending<A: crate::AppData> {
     AddPopup(WindowId, WindowId, kas::PopupDescriptor),
     AddWindow(WindowId, kas::Window<A>),
     CloseWindow(WindowId),
     Action(kas::Action),
-}
-
-#[cfg(winit)]
-impl<A: crate::AppData> std::fmt::Debug for Pending<A> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Pending::AddPopup(parent_id, id, popup) => f
-                .debug_tuple("AddPopup")
-                .field(&parent_id)
-                .field(&id)
-                .field(&popup)
-                .finish(),
-            Pending::AddWindow(id, _) => f.debug_tuple("AddWindow").field(&id).finish(),
-            Pending::CloseWindow(id) => f.debug_tuple("CloseWindow").field(&id).finish(),
-            Pending::Action(action) => f.debug_tuple("Action").field(&action).finish(),
-        }
-    }
 }
 
 #[cfg(winit)]

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -5,7 +5,7 @@
 
 //! Shared state
 
-use super::{PendingAction, Platform, WindowSurface};
+use super::{Pending, Platform, WindowSurface};
 use kas::config::Options;
 use kas::shell::Error;
 use kas::theme::Theme;
@@ -26,7 +26,7 @@ pub(super) struct ShellShared<Data: AppData, S: kas::draw::DrawSharedImpl, T> {
     clipboard: Option<Clipboard>,
     pub(super) draw: draw::SharedState<S>,
     pub(super) theme: T,
-    pub(super) pending: VecDeque<PendingAction<Data>>,
+    pub(super) pending: VecDeque<Pending<Data>>,
     pub(super) waker: Waker,
     window_id: u32,
 }
@@ -89,7 +89,7 @@ where
     pub(crate) fn handle_messages(&mut self, messages: &mut ErasedStack) {
         if messages.reset_and_has_any() {
             let action = self.data.handle_messages(messages);
-            self.shell.pending.push_back(PendingAction::Action(action));
+            self.shell.pending.push_back(Pending::Action(action));
         }
     }
 

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -22,7 +22,7 @@ use std::task::Waker;
 #[cfg(feature = "clipboard")] use arboard::Clipboard;
 
 /// Shell interface state
-pub(super) struct ShellShared<Data: AppData, S: kas::draw::DrawSharedImpl, T: Theme<S>> {
+pub struct ShellShared<Data: AppData, S: kas::draw::DrawSharedImpl, T: Theme<S>> {
     pub(super) platform: Platform,
     #[cfg(feature = "clipboard")]
     clipboard: Option<Clipboard>,
@@ -118,7 +118,7 @@ impl<Data: AppData, S: kas::draw::DrawSharedImpl, T: Theme<S>> ShellShared<Data,
     }
 }
 
-pub(super) trait ShellSharedErased {
+pub trait ShellSharedErased {
     /// Add a pop-up
     ///
     /// A pop-up may be presented as an overlay layer in the current window or
@@ -154,21 +154,37 @@ pub(super) trait ShellSharedErased {
     ///
     /// In case of failure, paste actions will simply fail. The implementation
     /// may wish to log an appropriate warning message.
+    ///
+    /// NOTE: on Wayland, use `WindowDataErased::wayland_clipboard` instead.
+    /// This split API probably can't be resolved until Winit integrates
+    /// clipboard support.
     fn get_clipboard(&mut self) -> Option<String>;
 
     /// Attempt to set clipboard contents
+    ///
+    /// NOTE: on Wayland, use `WindowDataErased::wayland_clipboard` instead.
+    /// This split API probably can't be resolved until Winit integrates
+    /// clipboard support.
     fn set_clipboard(&mut self, content: String);
 
     /// Get contents of primary buffer
     ///
     /// Linux has a "primary buffer" with implicit copy on text selection and
     /// paste on middle-click. This method does nothing on other platforms.
+    ///
+    /// NOTE: on Wayland, use `WindowDataErased::wayland_clipboard` instead.
+    /// This split API probably can't be resolved until Winit integrates
+    /// clipboard support.
     fn get_primary(&mut self) -> Option<String>;
 
     /// Set contents of primary buffer
     ///
     /// Linux has a "primary buffer" with implicit copy on text selection and
     /// paste on middle-click. This method does nothing on other platforms.
+    ///
+    /// NOTE: on Wayland, use `WindowDataErased::wayland_clipboard` instead.
+    /// This split API probably can't be resolved until Winit integrates
+    /// clipboard support.
     fn set_primary(&mut self, content: String);
 
     /// Adjust the theme

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -22,7 +22,7 @@ use std::task::Waker;
 #[cfg(feature = "clipboard")] use arboard::Clipboard;
 
 /// Shell interface state
-pub struct ShellShared<Data: AppData, S: WindowSurface, T: Theme<S::Shared>> {
+pub(crate) struct ShellShared<Data: AppData, S: WindowSurface, T: Theme<S::Shared>> {
     pub(super) platform: Platform,
     pub(super) config: Rc<RefCell<kas::event::Config>>,
     #[cfg(feature = "clipboard")]
@@ -35,7 +35,7 @@ pub struct ShellShared<Data: AppData, S: WindowSurface, T: Theme<S::Shared>> {
 }
 
 /// State shared between windows
-pub struct SharedState<Data: AppData, S: WindowSurface, T: Theme<S::Shared>> {
+pub(crate) struct SharedState<Data: AppData, S: WindowSurface, T: Theme<S::Shared>> {
     pub(super) shell: ShellShared<Data, S, T>,
     pub(super) data: Data,
     /// Estimated scale factor (from last window constructed or available screens)
@@ -95,7 +95,7 @@ where
         }
     }
 
-    pub fn on_exit(&self) {
+    pub(crate) fn on_exit(&self) {
         match self
             .options
             .write_config(&self.shell.config.borrow(), &self.shell.theme)
@@ -111,14 +111,14 @@ impl<Data: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellShared<Data, S, 
     ///
     /// TODO(opt): this should recycle used identifiers since WidgetId does not
     /// efficiently represent large numbers.
-    pub fn next_window_id(&mut self) -> WindowId {
+    pub(crate) fn next_window_id(&mut self) -> WindowId {
         let id = self.window_id + 1;
         self.window_id = id;
         WindowId::new(NonZeroU32::new(id).unwrap())
     }
 }
 
-pub trait ShellSharedErased {
+pub(crate) trait ShellSharedErased {
     /// Add a pop-up
     ///
     /// A pop-up may be presented as an overlay layer in the current window or

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -55,7 +55,7 @@ where
         config: Rc<RefCell<kas::event::Config>>,
     ) -> Result<Self, Error> {
         let platform = pw.platform();
-        let mut draw = kas::draw::SharedState::new(draw_shared, platform);
+        let mut draw = kas::draw::SharedState::new(draw_shared);
         theme.init(&mut draw);
 
         #[cfg(feature = "clipboard")]

--- a/crates/kas-core/src/shell/shared.rs
+++ b/crates/kas-core/src/shell/shared.rs
@@ -7,10 +7,12 @@
 
 use super::{Pending, Platform, WindowSurface};
 use kas::config::Options;
+use kas::draw::DrawShared;
 use kas::shell::Error;
-use kas::theme::Theme;
+use kas::theme::{Theme, ThemeControl};
 use kas::util::warn_about_error;
-use kas::{draw, AppData, ErasedStack, WindowId};
+use kas::{draw, Action, AppData, ErasedStack, WindowId};
+use std::any::TypeId;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::num::NonZeroU32;
@@ -20,7 +22,7 @@ use std::task::Waker;
 #[cfg(feature = "clipboard")] use arboard::Clipboard;
 
 /// Shell interface state
-pub(super) struct ShellShared<Data: AppData, S: kas::draw::DrawSharedImpl, T> {
+pub(super) struct ShellShared<Data: AppData, S: kas::draw::DrawSharedImpl, T: Theme<S>> {
     pub(super) platform: Platform,
     #[cfg(feature = "clipboard")]
     clipboard: Option<Clipboard>,
@@ -32,7 +34,7 @@ pub(super) struct ShellShared<Data: AppData, S: kas::draw::DrawSharedImpl, T> {
 }
 
 /// State shared between windows
-pub struct SharedState<Data: AppData, S: WindowSurface, T> {
+pub struct SharedState<Data: AppData, S: WindowSurface, T: Theme<S::Shared>> {
     pub(super) shell: ShellShared<Data, S::Shared, T>,
     pub(super) data: Data,
     pub(super) config: Rc<RefCell<kas::event::Config>>,
@@ -104,7 +106,7 @@ where
     }
 }
 
-impl<Data: AppData, S: kas::draw::DrawSharedImpl, T> ShellShared<Data, S, T> {
+impl<Data: AppData, S: kas::draw::DrawSharedImpl, T: Theme<S>> ShellShared<Data, S, T> {
     /// Return the next window identifier
     ///
     /// TODO(opt): this should recycle used identifiers since WidgetId does not
@@ -114,9 +116,110 @@ impl<Data: AppData, S: kas::draw::DrawSharedImpl, T> ShellShared<Data, S, T> {
         self.window_id = id;
         WindowId::new(NonZeroU32::new(id).unwrap())
     }
+}
 
-    #[inline]
-    pub fn get_clipboard(&mut self) -> Option<String> {
+pub(super) trait ShellSharedErased {
+    /// Add a pop-up
+    ///
+    /// A pop-up may be presented as an overlay layer in the current window or
+    /// via a new borderless window.
+    ///
+    /// Pop-ups support position hints: they are placed *next to* the specified
+    /// `rect`, preferably in the given `direction`.
+    ///
+    /// Returns `None` if window creation is not currently available (but note
+    /// that `Some` result does not guarantee the operation succeeded).
+    fn add_popup(&mut self, parent_id: WindowId, popup: crate::PopupDescriptor) -> WindowId;
+
+    /// Add a window
+    ///
+    /// Toolkits typically allow windows to be added directly, before start of
+    /// the event loop (e.g. `kas_wgpu::Toolkit::add`).
+    ///
+    /// This method is an alternative allowing a window to be added from an
+    /// event handler, albeit without error handling.
+    ///
+    /// Safety: this method *should* require generic parameter `Data` (data type
+    /// passed to the `Shell`). Realising this would require adding this type
+    /// parameter to `EventCx` and thus to all widgets (not necessarily the
+    /// type accepted by the widget as input). As an alternative we require the
+    /// caller to type-cast `Window<Data>` to `Window<()>` and pass in
+    /// `TypeId::of::<Data>()`.
+    unsafe fn add_window(&mut self, window: kas::Window<()>, data_type_id: TypeId) -> WindowId;
+
+    /// Close a window
+    fn close_window(&mut self, id: WindowId);
+
+    /// Attempt to get clipboard contents
+    ///
+    /// In case of failure, paste actions will simply fail. The implementation
+    /// may wish to log an appropriate warning message.
+    fn get_clipboard(&mut self) -> Option<String>;
+
+    /// Attempt to set clipboard contents
+    fn set_clipboard(&mut self, content: String);
+
+    /// Get contents of primary buffer
+    ///
+    /// Linux has a "primary buffer" with implicit copy on text selection and
+    /// paste on middle-click. This method does nothing on other platforms.
+    fn get_primary(&mut self) -> Option<String>;
+
+    /// Set contents of primary buffer
+    ///
+    /// Linux has a "primary buffer" with implicit copy on text selection and
+    /// paste on middle-click. This method does nothing on other platforms.
+    fn set_primary(&mut self, content: String);
+
+    /// Adjust the theme
+    ///
+    /// Note: theme adjustments apply to all windows, as does the [`Action`]
+    /// returned from the closure.
+    //
+    // TODO(opt): pass f by value, not boxed
+    fn adjust_theme<'s>(&'s mut self, f: Box<dyn FnOnce(&mut dyn ThemeControl) -> Action + 's>);
+
+    /// Access the [`DrawShared`] object
+    fn draw_shared(&mut self) -> &mut dyn DrawShared;
+
+    /// Access a Waker
+    fn waker(&self) -> &std::task::Waker;
+}
+
+impl<Data: AppData, S: kas::draw::DrawSharedImpl, T: Theme<S>> ShellSharedErased
+    for ShellShared<Data, S, T>
+{
+    fn add_popup(&mut self, parent_id: WindowId, popup: kas::PopupDescriptor) -> WindowId {
+        let id = self.next_window_id();
+        self.pending
+            .push_back(Pending::AddPopup(parent_id, id, popup));
+        id
+    }
+
+    unsafe fn add_window(&mut self, window: kas::Window<()>, data_type_id: TypeId) -> WindowId {
+        // Safety: the window should be `Window<Data>`. We cast to that.
+        if data_type_id != TypeId::of::<Data>() {
+            // If this fails it is not safe to add the window (though we could just return).
+            panic!("add_window: window has wrong Data type!");
+        }
+        let window: kas::Window<Data> = std::mem::transmute(window);
+
+        // By far the simplest way to implement this is to let our call
+        // anscestor, event::Loop::handle, do the work.
+        //
+        // In theory we could pass the EventLoopWindowTarget for *each* event
+        // handled to create the winit window here or use statics to generate
+        // errors now, but user code can't do much with this error anyway.
+        let id = self.next_window_id();
+        self.pending.push_back(Pending::AddWindow(id, window));
+        id
+    }
+
+    fn close_window(&mut self, id: WindowId) {
+        self.pending.push_back(Pending::CloseWindow(id));
+    }
+
+    fn get_clipboard(&mut self) -> Option<String> {
         #[cfg(feature = "clipboard")]
         {
             if let Some(cb) = self.clipboard.as_mut() {
@@ -130,8 +233,7 @@ impl<Data: AppData, S: kas::draw::DrawSharedImpl, T> ShellShared<Data, S, T> {
         None
     }
 
-    #[inline]
-    pub fn set_clipboard(&mut self, _content: String) {
+    fn set_clipboard<'c>(&mut self, _content: String) {
         #[cfg(feature = "clipboard")]
         if let Some(cb) = self.clipboard.as_mut() {
             match cb.set_text(_content) {
@@ -141,8 +243,7 @@ impl<Data: AppData, S: kas::draw::DrawSharedImpl, T> ShellShared<Data, S, T> {
         }
     }
 
-    #[inline]
-    pub fn get_primary(&mut self) -> Option<String> {
+    fn get_primary(&mut self) -> Option<String> {
         #[cfg(all(
             unix,
             not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
@@ -161,8 +262,7 @@ impl<Data: AppData, S: kas::draw::DrawSharedImpl, T> ShellShared<Data, S, T> {
         None
     }
 
-    #[inline]
-    pub fn set_primary(&mut self, _content: String) {
+    fn set_primary(&mut self, _content: String) {
         #[cfg(all(
             unix,
             not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
@@ -179,5 +279,19 @@ impl<Data: AppData, S: kas::draw::DrawSharedImpl, T> ShellShared<Data, S, T> {
                 Err(e) => warn_about_error("Failed to set clipboard contents", &e),
             }
         }
+    }
+
+    fn adjust_theme<'s>(&'s mut self, f: Box<dyn FnOnce(&mut dyn ThemeControl) -> Action + 's>) {
+        let action = f(&mut self.theme);
+        self.pending.push_back(Pending::Action(action));
+    }
+
+    fn draw_shared(&mut self) -> &mut dyn DrawShared {
+        &mut self.draw
+    }
+
+    #[inline]
+    fn waker(&self) -> &std::task::Waker {
+        &self.waker
     }
 }

--- a/crates/kas-core/src/shell/shell.rs
+++ b/crates/kas-core/src/shell/shell.rs
@@ -27,7 +27,7 @@ use winit::event_loop::{EventLoop, EventLoopBuilder, EventLoopProxy};
 /// been initialised first.
 pub struct Shell<Data: AppData, G: GraphicalShell, T: Theme<G::Shared>> {
     el: EventLoop<ProxyAction>,
-    windows: Vec<super::Window<Data, G::Surface, T>>,
+    windows: Vec<Box<super::Window<Data, G::Surface, T>>>,
     shared: SharedState<Data, G::Surface, T>,
 }
 
@@ -156,7 +156,7 @@ where
     #[inline]
     pub fn add(&mut self, window: Window<Data>) -> WindowId {
         let id = self.shared.shell.next_window_id();
-        let win = super::Window::new(&self.shared, id, window);
+        let win = Box::new(super::Window::new(&self.shared.shell, id, window));
         self.windows.push(win);
         id
     }

--- a/crates/kas-core/src/shell/shell.rs
+++ b/crates/kas-core/src/shell/shell.rs
@@ -177,8 +177,7 @@ where
     #[inline]
     pub fn run(self) -> Result<()> {
         let mut el = super::EventLoop::new(self.windows, self.shared);
-        self.el
-            .run(move |event, elwt, control_flow| el.handle(event, elwt, control_flow))?;
+        self.el.run(move |event, elwt| el.handle(event, elwt))?;
         Ok(())
     }
 }

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -301,11 +301,6 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
         } else if action.contains(Action::SET_RECT) {
             self.apply_size(shared, false);
         }
-        /*if action.contains(Action::Popup) {
-            let widget = &mut self.widget;
-            self.ev_state.with(&mut tkw, |cx| widget.resize_popups(cx));
-            self.ev_state.region_moved(&mut *self.widget);
-        } else*/
         if action.contains(Action::REGION_MOVED) {
             self.ev_state.region_moved(&mut self.widget, &shared.data);
         }

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -5,8 +5,9 @@
 
 //! Window types
 
+use super::common::WindowSurface;
+use super::shared::{SharedState, ShellShared};
 use super::ProxyAction;
-use super::{SharedState, WindowSurface};
 use kas::cast::Cast;
 use kas::draw::{color::Rgba, AnimationState};
 use kas::event::{config::WindowConfig, ConfigCx, CursorIcon, EventState};
@@ -14,7 +15,7 @@ use kas::geom::{Coord, Rect, Size};
 use kas::layout::SolveCache;
 use kas::theme::{DrawCx, SizeCx, ThemeSize};
 use kas::theme::{Theme, Window as _};
-use kas::{Action, AppData, ErasedStack, Layout, LayoutExt, Widget, WindowId};
+use kas::{autoimpl, Action, AppData, ErasedStack, Layout, LayoutExt, Widget, WindowId};
 use std::mem::take;
 use std::time::Instant;
 use winit::event::WindowEvent;
@@ -38,9 +39,10 @@ struct WindowData<S: WindowSurface, T: Theme<S::Shared>> {
 }
 
 /// Per-window data
+#[autoimpl(Debug ignore self._data, self.widget, self.ev_state, self.window)]
 pub struct Window<A: AppData, S: WindowSurface, T: Theme<S::Shared>> {
     _data: std::marker::PhantomData<A>,
-    widget: kas::Window<A>,
+    pub(super) widget: kas::Window<A>,
     pub(super) window_id: WindowId,
     ev_state: EventState,
     window: Option<WindowData<S, T>>,
@@ -50,7 +52,7 @@ pub struct Window<A: AppData, S: WindowSurface, T: Theme<S::Shared>> {
 impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
     /// Construct window state (widget)
     pub(super) fn new(
-        shared: &SharedState<A, S, T>,
+        shared: &ShellShared<A, S, T>,
         window_id: WindowId,
         widget: kas::Window<A>,
     ) -> Self {
@@ -59,7 +61,7 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
             _data: std::marker::PhantomData,
             widget,
             window_id,
-            ev_state: EventState::new(config, shared.shell.platform),
+            ev_state: EventState::new(config, shared.platform),
             window: None,
         }
     }

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -62,7 +62,7 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
             _data: std::marker::PhantomData,
             widget,
             window_id,
-            ev_state: EventState::new(config),
+            ev_state: EventState::new(config, shared.shell.platform),
             window: None,
         }
     }
@@ -90,7 +90,6 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
         self.ev_state.update_config(scale_factor, dpem);
         self.ev_state.full_configure(
             theme_window.size(),
-            &mut shared.shell.draw,
             self.window_id,
             &mut self.widget,
             &shared.data,
@@ -369,7 +368,6 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
 
         self.ev_state.full_configure(
             window.theme_window.size(),
-            &mut shared.shell.draw,
             self.window_id,
             &mut self.widget,
             &shared.data,
@@ -385,7 +383,7 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
         };
 
         let size = window.theme_window.size();
-        let mut cx = ConfigCx::new(&size, &mut shared.shell.draw, &mut self.ev_state);
+        let mut cx = ConfigCx::new(&size, &mut self.ev_state);
         cx.update(self.widget.as_node(&shared.data));
 
         log::trace!(target: "kas_perf::wgpu::window", "update: {}µs", time.elapsed().as_micros());
@@ -400,11 +398,7 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
         log::debug!("apply_size: rect={rect:?}");
 
         let solve_cache = &mut window.solve_cache;
-        let mut cx = ConfigCx::new(
-            window.theme_window.size(),
-            &mut shared.shell.draw,
-            &mut self.ev_state,
-        );
+        let mut cx = ConfigCx::new(window.theme_window.size(), &mut self.ev_state);
         solve_cache.apply_rect(self.widget.as_node(&shared.data), &mut cx, rect, true);
         if first {
             solve_cache.print_widget_heirarchy(self.widget.as_layout());

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -5,7 +5,7 @@
 
 //! Window types
 
-use super::{Pending, Platform, ProxyAction};
+use super::{Pending, ProxyAction};
 use super::{SharedState, ShellShared, ShellWindow, WindowSurface};
 use kas::cast::Cast;
 use kas::draw::{color::Rgba, AnimationState, DrawShared};
@@ -598,17 +598,17 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWi
         self.shared.pending.push_back(Pending::Action(action));
     }
 
-    fn size_and_draw_shared<'s>(&'s mut self) -> (&'s dyn ThemeSize, &'s mut dyn DrawShared) {
-        (self.window.theme_window.size(), &mut self.shared.draw)
+    fn theme_size(&self) -> &dyn ThemeSize {
+        self.window.theme_window.size()
+    }
+
+    fn draw_shared(&mut self) -> &mut dyn DrawShared {
+        &mut self.shared.draw
     }
 
     #[inline]
     fn set_cursor_icon(&mut self, icon: CursorIcon) {
         self.window.set_cursor_icon(icon);
-    }
-
-    fn platform(&self) -> Platform {
-        self.shared.platform
     }
 
     #[cfg(winit)]

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -609,11 +609,8 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWi
         self.shared.pending.push(PendingAction::Action(action));
     }
 
-    fn size_and_draw_shared<'s>(
-        &'s mut self,
-        f: Box<dyn FnOnce(&dyn ThemeSize, &mut dyn DrawShared) + 's>,
-    ) {
-        f(self.window.theme_window.size(), &mut self.shared.draw);
+    fn size_and_draw_shared<'s>(&'s mut self) -> (&'s dyn ThemeSize, &'s mut dyn DrawShared) {
+        (self.window.theme_window.size(), &mut self.shared.draw)
     }
 
     #[inline]

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -510,7 +510,7 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWi
         let id = self.shared.next_window_id();
         self.shared
             .pending
-            .push(PendingAction::AddPopup(parent_id, id, popup));
+            .push_back(PendingAction::AddPopup(parent_id, id, popup));
         id
     }
 
@@ -531,12 +531,14 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWi
         let id = self.shared.next_window_id();
         self.shared
             .pending
-            .push(PendingAction::AddWindow(id, window));
+            .push_back(PendingAction::AddWindow(id, window));
         id
     }
 
     fn close_window(&mut self, id: WindowId) {
-        self.shared.pending.push(PendingAction::CloseWindow(id));
+        self.shared
+            .pending
+            .push_back(PendingAction::CloseWindow(id));
     }
 
     #[inline]
@@ -595,7 +597,7 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWi
 
     fn adjust_theme<'s>(&'s mut self, f: Box<dyn FnOnce(&mut dyn ThemeControl) -> Action + 's>) {
         let action = f(&mut self.shared.theme);
-        self.shared.pending.push(PendingAction::Action(action));
+        self.shared.pending.push_back(PendingAction::Action(action));
     }
 
     fn size_and_draw_shared<'s>(&'s mut self) -> (&'s dyn ThemeSize, &'s mut dyn DrawShared) {

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -5,7 +5,7 @@
 
 //! Window types
 
-use super::{PendingAction, Platform, ProxyAction};
+use super::{Pending, Platform, ProxyAction};
 use super::{SharedState, ShellShared, ShellWindow, WindowSurface};
 use kas::cast::Cast;
 use kas::draw::{color::Rgba, AnimationState, DrawShared};
@@ -510,7 +510,7 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWi
         let id = self.shared.next_window_id();
         self.shared
             .pending
-            .push_back(PendingAction::AddPopup(parent_id, id, popup));
+            .push_back(Pending::AddPopup(parent_id, id, popup));
         id
     }
 
@@ -531,14 +531,12 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWi
         let id = self.shared.next_window_id();
         self.shared
             .pending
-            .push_back(PendingAction::AddWindow(id, window));
+            .push_back(Pending::AddWindow(id, window));
         id
     }
 
     fn close_window(&mut self, id: WindowId) {
-        self.shared
-            .pending
-            .push_back(PendingAction::CloseWindow(id));
+        self.shared.pending.push_back(Pending::CloseWindow(id));
     }
 
     #[inline]
@@ -597,7 +595,7 @@ impl<'a, A: AppData, S: WindowSurface, T: Theme<S::Shared>> ShellWindow for TkWi
 
     fn adjust_theme<'s>(&'s mut self, f: Box<dyn FnOnce(&mut dyn ThemeControl) -> Action + 's>) {
         let action = f(&mut self.shared.theme);
-        self.shared.pending.push_back(PendingAction::Action(action));
+        self.shared.pending.push_back(Pending::Action(action));
     }
 
     fn size_and_draw_shared<'s>(&'s mut self) -> (&'s dyn ThemeSize, &'s mut dyn DrawShared) {

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -99,8 +99,8 @@ impl<'a> DrawCx<'a> {
 
     /// Access a [`ConfigCx`]
     pub fn config_cx<F: FnOnce(&mut ConfigCx) -> T, T>(&mut self, f: F) -> T {
-        let (sh, draw, ev) = self.h.components();
-        let mut cx = ConfigCx::new(sh, draw.shared(), ev);
+        let (sh, _, ev) = self.h.components();
+        let mut cx = ConfigCx::new(sh, ev);
         f(&mut cx)
     }
 

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -187,7 +187,7 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// -   <code>hover_highlight = <em>bool</em></code> — if true, generate
 ///     `Events::handle_hover` to request a redraw on focus gained/lost
 /// -   <code>cursor_icon = <em>expr</em></code> — if used, generate
-///     `Event::handle_hover`, calling `cx.set_cursor_icon(expr)`
+///     `Event::handle_hover`, calling `cx.set_hover_cursor(expr)`
 /// -   <code>layout = <em>layout</em></code> — defines widget layout via an
 ///     expression; [see below for documentation](#layout)
 ///

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -778,7 +778,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                 #[inline]
                 fn handle_hover(&mut self, cx: &mut EventCx, state: bool) -> ::kas::event::IsUsed {
                     if state {
-                        cx.set_cursor_icon(#icon_expr);
+                        cx.set_hover_cursor(#icon_expr);
                     }
                     ::kas::event::Used
                 }
@@ -788,7 +788,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                 fn handle_hover(&mut self, cx: &mut EventCx, state: bool) -> ::kas::event::IsUsed {
                     cx.redraw(self.id());
                     if state {
-                        cx.set_cursor_icon(#icon_expr);
+                        cx.set_hover_cursor(#icon_expr);
                     }
                     ::kas::event::Used
                 }

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -191,24 +191,23 @@ impl_scope! {
             if let Some((program, mut pixmap)) = cx.try_pop::<(P, Pixmap)>() {
                 debug_assert!(matches!(self.inner, State::Rendering));
                 let size = (pixmap.width(), pixmap.height());
+                let ds = cx.draw_shared();
 
-                cx.draw_shared(|ds| {
-                    if let Some(im_size) = self.image.as_ref().and_then(|h| ds.image_size(h)) {
-                        if im_size != Size::conv(size) {
-                            if let Some(handle) = self.image.take() {
-                                ds.image_free(handle);
-                            }
+                if let Some(im_size) = self.image.as_ref().and_then(|h| ds.image_size(h)) {
+                    if im_size != Size::conv(size) {
+                        if let Some(handle) = self.image.take() {
+                            ds.image_free(handle);
                         }
                     }
+                }
 
-                    if self.image.is_none() {
-                        self.image = ds.image_alloc(size).ok();
-                    }
+                if self.image.is_none() {
+                    self.image = ds.image_alloc(size).ok();
+                }
 
-                    if let Some(handle) = self.image.as_ref() {
-                        ds.image_upload(handle, pixmap.data(), ImageFormat::Rgba8);
-                    }
-                });
+                if let Some(handle) = self.image.as_ref() {
+                    ds.image_upload(handle, pixmap.data(), ImageFormat::Rgba8);
+                }
 
                 cx.redraw(self.id());
 

--- a/crates/kas-view/src/filter/filter_list.rs
+++ b/crates/kas-view/src/filter/filter_list.rs
@@ -91,7 +91,7 @@ impl_scope! {
     impl Events for Self {
         fn handle_messages(&mut self, cx: &mut EventCx, data: &A) {
             if let Some(SetFilter(value)) = cx.try_pop() {
-                cx.config_cx(|cx| self.list.set_filter(cx, data, value));
+                self.list.set_filter(&mut cx.config_cx(), data, value);
             }
         }
     }
@@ -163,7 +163,7 @@ impl_scope! {
 
         fn handle_messages(&mut self, cx: &mut EventCx, data: &A) {
             if let Some(SetFilter(value)) = cx.try_pop() {
-                cx.config_cx(|cx| self.set_filter(cx, data, value));
+                self.set_filter(&mut cx.config_cx(), data, value);
             }
         }
     }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -659,7 +659,7 @@ impl_scope! {
                     return if let Some(i_data) = data_index {
                         // Set nav focus to i_data and update scroll position
                         if self.scroll.focus_rect(cx, solver.rect(i_data), self.core.rect) {
-                            cx.config_cx(|cx| self.update_widgets(cx, data));
+                            self.update_widgets(&mut cx.config_cx(), data);
                         }
                         let index = i_data % usize::conv(self.cur_len);
                         cx.next_nav_focus(self.widgets[index].widget.id(), false, FocusSource::Key);
@@ -704,7 +704,7 @@ impl_scope! {
                 .scroll
                 .scroll_by_event(cx, event, self.id(), self.core.rect);
             if moved {
-                cx.config_cx(|cx| self.update_widgets(cx, data));
+                self.update_widgets(&mut cx.config_cx(), data);
             }
             is_used | used_by_sber
         }
@@ -751,7 +751,7 @@ impl_scope! {
 
         fn handle_scroll(&mut self, cx: &mut EventCx, data: &A, scroll: Scroll) {
             self.scroll.scroll(cx, self.rect(), scroll);
-            cx.config_cx(|cx| self.update_widgets(cx, data));
+            self.update_widgets(&mut cx.config_cx(), data);
         }
     }
 
@@ -852,7 +852,7 @@ impl_scope! {
                 };
 
                 if self.scroll.focus_rect(cx, solver.rect(data_index), self.core.rect) {
-                    cx.config_cx(|cx| self.update_widgets(cx, data));
+                    self.update_widgets(&mut cx.config_cx(), data);
                 }
 
                 let index = data_index % usize::conv(self.cur_len);

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -608,7 +608,7 @@ impl_scope! {
                     return if let Some((ci, ri)) = data_index {
                         // Set nav focus and update scroll position
                         if self.scroll.focus_rect(cx, solver.rect(ci, ri), self.core.rect) {
-                            solver = cx.config_cx(|cx| self.update_widgets(cx, data));
+                            solver = self.update_widgets(&mut cx.config_cx(), data);
                         }
 
                         let index = solver.data_to_child(ci, ri);
@@ -671,7 +671,7 @@ impl_scope! {
                 .scroll
                 .scroll_by_event(cx, event, self.id(), self.core.rect);
             if moved {
-                cx.config_cx(|cx| self.update_widgets(cx, data));
+                self.update_widgets(&mut cx.config_cx(), data);
             }
             is_used | used_by_sber
         }
@@ -718,7 +718,7 @@ impl_scope! {
 
         fn handle_scroll(&mut self, cx: &mut EventCx, data: &A, scroll: Scroll) {
             self.scroll.scroll(cx, self.rect(), scroll);
-            cx.config_cx(|cx| self.update_widgets(cx, data));
+            self.update_widgets(&mut cx.config_cx(), data);
         }
     }
 
@@ -829,7 +829,7 @@ impl_scope! {
                 };
 
                 if self.scroll.focus_rect(cx, solver.rect(ci, ri), self.core.rect) {
-                    solver = cx.config_cx(|cx| self.update_widgets(cx, data));
+                    solver = self.update_widgets(&mut cx.config_cx(), data);
                 }
 
                 let index = solver.data_to_child(ci, ri);

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -112,7 +112,7 @@ impl<A, T: SpinnerValue> SpinnerGuard<A, T> {
 
     /// Returns new value if different
     fn handle_btn(&self, cx: &mut EventCx, data: &A, btn: SpinBtn) -> Option<T> {
-        let old_value = cx.config_cx(|cx| (self.state_fn)(cx, data));
+        let old_value = (self.state_fn)(&cx.config_cx(), data);
         let value = match btn {
             SpinBtn::Down => old_value.sub_step(self.step, self.start),
             SpinBtn::Up => old_value.add_step(self.step, self.end),
@@ -134,7 +134,7 @@ impl<A, T: SpinnerValue> EditGuard for SpinnerGuard<A, T> {
         if let Some(value) = edit.guard.parsed.take() {
             cx.push(ValueMsg(value));
         } else {
-            let value = cx.config_cx(|cx| (edit.guard.state_fn)(cx, data));
+            let value = (edit.guard.state_fn)(&cx.config_cx(), data);
             *cx |= edit.set_string(value.to_string());
         }
     }

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -260,7 +260,7 @@ impl_scope! {
                     let n = index >> 1;
                     assert!(n < self.handles.len());
                     *cx |= self.handles[n].set_offset(offset).1;
-                    cx.config_cx(|cx| self.adjust_size(cx, n));
+                    self.adjust_size(&mut cx.config_cx(), n);
                 }
             }
         }

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -193,7 +193,7 @@ impl_scope! {
 
         fn handle_messages(&mut self, cx: &mut EventCx, data: &W::Data) {
             if let Some(MsgSelectIndex(index)) = cx.try_pop() {
-                cx.config_cx(|cx| self.set_active(cx, data, index));
+                self.set_active(&mut cx.config_cx(), data, index);
                 if let Some(ref f) = self.on_change {
                     let title = self.tabs[index].get_str();
                     f(cx, data, index, title);


### PR DESCRIPTION
This updates to Winit master which fixes a touch-move bug (on Wayland).

Also fixes a bug with drag-opening a `ComboBox` menu. This was caused by re-ordering of pending actions resulting in an attempt to navigate to the first child of the menu before configuration. Originally the intention here was to use only a single pending list to avoid all re-ordering, but this PR takes a more limited solution:

`PressMove` events are sent immediately, instead of attempting to batch them (actual batching was already disabled). This may result in performance issues when rapidly scrolling a `ListView` which will require a more specific solution.

Behaviour change for attempting to grab mouse / touch input twice in a row to better handle the the odd place this does happen.