### PR TITLE
Remove return values on some closures; replace some custom widgets

### DIFF
--- a/crates/kas-core/src/app/mod.rs
+++ b/crates/kas-core/src/app/mod.rs
@@ -11,8 +11,8 @@ mod common;
 #[cfg(winit)] mod shared;
 #[cfg(winit)] mod window;
 
+use crate::messages::MessageStack;
 #[cfg(winit)] use crate::WindowId;
-use crate::{messages::MessageStack, Action};
 #[cfg(winit)] use app::PlatformWrapper;
 #[cfg(winit)] use event_loop::Loop as EventLoop;
 #[cfg(winit)] pub(crate) use shared::{AppShared, AppState};
@@ -41,17 +41,11 @@ pub trait AppData: 'static {
     /// This is the last message handler: it is called when, after traversing
     /// the widget tree (see [kas::event] module doc), a message is left on the
     /// stack. Unhandled messages will result in warnings in the log.
-    ///
-    /// The method returns an [`Action`], usually either [`Action::empty`]
-    /// (nothing to do) or [`Action::UPDATE`] (to update widgets).
-    /// This action affects all windows.
-    fn handle_messages(&mut self, messages: &mut MessageStack) -> Action;
+    fn handle_messages(&mut self, messages: &mut MessageStack);
 }
 
 impl AppData for () {
-    fn handle_messages(&mut self, _: &mut MessageStack) -> Action {
-        Action::empty()
-    }
+    fn handle_messages(&mut self, _: &mut MessageStack) {}
 }
 
 #[crate::autoimpl(Debug)]

--- a/crates/kas-core/src/app/shared.rs
+++ b/crates/kas-core/src/app/shared.rs
@@ -87,8 +87,13 @@ where
     #[inline]
     pub(crate) fn handle_messages(&mut self, messages: &mut MessageStack) {
         if messages.reset_and_has_any() {
-            let action = self.data.handle_messages(messages);
-            self.shared.pending.push_back(Pending::Action(action));
+            let count = messages.get_op_count();
+            self.data.handle_messages(messages);
+            if messages.get_op_count() != count {
+                self.shared
+                    .pending
+                    .push_back(Pending::Action(Action::UPDATE));
+            }
         }
     }
 

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -746,6 +746,15 @@ impl<'a> EventCx<'a> {
         self.messages.try_debug()
     }
 
+    /// Get the message stack operation count
+    ///
+    /// This is incremented every time the message stack is changed, thus can be
+    /// used to test whether a message handler did anything.
+    #[inline]
+    pub fn msg_op_count(&self) -> usize {
+        self.messages.get_op_count()
+    }
+
     /// Set a scroll action
     ///
     /// When setting [`Scroll::Rect`], use the widget's own coordinate space.

--- a/crates/kas-core/src/theme/config.rs
+++ b/crates/kas-core/src/theme/config.rs
@@ -281,7 +281,7 @@ mod defaults {
     }
 
     pub fn font_size() -> f32 {
-        14.0
+        16.0
     }
 
     pub fn color_schemes() -> BTreeMap<String, ColorsSrgb> {

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -25,12 +25,9 @@ struct AppData {
 }
 
 impl kas::app::AppData for AppData {
-    fn handle_messages(&mut self, messages: &mut kas::messages::MessageStack) -> Action {
+    fn handle_messages(&mut self, messages: &mut kas::messages::MessageStack) {
         if let Some(SetColor(color)) = messages.try_pop() {
             self.color = Some(color);
-            Action::UPDATE
-        } else {
-            Action::empty()
         }
     }
 }

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -47,9 +47,6 @@ fn make_window() -> impl Widget<Data = ()> {
                 timer.elapsed += now - last;
                 timer.last = Some(now);
                 cx.request_timer(0, Duration::new(0, 1));
-                true
-            } else {
-                false
             }
         })
 }

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -8,7 +8,7 @@
 //! Each window shares the counter, but has its own increment step.
 
 use kas::widgets::{format_data, label_any, Adapt, Button, Slider};
-use kas::{messages::MessageStack, Action, Window};
+use kas::{messages::MessageStack, Window};
 
 #[derive(Clone, Debug)]
 struct Increment(i32);
@@ -16,12 +16,9 @@ struct Increment(i32);
 #[derive(Clone, Copy, Debug)]
 struct Count(i32);
 impl kas::app::AppData for Count {
-    fn handle_messages(&mut self, messages: &mut MessageStack) -> Action {
+    fn handle_messages(&mut self, messages: &mut MessageStack) {
         if let Some(Increment(add)) = messages.try_pop() {
             self.0 += add;
-            Action::UPDATE
-        } else {
-            Action::empty()
         }
     }
 }


### PR DESCRIPTION
`fn AppData::handle_messages` previously returned `Action`, however:

- The only sensible return values are `Action::empty()` and `Action::UPDATE`, hence we could replace with `bool`
- Assuming `UPDATE` when any message was removed from the stack is a good enough approximation, hence we don't need a return value at all

Similarly, `Adapt`'s message and timer handlers can also get away without using any return values (on the assumption that a timer is only requested when it is likely that something will happen, and that `Adapt` only makes things happen by adjusting its state; these appear reasonable assumptions given the intended usages).

Also, replace a couple more instances of custom widgets in examples.

Also increase the default font size to 16px (12pt).