### PR TITLE
ScrollText widget, font sizes in pixels, AdaptWidget::on_messages, misc fixes

### DIFF
--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -53,6 +53,7 @@ enum ProxyAction {
 #[cfg(test)]
 mod test {
     use super::*;
+    use raw_window_handle as raw;
     use std::time::Instant;
 
     struct Draw;
@@ -231,7 +232,7 @@ mod test {
 
         fn new<W>(_: &mut Self::Shared, _: W) -> Result<Self>
         where
-            W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRawDisplayHandle,
+            W: raw::HasWindowHandle + raw::HasDisplayHandle,
             Self: Sized,
         {
             todo!()

--- a/crates/kas-core/src/theme/config.rs
+++ b/crates/kas-core/src/theme/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
     #[cfg_attr(feature = "serde", serde(skip))]
     dirty: bool,
 
-    /// Standard font size, in units of points-per-Em
+    /// Standard font size, in units of pixels-per-Em
     #[cfg_attr(feature = "serde", serde(default = "defaults::font_size"))]
     font_size: f32,
 
@@ -146,7 +146,9 @@ impl Default for RasterConfig {
 impl Config {
     /// Standard font size
     ///
-    /// Units: points per Em. Pixel size depends on the screen's scale factor.
+    /// Units: logical (unscaled) pixels per Em.
+    ///
+    /// To convert to Points, multiply by three quarters.
     #[inline]
     pub fn font_size(&self) -> f32 {
         self.font_size
@@ -279,7 +281,7 @@ mod defaults {
     }
 
     pub fn font_size() -> f32 {
-        10.0
+        14.0
     }
 
     pub fn color_schemes() -> BTreeMap<String, ColorsSrgb> {

--- a/crates/kas-core/src/theme/dimensions.rs
+++ b/crates/kas-core/src/theme/dimensions.rs
@@ -110,9 +110,8 @@ pub struct Dimensions {
 }
 
 impl Dimensions {
-    pub fn new(params: &Parameters, pt_size: f32, scale: f32) -> Self {
-        let dpp = scale * (96.0 / 72.0);
-        let dpem = dpp * pt_size;
+    pub fn new(params: &Parameters, font_size: f32, scale: f32) -> Self {
+        let dpem = scale * font_size;
 
         let text_m0 = (params.m_text.0 * scale).cast_nearest();
         let text_m1 = (params.m_text.1 * scale).cast_nearest();

--- a/crates/kas-widgets/src/adapt/adapt_widget.rs
+++ b/crates/kas-widgets/src/adapt/adapt_widget.rs
@@ -8,13 +8,14 @@
 use super::{Map, MapAny, OnUpdate, Reserve, WithLabel};
 use kas::cast::{Cast, CastFloat};
 use kas::dir::Directional;
-use kas::event::ConfigCx;
+use kas::event::{ConfigCx, EventCx};
 use kas::geom::Vec2;
 use kas::layout::{AxisInfo, SizeRules};
 use kas::text::AccessString;
 use kas::theme::SizeCx;
+#[allow(unused)] use kas::Events;
 use kas::Widget;
-#[allow(unused)] use kas::{Events, Layout};
+use std::fmt::Debug;
 
 /// Provides `.map_any()`
 ///
@@ -64,6 +65,29 @@ pub trait AdaptWidget: Widget + Sized {
         F: Fn(&mut ConfigCx, &mut Self, &Self::Data) + 'static,
     {
         OnUpdate::new(self).on_update(f)
+    }
+
+    /// Add a handler on message of type `M`
+    ///
+    /// Returns a wrapper around the input widget.
+    #[must_use]
+    fn on_message<M, H>(self, handler: H) -> OnUpdate<Self>
+    where
+        M: Debug + 'static,
+        H: Fn(&mut EventCx, &mut Self, &Self::Data, M) + 'static,
+    {
+        OnUpdate::new(self).on_message(handler)
+    }
+
+    /// Add a generic message handler
+    ///
+    /// Returns a wrapper around the input widget.
+    #[must_use]
+    fn on_messages<H>(self, handler: H) -> OnUpdate<Self>
+    where
+        H: Fn(&mut EventCx, &mut Self, &Self::Data) + 'static,
+    {
+        OnUpdate::new(self).on_messages(handler)
     }
 
     /// Construct a wrapper, setting minimum size in pixels

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -44,8 +44,10 @@
 //! -   [`Filler`]: an empty widget, sometimes used to fill space
 //! -   [`Image`]: a pixmap image
 //! -   [`Label`], [`AccessLabel`]: are static text labels
+//! -   [`Text`]: a dynamic (input-data derived) text label
 //! -   [`Mark`]: a small mark
-//! -   [`ScrollLabel`]: text label supporting scrolling and selection
+//! -   [`ScrollLabel`]: static text label supporting scrolling and selection
+//! -   [`ScrollText`]: dynamic text label supporting scrolling and selection
 //! -   [`Separator`]: a visible bar to separate things
 //! -   [`format_value`] and [`format_data`] are constructors for [`Text`],
 //!     displaying a text label derived from input data
@@ -84,6 +86,7 @@ mod radio_box;
 mod scroll;
 mod scroll_bar;
 mod scroll_label;
+mod scroll_text;
 mod separator;
 mod slider;
 mod spinner;
@@ -111,6 +114,7 @@ pub use radio_box::{RadioBox, RadioButton};
 pub use scroll::ScrollRegion;
 pub use scroll_bar::{ScrollBar, ScrollBarRegion, ScrollBars, ScrollMsg};
 pub use scroll_label::ScrollLabel;
+pub use scroll_text::ScrollText;
 pub use separator::Separator;
 pub use slider::{Slider, SliderValue};
 pub use spinner::{Spinner, SpinnerValue};

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -302,6 +302,9 @@ Demonstration of *as-you-type* formatting from **Markdown**.
         #[widget{
             layout = float! [
                 pack!(right top, Button::label_msg("↻", MsgDirection).map_any()),
+                // NOTE: non_navigable! is needed here to avoid requiring a
+                // nav_next impl on list! (not generable with non-static
+                // direction). TODO: find a more general solution.
                 list!(self.dir, [self.editor, non_navigable!(self.label)]),
             ];
         }]


### PR DESCRIPTION
Most notable is probably the `ScrollText` widget, requested in #415 (CC @m-hugo). Not currently used.

Font sizes probably shouldn't use old imperial units intended for publishing on paper (even if Windows and many Linux DEs still do).