### PR TITLE
Remove WGSL feature

### DIFF
--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -48,6 +48,7 @@ version = "0.6.0"
 
 [dependencies.wgpu]
 version = "0.18.0"
+default-features = false
 features = ["spirv"]
 
 [build-dependencies]

--- a/crates/kas-wgpu/src/draw/shaded_square.rs
+++ b/crates/kas-wgpu/src/draw/shaded_square.rs
@@ -48,8 +48,8 @@ impl Pipeline {
             label: Some("SS render_pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
-                module: &shaders.shaded_square,
-                entry_point: "vert",
+                module: &shaders.vert_shaded_square,
+                entry_point: "main",
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -72,8 +72,8 @@ impl Pipeline {
             depth_stencil: None,
             multisample: Default::default(),
             fragment: Some(wgpu::FragmentState {
-                module: &shaders.shaded_square,
-                entry_point: "frag",
+                module: &shaders.frag_shaded_square,
+                entry_point: "main",
                 targets: &[Some(wgpu::ColorTargetState {
                     format: super::RENDER_TEX_FORMAT,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),

--- a/crates/kas-wgpu/src/draw/shaders.rs
+++ b/crates/kas-wgpu/src/draw/shaders.rs
@@ -5,21 +5,22 @@
 
 //! Shader management
 
-use wgpu::{include_spirv, include_wgsl, ShaderModule};
+use wgpu::{include_spirv, ShaderModule};
 
 /// Shader manager
 pub struct ShaderManager {
     pub vert_flat_round: ShaderModule,
     pub vert_round_2col: ShaderModule,
     pub vert_shaded_round: ShaderModule,
+    pub vert_shaded_square: ShaderModule,
     pub vert_image: ShaderModule,
     pub vert_glyph: ShaderModule,
     pub frag_flat_round: ShaderModule,
     pub frag_round_2col: ShaderModule,
     pub frag_shaded_round: ShaderModule,
+    pub frag_shaded_square: ShaderModule,
     pub frag_image: ShaderModule,
     pub frag_glyph: ShaderModule,
-    pub shaded_square: ShaderModule,
 }
 
 macro_rules! create {
@@ -33,17 +34,16 @@ impl ShaderManager {
         let vert_flat_round = create!(device, "shaders/flat_round.vert.spv");
         let vert_round_2col = create!(device, "shaders/round_2col.vert.spv");
         let vert_shaded_round = create!(device, "shaders/shaded_round.vert.spv");
+        let vert_shaded_square = create!(device, "shaders/shaded_square.vert.spv");
         let vert_image = create!(device, "shaders/image.vert.spv");
         let vert_glyph = create!(device, "shaders/glyph.vert.spv");
 
         let frag_flat_round = create!(device, "shaders/flat_round.frag.spv");
         let frag_round_2col = create!(device, "shaders/round_2col.frag.spv");
         let frag_shaded_round = create!(device, "shaders/shaded_round.frag.spv");
+        let frag_shaded_square = create!(device, "shaders/shaded_square.frag.spv");
         let frag_image = create!(device, "shaders/image.frag.spv");
         let frag_glyph = create!(device, "shaders/glyph.frag.spv");
-
-        let shaded_square =
-            device.create_shader_module(include_wgsl!("shaders/shaded_square.wgsl"));
 
         ShaderManager {
             vert_image,
@@ -51,12 +51,13 @@ impl ShaderManager {
             vert_flat_round,
             vert_round_2col,
             vert_shaded_round,
+            vert_shaded_square,
             frag_flat_round,
             frag_round_2col,
             frag_shaded_round,
+            frag_shaded_square,
             frag_image,
             frag_glyph,
-            shaded_square,
         }
     }
 }


### PR DESCRIPTION
This results in approximately 3% decrease in binary size. Testing the `gallery` example:

Old sizes
Debug build: 321M (37M=38182856 stripped)
Release build: 24412192 (14517808 stripped)

GSL only
Debug build: 336350520 (38185560 stripped)
Release build: 24414888 (14520544 stripped)

Without WGSL
Debug build: 331809320 (37205936 stripped)
Release build: 23913536 (14090504 stripped)
