### PR TITLE
Use WGPU 0.18.1; updates

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -102,7 +102,7 @@ cfg-if = "1.0.0"
 smol_str = "0.2.0"
 
 [target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
-smithay-clipboard = { version = "0.6.6", optional = true }
+smithay-clipboard = { version = "0.7.0", optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 arboard = { version = "3.2.0", optional = true, default-features = false }

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -96,7 +96,7 @@ ron = { version = "0.8.0", package = "ron", optional = true }
 toml = { version = "0.8.2", package = "toml", optional = true }
 num_enum = "0.7.0"
 dark-light = { version = "1.0", optional = true }
-raw-window-handle = "0.6.0"
+raw-window-handle = "0.5.0"
 async-global-executor = { version = "2.3.1", optional = true }
 cfg-if = "1.0.0"
 smol_str = "0.2.0"
@@ -123,4 +123,4 @@ version = "0.5.0" # used in doc links
 version = "0.29.2"
 optional = true
 default-features = false
-features = ["rwh_06"]
+features = ["rwh_05"]

--- a/crates/kas-core/src/shell/common.rs
+++ b/crates/kas-core/src/shell/common.rs
@@ -199,7 +199,7 @@ pub trait WindowSurface {
     /// It is required to call [`WindowSurface::do_resize`] after this.
     fn new<W>(shared: &mut Self::Shared, window: W) -> Result<Self>
     where
-        W: raw::HasWindowHandle + raw::HasDisplayHandle,
+        W: raw::HasRawWindowHandle + raw::HasRawDisplayHandle,
         Self: Sized;
 
     /// Get current surface size

--- a/crates/kas-core/src/shell/mod.rs
+++ b/crates/kas-core/src/shell/mod.rs
@@ -232,7 +232,7 @@ mod test {
 
         fn new<W>(_: &mut Self::Shared, _: W) -> Result<Self>
         where
-            W: raw::HasWindowHandle + raw::HasDisplayHandle,
+            W: raw::HasRawWindowHandle + raw::HasRawDisplayHandle,
             Self: Sized,
         {
             todo!()

--- a/crates/kas-core/src/shell/window.rs
+++ b/crates/kas-core/src/shell/window.rs
@@ -158,12 +158,11 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
         );
 
         #[cfg(all(wayland_platform, feature = "clipboard"))]
-        use raw_window_handle::{HasDisplayHandle, RawDisplayHandle, WaylandDisplayHandle};
-        // TODO: this shouldn't unwrap
+        use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle, WaylandDisplayHandle};
         #[cfg(all(wayland_platform, feature = "clipboard"))]
-        let wayland_clipboard = match window.display_handle().unwrap().as_raw() {
+        let wayland_clipboard = match window.raw_display_handle() {
             RawDisplayHandle::Wayland(WaylandDisplayHandle { display, .. }) => {
-                Some(unsafe { smithay_clipboard::Clipboard::new(display.as_ptr()) })
+                Some(unsafe { smithay_clipboard::Clipboard::new(display) })
             }
             _ => None,
         };

--- a/crates/kas-resvg/Cargo.toml
+++ b/crates/kas-resvg/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 svg = ["dep:resvg", "dep:usvg"]
 
 [dependencies]
-tiny-skia = { version = "0.10.0" }
-resvg = { version = "0.35.0", optional = true }
-usvg = { version = "0.35.0", optional = true }
+tiny-skia = { version = "0.11.0" }
+resvg = { version = "0.36.0", optional = true }
+usvg = { version = "0.36.0", optional = true }
 once_cell = "1.17.0"
 thiserror = "1.0.23"
 

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -27,7 +27,7 @@ raster = ["kas-text/raster"]
 
 [dependencies]
 bytemuck = "1.7.0"
-futures-lite = "1.12"
+futures-lite = "2.0"
 log = "0.4"
 thiserror = "1.0.23"
 guillotiere = "0.6.0"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -33,6 +33,10 @@ thiserror = "1.0.23"
 guillotiere = "0.6.0"
 rustc-hash = "1.0"
 
+# Force patch versions of naga and wgpu-core (otherwise not needed as direct dependencies)
+naga = "0.14.1"
+wgpu-core = "0.18.1"
+
 [dependencies.kas]
 # Rename package purely for convenience:
 version = "0.14.0-alpha"
@@ -45,8 +49,6 @@ version = "0.6.0"
 [dependencies.wgpu]
 version = "0.18.0"
 features = ["spirv"]
-git = "https://github.com/gfx-rs/wgpu.git"
-rev = "1dc5347b141f98392fa012ae3416901faf4249a5"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/kas-wgpu/src/surface.rs
+++ b/crates/kas-wgpu/src/surface.rs
@@ -25,7 +25,7 @@ impl<C: CustomPipe> WindowSurface for Surface<C> {
 
     fn new<W>(shared: &mut Self::Shared, window: W) -> Result<Self, Error>
     where
-        W: raw::HasWindowHandle + raw::HasDisplayHandle,
+        W: raw::HasRawWindowHandle + raw::HasRawDisplayHandle,
         Self: Sized,
     {
         let surface = unsafe { shared.instance.create_surface(&window) }


### PR DESCRIPTION
This rolls back raw-window-handle to 0.5.0 since this is the version supported by the last WGPU release.

This PR should enable a KAS release (after updating the CHANGELOG), though I may make a few other changes first.