### PR TITLE
Rename timer_update → timer, add AdaptEventCx, pass only ConfigCx to Widget::_nav_next

### DIFF
--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -5,7 +5,7 @@
 
 //! Widget method implementations
 
-use crate::event::{Event, EventCx, FocusSource, IsUsed, Scroll, Unused, Used};
+use crate::event::{ConfigCx, Event, EventCx, FocusSource, IsUsed, Scroll, Unused, Used};
 #[cfg(debug_assertions)] use crate::util::IdentifyWidget;
 use crate::{Erased, Events, Id, Layout, NavAdvance, Node, Widget};
 
@@ -132,7 +132,7 @@ pub fn _replay<W: Events>(
 /// Generic implementation of [`Widget::_nav_next`]
 pub fn _nav_next<W: Events>(
     widget: &mut W,
-    cx: &mut EventCx,
+    cx: &mut ConfigCx,
     data: &<W as Widget>::Data,
     focus: Option<&Id>,
     advance: NavAdvance,
@@ -143,7 +143,7 @@ pub fn _nav_next<W: Events>(
 
 fn nav_next(
     mut widget: Node<'_>,
-    cx: &mut EventCx,
+    cx: &mut ConfigCx,
     focus: Option<&Id>,
     advance: NavAdvance,
     navigable: bool,

--- a/crates/kas-core/src/core/node.rs
+++ b/crates/kas-core/src/core/node.rs
@@ -38,7 +38,7 @@ trait NodeT {
     fn _replay(&mut self, cx: &mut EventCx, id: Id, msg: Erased);
     fn _nav_next(
         &mut self,
-        cx: &mut EventCx,
+        cx: &mut ConfigCx,
         focus: Option<&Id>,
         advance: NavAdvance,
     ) -> Option<Id>;
@@ -102,7 +102,7 @@ impl<'a, T> NodeT for (&'a mut dyn Widget<Data = T>, &'a T) {
     }
     fn _nav_next(
         &mut self,
-        cx: &mut EventCx,
+        cx: &mut ConfigCx,
         focus: Option<&Id>,
         advance: NavAdvance,
     ) -> Option<Id> {
@@ -369,7 +369,7 @@ impl<'a> Node<'a> {
     // NOTE: public on account of ListView
     pub fn _nav_next(
         &mut self,
-        cx: &mut EventCx,
+        cx: &mut ConfigCx,
         focus: Option<&Id>,
         advance: NavAdvance,
     ) -> Option<Id> {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -433,7 +433,7 @@ pub trait Widget: Layout {
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
     fn _nav_next(
         &mut self,
-        cx: &mut EventCx,
+        cx: &mut ConfigCx,
         data: &Self::Data,
         focus: Option<&Id>,
         advance: NavAdvance,

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -383,11 +383,15 @@ pub trait Widget: Layout {
     }
 
     /// Internal method: configure recursively
+    ///
+    /// Do not implement this method directly!
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
     fn _configure(&mut self, cx: &mut ConfigCx, data: &Self::Data, id: Id);
 
     /// Internal method: update recursively
+    ///
+    /// Do not implement this method directly!
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
     fn _update(&mut self, cx: &mut ConfigCx, data: &Self::Data);
@@ -397,6 +401,8 @@ pub trait Widget: Layout {
     /// If `disabled`, widget `id` does not receive the `event`. Widget `id` is
     /// the first disabled widget (may be an ancestor of the original target);
     /// ancestors of `id` are not disabled.
+    ///
+    /// Do not implement this method directly!
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
     fn _send(
@@ -412,6 +418,8 @@ pub trait Widget: Layout {
     ///
     /// Behaves as if an event had been sent to `id`, then the widget had pushed
     /// `msg` to the message stack. Widget `id` or any ancestor may handle.
+    ///
+    /// Do not implement this method directly!
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
     fn _replay(&mut self, cx: &mut EventCx, data: &Self::Data, id: Id, msg: Erased);
@@ -419,6 +427,8 @@ pub trait Widget: Layout {
     /// Internal method: search for the previous/next navigation target
     ///
     /// `focus`: the current focus or starting point.
+    ///
+    /// Do not implement this method directly!
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
     fn _nav_next(

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -198,13 +198,23 @@ impl ScrollComponent {
     ///
     /// Returns [`Action::REGION_MOVED`] when the scroll offset changes.
     pub fn focus_rect(&mut self, cx: &mut EventCx, rect: Rect, window_rect: Rect) -> Action {
+        let action = self.self_focus_rect(rect, window_rect);
+        cx.set_scroll(Scroll::Rect(rect - self.offset));
+        action
+    }
+
+    /// Scroll self to make the given `rect` visible
+    ///
+    /// This is identical to [`Self::focus_rect`] except that it does not call
+    /// [`EventCx::set_scroll`], thus will not affect ancestors.
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
+    pub fn self_focus_rect(&mut self, rect: Rect, window_rect: Rect) -> Action {
         self.glide.stop();
         let v = rect.pos - window_rect.pos;
         let off = Offset::conv(rect.size) - Offset::conv(window_rect.size);
         let offset = self.offset.max(v + off).min(v);
-        let action = self.set_offset(offset);
-        cx.set_scroll(Scroll::Rect(rect - self.offset));
-        action
+        self.set_offset(offset)
     }
 
     /// Handle a [`Scroll`] action

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -326,7 +326,7 @@ impl ScrollComponent {
                 let timeout = cx.config().scroll_flick_timeout();
                 let pan_dist_thresh = cx.config().pan_dist_thresh();
                 if self.glide.press_end(timeout, pan_dist_thresh) {
-                    cx.request_timer_update(id.clone(), TIMER_GLIDE, Duration::new(0, 0), true);
+                    cx.request_timer_update(id.clone(), TIMER_GLIDE, Duration::new(0, 0));
                 }
             }
             Event::TimerUpdate(pl) if pl == TIMER_GLIDE => {
@@ -338,7 +338,7 @@ impl ScrollComponent {
 
                     if self.glide.vel != Vec2::ZERO {
                         let dur = Duration::from_millis(GLIDE_POLL_MS);
-                        cx.request_timer_update(id.clone(), TIMER_GLIDE, dur, true);
+                        cx.request_timer_update(id.clone(), TIMER_GLIDE, dur);
                         cx.set_scroll(Scroll::Scrolled);
                     }
                 }
@@ -416,7 +416,7 @@ impl TextInput {
                     PressSource::Touch(touch_id) => {
                         self.touch_phase = TouchPhase::Start(touch_id, press.coord);
                         let delay = cx.config().touch_select_delay();
-                        cx.request_timer_update(w_id.clone(), TIMER_SELECT, delay, false);
+                        cx.request_timer_update(w_id.clone(), TIMER_SELECT, delay);
                         None
                     }
                     PressSource::Mouse(..) if cx.config_enable_mouse_text_pan() => {
@@ -474,7 +474,7 @@ impl TextInput {
                         || matches!(press.source, PressSource::Mouse(..) if cx.config_enable_mouse_text_pan()))
                 {
                     self.touch_phase = TouchPhase::None;
-                    cx.request_timer_update(w_id, TIMER_GLIDE, Duration::new(0, 0), true);
+                    cx.request_timer_update(w_id, TIMER_GLIDE, Duration::new(0, 0));
                 }
                 Action::None
             }
@@ -499,7 +499,7 @@ impl TextInput {
                 let decay = cx.config().scroll_flick_decay();
                 if let Some(delta) = self.glide.step(timeout, decay) {
                     let dur = Duration::from_millis(GLIDE_POLL_MS);
-                    cx.request_timer_update(w_id, TIMER_GLIDE, dur, true);
+                    cx.request_timer_update(w_id, TIMER_GLIDE, dur);
                     Action::Pan(delta)
                 } else {
                     Action::None

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -200,16 +200,16 @@ impl EventState {
     /// Requesting an update with `delay == 0` is valid, except from an
     /// [`Event::TimerUpdate`] handler (where it may cause an infinite loop).
     ///
-    /// If multiple updates with the same `id` and `payload` are requested,
-    /// these are merged (using the earliest time if `first` is true).
-    pub fn request_timer_update(&mut self, id: Id, payload: u64, delay: Duration, first: bool) {
+    /// Multiple timer requests with the same `id` and `payload` are merged
+    /// (choosing the earliest time).
+    pub fn request_timer_update(&mut self, id: Id, payload: u64, delay: Duration) {
         let time = Instant::now() + delay;
         if let Some(row) = self
             .time_updates
             .iter_mut()
             .find(|row| row.1 == id && row.2 == payload)
         {
-            if (first && row.0 <= time) || (!first && row.0 >= time) {
+            if row.0 <= time {
                 return;
             }
 

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -188,21 +188,21 @@ impl EventState {
         }
     }
 
-    /// Schedule an update
+    /// Schedule a timed update
     ///
     /// Widget updates may be used for animation and timed responses. See also
     /// [`Draw::animate`](crate::draw::Draw::animate) for animation.
     ///
-    /// Widget `id` will receive [`Event::TimerUpdate`] with this `payload` at
+    /// Widget `id` will receive [`Event::Timer`] with this `payload` at
     /// approximately `time = now + delay` (or possibly a little later due to
     /// frame-rate limiters and processing time).
     ///
     /// Requesting an update with `delay == 0` is valid, except from an
-    /// [`Event::TimerUpdate`] handler (where it may cause an infinite loop).
+    /// [`Event::Timer`] handler (where it may cause an infinite loop).
     ///
     /// Multiple timer requests with the same `id` and `payload` are merged
     /// (choosing the earliest time).
-    pub fn request_timer_update(&mut self, id: Id, payload: u64, delay: Duration) {
+    pub fn request_timer(&mut self, id: Id, payload: u64, delay: Duration) {
         let time = Instant::now() + delay;
         if let Some(row) = self
             .time_updates
@@ -216,7 +216,7 @@ impl EventState {
             row.0 = time;
             log::trace!(
                 target: "kas_core::event",
-                "request_timer_update: update {id} at now+{}ms",
+                "request_timer: update {id} at now+{}ms",
                 delay.as_millis()
             );
         } else {

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -474,7 +474,7 @@ impl<'a> EventCx<'a> {
                         // No mouse grab but have a hover target
                         if self.config.mouse_nav_focus() {
                             if let Some(id) =
-                                win._nav_next(self, data, Some(&start_id), NavAdvance::None)
+                                self.nav_next(win.as_node(data), Some(&start_id), NavAdvance::None)
                             {
                                 self.set_nav_focus(id, FocusSource::Pointer);
                             }
@@ -502,7 +502,7 @@ impl<'a> EventCx<'a> {
                         if let Some(id) = start_id.as_ref() {
                             if self.config.touch_nav_focus() {
                                 if let Some(id) =
-                                    win._nav_next(self, data, Some(id), NavAdvance::None)
+                                    self.nav_next(win.as_node(data), Some(id), NavAdvance::None)
                                 {
                                     self.set_nav_focus(id, FocusSource::Pointer);
                                 }

--- a/crates/kas-core/src/event/cx/cx_shell.rs
+++ b/crates/kas-core/src/event/cx/cx_shell.rs
@@ -268,7 +268,7 @@ impl<'a> EventCx<'a> {
             }
 
             let update = self.time_updates.pop().unwrap();
-            self.send_event(widget.re(), update.1, Event::TimerUpdate(update.2));
+            self.send_event(widget.re(), update.1, Event::Timer(update.2));
         }
 
         self.time_updates.sort_by(|a, b| b.0.cmp(&a.0)); // reverse sort

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -563,25 +563,16 @@ impl<'a> EventCx<'a> {
     }
 
     // Call Widget::_nav_next
+    #[inline]
     fn nav_next(
         &mut self,
         mut widget: Node<'_>,
         focus: Option<&Id>,
         advance: NavAdvance,
     ) -> Option<Id> {
-        debug_assert!(self.scroll == Scroll::None);
-        debug_assert!(self.last_child.is_none());
-        self.messages.set_base();
         log::trace!(target: "kas_core::event", "nav_next: focus={focus:?}, advance={advance:?}");
 
-        let result = widget._nav_next(self, focus, advance);
-
-        // Ignore residual values
-        self.last_child = None;
-        self.scroll = Scroll::None;
-        assert!(!self.messages.has_any());
-
-        result
+        widget._nav_next(&mut self.config_cx(), focus, advance)
     }
 
     // Clear old hover, set new hover, send events.

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -173,10 +173,10 @@ pub enum Event {
     /// Update from a timer
     ///
     /// This event is received after requesting timed wake-up(s)
-    /// (see [`EventState::request_timer_update`]).
+    /// (see [`EventState::request_timer`]).
     ///
-    /// The `u64` payload is copied from [`EventState::request_timer_update`].
-    TimerUpdate(u64),
+    /// The `u64` payload is copied from [`EventState::request_timer`].
+    Timer(u64),
     /// Notification that a popup has been closed
     ///
     /// This is sent to the popup when closed.
@@ -302,7 +302,7 @@ impl Event {
             Command(_, _) => false,
             Key(_, _) | Scroll(_) | Pan { .. } => false,
             CursorMove { .. } | PressStart { .. } | PressMove { .. } | PressEnd { .. } => false,
-            TimerUpdate(_) | PopupClosed(_) => true,
+            Timer(_) | PopupClosed(_) => true,
             NavFocus { .. } | SelFocus(_) | KeyFocus | MouseHover(_) => false,
             LostNavFocus | LostKeyFocus | LostSelFocus => true,
         }
@@ -323,7 +323,7 @@ impl Event {
             Command(_, _) | Scroll(_) | Pan { .. } => true,
             CursorMove { .. } | PressStart { .. } => true,
             PressMove { .. } | PressEnd { .. } => false,
-            TimerUpdate(_) | PopupClosed(_) => false,
+            Timer(_) | PopupClosed(_) => false,
             NavFocus { .. } | LostNavFocus => false,
             SelFocus(_) | LostSelFocus => false,
             KeyFocus | LostKeyFocus => false,

--- a/crates/kas-core/src/hidden.rs
+++ b/crates/kas-core/src/hidden.rs
@@ -191,7 +191,7 @@ impl_scope! {
 
         fn _nav_next(
             &mut self,
-            cx: &mut EventCx,
+            cx: &mut ConfigCx,
             _: &A,
             focus: Option<&Id>,
             advance: NavAdvance,

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -599,7 +599,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
 
                 fn _nav_next(
                     &mut self,
-                    cx: &mut ::kas::event::EventCx,
+                    cx: &mut ::kas::event::ConfigCx,
                     data: &Self::Data,
                     focus: Option<&::kas::Id>,
                     advance: ::kas::NavAdvance,
@@ -1141,7 +1141,7 @@ fn widget_recursive_methods(core_path: &Toks) -> Toks {
 
         fn _nav_next(
             &mut self,
-            cx: &mut ::kas::event::EventCx,
+            cx: &mut ::kas::event::ConfigCx,
             data: &Self::Data,
             focus: Option<&::kas::Id>,
             advance: ::kas::NavAdvance,

--- a/crates/kas-view/src/data_traits.rs
+++ b/crates/kas-view/src/data_traits.rs
@@ -173,9 +173,9 @@ pub trait ListData: SharedData {
 #[autoimpl(for<T: trait + ?Sized> &T, &mut T, std::rc::Rc<T>, std::sync::Arc<T>, Box<T>)]
 pub trait MatrixData: SharedData {
     /// Column key type
-    type ColKey: DataKey;
+    type ColKey;
     /// Row key type
-    type RowKey: DataKey;
+    type RowKey;
 
     type ColKeyIter<'b>: Iterator<Item = Self::ColKey>
     where

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -812,7 +812,7 @@ impl_scope! {
         // Non-standard implementation to allow mapping new children
         fn _nav_next(
             &mut self,
-            cx: &mut EventCx,
+            cx: &mut ConfigCx,
             data: &A,
             focus: Option<&Id>,
             advance: NavAdvance,
@@ -855,10 +855,10 @@ impl_scope! {
                     last_data
                 };
 
-                let act = self.scroll.focus_rect(cx, solver.rect(data_index), self.core.rect);
+                let act = self.scroll.self_focus_rect(solver.rect(data_index), self.core.rect);
                 if !act.is_empty() {
                     cx.action(&self, act);
-                    self.update_widgets(&mut cx.config_cx(), data);
+                    self.update_widgets(cx, data);
                 }
 
                 let index = data_index % usize::conv(self.cur_len);

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -780,7 +780,7 @@ impl_scope! {
         // Non-standard implementation to allow mapping new children
         fn _nav_next(
             &mut self,
-            cx: &mut EventCx,
+            cx: &mut ConfigCx,
             data: &A,
             focus: Option<&Id>,
             advance: NavAdvance,
@@ -833,10 +833,10 @@ impl_scope! {
                     (d_cols - 1, d_rows - 1)
                 };
 
-                let action = self.scroll.focus_rect(cx, solver.rect(ci, ri), self.core.rect);
+                let action = self.scroll.self_focus_rect(solver.rect(ci, ri), self.core.rect);
                 if !action.is_empty() {
                     cx.action(&self, action);
-                    solver = self.update_widgets(&mut cx.config_cx(), data);
+                    solver = self.update_widgets(cx, data);
                 }
 
                 let index = solver.data_to_child(ci, ri);

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -29,6 +29,7 @@ unicode-segmentation = "1.7"
 thiserror = "1.0.23"
 image = { version = "0.24.1", optional = true }
 kas-macros = { version = "0.14.0-alpha", path = "../kas-macros" }
+linear-map = "1.2.0"
 
 # We must rename this package since macros expect kas to be in scope:
 kas = { version = "0.14.0-alpha", package = "kas-core", path = "../kas-core" }

--- a/crates/kas-widgets/src/adapt/mod.rs
+++ b/crates/kas-widgets/src/adapt/mod.rs
@@ -11,7 +11,7 @@ mod adapt_widget;
 mod reserve;
 mod with_label;
 
-pub use adapt::{Adapt, Map};
+pub use adapt::{Adapt, AdaptConfigCx, AdaptEventCx, Map};
 pub use adapt_events::OnUpdate;
 pub use adapt_widget::*;
 #[doc(inline)] pub use kas::hidden::MapAny;

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -132,7 +132,7 @@ impl_scope! {
     impl<Data, D: Directional> Events for MenuBar<Data, D> {
         fn handle_event(&mut self, cx: &mut EventCx, data: &Data, event: Event) -> IsUsed {
             match event {
-                Event::TimerUpdate(id_code) => {
+                Event::Timer(id_code) => {
                     if let Some(id) = self.delayed_open.clone() {
                         if id.as_u64() == id_code {
                             self.set_menu_path(cx, data, Some(&id), false);
@@ -193,7 +193,7 @@ impl_scope! {
                         } else if id != self.delayed_open {
                             cx.set_nav_focus(id.clone(), FocusSource::Pointer);
                             let delay = cx.config().menu_delay();
-                            cx.request_timer_update(self.id(), id.as_u64(), delay);
+                            cx.request_timer(self.id(), id.as_u64(), delay);
                             self.delayed_open = Some(id);
                         }
                     } else {

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -193,7 +193,7 @@ impl_scope! {
                         } else if id != self.delayed_open {
                             cx.set_nav_focus(id.clone(), FocusSource::Pointer);
                             let delay = cx.config().menu_delay();
-                            cx.request_timer_update(self.id(), id.as_u64(), delay, true);
+                            cx.request_timer_update(self.id(), id.as_u64(), delay);
                             self.delayed_open = Some(id);
                         }
                     } else {

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -203,7 +203,7 @@ impl_scope! {
         fn force_visible(&mut self, cx: &mut EventState) {
             self.force_visible = true;
             let delay = cx.config().touch_select_delay();
-            cx.request_timer_update(self.id(), 0, delay, false);
+            cx.request_timer_update(self.id(), 0, delay);
         }
 
         #[inline]

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -203,7 +203,7 @@ impl_scope! {
         fn force_visible(&mut self, cx: &mut EventState) {
             self.force_visible = true;
             let delay = cx.config().touch_select_delay();
-            cx.request_timer_update(self.id(), 0, delay);
+            cx.request_timer(self.id(), 0, delay);
         }
 
         #[inline]
@@ -325,7 +325,7 @@ impl_scope! {
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
-                Event::TimerUpdate(_) => {
+                Event::Timer(_) => {
                     self.force_visible = false;
                     cx.redraw(self);
                     Used

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -59,11 +59,11 @@ fn calc_ui() -> Window<()> {
 
     let ui = Adapt::new(kas::column![display, buttons], Calculator::new())
         .on_message(|_, calc, key| calc.handle(key))
-        .on_configure(|cx, adapt| {
+        .on_configure(|cx, _| {
             cx.disable_nav_focus(true);
 
             // Enable key bindings without Alt held:
-            cx.enable_alt_bypass(adapt.id_ref(), true);
+            cx.enable_alt_bypass(true);
         });
 
     Window::new(ui, "Calculator")

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -8,7 +8,7 @@
 //! Demonstrates low-level drawing and timer handling.
 //!
 //! Note that two forms of animation are possible: calling `draw.draw_device().animate();`
-//! in `fn Clock::draw`, or using `Event::TimerUpdate`. We use the latter since
+//! in `fn Clock::draw`, or using `Event::Timer`. We use the latter since
 //! it lets us draw at 1 FPS with exactly the right frame time.
 
 extern crate chrono;
@@ -125,12 +125,12 @@ impl_scope! {
         type Data = ();
 
         fn configure(&mut self, cx: &mut ConfigCx) {
-            cx.request_timer_update(self.id(), 0, Duration::new(0, 0));
+            cx.request_timer(self.id(), 0, Duration::new(0, 0));
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
-                Event::TimerUpdate(0) => {
+                Event::Timer(0) => {
                     self.now = Local::now();
                     let date = self.now.format("%Y-%m-%d").to_string();
                     let time = self.now.format("%H:%M:%S").to_string();
@@ -142,7 +142,7 @@ impl_scope! {
                         .expect("invalid font_id");
                     let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
                     log::info!("Requesting update in {}ns", ns);
-                    cx.request_timer_update(self.id(), 0, Duration::new(0, ns));
+                    cx.request_timer(self.id(), 0, Duration::new(0, ns));
                     cx.redraw(self);
                     Used
                 }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -125,7 +125,7 @@ impl_scope! {
         type Data = ();
 
         fn configure(&mut self, cx: &mut ConfigCx) {
-            cx.request_timer_update(self.id(), 0, Duration::new(0, 0), true);
+            cx.request_timer_update(self.id(), 0, Duration::new(0, 0));
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
@@ -142,7 +142,7 @@ impl_scope! {
                         .expect("invalid font_id");
                     let ns = 1_000_000_000 - (self.now.time().nanosecond() % 1_000_000_000);
                     log::info!("Requesting update in {}ns", ns);
-                    cx.request_timer_update(self.id(), 0, Duration::new(0, ns), true);
+                    cx.request_timer_update(self.id(), 0, Duration::new(0, ns));
                     cx.redraw(self);
                     Used
                 }

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -40,13 +40,13 @@ fn make_window() -> Box<dyn kas::Widget<Data = ()>> {
             }
             fn handle_event(&mut self, cx: &mut EventCx, data: &(), event: Event) -> IsUsed {
                 match event {
-                    Event::TimerUpdate(0) => {
+                    Event::Timer(0) => {
                         if let Some(last) = self.last {
                             let now = Instant::now();
                             self.elapsed += now - last;
                             self.last = Some(now);
                             cx.update(self.as_node(data));
-                            cx.request_timer_update(self.id(), 0, Duration::new(0, 1));
+                            cx.request_timer(self.id(), 0, Duration::new(0, 1));
                         }
                         Used
                     }
@@ -64,7 +64,7 @@ fn make_window() -> Box<dyn kas::Widget<Data = ()>> {
                         self.elapsed += now - last;
                     } else {
                         self.last = Some(now);
-                        cx.request_timer_update(self.id(), 0, Duration::new(0, 0));
+                        cx.request_timer(self.id(), 0, Duration::new(0, 0));
                     }
                 }
             }

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -46,7 +46,7 @@ fn make_window() -> Box<dyn kas::Widget<Data = ()>> {
                             self.elapsed += now - last;
                             self.last = Some(now);
                             cx.update(self.as_node(data));
-                            cx.request_timer_update(self.id(), 0, Duration::new(0, 1), true);
+                            cx.request_timer_update(self.id(), 0, Duration::new(0, 1));
                         }
                         Used
                     }
@@ -64,7 +64,7 @@ fn make_window() -> Box<dyn kas::Widget<Data = ()>> {
                         self.elapsed += now - last;
                     } else {
                         self.last = Some(now);
-                        cx.request_timer_update(self.id(), 0, Duration::new(0, 0), true);
+                        cx.request_timer_update(self.id(), 0, Duration::new(0, 0));
                     }
                 }
             }


### PR DESCRIPTION
This is a series of fixes and tweaks used while updating [7GUIs](https://github.com/kas-gui/7guis).

- Remove parameter `first` of `EventState::request_timer_update` since it is reasonable to always use `true`
- Rename `timer_update` → `timer` for brevity
- Add `AdaptConfigCx` and `AdaptEventCx`. These are essentially `ConfigCx` / `EventCx` plus an `Id`, allowing some methods to be called without specifying an `id` (for use from methods like `Adapt::on_configure`). This is very much a half-baked addition; likely more methods should be supported, possibly these should be moved to `kas-core`, possibly even integrated with `ConfigCx` and `EventCx` (the latter is not ideal since various methods such as `_send` impls would need to update the `id` both before and after recursing to children).
- Remove `MatrixData::ColKey: DataKey` and `RowKey: DataKey` bound (not needed)
- Pass only `ConfigCx` (instead of `EventCx`) into `Widget::_nav_next`. This fixes a slightly obscure bug where `ListView::_nav_next` would set `EventCx::scroll`, nothing would handle or clear this, and later a `debug_assert!` on `EventCx::send_event` would fail.