### PR TITLE
Make AdaptEvents a thin wrapper over an inner widget

### DIFF
--- a/crates/kas-core/src/event/cx/config.rs
+++ b/crates/kas-core/src/event/cx/config.rs
@@ -16,7 +16,8 @@ use crate::{Id, Node};
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
-#[allow(unused)] use crate::{event::Event, Events, Layout};
+#[allow(unused)] use crate::event::{Event, EventCx};
+#[allow(unused)] use crate::{Events, Layout};
 
 /// Widget configuration and update context
 ///

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -738,6 +738,14 @@ impl<'a> EventCx<'a> {
         self.messages.try_observe()
     }
 
+    /// Try getting a debug representation of the last message on the stack
+    ///
+    /// Note: this method will always return `None` in release builds.
+    /// This may or may not change in future versions.
+    pub fn try_debug(&self) -> Option<&dyn Debug> {
+        self.messages.try_debug()
+    }
+
     /// Set a scroll action
     ///
     /// When setting [`Scroll::Rect`], use the widget's own coordinate space.

--- a/crates/kas-core/src/messages.rs
+++ b/crates/kas-core/src/messages.rs
@@ -182,6 +182,26 @@ impl MessageStack {
             None
         }
     }
+
+    /// Try getting a debug representation of the last message on the stack
+    ///
+    /// Note: this method will always return `None` in release builds.
+    /// This may or may not change in future versions.
+    pub fn try_debug(&self) -> Option<&dyn Debug> {
+        cfg_if::cfg_if! {
+            if #[cfg(debug_assertions)] {
+                if let Some(m) = self.stack.last(){
+                    println!("message: {:?}", &m.fmt);
+                } else {
+                    println!("empty stack");
+                }
+                self.stack.last().map(|m| &m.fmt as &dyn Debug)
+            } else {
+                println!("release");
+                None
+            }
+        }
+    }
 }
 
 impl Drop for MessageStack {

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -698,7 +698,8 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                 }
             };
 
-            let layout_methods = layout.layout_methods(&quote! { self.#core })?;
+            // Generated layout methods are wrapped, so we don't require debug assertions here.
+            let layout_methods = layout.layout_methods(&quote! { self.#core }, false)?;
             scope.generated.push(quote! {
                 impl #impl_generics ::kas::layout::AutoLayout for #impl_target {
                     #layout_methods

--- a/crates/kas-view/src/driver.rs
+++ b/crates/kas-view/src/driver.rs
@@ -70,9 +70,9 @@ pub trait Driver<Item, Data: SharedData<Item = Item>> {
     fn on_messages(
         &mut self,
         cx: &mut EventCx,
+        widget: &mut Self::Widget,
         data: &Data,
         key: &Data::Key,
-        widget: &mut Self::Widget,
     ) {
         let _ = (cx, data, key, widget);
     }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -721,7 +721,7 @@ impl_scope! {
                     None => return,
                 };
 
-                self.driver.on_messages(cx, data, &key, &mut w.widget);
+                self.driver.on_messages(cx, &mut w.widget, data, &key);
             } else {
                 // Message is from self
                 key = match self.press_target.as_ref() {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -689,7 +689,7 @@ impl_scope! {
                     None => return,
                 };
 
-                self.driver.on_messages(cx, data, &key, &mut w.widget);
+                self.driver.on_messages(cx, &mut w.widget, data, &key);
             } else {
                 // Message is from self
                 key = match self.press_target.clone() {

--- a/crates/kas-widgets/src/adapt/adapt_events.rs
+++ b/crates/kas-widgets/src/adapt/adapt_events.rs
@@ -6,120 +6,264 @@
 //! Event adapters
 
 use super::{AdaptConfigCx, AdaptEventCx};
-use kas::event::{ConfigCx, EventCx};
-use kas::{autoimpl, impl_scope, widget_index, Events, LayoutExt, Widget};
+use kas::event::{ConfigCx, Event, EventCx, IsUsed, Unused};
+use kas::geom::{Coord, Rect};
+use kas::layout::{AxisInfo, SizeRules, Visitor};
+use kas::theme::{DrawCx, SizeCx};
+use kas::{autoimpl, widget_index};
+use kas::{CoreData, Events, Id, Layout, LayoutExt, NavAdvance, Node, Widget};
 use std::fmt::Debug;
 
-impl_scope! {
-    /// Wrapper with configure / update / message handling callbacks.
+/// Wrapper with configure / update / message handling callbacks.
+///
+/// This type is constructed by some [`AdaptWidget`](super::AdaptWidget) methods.
+#[autoimpl(Deref, DerefMut using self.inner)]
+#[autoimpl(Scrollable using self.inner where W: trait)]
+pub struct AdaptEvents<W: Widget> {
+    core: CoreData,
+    pub inner: W,
+    on_configure: Option<Box<dyn Fn(&mut AdaptConfigCx, &mut W)>>,
+    on_update: Option<Box<dyn Fn(&mut AdaptConfigCx, &mut W, &W::Data)>>,
+    message_handlers: Vec<Box<dyn Fn(&mut AdaptEventCx, &mut W, &W::Data)>>,
+}
+
+impl<W: Widget> AdaptEvents<W> {
+    /// Construct
+    #[inline]
+    pub fn new(inner: W) -> Self {
+        AdaptEvents {
+            core: Default::default(),
+            inner,
+            on_configure: None,
+            on_update: None,
+            message_handlers: vec![],
+        }
+    }
+
+    /// Call the given closure on [`Events::configure`]
+    #[must_use]
+    pub fn on_configure<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&mut AdaptConfigCx, &mut W) + 'static,
+    {
+        self.on_configure = Some(Box::new(f));
+        self
+    }
+
+    /// Call the given closure on [`Events::update`]
+    #[must_use]
+    pub fn on_update<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&mut AdaptConfigCx, &mut W, &W::Data) + 'static,
+    {
+        self.on_update = Some(Box::new(f));
+        self
+    }
+
+    /// Add a handler on message of type `M`
     ///
-    /// This type is constructed by some [`AdaptWidget`](super::AdaptWidget) methods.
-    #[autoimpl(Deref, DerefMut using self.inner)]
-    #[autoimpl(Scrollable using self.inner where W: trait)]
-    #[widget {
-        layout = self.inner;
-    }]
-    pub struct AdaptEvents<W: Widget> {
-        core: widget_core!(),
-        #[widget]
-        pub inner: W,
-        on_configure: Option<Box<dyn Fn(&mut AdaptConfigCx, &mut W)>>,
-        on_update: Option<Box<dyn Fn(&mut AdaptConfigCx, &mut W, &W::Data)>>,
-        message_handlers: Vec<Box<dyn Fn(&mut AdaptEventCx, &mut W, &W::Data)>>,
+    /// Where access to input data is required, use [`Self::on_messages`] instead.
+    #[must_use]
+    pub fn on_message<M, H>(self, handler: H) -> Self
+    where
+        M: Debug + 'static,
+        H: Fn(&mut AdaptEventCx, &mut W, M) + 'static,
+    {
+        self.on_messages(move |cx, w, _data| {
+            if let Some(m) = cx.try_pop() {
+                handler(cx, w, m);
+            }
+        })
     }
 
-    impl Self {
-        /// Construct
-        #[inline]
-        pub fn new(inner: W) -> Self {
-            AdaptEvents {
-                core: Default::default(),
-                inner,
-                on_configure: None,
-                on_update: None,
-                message_handlers: vec![],
-            }
-        }
+    /// Add a generic message handler
+    #[must_use]
+    pub fn on_messages<H>(mut self, handler: H) -> Self
+    where
+        H: Fn(&mut AdaptEventCx, &mut W, &W::Data) + 'static,
+    {
+        self.message_handlers.push(Box::new(handler));
+        self
+    }
+}
 
-        /// Call the given closure on [`Events::configure`]
-        #[must_use]
-        pub fn on_configure<F>(mut self, f: F) -> Self
-        where
-            F: Fn(&mut AdaptConfigCx, &mut W) + 'static,
-        {
-            self.on_configure = Some(Box::new(f));
-            self
+impl<W: Widget> Events for AdaptEvents<W> {
+    fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+        let id = self.make_child_id(widget_index!(0usize));
+        cx.configure(self.inner.as_node(data), id.clone());
+        if let Some(ref f) = self.on_configure {
+            let mut cx = AdaptConfigCx::new(cx, id.clone());
+            f(&mut cx, &mut self.inner);
         }
-
-        /// Call the given closure on [`Events::update`]
-        #[must_use]
-        pub fn on_update<F>(mut self, f: F) -> Self
-        where
-            F: Fn(&mut AdaptConfigCx, &mut W, &W::Data) + 'static,
-        {
-            self.on_update = Some(Box::new(f));
-            self
-        }
-
-        /// Add a handler on message of type `M`
-        ///
-        /// Where access to input data is required, use [`Self::on_messages`] instead.
-        #[must_use]
-        pub fn on_message<M, H>(self, handler: H) -> Self
-        where
-            M: Debug + 'static,
-            H: Fn(&mut AdaptEventCx, &mut W, M) + 'static,
-        {
-            self.on_messages(move |cx, w, _data| {
-                if let Some(m) = cx.try_pop() {
-                    handler(cx, w, m);
-                }
-            })
-        }
-
-        /// Add a generic message handler
-        #[must_use]
-        pub fn on_messages<H>(mut self, handler: H) -> Self
-        where
-            H: Fn(&mut AdaptEventCx, &mut W, &W::Data) + 'static,
-        {
-            self.message_handlers.push(Box::new(handler));
-            self
+        if let Some(ref f) = self.on_update {
+            let mut cx = AdaptConfigCx::new(cx, id);
+            f(&mut cx, &mut self.inner, data);
         }
     }
 
-    impl Events for Self {
-        type Data = W::Data;
+    fn update_recurse(&mut self, cx: &mut ConfigCx, data: &W::Data) {
+        cx.update(self.inner.as_node(data));
+        if let Some(ref f) = self.on_update {
+            let mut cx = AdaptConfigCx::new(cx, self.inner.id());
+            f(&mut cx, &mut self.inner, data);
+        }
+    }
 
-        // This is a little bit hacky: the closures operate on self.inner, so we
-        // need to ensure that is configured / updated first!
+    fn handle_messages(&mut self, cx: &mut EventCx, data: &W::Data) {
+        let mut cx = AdaptEventCx::new(cx, self.inner.id());
+        for handler in self.message_handlers.iter() {
+            handler(&mut cx, &mut self.inner, data);
+        }
+    }
 
-        fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
-            let id = self.make_child_id(widget_index!(self.inner));
-            cx.configure(self.inner.as_node(data), id.clone());
-            if let Some(ref f) = self.on_configure {
-                let mut cx = AdaptConfigCx::new(cx, id.clone());
-                f(&mut cx, &mut self.inner);
+    fn steal_event(&mut self, _: &mut EventCx, _: &Self::Data, _: &Id, _: &Event) -> IsUsed {
+        #[cfg(debug_assertions)]
+        self.core.status.require_rect(&self.core.id);
+        Unused
+    }
+
+    fn handle_event(&mut self, _: &mut EventCx, _: &Self::Data, _: Event) -> IsUsed {
+        #[cfg(debug_assertions)]
+        self.core.status.require_rect(&self.core.id);
+        Unused
+    }
+}
+impl<W: Widget> Widget for AdaptEvents<W> {
+    type Data = W::Data;
+
+    #[inline]
+    fn as_node<'a>(&'a mut self, data: &'a Self::Data) -> Node<'a> {
+        Node::new(self, data)
+    }
+
+    fn for_child_node(
+        &mut self,
+        data: &Self::Data,
+        index: usize,
+        closure: Box<dyn FnOnce(Node<'_>) + '_>,
+    ) {
+        match index {
+            0usize => closure(self.inner.as_node(data)),
+            _ => (),
+        }
+    }
+
+    fn _configure(&mut self, cx: &mut ConfigCx, data: &Self::Data, id: Id) {
+        self.core.id = id;
+        #[cfg(debug_assertions)]
+        self.core.status.configure(&self.core.id);
+        Events::configure(self, cx);
+        Events::update(self, cx, data);
+        Events::configure_recurse(self, cx, data);
+    }
+
+    fn _update(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+        #[cfg(debug_assertions)]
+        self.core.status.update(&self.core.id);
+        Events::update(self, cx, data);
+        Events::update_recurse(self, cx, data);
+    }
+
+    fn _send(&mut self, cx: &mut EventCx, data: &Self::Data, id: Id, event: Event) -> IsUsed {
+        kas::impls::_send(self, cx, data, id, event)
+    }
+
+    fn _replay(&mut self, cx: &mut EventCx, data: &Self::Data, id: Id) {
+        kas::impls::_replay(self, cx, data, id);
+    }
+
+    fn _nav_next(
+        &mut self,
+        cx: &mut ConfigCx,
+        data: &Self::Data,
+        focus: Option<&Id>,
+        advance: NavAdvance,
+    ) -> Option<Id> {
+        kas::impls::_nav_next(self, cx, data, focus, advance)
+    }
+}
+
+impl<W: Widget> Layout for AdaptEvents<W> {
+    #[inline]
+    fn as_layout(&self) -> &dyn Layout {
+        self
+    }
+
+    #[inline]
+    fn id_ref(&self) -> &Id {
+        &self.core.id
+    }
+
+    #[inline]
+    fn rect(&self) -> Rect {
+        self.core.rect
+    }
+
+    #[inline]
+    fn widget_name(&self) -> &'static str {
+        "AdaptEvents"
+    }
+
+    fn num_children(&self) -> usize {
+        1usize
+    }
+
+    fn get_child(&self, index: usize) -> Option<&dyn Layout> {
+        match index {
+            0usize => Some(self.inner.as_layout()),
+            _ => None,
+        }
+    }
+
+    fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
+        #[cfg(debug_assertions)]
+        self.core.status.size_rules(&self.core.id, axis);
+
+        (Visitor::single(&mut self.inner)).size_rules(sizer, axis)
+    }
+
+    fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect) {
+        #[cfg(debug_assertions)]
+        self.core.status.set_rect(&self.core.id);
+
+        self.core.rect = rect;
+        (Visitor::single(&mut self.inner)).set_rect(cx, rect);
+    }
+
+    fn nav_next(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
+        let mut iter = [0usize].into_iter();
+        if !reverse {
+            if let Some(wi) = from {
+                let _ = iter.find(|x| *x == wi);
             }
-            if let Some(ref f) = self.on_update {
-                let mut cx = AdaptConfigCx::new(cx, id);
-                f(&mut cx, &mut self.inner, data);
+            iter.next()
+        } else {
+            let mut iter = iter.rev();
+            if let Some(wi) = from {
+                let _ = iter.find(|x| *x == wi);
             }
+            iter.next()
+        }
+    }
+
+    fn find_id(&mut self, coord: Coord) -> Option<Id> {
+        #[cfg(debug_assertions)]
+        self.core.status.require_rect(&self.core.id);
+
+        if !self.rect().contains(coord) {
+            return None;
         }
 
-        fn update_recurse(&mut self, cx: &mut ConfigCx, data: &W::Data) {
-            cx.update(self.inner.as_node(data));
-            if let Some(ref f) = self.on_update {
-                let mut cx = AdaptConfigCx::new(cx, self.inner.id());
-                f(&mut cx, &mut self.inner, data);
-            }
-        }
+        let coord = coord + self.translation();
+        (Visitor::single(&mut self.inner))
+            .find_id(coord)
+            .or_else(|| Some(self.id()))
+    }
 
-        fn handle_messages(&mut self, cx: &mut EventCx, data: &W::Data) {
-            let mut cx = AdaptEventCx::new(cx, self.inner.id());
-            for handler in self.message_handlers.iter() {
-                handler(&mut cx, &mut self.inner, data);
-            }
-        }
+    fn draw(&mut self, draw: DrawCx) {
+        #[cfg(debug_assertions)]
+        self.core.status.require_rect(&self.core.id);
+
+        (Visitor::single(&mut self.inner)).draw(draw);
     }
 }

--- a/crates/kas-widgets/src/adapt/adapt_widget.rs
+++ b/crates/kas-widgets/src/adapt/adapt_widget.rs
@@ -80,6 +80,29 @@ pub trait AdaptWidget: Widget + Sized {
         AdaptEvents::new(self).on_message(handler)
     }
 
+    /// Add a child handler to map messages of type `M` to `N`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use kas::messages::Select;
+    /// use kas_widgets::{AdaptWidget, Row, Tab};
+    ///
+    /// #[derive(Clone, Debug)]
+    /// struct MsgSelectIndex(usize);
+    ///
+    /// let tabs = Row::new([Tab::new("A")])
+    ///     .map_message(|index, Select| MsgSelectIndex(index));
+    /// ```
+    fn map_message<M, N, H>(self, handler: H) -> AdaptEvents<Self>
+    where
+        M: Debug + 'static,
+        N: Debug + 'static,
+        H: Fn(usize, M) -> N + 'static,
+    {
+        AdaptEvents::new(self).map_message(handler)
+    }
+
     /// Add a generic message handler
     ///
     /// Returns a wrapper around the input widget.

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -5,11 +5,9 @@
 
 //! A grid widget
 
-use crate::adapt::AdaptEventCx;
 use kas::layout::{DynGridStorage, GridChildInfo, GridDimensions};
 use kas::layout::{GridSetter, GridSolver, RulesSetter, RulesSolver};
 use kas::{layout, prelude::*};
-use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
 
 /// A grid of boxed widgets
@@ -47,11 +45,6 @@ impl_scope! {
     /// ## Performance
     ///
     /// Most operations are `O(n)` in the number of children.
-    ///
-    /// # Messages
-    ///
-    /// If a handler is specified via [`Self::on_messages`] then this handler is
-    /// called when a child pushes a message.
     #[autoimpl(Default)]
     #[widget]
     pub struct Grid<W: Widget> {
@@ -59,7 +52,6 @@ impl_scope! {
         widgets: Vec<(GridChildInfo, W)>,
         data: DynGridStorage,
         dim: GridDimensions,
-        message_handlers: Vec<Box<dyn Fn(&mut AdaptEventCx, &W::Data, usize) -> bool>>,
     }
 
     impl Widget for Self {
@@ -119,24 +111,6 @@ impl_scope! {
             }
         }
     }
-
-    impl Events for Self {
-        fn handle_messages(&mut self, cx: &mut EventCx, data: &Self::Data) {
-            if self.message_handlers.is_empty() {
-                return;
-            }
-            if let Some(index) = cx.last_child() {
-                let mut update = false;
-                let mut cx = AdaptEventCx::new(cx, self.id());
-                for handler in self.message_handlers.iter() {
-                    update |= handler(&mut cx, data, index);
-                }
-                if update {
-                    cx.update(self.as_node(data));
-                }
-            }
-        }
-    }
 }
 
 impl<W: Widget> Grid<W> {
@@ -155,65 +129,6 @@ impl<W: Widget> Grid<W> {
         };
         grid.calc_dim();
         grid
-    }
-
-    /// Add a child handler to map messages of type `M` to `N`
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use kas::messages::Select;
-    /// use kas_widgets::{Row, Tab};
-    ///
-    /// #[derive(Clone, Debug)]
-    /// struct MsgSelectIndex(usize);
-    ///
-    /// let tabs: Row<Tab> = Row::new([]).map_message(|index, Select| MsgSelectIndex(index));
-    /// ```
-    pub fn map_message<M, N, H>(self, handler: H) -> Self
-    where
-        M: Debug + 'static,
-        N: Debug + 'static,
-        H: Fn(usize, M) -> N + 'static,
-    {
-        self.on_messages(move |cx, _data, index| {
-            if let Some(m) = cx.try_pop() {
-                cx.push(handler(index, m));
-            }
-            false
-        })
-    }
-
-    /// Add a child handler for messages of type `M`
-    ///
-    /// Where multiple message types must be handled or access to the
-    /// [`AdaptEventCx`] is required, use [`Self::on_messages`] instead.
-    pub fn on_message<M, H>(self, handler: H) -> Self
-    where
-        M: Debug + 'static,
-        H: Fn(&mut AdaptEventCx, usize, M) + 'static,
-    {
-        self.on_messages(move |cx, _data, index| {
-            if let Some(m) = cx.try_pop() {
-                handler(cx, index, m);
-                true
-            } else {
-                false
-            }
-        })
-    }
-
-    /// Add a child message handler (inline style)
-    ///
-    /// This handler is called when a child pushes a message:
-    /// `f(cx, index)`, where `index` is the child's index.
-    #[inline]
-    pub fn on_messages<H>(mut self, handler: H) -> Self
-    where
-        H: Fn(&mut AdaptEventCx, &W::Data, usize) -> bool + 'static,
-    {
-        self.message_handlers.push(Box::new(handler));
-        self
     }
 
     /// Get grid dimensions

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -222,33 +222,6 @@ impl_scope! {
             }
         }
 
-        /// Add a child handler to map messages of type `M` to `N`
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// use kas::messages::Select;
-        /// use kas_widgets::{Row, Tab};
-        ///
-        /// #[derive(Clone, Debug)]
-        /// struct MsgSelectIndex(usize);
-        ///
-        /// let tabs: Row<Tab> = Row::new([]).map_message(|index, Select| MsgSelectIndex(index));
-        /// ```
-        pub fn map_message<M, N, H>(self, handler: H) -> Self
-        where
-            M: Debug + 'static,
-            N: Debug + 'static,
-            H: Fn(usize, M) -> N + 'static,
-        {
-            self.on_messages(move |cx, _data, index| {
-                if let Some(m) = cx.try_pop() {
-                    cx.push(handler(index, m));
-                }
-                false
-            })
-        }
-
         /// Add a child handler for messages of type `M`
         ///
         /// Where multiple message types must be handled or access to the

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -5,6 +5,7 @@
 
 //! A tabbed stack
 
+use crate::adapt::{AdaptEvents, AdaptWidget};
 use crate::{AccessLabel, Row, Stack};
 use kas::layout::{FrameStorage, Visitor};
 use kas::messages::Select;
@@ -122,7 +123,7 @@ impl_scope! {
         core: widget_core!(),
         direction: Direction,
         #[widget(&())]
-        tabs: Row<Tab>, // TODO: want a TabBar widget for scrolling support?
+        tabs: AdaptEvents<Row<Tab>>, // TODO: want a TabBar widget for scrolling support?
         #[widget]
         stack: Stack<W>,
         on_change: Option<Box<dyn Fn(&mut EventCx, &W::Data, usize, &str)>>,

--- a/crates/kas-widgets/src/text.rs
+++ b/crates/kas-widgets/src/text.rs
@@ -16,7 +16,8 @@ impl_scope! {
     /// `Text` derives its contents from input data. Use [`Label`](crate::Label)
     /// instead for fixed contents.
     ///
-    /// See also macros [`format_data`] and [`format_value`] which construct a
+    /// See also macros [`format_data`](super::format_data) and
+    /// [`format_value`](super::format_value) which construct a
     /// `Text` widget. See also parameterizations [`StrText`], [`StringText`].
     ///
     /// Vertical alignment defaults to centred, horizontal alignment depends on


### PR DESCRIPTION
`AdaptEvents` is now a special thin wrapper over the inner widget. Implications:

- It does not have its own `Id`
- Introspection over a tree with an `AdaptEvents`-wrapped widget would see a different `widget_name` (affecting debug output) but otherwise identical tree, assuming the wrapper did not use any message handlers
- Usage of `EventCx::last_child` from `AdaptEvents` now works as expected (instead of just returning the index of the wrapped child, 0)

The latter is the main motivation, and makes it unnecessary to have message handler support in `Grid` and `List` (which could be confusing in practice without also supporting `.on_configure` and `.on_update` on those types).

This exposed a couple of potential issues in `ComboBox` which were fixed.

Also: add `fn EventCx::try_debug` to support debugging of unexpected message types in message handlers.