### PR TITLE
Add Collection trait

### DIFF
--- a/crates/kas-core/src/core/collection.rs
+++ b/crates/kas-core/src/core/collection.rs
@@ -1,0 +1,196 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! The [`Collection`] trait
+
+use crate::{Layout, Node, Widget};
+use std::ops::RangeBounds;
+
+/// A collection of (child) widgets
+///
+/// Essentially, implementating types are lists of widgets. Simple examples are
+/// `Vec<W>` and `[W; N]` where `W: Widget` and `const N: usize`. A more complex
+/// example would be a custom struct where each field is a widget.
+pub trait Collection {
+    /// The associated data type
+    type Data;
+
+    /// True if the collection is empty
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The number of widgets
+    fn len(&self) -> usize;
+
+    /// Get a widget as a [`Layout`]
+    fn get_layout(&self, index: usize) -> Option<&dyn Layout>;
+
+    /// Get a widget as a mutable [`Layout`]
+    fn get_mut_layout(&mut self, index: usize) -> Option<&mut dyn Layout>;
+
+    /// Operate on a widget as a [`Node`]
+    fn for_node(
+        &mut self,
+        data: &Self::Data,
+        index: usize,
+        closure: Box<dyn FnOnce(Node<'_>) + '_>,
+    );
+
+    /// Iterate over elements as [`Layout`] items within `range`
+    ///
+    /// Note: there is currently no mutable equivalent due to the streaming
+    /// iterator problem.
+    fn iter_layout(&self, range: impl RangeBounds<usize>) -> CollectionIterLayout<'_, Self> {
+        use std::ops::Bound::{Excluded, Included, Unbounded};
+        let start = match range.start_bound() {
+            Included(start) => *start,
+            Excluded(start) => *start + 1,
+            Unbounded => 0,
+        };
+        let end = match range.end_bound() {
+            Included(end) => *end + 1,
+            Excluded(end) => *end,
+            Unbounded => self.len(),
+        };
+        CollectionIterLayout {
+            start,
+            end,
+            collection: self,
+        }
+    }
+
+    /// Binary searches this collection with a comparator function.
+    ///
+    /// Similar to [`slice::binary_search_by`][<[()]>::binary_search_by], the
+    /// comparator function should return whether the element is `Less` than,
+    /// `Equal` to, or `Greater` than the desired target, and the collection
+    /// should be sorted by this comparator (if not, the result is meaningless).
+    ///
+    /// Returns:
+    ///
+    /// -   `Some(Ok(index))` if an `Equal` element is found at `index`
+    /// -   `Some(Err(index))` if no `Equal` element is found; in this case such
+    ///     an element could be inserted at `index`
+    /// -   `None` if [`Collection::get_layout`] returns `None` for some
+    ///     `index` less than [`Collection::len`]. This is an error case that
+    ///     should not occur.
+    fn binary_search_by<'a, F>(&'a self, mut f: F) -> Option<Result<usize, usize>>
+    where
+        F: FnMut(&'a dyn Layout) -> std::cmp::Ordering,
+    {
+        use std::cmp::Ordering::{Greater, Less};
+
+        // INVARIANTS:
+        // - 0 <= left <= left + size = right <= self.len()
+        // - f returns Less for everything in self[..left]
+        // - f returns Greater for everything in self[right..]
+        let mut size = self.len();
+        let mut left = 0;
+        let mut right = size;
+        while left < right {
+            let mid = left + size / 2;
+
+            let cmp = f(self.get_layout(mid)?);
+
+            if cmp == Less {
+                left = mid + 1;
+            } else if cmp == Greater {
+                right = mid;
+            } else {
+                return Some(Ok(mid));
+            }
+
+            size = right - left;
+        }
+
+        Some(Err(left))
+    }
+}
+
+/// An iterator over a [`Collection`] as [`Layout`] elements
+pub struct CollectionIterLayout<'a, C: Collection + ?Sized> {
+    start: usize,
+    end: usize,
+    collection: &'a C,
+}
+
+impl<'a, C: Collection + ?Sized> Iterator for CollectionIterLayout<'a, C> {
+    type Item = &'a dyn Layout;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.start;
+        if index < self.end {
+            self.start += 1;
+            self.collection.get_layout(index)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, C: Collection + ?Sized> DoubleEndedIterator for CollectionIterLayout<'a, C> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            let index = self.end - 1;
+            self.end = index;
+            self.collection.get_layout(index)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, C: Collection + ?Sized> ExactSizeIterator for CollectionIterLayout<'a, C> {}
+
+macro_rules! impl_slice {
+    (($($gg:tt)*) for $t:ty) => {
+        impl<$($gg)*> Collection for $t {
+            type Data = W::Data;
+
+            #[inline]
+            fn len(&self) -> usize {
+                <[W]>::len(self)
+            }
+
+            #[inline]
+            fn get_layout(&self, index: usize) -> Option<&dyn Layout> {
+                self.get(index).map(|w| w as &dyn Layout)
+            }
+
+            #[inline]
+            fn get_mut_layout(&mut self, index: usize) -> Option<&mut dyn Layout> {
+                self.get_mut(index).map(|w| w as &mut dyn Layout)
+            }
+
+            #[inline]
+            fn for_node(
+                &mut self,
+                data: &W::Data,
+                index: usize,
+                closure: Box<dyn FnOnce(Node<'_>) + '_>,
+            ) {
+                if let Some(w) = self.get_mut(index) {
+                    closure(w.as_node(data));
+                }
+            }
+
+            #[inline]
+            fn binary_search_by<'a, F>(&'a self, mut f: F) -> Option<Result<usize, usize>>
+            where
+                F: FnMut(&'a dyn Layout) -> std::cmp::Ordering,
+            {
+                Some(<[W]>::binary_search_by(self, move |w| f(w.as_layout())))
+            }
+        }
+    };
+}
+
+// NOTE: If Rust had better lifetime analysis we could replace
+// the following impls with a single one:
+// impl<W: Widget, T: std::ops::Deref<Target = [W]> + ?Sized> Collection for T
+impl_slice!((const N: usize, W: Widget) for [W; N]);
+impl_slice!((W: Widget) for [W]);
+impl_slice!((W: Widget) for Vec<W>);

--- a/crates/kas-core/src/core/mod.rs
+++ b/crates/kas-core/src/core/mod.rs
@@ -5,6 +5,7 @@
 
 //! Core widget types
 
+mod collection;
 mod data;
 mod layout;
 mod node;
@@ -16,6 +17,7 @@ mod widget_id;
 #[cfg_attr(doc_cfg, doc(cfg(internal_doc)))]
 pub mod impls;
 
+pub use collection::Collection;
 pub use data::*;
 pub use layout::*;
 pub use node::Node;

--- a/crates/kas-macros/src/collection.rs
+++ b/crates/kas-macros/src/collection.rs
@@ -1,0 +1,216 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Collection macro
+
+use proc_macro2::{Span, TokenStream as Toks};
+use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
+use syn::parse::{Parse, ParseStream, Result};
+use syn::spanned::Spanned;
+use syn::{Expr, Ident, Lifetime, LitStr, Token};
+
+#[derive(Debug)]
+pub enum StorIdent {
+    Named(Ident, Span),
+    Generated(String, Span),
+}
+impl From<Lifetime> for StorIdent {
+    fn from(lt: Lifetime) -> StorIdent {
+        let span = lt.span();
+        StorIdent::Named(lt.ident, span)
+    }
+}
+impl ToTokens for StorIdent {
+    fn to_tokens(&self, toks: &mut Toks) {
+        match self {
+            StorIdent::Named(ident, _) => ident.to_tokens(toks),
+            StorIdent::Generated(string, span) => Ident::new(string, *span).to_tokens(toks),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct NameGenerator(usize);
+impl NameGenerator {
+    pub fn next(&mut self) -> StorIdent {
+        let name = format!("_stor{}", self.0);
+        self.0 += 1;
+        StorIdent::Generated(name, Span::call_site())
+    }
+
+    pub fn parse_or_next(&mut self, input: ParseStream) -> Result<StorIdent> {
+        if input.peek(Lifetime) {
+            Ok(input.parse::<Lifetime>()?.into())
+        } else {
+            Ok(self.next())
+        }
+    }
+}
+
+pub enum Item {
+    Label(StorIdent, LitStr),
+    Widget(StorIdent, Expr),
+}
+
+impl Item {
+    fn parse(input: ParseStream, gen: &mut NameGenerator) -> Result<Self> {
+        if input.peek(LitStr) {
+            Ok(Item::Label(gen.next(), input.parse()?))
+        } else {
+            Ok(Item::Widget(gen.next(), input.parse()?))
+        }
+    }
+}
+
+pub struct Collection(Vec<Item>);
+
+impl Parse for Collection {
+    fn parse(inner: ParseStream) -> Result<Self> {
+        let mut gen = NameGenerator::default();
+
+        let mut items = vec![];
+        while !inner.is_empty() {
+            items.push(Item::parse(inner, &mut gen)?);
+
+            if inner.is_empty() {
+                break;
+            }
+
+            let _: Token![,] = inner.parse()?;
+        }
+
+        Ok(Collection(items))
+    }
+}
+
+#[derive(Default)]
+pub struct StorageFields {
+    pub ty_toks: Toks,
+    pub def_toks: Toks,
+}
+
+impl Collection {
+    fn storage_fields(
+        &self,
+        children: &mut Vec<Toks>,
+        no_data: bool,
+        data_ty: &Toks,
+    ) -> StorageFields {
+        let (mut ty_toks, mut def_toks) = (Toks::new(), Toks::new());
+        for item in &self.0 {
+            match item {
+                Item::Label(stor, text) => {
+                    children.push(stor.to_token_stream());
+                    let span = text.span();
+                    if no_data {
+                        ty_toks.append_all(quote! { #stor: ::kas::hidden::StrLabel, });
+                        def_toks.append_all(
+                            quote_spanned! {span=> #stor: ::kas::hidden::StrLabel::new(#text), },
+                        );
+                    } else {
+                        ty_toks.append_all(
+                            quote! { #stor: ::kas::hidden::MapAny<#data_ty, ::kas::hidden::StrLabel>, },
+                        );
+                        def_toks.append_all(
+                            quote_spanned! {span=> #stor: ::kas::hidden::MapAny::new(::kas::hidden::StrLabel::new(#text)), },
+                        );
+                    }
+                }
+                Item::Widget(stor, expr) => {
+                    children.push(stor.to_token_stream());
+                    ty_toks.append_all(quote! { #stor: Box<dyn ::kas::Widget<Data = #data_ty>>, });
+                    let span = expr.span();
+                    def_toks.append_all(quote_spanned! {span=> #stor: Box::new(#expr), });
+                }
+            }
+        }
+
+        StorageFields { ty_toks, def_toks }
+    }
+
+    pub fn expand(&self) -> Toks {
+        let any_widgets = self.0.iter().any(|item| matches!(item, Item::Widget(_, _)));
+
+        let name = Ident::new("_Collection", Span::call_site());
+        let (data_ty, impl_generics, impl_target) = if any_widgets {
+            (
+                quote! { _Data },
+                quote! { <_Data> },
+                quote! { #name <_Data> },
+            )
+        } else {
+            (quote! { () }, quote! {}, quote! { #name })
+        };
+
+        let mut children = Vec::new();
+        let stor_defs = self.storage_fields(&mut children, !any_widgets, &data_ty);
+        let stor_ty = &stor_defs.ty_toks;
+        let stor_def = &stor_defs.def_toks;
+
+        let len = children.len();
+        let is_empty = match len {
+            0 => quote! { true },
+            _ => quote! { false },
+        };
+
+        let mut get_layout_rules = quote! {};
+        let mut get_mut_layout_rules = quote! {};
+        let mut for_node_rules = quote! {};
+        for (index, path) in children.iter().enumerate() {
+            get_layout_rules.append_all(quote! {
+                #index => Some(&self.#path),
+            });
+            get_mut_layout_rules.append_all(quote! {
+                #index => Some(&mut self.#path),
+            });
+            for_node_rules.append_all(quote! {
+                #index => closure(self.#path.as_node(data)),
+            });
+        }
+
+        let toks = quote! {{
+            struct #name #impl_generics {
+                #stor_ty
+            }
+
+            impl #impl_generics ::kas::Collection for #impl_target {
+                type Data = #data_ty;
+
+                fn is_empty(&self) -> bool { #is_empty }
+                fn len(&self) -> usize { #len }
+
+                fn get_layout(&self, index: usize) -> Option<&dyn Layout> {
+                    match index {
+                        #get_layout_rules
+                        _ => None,
+                    }
+                }
+                fn get_mut_layout(&mut self, index: usize) -> Option<&mut dyn Layout> {
+                    match index {
+                        #get_mut_layout_rules
+                        _ => None,
+                    }
+                }
+                fn for_node(
+                    &mut self,
+                    data: &Self::Data,
+                    index: usize,
+                    closure: Box<dyn FnOnce(Node<'_>) + '_>,
+                ) {
+                    match index {
+                        #for_node_rules
+                        _ => (),
+                    }
+                }
+            }
+
+            #name {
+                #stor_def
+            }
+        }};
+        // println!("{}", toks);
+        toks
+    }
+}

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -231,10 +231,6 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; `self` `.` _Member_\
 /// > &nbsp;&nbsp; A named child: `self.foo` (more precisely, this matches any expression starting `self`, and uses `&mut (#expr)`)
 /// >
-/// > _Slice_ :\
-/// > &nbsp;&nbsp; `slice!` _Storage_? `(` _Direction_ `,` `self` `.` _Member_ `)`\
-/// > &nbsp;&nbsp; A field with type `[W]` for some `W: Layout`. (Note: this does not automatically register the slice widgets as children for the purpose of configuration and event-handling. An explicit implementation of `Widget::get_child` will be required.)
-/// >
 /// > _Frame_ :\
 /// > &nbsp;&nbsp; `frame!` _Storage_? `(` _Layout_ ( `,` `style` `=` _Expr_ )? `)`\
 /// > &nbsp;&nbsp; Adds a frame of type _Expr_ around content, defaulting to `FrameStyle::Frame`.

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -16,6 +16,7 @@ use syn::parse_macro_input;
 use syn::spanned::Spanned;
 
 mod class_traits;
+mod collection;
 mod extends;
 mod make_layout;
 mod widget;
@@ -685,6 +686,29 @@ pub fn pack(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn margins(input: TokenStream) -> TokenStream {
     parse_macro_input!(input with make_layout::Tree::margins).expand_layout("_Margins")
+}
+
+/// Generate an anonymous struct which implements [`kas::Collection`]
+///
+/// Each item must be either a string literal (inferred as a static label) or a
+/// widget (implements [`kas::Widget`](https://docs.rs/kas/latest/kas/trait.Widget.html)).
+///
+/// # Example
+///
+/// ```ignore
+/// let list = kas::widgets::List::right(kas::collection![
+///     "A checkbox",
+///     kas::widgets::CheckBox::new(|_, _| false),
+/// ]);
+/// ```
+///
+/// [`kas::Collection`]: https://docs.rs/kas/latest/kas/trait.Collection.html
+#[proc_macro_error]
+#[proc_macro]
+pub fn collection(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input as collection::Collection)
+        .expand()
+        .into()
 }
 
 /// A trait implementation is an extension over some base

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -40,7 +40,7 @@ impl_scope! {
         #[widget(&())]
         mark: Mark,
         #[widget(&())]
-        popup: Popup<AdaptEvents<Column<MenuEntry<V>>>>,
+        popup: Popup<AdaptEvents<Column<Vec<MenuEntry<V>>>>>,
         active: usize,
         opening: bool,
         state_fn: Box<dyn Fn(&ConfigCx, &A) -> V>,

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -11,6 +11,12 @@ use kas::text::format::{EditableText, FormattableText};
 use kas::text::Text;
 use kas::theme::TextClass;
 
+/// Construct a [`Label`]
+#[inline]
+pub fn label<T: FormattableText + 'static>(label: T) -> Label<T> {
+    Label::new(label)
+}
+
 /// Construct a [`Label`] which accepts any data
 ///
 /// This is just a shortcut for `Label::new(text).map_any()`.

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -106,7 +106,7 @@ pub use filler::Filler;
 pub use frame::Frame;
 pub use grid::{BoxGrid, Grid};
 pub use grip::{GripMsg, GripPart};
-pub use label::{label_any, AccessLabel, Label, StrLabel, StringLabel};
+pub use label::{label, label_any, AccessLabel, Label, StrLabel, StringLabel};
 pub use list::*;
 pub use mark::{Mark, MarkButton};
 pub use nav_frame::NavFrame;

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -119,7 +119,7 @@ pub use scroll_text::ScrollText;
 pub use separator::Separator;
 pub use slider::{Slider, SliderValue};
 pub use spinner::{Spinner, SpinnerValue};
-pub use splitter::*;
+pub use splitter::Splitter;
 pub use stack::{BoxStack, Stack};
 pub use tab_stack::{BoxTabStack, Tab, TabStack};
 pub use text::{StrText, StringText, Text};

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -156,7 +156,7 @@ impl_scope! {
     where
         D: Default,
     {
-        /// Construct a new instance
+        /// Construct a new instance with default-constructed direction
         ///
         /// This constructor is available where the direction is determined by the
         /// type: for `D: Directional + Default`. In other cases, use
@@ -207,28 +207,28 @@ impl_scope! {
     }
 
     impl<C: Collection> List<C, kas::dir::Left> {
-        /// Construct a new instance
+        /// Construct a new instance with fixed direction
         #[inline]
         pub fn left(widgets: C) -> Self {
             Self::new(widgets)
         }
     }
     impl<C: Collection> List<C, kas::dir::Right> {
-        /// Construct a new instance
+        /// Construct a new instance with fixed direction
         #[inline]
         pub fn right(widgets: C) -> Self {
             Self::new(widgets)
         }
     }
     impl<C: Collection> List<C, kas::dir::Up> {
-        /// Construct a new instance
+        /// Construct a new instance with fixed direction
         #[inline]
         pub fn up(widgets: C) -> Self {
             Self::new(widgets)
         }
     }
     impl<C: Collection> List<C, kas::dir::Down> {
-        /// Construct a new instance
+        /// Construct a new instance with fixed direction
         #[inline]
         pub fn down(widgets: C) -> Self {
             Self::new(widgets)

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -200,6 +200,7 @@ impl_scope! {
         ///         }
         ///     });
         /// ```
+        #[inline]
         pub fn new(widgets: C) -> Self {
             Self::new_dir(widgets, D::default())
         }
@@ -207,24 +208,28 @@ impl_scope! {
 
     impl<C: Collection> List<C, kas::dir::Left> {
         /// Construct a new instance
+        #[inline]
         pub fn left(widgets: C) -> Self {
             Self::new(widgets)
         }
     }
     impl<C: Collection> List<C, kas::dir::Right> {
         /// Construct a new instance
+        #[inline]
         pub fn right(widgets: C) -> Self {
             Self::new(widgets)
         }
     }
     impl<C: Collection> List<C, kas::dir::Up> {
         /// Construct a new instance
+        #[inline]
         pub fn up(widgets: C) -> Self {
             Self::new(widgets)
         }
     }
     impl<C: Collection> List<C, kas::dir::Down> {
         /// Construct a new instance
+        #[inline]
         pub fn down(widgets: C) -> Self {
             Self::new(widgets)
         }

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -110,7 +110,7 @@ impl_scope! {
 
         fn draw(&mut self, mut draw: DrawCx) {
             let solver = RowPositionSolver::new(self.direction);
-            solver.for_children(&mut self.widgets, self.core.rect, |w| draw.recurse(w));
+            solver.for_children_mut(&mut self.widgets, self.core.rect, |w| draw.recurse(w));
         }
     }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -211,12 +211,12 @@ impl_scope! {
             // as with find_id, there's not much harm in invoking the solver twice
 
             let solver = layout::RowPositionSolver::new(self.direction);
-            solver.for_children(&mut self.widgets, draw.get_clip_rect(), |w| {
+            solver.for_children_mut(&mut self.widgets, draw.get_clip_rect(), |w| {
                 draw.recurse(w);
             });
 
             let solver = layout::RowPositionSolver::new(self.direction);
-            solver.for_children(&mut self.handles, draw.get_clip_rect(), |w| {
+            solver.for_children_mut(&mut self.handles, draw.get_clip_rect(), |w| {
                 draw.separator(w.rect())
             });
         }

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -282,11 +282,16 @@ impl_scope! {
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
             if let Some(index) = cx.last_child() {
                 if (index & 1) == 1 {
-                    if let Some(GripMsg::PressMove(offset)) = cx.try_pop() {
+                    if let Some(GripMsg::PressMove(mut offset)) = cx.try_pop() {
                         let n = index >> 1;
                         assert!(n < self.grips.len());
-                        let action = self.grips[n].set_offset(offset).1;
-                        cx.action(&self, action);
+                        if let Some(grip) = self.grips.get_mut(n) {
+                            if self.direction.is_reversed() {
+                                offset = Offset::conv(grip.track().size) - offset;
+                            }
+                            let action = grip.set_offset(offset).1;
+                            cx.action(&self, action);
+                        }
                         self.adjust_size(&mut cx.config_cx(), n);
                     }
                 }

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -33,38 +33,51 @@ impl_scope! {
     }
 
     impl Self where D: Default {
-        /// Construct a new instance
+        /// Construct a new instance with default-constructed direction
         #[inline]
         pub fn new(widgets: C) -> Self {
             Self::new_dir(widgets, Default::default())
         }
     }
     impl<C: Collection> Splitter<C, kas::dir::Left> {
-        /// Construct a new instance
+        /// Construct a new instance with fixed direction
         #[inline]
         pub fn left(widgets: C) -> Self {
             Self::new(widgets)
         }
     }
     impl<C: Collection> Splitter<C, kas::dir::Right> {
-        /// Construct a new instance
+        /// Construct a new instance with fixed direction
         #[inline]
         pub fn right(widgets: C) -> Self {
             Self::new(widgets)
         }
     }
     impl<C: Collection> Splitter<C, kas::dir::Up> {
-        /// Construct a new instance
+        /// Construct a new instance with fixed direction
         #[inline]
         pub fn up(widgets: C) -> Self {
             Self::new(widgets)
         }
     }
     impl<C: Collection> Splitter<C, kas::dir::Down> {
-        /// Construct a new instance
+        /// Construct a new instance with fixed direction
         #[inline]
         pub fn down(widgets: C) -> Self {
             Self::new(widgets)
+        }
+    }
+
+    impl<C: Collection> Splitter<C, Direction> {
+        /// Set the direction of contents
+        pub fn set_direction(&mut self, direction: Direction) -> Action {
+            if direction == self.direction {
+                return Action::empty();
+            }
+
+            self.direction = direction;
+            // Note: most of the time SET_RECT would be enough, but margins can be different
+            Action::RESIZE
         }
     }
 

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -123,7 +123,7 @@ impl_scope! {
         core: widget_core!(),
         direction: Direction,
         #[widget(&())]
-        tabs: AdaptEvents<Row<Tab>>, // TODO: want a TabBar widget for scrolling support?
+        tabs: AdaptEvents<Row<Vec<Tab>>>, // TODO: want a TabBar widget for scrolling support?
         #[widget]
         stack: Stack<W>,
         on_change: Option<Box<dyn Fn(&mut EventCx, &W::Data, usize, &str)>>,
@@ -138,7 +138,7 @@ impl_scope! {
                 core: Default::default(),
                 direction: Direction::Up,
                 stack: Stack::new(),
-                tabs: Row::new([]).map_message(|index, Select| MsgSelectIndex(index)),
+                tabs: Row::new(vec![]).map_message(|index, Select| MsgSelectIndex(index)),
                 on_change: None,
             }
         }

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -164,7 +164,7 @@ fn main() -> kas::app::Result<()> {
         active_string: ListEntry::new(0).label.get_string(),
     };
 
-    let list = List::new([]).on_update(|cx, list, data: &Data| {
+    let list = List::new(vec![]).on_update(|cx, list, data: &Data| {
         let act = list.set_direction(data.dir);
         let len = data.len;
         if len != list.len() {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -310,7 +310,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
 
     let ui = kas::float![
         pack!(right top, Button::label_msg("↻", MsgDirection).map_any()),
-        List::new(kas::collection![
+        Splitter::new(kas::collection![
             EditBox::new(Guard)
                 .with_multi_line(true)
                 .with_lines(4, 12)

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -23,7 +23,7 @@ fn main() -> kas::app::Result<()> {
             Button::label_msg("+", Message::Incr),
         ]
         .map_any(),
-        Splitter::right([]).on_update(|cx, panes, len| panes.resize_with(len, cx, *len, |n| {
+        Splitter::right(vec![]).on_update(|cx, panes, len| panes.resize_with(len, cx, *len, |n| {
             EditField::text(format!("Pane {}", n + 1)).with_multi_line(true)
         })),
     ];


### PR DESCRIPTION
Adds a trait representing a "list of widgets", e.g. `Vec<W>` or a struct where each field is a widget.

Adds `kas::collection!` to generate an anonymous implementation and instance of a `Collection`.

Adjusts `List` and `Splitter` widgets to use `Collection`; as such they no longer have the restriction that each child must have the same type.

Uses this to rewrite the Gallery's editor to use a `Splitter` and not use a custom widget.