### PR TITLE
Support message sending

### DIFF
--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -15,14 +15,13 @@ pub fn _send<W: Events>(
     cx: &mut EventCx,
     data: &<W as Widget>::Data,
     id: Id,
-    disabled: bool,
     event: Event,
 ) -> IsUsed {
     let mut is_used = Unused;
     let do_handle_event;
 
     if id == widget.id_ref() {
-        if disabled {
+        if cx.target_is_disabled {
             return is_used;
         }
 
@@ -49,7 +48,7 @@ pub fn _send<W: Events>(
                 let translation = widget.translation();
                 let mut _found = false;
                 widget.as_node(data).for_child(index, |mut node| {
-                    is_used = node._send(cx, id.clone(), disabled, event.clone() + translation);
+                    is_used = node._send(cx, id.clone(), event.clone() + translation);
                     _found = true;
                 });
 

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -7,7 +7,7 @@
 
 use crate::event::{ConfigCx, Event, EventCx, FocusSource, IsUsed, Scroll, Unused, Used};
 #[cfg(debug_assertions)] use crate::util::IdentifyWidget;
-use crate::{messages::Erased, Events, Id, Layout, NavAdvance, Node, Widget};
+use crate::{Events, Id, Layout, NavAdvance, Node, Widget};
 
 /// Generic implementation of [`Widget::_send`]
 pub fn _send<W: Events>(
@@ -84,17 +84,11 @@ pub fn _send<W: Events>(
 }
 
 /// Generic implementation of [`Widget::_replay`]
-pub fn _replay<W: Events>(
-    widget: &mut W,
-    cx: &mut EventCx,
-    data: &<W as Widget>::Data,
-    id: Id,
-    msg: Erased,
-) {
+pub fn _replay<W: Events>(widget: &mut W, cx: &mut EventCx, data: &<W as Widget>::Data, id: Id) {
     if let Some(index) = widget.find_child_index(&id) {
         let mut _found = false;
         widget.as_node(data).for_child(index, |mut node| {
-            node._replay(cx, id.clone(), msg);
+            node._replay(cx, id.clone());
             _found = true;
         });
 
@@ -116,7 +110,6 @@ pub fn _replay<W: Events>(
             widget.handle_messages(cx, data);
         }
     } else if id == widget.id_ref() {
-        cx.push_erased(msg);
         widget.handle_messages(cx, data);
     } else {
         // This implies use of push_async / push_spawn from a widget which was

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -27,7 +27,8 @@ pub fn _send<W: Events>(
 
         match &event {
             Event::MouseHover(state) => {
-                is_used |= widget.handle_hover(cx, *state);
+                widget.handle_hover(cx, *state);
+                return Used;
             }
             Event::NavFocus(FocusSource::Key) => {
                 cx.set_scroll(Scroll::Rect(widget.rect()));

--- a/crates/kas-core/src/core/node.rs
+++ b/crates/kas-core/src/core/node.rs
@@ -34,7 +34,7 @@ trait NodeT {
     fn _configure(&mut self, cx: &mut ConfigCx, id: Id);
     fn _update(&mut self, cx: &mut ConfigCx);
 
-    fn _send(&mut self, cx: &mut EventCx, id: Id, disabled: bool, event: Event) -> IsUsed;
+    fn _send(&mut self, cx: &mut EventCx, id: Id, event: Event) -> IsUsed;
     fn _replay(&mut self, cx: &mut EventCx, id: Id, msg: Erased);
     fn _nav_next(
         &mut self,
@@ -94,8 +94,8 @@ impl<'a, T> NodeT for (&'a mut dyn Widget<Data = T>, &'a T) {
         self.0._update(cx, self.1);
     }
 
-    fn _send(&mut self, cx: &mut EventCx, id: Id, disabled: bool, event: Event) -> IsUsed {
-        self.0._send(cx, self.1, id, disabled, event)
+    fn _send(&mut self, cx: &mut EventCx, id: Id, event: Event) -> IsUsed {
+        self.0._send(cx, self.1, id, event)
     }
     fn _replay(&mut self, cx: &mut EventCx, id: Id, msg: Erased) {
         self.0._replay(cx, self.1, id, msg);
@@ -344,18 +344,12 @@ impl<'a> Node<'a> {
     }
 
     /// Internal method: send recursively
-    pub(crate) fn _send(
-        &mut self,
-        cx: &mut EventCx,
-        id: Id,
-        disabled: bool,
-        event: Event,
-    ) -> IsUsed {
+    pub(crate) fn _send(&mut self, cx: &mut EventCx, id: Id, event: Event) -> IsUsed {
         cfg_if::cfg_if! {
             if #[cfg(feature = "unsafe_node")] {
-                self.0._send(cx, self.1, id, disabled, event)
+                self.0._send(cx, self.1, id, event)
             } else {
-                self.0._send(cx, id, disabled, event)
+                self.0._send(cx, id, event)
             }
         }
     }

--- a/crates/kas-core/src/core/node.rs
+++ b/crates/kas-core/src/core/node.rs
@@ -10,7 +10,7 @@ use crate::event::{ConfigCx, Event, EventCx, IsUsed};
 use crate::geom::{Coord, Rect};
 use crate::layout::{AxisInfo, SizeRules};
 use crate::theme::{DrawCx, SizeCx};
-use crate::{messages::Erased, Id, Layout, NavAdvance};
+use crate::{Id, Layout, NavAdvance};
 
 #[cfg(not(feature = "unsafe_node"))]
 trait NodeT {
@@ -35,7 +35,7 @@ trait NodeT {
     fn _update(&mut self, cx: &mut ConfigCx);
 
     fn _send(&mut self, cx: &mut EventCx, id: Id, event: Event) -> IsUsed;
-    fn _replay(&mut self, cx: &mut EventCx, id: Id, msg: Erased);
+    fn _replay(&mut self, cx: &mut EventCx, id: Id);
     fn _nav_next(
         &mut self,
         cx: &mut ConfigCx,
@@ -97,8 +97,8 @@ impl<'a, T> NodeT for (&'a mut dyn Widget<Data = T>, &'a T) {
     fn _send(&mut self, cx: &mut EventCx, id: Id, event: Event) -> IsUsed {
         self.0._send(cx, self.1, id, event)
     }
-    fn _replay(&mut self, cx: &mut EventCx, id: Id, msg: Erased) {
-        self.0._replay(cx, self.1, id, msg);
+    fn _replay(&mut self, cx: &mut EventCx, id: Id) {
+        self.0._replay(cx, self.1, id);
     }
     fn _nav_next(
         &mut self,
@@ -355,12 +355,12 @@ impl<'a> Node<'a> {
     }
 
     /// Internal method: replay recursively
-    pub(crate) fn _replay(&mut self, cx: &mut EventCx, id: Id, msg: Erased) {
+    pub(crate) fn _replay(&mut self, cx: &mut EventCx, id: Id) {
         cfg_if::cfg_if! {
             if #[cfg(feature = "unsafe_node")] {
-                self.0._replay(cx, self.1, id, msg);
+                self.0._replay(cx, self.1, id);
             } else {
-                self.0._replay(cx, id, msg);
+                self.0._replay(cx, id);
             }
         }
     }

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -398,21 +398,10 @@ pub trait Widget: Layout {
 
     /// Internal method: send recursively
     ///
-    /// If `disabled`, widget `id` does not receive the `event`. Widget `id` is
-    /// the first disabled widget (may be an ancestor of the original target);
-    /// ancestors of `id` are not disabled.
-    ///
     /// Do not implement this method directly!
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    fn _send(
-        &mut self,
-        cx: &mut EventCx,
-        data: &Self::Data,
-        id: Id,
-        disabled: bool,
-        event: Event,
-    ) -> IsUsed;
+    fn _send(&mut self, cx: &mut EventCx, data: &Self::Data, id: Id, event: Event) -> IsUsed;
 
     /// Internal method: replay recursively
     ///

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -140,13 +140,11 @@ pub trait Events: Widget + Sized {
 
     /// Mouse focus handler
     ///
-    /// Called on [`Event::MouseHover`] before [`Self::handle_event`].
-    /// `state` is true when hovered.
+    /// Called when mouse hover state changes.
     ///
     /// When the [`#widget`] macro properties `hover_highlight` or `cursor_icon`
     /// are used, an instance of this method is generated. Otherwise, the
-    /// default implementation of this method does nothing and equivalent
-    /// functionality could be implemented in [`Events::handle_event`] instead.
+    /// default implementation of this method does nothing.
     ///
     /// Note: to implement `hover_highlight`, simply request a redraw on
     /// focus gain and loss. To implement `cursor_icon`, call
@@ -154,9 +152,8 @@ pub trait Events: Widget + Sized {
     ///
     /// [`#widget`]: macros::widget
     #[inline]
-    fn handle_hover(&mut self, cx: &mut EventCx, state: bool) -> IsUsed {
+    fn handle_hover(&mut self, cx: &mut EventCx, state: bool) {
         let _ = (cx, state);
-        Unused
     }
 
     /// Handle an [`Event`]

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -8,7 +8,7 @@
 use super::{Layout, Node};
 #[allow(unused)] use crate::event::Used;
 use crate::event::{ConfigCx, Event, EventCx, IsUsed, Scroll, Unused};
-use crate::{messages::Erased, Id};
+use crate::Id;
 use kas_macros::autoimpl;
 
 #[allow(unused)] use kas_macros as macros;
@@ -402,13 +402,13 @@ pub trait Widget: Layout {
 
     /// Internal method: replay recursively
     ///
-    /// Behaves as if an event had been sent to `id`, then the widget had pushed
-    /// `msg` to the message stack. Widget `id` or any ancestor may handle.
+    /// Traverses the widget tree to `id`, then unwinds.
+    /// It is expected that some message is available on the stack.
     ///
     /// Do not implement this method directly!
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
-    fn _replay(&mut self, cx: &mut EventCx, data: &Self::Data, id: Id, msg: Erased);
+    fn _replay(&mut self, cx: &mut EventCx, data: &Self::Data, id: Id);
 
     /// Internal method: search for the previous/next navigation target
     ///

--- a/crates/kas-core/src/event/cx/config.rs
+++ b/crates/kas-core/src/event/cx/config.rs
@@ -9,9 +9,11 @@ use super::PendingNavFocus;
 use crate::event::{EventState, FocusSource};
 use crate::geom::{Rect, Size};
 use crate::layout::AlignPair;
+use crate::messages::Erased;
 use crate::text::TextApi;
 use crate::theme::{Feature, SizeCx, TextClass, ThemeSize};
 use crate::{Id, Node};
+use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
 #[allow(unused)] use crate::{event::Event, Events, Layout};
@@ -86,6 +88,28 @@ impl<'a> ConfigCx<'a> {
     #[inline]
     pub fn update(&mut self, mut widget: Node<'_>) {
         widget._update(self);
+    }
+
+    /// Push a message (replay)
+    ///
+    /// Unlike [`EventCx::push`], this is not handled while unwinding
+    /// from event sending, but via a fresh traversal of the widget tree.
+    ///
+    /// TODO: `id` should not be part of the function signature?
+    pub fn push<M: Debug + 'static>(&mut self, id: Id, msg: M) {
+        self.send(id, msg);
+    }
+
+    /// Push a type-erased message (replay)
+    ///
+    /// Unlike [`EventCx::push_erased`], this is not handled while unwinding
+    /// from event sending, but via a fresh traversal of the widget tree.
+    ///
+    /// The message may be [popped](EventCx::try_pop) or
+    /// [observed](EventCx::try_observe) from [`Events::handle_messages`]
+    /// by the widget itself, its parent, or any ancestor.
+    pub fn push_erased(&mut self, id: Id, msg: Erased) {
+        self.send_erased(id, msg);
     }
 
     /// Align a feature's rect

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -380,7 +380,12 @@ impl EventState {
     /// Does nothing when `code` is `None`.
     pub fn depress_with_key(&mut self, id: Id, code: impl Into<Option<PhysicalKey>>) {
         fn inner(state: &mut EventState, id: Id, code: PhysicalKey) {
-            if state.key_depress.values().any(|v| *v == id) {
+            if state
+                .key_depress
+                .get(&code)
+                .map(|target| *target == id)
+                .unwrap_or(false)
+            {
                 return;
             }
 

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -574,6 +574,16 @@ impl EventState {
         self.hover_icon = icon;
     }
 
+    /// Send a message to `id`
+    pub fn send<M: Debug + 'static>(&mut self, id: Id, msg: M) {
+        self.send_erased(id, Erased::new(msg));
+    }
+
+    /// Send an erased message to `id`
+    pub fn send_erased(&mut self, id: Id, msg: Erased) {
+        self.send_queue.push_back((id, msg));
+    }
+
     /// Asynchronously push a message to the stack via a [`Future`]
     ///
     /// The future is polled after event handling and after drawing and is able

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -376,13 +376,21 @@ impl EventState {
     /// Note that keyboard shortcuts and mnemonics should usually match against
     /// the "logical key". [`PhysicalKey`] is used here since the the logical key
     /// may be changed by modifier keys.
-    pub fn depress_with_key(&mut self, id: Id, code: PhysicalKey) {
-        if self.key_depress.values().any(|v| *v == id) {
-            return;
+    ///
+    /// Does nothing when `code` is `None`.
+    pub fn depress_with_key(&mut self, id: Id, code: impl Into<Option<PhysicalKey>>) {
+        fn inner(state: &mut EventState, id: Id, code: PhysicalKey) {
+            if state.key_depress.values().any(|v| *v == id) {
+                return;
+            }
+
+            state.key_depress.insert(code, id.clone());
+            state.action(id, Action::REDRAW);
         }
 
-        self.key_depress.insert(code, id.clone());
-        self.action(id, Action::REDRAW);
+        if let Some(code) = code.into() {
+            inner(self, id, code);
+        }
     }
 
     /// Request keyboard input focus

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -212,6 +212,8 @@ pub struct EventState {
     popups: SmallVec<[(WindowId, crate::PopupDescriptor, Option<Id>); 16]>,
     popup_removed: SmallVec<[(Id, WindowId); 16]>,
     time_updates: Vec<(Instant, Id, u64)>,
+    // Set of messages awaiting sending
+    send_queue: VecDeque<(Id, Erased)>,
     // Set of futures of messages together with id of sending widget
     fut_messages: Vec<(Id, Pin<Box<dyn Future<Output = Erased>>>)>,
     // Widget requiring update (and optionally configure)

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -533,7 +533,8 @@ impl<'a> EventCx<'a> {
         log::trace!(target: "kas_core::event", "replay: id={id}: {msg:?}");
 
         self.target_is_disabled = false;
-        widget._replay(self, id, msg);
+        self.push_erased(msg);
+        widget._replay(self, id);
         self.last_child = None;
         self.scroll = Scroll::None;
     }

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -371,6 +371,7 @@ pub struct EventCx<'a> {
     shared: &'a mut dyn AppShared,
     window: &'a dyn WindowDataErased,
     messages: &'a mut MessageStack,
+    pub(crate) target_is_disabled: bool,
     last_child: Option<usize>,
     scroll: Scroll,
 }
@@ -531,6 +532,7 @@ impl<'a> EventCx<'a> {
         self.messages.set_base();
         log::trace!(target: "kas_core::event", "replay: id={id}: {msg:?}");
 
+        self.target_is_disabled = false;
         widget._replay(self, id, msg);
         self.last_child = None;
         self.scroll = Scroll::None;
@@ -556,8 +558,9 @@ impl<'a> EventCx<'a> {
                 log::trace!(target: "kas_core::event", "target is disabled; sending to ancestor {id}");
             }
         }
+        self.target_is_disabled = disabled;
 
-        let used = widget._send(self, id, disabled, event) == Used;
+        let used = widget._send(self, id, event) == Used;
 
         self.last_child = None;
         self.scroll = Scroll::None;

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -119,6 +119,7 @@ impl EventState {
             shared,
             window,
             messages,
+            target_is_disabled: false,
             last_child: None,
             scroll: Scroll::None,
         };

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -52,6 +52,7 @@ impl EventState {
             popups: Default::default(),
             popup_removed: Default::default(),
             time_updates: vec![],
+            send_queue: Default::default(),
             fut_messages: vec![],
             pending_update: None,
             pending_sel_focus: None,
@@ -220,6 +221,11 @@ impl EventState {
             while let Some((id, cmd)) = cx.pending_cmds.pop_front() {
                 log::trace!(target: "kas_core::event", "sending pending command {cmd:?} to {id}");
                 cx.send_event(win.as_node(data), id, Event::Command(cmd, None));
+            }
+
+            while let Some((id, msg)) = cx.send_queue.pop_front() {
+                log::trace!(target: "kas_core::event", "sending message {msg:?} to {id}");
+                cx.replay(win.as_node(data), id, msg);
             }
 
             // Poll futures almost last. This means that any newly pushed future

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -325,8 +325,9 @@ impl Event {
     pub fn is_reusable(&self) -> bool {
         use Event::*;
         match self {
-            // Events sent to navigation focus
-            Command(_, _) => true,
+            // Events sent to navigation focus given some code,
+            // otherwise sent to a specific target.
+            Command(_, code) => code.is_some(),
 
             // Events sent to mouse focus
             Scroll(_) | Pan { .. } => true,

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -275,9 +275,7 @@ impl Event {
     ) -> IsUsed {
         match self {
             Event::Command(cmd, code) if cmd.is_activate() => {
-                if let Some(code) = code {
-                    cx.depress_with_key(id, code);
-                }
+                cx.depress_with_key(id, code);
                 f(cx)
             }
             Event::PressStart { press, .. } if press.is_primary() => press.grab(id).with_cx(cx),

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -310,20 +310,35 @@ impl Event {
 
     /// Can the event be received by [`Events::handle_event`] during unwinding?
     ///
-    /// Events which may be sent to the widget under the mouse or to the
-    /// keyboard navigation target may be acted on by an ancestor if unused.
-    /// Other events may not be; e.g. [`Event::PressMove`] and
-    /// [`Event::PressEnd`] are only received by the widget requesting them
-    /// while [`Event::LostKeyFocus`] (and similar events) are only sent to a
-    /// specific widget.
+    /// Some events are sent to the widget with navigation focus (e.g.
+    /// [`Event::Command`]). Others are sent to the widget under the mouse (e.g.
+    /// [`Event::PressStart`]). All these events may be "reused" by an ancestor
+    /// widget if not [`Used`] by the original target.
+    ///
+    /// Other events are sent to a specific widget as a result of a request
+    /// (e.g. [`Event::Key`], [`Event::PressEnd`]), or as a notification of
+    /// focus change (e.g. [`Event::LostKeyFocus`]). These events may never be
+    /// "reused".
+    ///
+    /// Note: this could alternatively be seen as a property of the addressing
+    /// mechanism, currently just an [`Id`].
     pub fn is_reusable(&self) -> bool {
         use Event::*;
         match self {
-            Key(_, _) => false,
-            Command(_, _) | Scroll(_) | Pan { .. } => true,
+            // Events sent to navigation focus
+            Command(_, _) => true,
+
+            // Events sent to mouse focus
+            Scroll(_) | Pan { .. } => true,
             CursorMove { .. } | PressStart { .. } => true,
+
+            // Events sent to requester
+            Key(_, _) => false,
             PressMove { .. } | PressEnd { .. } => false,
-            Timer(_) | PopupClosed(_) => false,
+            Timer(_) => false,
+
+            // Notifications of focus/status change
+            PopupClosed(_) => false,
             NavFocus { .. } | LostNavFocus => false,
             SelFocus(_) | LostSelFocus => false,
             KeyFocus | LostKeyFocus => false,

--- a/crates/kas-core/src/hidden.rs
+++ b/crates/kas-core/src/hidden.rs
@@ -181,8 +181,8 @@ impl_scope! {
 
         fn _update(&mut self, _: &mut ConfigCx, _: &A) {}
 
-        fn _send(&mut self, cx: &mut EventCx, _: &A, id: Id, disabled: bool, event: Event) -> IsUsed {
-            self.inner._send(cx, &(), id, disabled, event)
+        fn _send(&mut self, cx: &mut EventCx, _: &A, id: Id, event: Event) -> IsUsed {
+            self.inner._send(cx, &(), id, event)
         }
 
         fn _replay(&mut self, cx: &mut EventCx, _: &A, id: Id, msg: Erased) {

--- a/crates/kas-core/src/hidden.rs
+++ b/crates/kas-core/src/hidden.rs
@@ -15,7 +15,7 @@ use crate::geom::{Coord, Offset, Rect};
 use crate::layout::{Align, AxisInfo, SizeRules};
 use crate::text::{Text, TextApi};
 use crate::theme::{DrawCx, SizeCx, TextClass};
-use crate::{messages::Erased, Id, Layout, NavAdvance, Node, Widget};
+use crate::{Id, Layout, NavAdvance, Node, Widget};
 use kas_macros::{autoimpl, impl_scope};
 
 impl_scope! {
@@ -185,8 +185,8 @@ impl_scope! {
             self.inner._send(cx, &(), id, event)
         }
 
-        fn _replay(&mut self, cx: &mut EventCx, _: &A, id: Id, msg: Erased) {
-            self.inner._replay(cx, &(), id, msg);
+        fn _replay(&mut self, cx: &mut EventCx, _: &A, id: Id) {
+            self.inner._replay(cx, &(), id);
         }
 
         fn _nav_next(

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -581,10 +581,9 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                     cx: &mut ::kas::event::EventCx,
                     data: &Self::Data,
                     id: ::kas::Id,
-                    disabled: bool,
                     event: ::kas::event::Event,
                 ) -> ::kas::event::IsUsed {
-                    self.#inner._send(cx, data, id, disabled, event)
+                    self.#inner._send(cx, data, id, event)
                 }
 
                 fn _replay(
@@ -1123,10 +1122,9 @@ fn widget_recursive_methods(core_path: &Toks) -> Toks {
             cx: &mut ::kas::event::EventCx,
             data: &Self::Data,
             id: ::kas::Id,
-            disabled: bool,
             event: ::kas::event::Event,
         ) -> ::kas::event::IsUsed {
-            ::kas::impls::_send(self, cx, data, id, disabled, event)
+            ::kas::impls::_send(self, cx, data, id, event)
         }
 
         fn _replay(

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -766,28 +766,25 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
             (false, None) => quote! {},
             (true, None) => quote! {
                 #[inline]
-                fn handle_hover(&mut self, cx: &mut EventCx, _: bool) -> ::kas::event::IsUsed {
+                fn handle_hover(&mut self, cx: &mut EventCx, _: bool) {
                     cx.redraw(self);
-                    ::kas::event::Used
                 }
             },
             (false, Some(icon_expr)) => quote! {
                 #[inline]
-                fn handle_hover(&mut self, cx: &mut EventCx, state: bool) -> ::kas::event::IsUsed {
+                fn handle_hover(&mut self, cx: &mut EventCx, state: bool) {
                     if state {
                         cx.set_hover_cursor(#icon_expr);
                     }
-                    ::kas::event::Used
                 }
             },
             (true, Some(icon_expr)) => quote! {
                 #[inline]
-                fn handle_hover(&mut self, cx: &mut EventCx, state: bool) -> ::kas::event::IsUsed {
+                fn handle_hover(&mut self, cx: &mut EventCx, state: bool) {
                     cx.redraw(self);
                     if state {
                         cx.set_hover_cursor(#icon_expr);
                     }
-                    ::kas::event::Used
                 }
             },
         };

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -591,9 +591,8 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                     cx: &mut ::kas::event::EventCx,
                     data: &Self::Data,
                     id: ::kas::Id,
-                    msg: ::kas::messages::Erased,
                 ) {
-                    self.#inner._replay(cx, data, id, msg);
+                    self.#inner._replay(cx, data, id);
                 }
 
                 fn _nav_next(
@@ -1129,9 +1128,8 @@ fn widget_recursive_methods(core_path: &Toks) -> Toks {
             cx: &mut ::kas::event::EventCx,
             data: &Self::Data,
             id: ::kas::Id,
-            msg: ::kas::messages::Erased,
         ) {
-            ::kas::impls::_replay(self, cx, data, id, msg);
+            ::kas::impls::_replay(self, cx, data, id);
         }
 
         fn _nav_next(

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -804,8 +804,8 @@ impl_scope! {
             kas::impls::_send(self, cx, data, id, event)
         }
 
-        fn _replay(&mut self, cx: &mut EventCx, data: &A, id: Id, msg: kas::messages::Erased) {
-            kas::impls::_replay(self, cx, data, id, msg);
+        fn _replay(&mut self, cx: &mut EventCx, data: &A, id: Id) {
+            kas::impls::_replay(self, cx, data, id);
         }
 
         // Non-standard implementation to allow mapping new children

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -799,10 +799,9 @@ impl_scope! {
             cx: &mut EventCx,
             data: &A,
             id: Id,
-            disabled: bool,
             event: Event,
         ) -> IsUsed {
-            kas::impls::_send(self, cx, data, id, disabled, event)
+            kas::impls::_send(self, cx, data, id, event)
         }
 
         fn _replay(&mut self, cx: &mut EventCx, data: &A, id: Id, msg: kas::messages::Erased) {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -767,10 +767,9 @@ impl_scope! {
             cx: &mut EventCx,
             data: &A,
             id: Id,
-            disabled: bool,
             event: Event,
         ) -> IsUsed {
-            kas::impls::_send(self, cx, data, id, disabled, event)
+            kas::impls::_send(self, cx, data, id, event)
         }
 
         fn _replay(&mut self, cx: &mut EventCx, data: &A, id: Id, msg: kas::messages::Erased) {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -772,8 +772,8 @@ impl_scope! {
             kas::impls::_send(self, cx, data, id, event)
         }
 
-        fn _replay(&mut self, cx: &mut EventCx, data: &A, id: Id, msg: kas::messages::Erased) {
-            kas::impls::_replay(self, cx, data, id, msg);
+        fn _replay(&mut self, cx: &mut EventCx, data: &A, id: Id) {
+            kas::impls::_replay(self, cx, data, id);
         }
 
         // Non-standard implementation to allow mapping new children

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -115,9 +115,7 @@ impl_scope! {
                 if let Some(f) = self.on_press.as_ref() {
                     f(cx, data);
                 }
-                if let Some(code) = code {
-                    cx.depress_with_key(self.id(), code);
-                }
+                cx.depress_with_key(self.id(), code);
             }
         }
     }

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -205,9 +205,7 @@ impl_scope! {
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Self::Data) {
             if let Some(kas::messages::Activate(code)) = cx.try_pop() {
                 self.inner.toggle(cx, data);
-                if let Some(code) = code {
-                    cx.depress_with_key(self.inner.id(), code);
-                }
+                cx.depress_with_key(self.inner.id(), code);
             }
         }
     }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -92,9 +92,7 @@ impl_scope! {
                         match cmd {
                             cmd if cmd.is_activate() => {
                                 self.popup.close(cx);
-                                if let Some(code) = code {
-                                    cx.depress_with_key(self.id(), code);
-                                }
+                                cx.depress_with_key(self.id(), code);
                             }
                             Command::Up => next(cx, false, true),
                             Command::Down => next(cx, false, false),
@@ -107,9 +105,7 @@ impl_scope! {
                         let action = match cmd {
                             cmd if cmd.is_activate() => {
                                 open_popup(self, cx, FocusSource::Key);
-                                if let Some(code) = code {
-                                    cx.depress_with_key(self.id(), code);
-                                }
+                                cx.depress_with_key(self.id(), code);
                                 Action::empty()
                             }
                             Command::Up => self.set_active(self.active.saturating_sub(1)),

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -1534,9 +1534,7 @@ impl<G: EditGuard> EditField<G> {
             EditAction::None => Used,
             EditAction::Unused => Unused,
             EditAction::Activate => {
-                if let Some(code) = code {
-                    cx.depress_with_key(self.id(), code);
-                }
+                cx.depress_with_key(self.id(), code);
                 G::activate(self, cx, data)
             }
             EditAction::Edit => {

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -125,14 +125,15 @@ impl_scope! {
             if self.message_handlers.is_empty() {
                 return;
             }
-            let mut update = false;
-            let mut cx = AdaptEventCx::new(cx, self.id());
-            let index = cx.last_child().expect("message not sent from self");
-            for handler in self.message_handlers.iter() {
-                update |= handler(&mut cx, data, index);
-            }
-            if update {
-                cx.update(self.as_node(data));
+            if let Some(index) = cx.last_child() {
+                let mut update = false;
+                let mut cx = AdaptEventCx::new(cx, self.id());
+                for handler in self.message_handlers.iter() {
+                    update |= handler(&mut cx, data, index);
+                }
+                if update {
+                    cx.update(self.as_node(data));
+                }
             }
         }
     }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -143,14 +143,15 @@ impl_scope! {
             if self.message_handlers.is_empty() {
                 return;
             }
-            let mut update = false;
-            let mut cx = AdaptEventCx::new(cx, self.id());
-            let index = cx.last_child().expect("message not sent from self");
-            for handler in self.message_handlers.iter() {
-                update |= handler(&mut cx, data, index);
-            }
-            if update {
-                cx.update(self.as_node(data));
+            if let Some(index) = cx.last_child() {
+                let mut update = false;
+                let mut cx = AdaptEventCx::new(cx, self.id());
+                for handler in self.message_handlers.iter() {
+                    update |= handler(&mut cx, data, index);
+                }
+                if update {
+                    cx.update(self.as_node(data));
+                }
             }
         }
     }

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -74,9 +74,7 @@ impl_scope! {
             match event {
                 Event::Command(cmd, code) if cmd.is_activate() => {
                     cx.push(self.msg.clone());
-                    if let Some(code) = code {
-                        cx.depress_with_key(self.id(), code);
-                    }
+                    cx.depress_with_key(self.id(), code);
                     Used
                 }
                 _ => Unused,
@@ -86,9 +84,7 @@ impl_scope! {
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
             if let Some(kas::messages::Activate(code)) = cx.try_pop() {
                 cx.push(self.msg.clone());
-                if let Some(code) = code {
-                    cx.depress_with_key(self.id(), code);
-                }
+                cx.depress_with_key(self.id(), code);
             }
         }
     }
@@ -141,9 +137,7 @@ impl_scope! {
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Self::Data) {
             if let Some(kas::messages::Activate(code)) = cx.try_pop() {
                 self.checkbox.toggle(cx, data);
-                if let Some(code) = code {
-                    cx.depress_with_key(self.id(), code);
-                }
+                cx.depress_with_key(self.id(), code);
             }
         }
     }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -125,9 +125,7 @@ impl_scope! {
             match event {
                 Event::Command(cmd, code) if cmd.is_activate() => {
                     self.open_menu(cx, data, true);
-                    if let Some(code) = code {
-                        cx.depress_with_key(self.id(), code);
-                    }
+                    cx.depress_with_key(self.id(), code);
                     Used
                 }
                 Event::Command(cmd, _) => self.handle_dir_key(cx, data, cmd),
@@ -138,9 +136,7 @@ impl_scope! {
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Data) {
             if let Some(kas::messages::Activate(code)) = cx.try_pop() {
                 self.popup.open(cx, data, self.id());
-                if let Some(code) = code {
-                    cx.depress_with_key(self.id(), code);
-                }
+                cx.depress_with_key(self.id(), code);
             } else {
                 self.popup.close(cx);
             }

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -47,9 +47,7 @@ impl_scope! {
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
                 Event::Command(cmd, code) if cmd.is_activate() => {
-                    if let Some(code) = code {
-                        cx.depress_with_key(self.id(), code);
-                    }
+                    cx.depress_with_key(self.id(), code);
                     cx.push(kas::messages::Select);
                     Used
                 }

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -165,9 +165,7 @@ impl_scope! {
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Self::Data) {
             if let Some(kas::messages::Activate(code)) = cx.try_pop() {
                 self.inner.select(cx, data);
-                if let Some(code) = code {
-                    cx.depress_with_key(self.inner.id(), code);
-                }
+                cx.depress_with_key(self.inner.id(), code);
             }
         }
     }

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -559,13 +559,13 @@ impl_scope! {
 
     impl Events for Self {
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
-            let index = cx.last_child().expect("message not sent from self");
-            if index == widget_index![self.horiz_bar] {
+            let index = cx.last_child();
+            if index == Some(widget_index![self.horiz_bar]) {
                 if let Some(ScrollMsg(x)) = cx.try_pop() {
                     let offset = Offset(x, self.inner.scroll_offset().1);
                     self.inner.set_scroll_offset(cx, offset);
                 }
-            } else if index == widget_index![self.vert_bar] {
+            } else if index == Some(widget_index![self.vert_bar]) {
                 if let Some(ScrollMsg(y)) = cx.try_pop() {
                     let offset = Offset(self.inner.scroll_offset().0, y);
                     self.inner.set_scroll_offset(cx, offset);

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -375,9 +375,7 @@ impl_scope! {
                         _ => return Unused,
                     };
 
-                    if let Some(code) = code {
-                        cx.depress_with_key(self.id(), code);
-                    }
+                    cx.depress_with_key(self.id(), code);
 
                     let action = self.set_value(value);
                     if !action.is_empty() {

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -305,15 +305,11 @@ impl_scope! {
             let btn = match event {
                 Event::Command(cmd, code) => match cmd {
                     Command::Down => {
-                        if let Some(code) = code {
-                            cx.depress_with_key(self.b_down.id(), *code);
-                        }
+                        cx.depress_with_key(self.b_down.id(), *code);
                         SpinBtn::Down
                     }
                     Command::Up => {
-                        if let Some(code) = code {
-                            cx.depress_with_key(self.b_up.id(), *code);
-                        }
+                        cx.depress_with_key(self.b_up.id(), *code);
                         SpinBtn::Up
                     }
                     _ => return Unused,

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -254,14 +254,15 @@ impl_scope! {
         }
 
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
-            let index = cx.last_child().expect("message not sent from self");
-            if (index & 1) == 1 {
-                if let Some(GripMsg::PressMove(offset)) = cx.try_pop() {
-                    let n = index >> 1;
-                    assert!(n < self.handles.len());
-                    let action = self.handles[n].set_offset(offset).1;
-                    cx.action(&self, action);
-                    self.adjust_size(&mut cx.config_cx(), n);
+            if let Some(index) = cx.last_child() {
+                if (index & 1) == 1 {
+                    if let Some(GripMsg::PressMove(offset)) = cx.try_pop() {
+                        let n = index >> 1;
+                        assert!(n < self.handles.len());
+                        let action = self.handles[n].set_offset(offset).1;
+                        cx.action(&self, action);
+                        self.adjust_size(&mut cx.config_cx(), n);
+                    }
                 }
             }
         }

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -78,9 +78,7 @@ impl_scope! {
         fn handle_messages(&mut self, cx: &mut EventCx, _: &()) {
             if let Some(kas::messages::Activate(code)) = cx.try_pop() {
                 cx.push(Select);
-                if let Some(code) = code {
-                    cx.depress_with_key(self.id(), code);
-                }
+                cx.depress_with_key(self.id(), code);
             }
         }
     }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -13,6 +13,7 @@ use kas::event::Key;
 use kas::prelude::*;
 use kas::resvg::Svg;
 use kas::theme::{MarginStyle, ThemeControl};
+use kas::widgets::adapt::AdaptEvents;
 use kas::widgets::*;
 
 #[derive(Debug, Default)]
@@ -260,19 +261,29 @@ fn editor() -> Box<dyn Widget<Data = AppData>> {
     #[derive(Clone, Debug)]
     struct MsgDirection;
 
+    #[derive(Clone, Debug)]
+    struct SetLabelId(Id);
+
+    #[derive(Debug, Default)]
+    struct GuardData {
+        disabled: bool,
+        label_id: Id,
+    }
+
     struct Guard;
     impl EditGuard for Guard {
-        type Data = AppData;
+        type Data = GuardData;
 
-        fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &AppData) {
+        fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &GuardData) {
             cx.set_disabled(edit.id(), data.disabled);
         }
 
-        fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &AppData) {
+        fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, data: &GuardData) {
             let result = Markdown::new(edit.get_str());
             let act = edit.set_error_state(result.is_err());
             cx.action(edit, act);
-            cx.push(result.unwrap_or_else(|err| Markdown::new(&format!("{err}")).unwrap()));
+            let text = result.unwrap_or_else(|err| Markdown::new(&format!("{err}")).unwrap());
+            cx.send(data.label_id.clone(), text);
         }
     }
 
@@ -307,17 +318,29 @@ Demonstration of *as-you-type* formatting from **Markdown**.
         struct {
             core: widget_core!(),
             dir: Direction = Direction::Up,
-            #[widget] editor: EditBox<Guard> =
+            guard_data: GuardData = GuardData::default(),
+            #[widget(&self.guard_data)] editor: EditBox<Guard> =
                 EditBox::new(Guard)
                     .with_multi_line(true)
                     .with_lines(4, 12)
                     .with_text(doc),
-            #[widget(&())] label: ScrollLabel<Markdown> =
-                ScrollLabel::new(Markdown::new(doc).unwrap()),
+            #[widget(&())] label: AdaptEvents<ScrollLabel<Markdown>> =
+                ScrollLabel::new(Markdown::new(doc).unwrap())
+                .on_configure(|cx, label| {
+                    cx.push(label.id(), SetLabelId(label.id()));
+                })
+                .on_message(|cx, label, text| {
+                    let act = label.set_text(text);
+                    cx.action(label, act);
+                }),
         }
 
         impl Events for Self {
             type Data = AppData;
+
+            fn update(&mut self, _: &mut ConfigCx, data: &AppData) {
+                self.guard_data.disabled = data.disabled;
+            }
 
             fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
                 if let Some(MsgDirection) = cx.try_pop() {
@@ -326,9 +349,8 @@ Demonstration of *as-you-type* formatting from **Markdown**.
                         _ => Direction::Up,
                     };
                     cx.resize(self);
-                } else if let Some(md) = cx.try_pop::<Markdown>() {
-                    let act = self.label.set_text(md);
-                    cx.action(self, act);
+                } else if let Some(SetLabelId(id)) = cx.try_pop() {
+                    self.guard_data.label_id = id;
                 }
             }
         }


### PR DESCRIPTION
- Add `fn EventState::send<M: Debug + 'static>(&mut self, id: Id, msg: M)` to send a type-erased message to a designated target
- Add `fn ConfigCx::push<M: Debug + 'static>(&mut self, id: Id, msg: M)` to emit a type-erased message from configure/update

Currently the second method is just a wrapper around the first, but (a) there might be a distinction between "push/emit a reusable message" and "send a non-reusable message" in the future and (b) `ConfigCx` *might* gain an embedded `Id` for the current widget, in which case `push` would lose the `id` parameter (but `send` would not).

> [handle_messages impls: do not expect cx.last_child().is_some()](https://github.com/kas-gui/kas/commit/6791f6e9592fe63fa97ab9af633cbfc13a51ca29)

Since it's now possible to *send* a message, `handle_messages` cannot assume that a message comes from a child.