### PR TITLE
Update deps and enable winit/x11 by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 # markdown, resvg. Recommended also: clipboard, yaml (or some config format).
 minimal = ["wgpu", "winit", "wayland"]
 # All recommended features for optimal experience
-default = ["minimal", "view", "image", "resvg", "clipboard", "markdown", "shaping", "spawn"]
+default = ["minimal", "x11", "view", "image", "resvg", "clipboard", "markdown", "shaping", "spawn"]
 # All standard test target features
 # NOTE: dynamic is excluded due to linker problems on Windows
 stable = ["default", "serde", "toml", "yaml", "json", "ron", "macros_log"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ features = ["raster"]
 
 [dev-dependencies]
 chrono = "0.4"
-env_logger = "0.10"
+env_logger = "0.11"
 log = "0.4"
 
 [workspace]

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -94,7 +94,7 @@ ron = { version = "0.8.0", package = "ron", optional = true }
 toml = { version = "0.8.2", package = "toml", optional = true }
 num_enum = "0.7.0"
 dark-light = { version = "1.0", optional = true }
-raw-window-handle = "0.5.0"
+raw-window-handle = "0.6.0"
 async-global-executor = { version = "2.3.1", optional = true }
 cfg-if = "1.0.0"
 smol_str = "0.2.0"
@@ -121,4 +121,4 @@ version = "0.5.0" # used in doc links
 version = "0.29.2"
 optional = true
 default-features = false
-features = ["rwh_05"]
+features = ["rwh_06"]

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -78,7 +78,7 @@ spawn = ["dep:async-global-executor"]
 unsafe_node = []
 
 [build-dependencies]
-cfg_aliases = "0.1.1"
+cfg_aliases = "0.2.0"
 
 [dependencies]
 log = "0.4"

--- a/crates/kas-core/src/app/app.rs
+++ b/crates/kas-core/src/app/app.rs
@@ -18,8 +18,8 @@ use winit::event_loop::{EventLoop, EventLoopBuilder, EventLoopProxy};
 
 pub struct Application<Data: AppData, G: AppGraphicsBuilder, T: Theme<G::Shared>> {
     el: EventLoop<ProxyAction>,
-    windows: Vec<Box<super::Window<Data, G::Surface, T>>>,
-    state: AppState<Data, G::Surface, T>,
+    windows: Vec<Box<super::Window<Data, G, T>>>,
+    state: AppState<Data, G, T>,
 }
 
 impl_scope! {

--- a/crates/kas-core/src/app/common.rs
+++ b/crates/kas-core/src/app/common.rs
@@ -185,7 +185,7 @@ pub trait AppGraphicsBuilder {
     type Shared: DrawSharedImpl;
 
     /// Window surface
-    type Surface: WindowSurface<Shared = Self::Shared> + 'static;
+    type Surface<'a>: WindowSurface<Shared = Self::Shared>;
 
     /// Construct shared state
     fn build(self) -> Result<Self::Shared>;

--- a/crates/kas-core/src/app/common.rs
+++ b/crates/kas-core/src/app/common.rs
@@ -20,6 +20,10 @@ use thiserror::Error;
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Window-handle error
+    #[error(transparent)]
+    Handle(#[from] raw::HandleError),
+
     /// Failure from the graphics sub-system
     #[error("error from graphics sub-system")]
     Graphics(Box<dyn std::error::Error + 'static>),
@@ -199,7 +203,7 @@ pub trait WindowSurface {
     /// It is required to call [`WindowSurface::do_resize`] after this.
     fn new<W>(shared: &mut Self::Shared, window: W) -> Result<Self>
     where
-        W: raw::HasRawWindowHandle + raw::HasRawDisplayHandle,
+        W: raw::HasWindowHandle + raw::HasDisplayHandle + Send + Sync,
         Self: Sized;
 
     /// Get current surface size

--- a/crates/kas-core/src/app/event_loop.rs
+++ b/crates/kas-core/src/app/event_loop.rs
@@ -5,8 +5,8 @@
 
 //! Event loop and handling
 
-use super::{AppData, AppState, Pending};
-use super::{ProxyAction, Window, WindowSurface};
+use super::{AppData, AppGraphicsBuilder, AppState, Pending};
+use super::{ProxyAction, Window};
 use kas::theme::Theme;
 use kas::{Action, WindowId};
 use std::collections::HashMap;
@@ -16,28 +16,28 @@ use winit::event_loop::{ControlFlow, EventLoopWindowTarget};
 use winit::window as ww;
 
 /// Event-loop data structure (i.e. all run-time state)
-pub(super) struct Loop<A: AppData, S: WindowSurface, T: Theme<S::Shared>>
+pub(super) struct Loop<A: AppData, G: AppGraphicsBuilder, T: Theme<G::Shared>>
 where
     T::Window: kas::theme::Window,
 {
     /// State is suspended until we receive Event::Resumed
     suspended: bool,
     /// Window states
-    windows: HashMap<WindowId, Box<Window<A, S, T>>>,
+    windows: HashMap<WindowId, Box<Window<A, G, T>>>,
     popups: HashMap<WindowId, WindowId>,
     /// Translates our WindowId to winit's
     id_map: HashMap<ww::WindowId, WindowId>,
     /// Application state passed from Toolkit
-    state: AppState<A, S, T>,
+    state: AppState<A, G, T>,
     /// Timer resumes: (time, window identifier)
     resumes: Vec<(Instant, WindowId)>,
 }
 
-impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Loop<A, S, T>
+impl<A: AppData, G: AppGraphicsBuilder, T: Theme<G::Shared>> Loop<A, G, T>
 where
     T::Window: kas::theme::Window,
 {
-    pub(super) fn new(mut windows: Vec<Box<Window<A, S, T>>>, state: AppState<A, S, T>) -> Self {
+    pub(super) fn new(mut windows: Vec<Box<Window<A, G, T>>>, state: AppState<A, G, T>) -> Self {
         Loop {
             suspended: true,
             windows: windows.drain(..).map(|w| (w.window_id, w)).collect(),

--- a/crates/kas-core/src/app/mod.rs
+++ b/crates/kas-core/src/app/mod.rs
@@ -248,14 +248,6 @@ mod test {
     impl WindowSurface for Surface {
         type Shared = DrawShared;
 
-        fn new<W>(_: &mut Self::Shared, _: W) -> Result<Self>
-        where
-            W: rwh::HasRawWindowHandle + rwh::HasRawDisplayHandle,
-            Self: Sized,
-        {
-            todo!()
-        }
-
         fn size(&self) -> crate::prelude::Size {
             todo!()
         }
@@ -280,10 +272,31 @@ mod test {
         }
     }
 
+    struct AGB;
+    impl AppGraphicsBuilder for AGB {
+        type DefaultTheme = crate::theme::SimpleTheme;
+
+        type Shared = DrawShared;
+
+        type Surface<'a> = Surface;
+
+        fn build(self) -> Result<Self::Shared> {
+            todo!()
+        }
+
+        fn new_surface<'window, W>(_: &mut Self::Shared, _: W) -> Result<Self::Surface<'window>>
+        where
+            W: rwh::HasWindowHandle + rwh::HasDisplayHandle + Send + Sync + 'window,
+            Self: Sized,
+        {
+            todo!()
+        }
+    }
+
     #[test]
     fn size_of_pending() {
         assert_eq!(
-            std::mem::size_of::<Pending<(), Surface, crate::theme::SimpleTheme>>(),
+            std::mem::size_of::<Pending<(), AGB, crate::theme::SimpleTheme>>(),
             32
         );
     }

--- a/crates/kas-core/src/app/mod.rs
+++ b/crates/kas-core/src/app/mod.rs
@@ -71,7 +71,7 @@ enum ProxyAction {
 #[cfg(test)]
 mod test {
     use super::*;
-    use raw_window_handle as raw;
+    use raw_window_handle as rwh;
     use std::time::Instant;
 
     struct Draw;
@@ -250,7 +250,7 @@ mod test {
 
         fn new<W>(_: &mut Self::Shared, _: W) -> Result<Self>
         where
-            W: raw::HasRawWindowHandle + raw::HasRawDisplayHandle,
+            W: rwh::HasRawWindowHandle + rwh::HasRawDisplayHandle,
             Self: Sized,
         {
             todo!()

--- a/crates/kas-core/src/app/mod.rs
+++ b/crates/kas-core/src/app/mod.rs
@@ -50,11 +50,11 @@ impl AppData for () {
 
 #[crate::autoimpl(Debug)]
 #[cfg(winit)]
-enum Pending<A: AppData, S: WindowSurface, T: kas::theme::Theme<S::Shared>> {
+enum Pending<A: AppData, G: AppGraphicsBuilder, T: kas::theme::Theme<G::Shared>> {
     AddPopup(WindowId, WindowId, kas::PopupDescriptor),
-    // NOTE: we don't need S, T here if we construct the Window later.
+    // NOTE: we don't need G, T here if we construct the Window later.
     // But this way we can pass a single boxed value.
-    AddWindow(WindowId, Box<Window<A, S, T>>),
+    AddWindow(WindowId, Box<Window<A, G, T>>),
     CloseWindow(WindowId),
     Action(kas::Action),
 }

--- a/crates/kas-core/src/app/window.rs
+++ b/crates/kas-core/src/app/window.rs
@@ -158,12 +158,15 @@ impl<A: AppData, S: WindowSurface, T: Theme<S::Shared>> Window<A, S, T> {
         );
 
         #[cfg(all(wayland_platform, feature = "clipboard"))]
-        use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle, WaylandDisplayHandle};
+        use raw_window_handle::{HasDisplayHandle, RawDisplayHandle, WaylandDisplayHandle};
         #[cfg(all(wayland_platform, feature = "clipboard"))]
-        let wayland_clipboard = match window.raw_display_handle() {
-            RawDisplayHandle::Wayland(WaylandDisplayHandle { display, .. }) => {
-                Some(unsafe { smithay_clipboard::Clipboard::new(display) })
-            }
+        let wayland_clipboard = match window.display_handle() {
+            Ok(handle) => match handle.as_raw() {
+                RawDisplayHandle::Wayland(WaylandDisplayHandle { display, .. }) => {
+                    Some(unsafe { smithay_clipboard::Clipboard::new(display.as_ptr()) })
+                }
+                _ => None,
+            },
             _ => None,
         };
 

--- a/crates/kas-resvg/Cargo.toml
+++ b/crates/kas-resvg/Cargo.toml
@@ -26,8 +26,8 @@ svg = ["dep:resvg", "dep:usvg"]
 
 [dependencies]
 tiny-skia = { version = "0.11.0" }
-resvg = { version = "0.36.0", optional = true }
-usvg = { version = "0.36.0", optional = true }
+resvg = { version = "0.38.0", optional = true }
+usvg = { version = "0.38.0", optional = true }
 once_cell = "1.17.0"
 thiserror = "1.0.23"
 

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -86,11 +86,10 @@ enum State {
 
 async fn draw(svg: Source, mut pixmap: Pixmap) -> Pixmap {
     if let Ok(tree) = svg.tree() {
-        let tree = resvg::Tree::from_usvg(&tree);
         let w = f32::conv(pixmap.width()) / tree.size.width();
         let h = f32::conv(pixmap.height()) / tree.size.height();
         let transform = Transform::from_scale(w, h);
-        tree.render(transform, &mut pixmap.as_mut());
+        resvg::render(&tree, transform, &mut pixmap.as_mut());
     }
     pixmap
 }

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -37,10 +37,6 @@ thiserror = "1.0.23"
 guillotiere = "0.6.0"
 rustc-hash = "1.0"
 
-# Force patch versions of naga and wgpu-core (otherwise not needed as direct dependencies)
-naga = "0.14.1"
-wgpu-core = "0.18.1"
-
 [dependencies.kas]
 # Rename package purely for convenience:
 version = "0.14.1"
@@ -51,7 +47,7 @@ path = "../kas-core"
 version = "0.6.0"
 
 [dependencies.wgpu]
-version = "0.18.0"
+version = "0.19.1"
 default-features = false
 features = ["spirv"]
 

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -46,7 +46,7 @@ impl<C: CustomPipe> DrawPipe<C> {
 
         // Use adapter texture size limits to support the largest window surface possible
         let mut desc = CB::device_descriptor();
-        desc.limits = desc.limits.using_resolution(adapter.limits());
+        desc.required_limits = desc.required_limits.using_resolution(adapter.limits());
 
         let trace_path = options.wgpu_trace_path.as_deref();
         let req = adapter.request_device(&desc, trace_path);

--- a/crates/kas-wgpu/src/lib.rs
+++ b/crates/kas-wgpu/src/lib.rs
@@ -29,6 +29,7 @@ mod surface;
 use crate::draw::{CustomPipeBuilder, DrawPipe};
 use kas::app::{AppBuilder, AppGraphicsBuilder, Result};
 use kas::theme::{FlatTheme, Theme};
+use wgpu::rwh;
 
 pub use draw_shaded::{DrawShaded, DrawShadedImpl};
 pub use options::Options;
@@ -55,6 +56,17 @@ impl<CB: CustomPipeBuilder> AppGraphicsBuilder for WgpuBuilder<CB> {
             options.load_from_env();
         }
         DrawPipe::new(self.custom, &options)
+    }
+
+    fn new_surface<'window, W>(
+        shared: &mut Self::Shared,
+        window: W,
+    ) -> Result<Self::Surface<'window>>
+    where
+        W: rwh::HasWindowHandle + rwh::HasDisplayHandle + Send + Sync + 'window,
+        Self: Sized,
+    {
+        surface::Surface::new(shared, window)
     }
 }
 

--- a/crates/kas-wgpu/src/lib.rs
+++ b/crates/kas-wgpu/src/lib.rs
@@ -47,7 +47,7 @@ impl<CB: CustomPipeBuilder> AppGraphicsBuilder for WgpuBuilder<CB> {
 
     type Shared = DrawPipe<CB::Pipe>;
 
-    type Surface = surface::Surface<CB::Pipe>;
+    type Surface<'a> = surface::Surface<'a, CB::Pipe>;
 
     fn build(self) -> Result<Self::Shared> {
         let mut options = self.options;

--- a/crates/kas-wgpu/src/options.rs
+++ b/crates/kas-wgpu/src/options.rs
@@ -87,7 +87,6 @@ impl Options {
                 "VULKAN" => Backends::VULKAN,
                 "GL" => Backends::GL,
                 "METAL" => Backends::METAL,
-                "DX11" => Backends::DX11,
                 "DX12" => Backends::DX12,
                 "BROWSER_WEBGPU" => Backends::BROWSER_WEBGPU,
                 "PRIMARY" => Backends::PRIMARY,

--- a/crates/kas-wgpu/src/surface.rs
+++ b/crates/kas-wgpu/src/surface.rs
@@ -6,7 +6,7 @@
 //! WGPU window surface
 
 use crate::draw::{CustomPipe, DrawPipe, DrawWindow};
-use kas::app::{raw_window_handle as raw, Error, WindowSurface};
+use kas::app::{raw_window_handle as rwh, Error, WindowSurface};
 use kas::cast::Cast;
 use kas::draw::color::Rgba;
 use kas::draw::{DrawIface, DrawSharedImpl, WindowCommon};
@@ -20,20 +20,16 @@ pub struct Surface<'a, C: CustomPipe> {
     draw: DrawWindow<C::Window>,
 }
 
-impl<'a, C: CustomPipe> WindowSurface for Surface<'a, C> {
-    type Shared = DrawPipe<C>;
-
-    fn new<W>(shared: &mut Self::Shared, window: W) -> Result<Self, Error>
+impl<'a, C: CustomPipe> Surface<'a, C> {
+    pub fn new<W>(shared: &mut <Self as WindowSurface>::Shared, window: W) -> Result<Self, Error>
     where
-        W: raw::HasWindowHandle + raw::HasDisplayHandle + Send + Sync,
+        W: rwh::HasWindowHandle + rwh::HasDisplayHandle + Send + Sync + 'a,
         Self: Sized,
     {
-        let surface = unsafe {
-            // TODO: handle window lifetime safely
-            let target = wgpu::SurfaceTargetUnsafe::from_window(&window)?;
-            shared.instance.create_surface_unsafe(target)
-        }
-        .map_err(|e| Error::Graphics(Box::new(e)))?;
+        let surface = shared
+            .instance
+            .create_surface(window)
+            .map_err(|e| Error::Graphics(Box::new(e)))?;
         let sc_desc = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: crate::draw::RENDER_TEX_FORMAT,
@@ -55,6 +51,10 @@ impl<'a, C: CustomPipe> WindowSurface for Surface<'a, C> {
             draw: shared.new_window(),
         })
     }
+}
+
+impl<'a, C: CustomPipe> WindowSurface for Surface<'a, C> {
+    type Shared = DrawPipe<C>;
 
     fn size(&self) -> Size {
         Size::new(self.sc_desc.width.cast(), self.sc_desc.height.cast())

--- a/crates/kas-wgpu/src/surface.rs
+++ b/crates/kas-wgpu/src/surface.rs
@@ -14,13 +14,13 @@ use kas::geom::Size;
 use std::time::Instant;
 
 /// Per-window data
-pub struct Surface<C: CustomPipe> {
-    surface: wgpu::Surface<'static>,
+pub struct Surface<'a, C: CustomPipe> {
+    surface: wgpu::Surface<'a>,
     sc_desc: wgpu::SurfaceConfiguration,
     draw: DrawWindow<C::Window>,
 }
 
-impl<C: CustomPipe> WindowSurface for Surface<C> {
+impl<'a, C: CustomPipe> WindowSurface for Surface<'a, C> {
     type Shared = DrawPipe<C>;
 
     fn new<W>(shared: &mut Self::Shared, window: W) -> Result<Self, Error>

--- a/examples/mandlebrot/Cargo.toml
+++ b/examples/mandlebrot/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 kas = { version = "0.14.1", features = ["wgpu"], path = "../.." }
 kas-wgpu = { version = "0.14.1", path = "../../crates/kas-wgpu" }
 chrono = "0.4"
-env_logger = "0.10"
+env_logger = "0.11"
 log = "0.4"
 bytemuck = "1.7.0"
 

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -101,8 +101,8 @@ impl CustomPipeBuilder for PipeBuilder {
     fn device_descriptor() -> wgpu::DeviceDescriptor<'static> {
         wgpu::DeviceDescriptor {
             label: None,
-            features: wgpu::Features::PUSH_CONSTANTS | SHADER_FLOAT64,
-            limits: wgpu::Limits {
+            required_features: wgpu::Features::PUSH_CONSTANTS | SHADER_FLOAT64,
+            required_limits: wgpu::Limits {
                 max_push_constant_size: size_of::<PushConstants>().cast(),
                 ..Default::default()
             },


### PR DESCRIPTION
It turns out that examples were failing on X11 with a confusing message. https://github.com/rust-windowing/winit/pull/3414 fixes the message; this PR adds X11 to the default feature selection.

Update dependencies: `env_logger`, `cfg_aliases`, `resvg` and most significantly `wgpu`.

Safe handling of the window/surface lifetime. For now this uses `Arc<winit::window::Window>` to ensure the window outlives the surface. A true (efficient) solution would be closer to the self-referential struct problem (though without the aliasing and pinning sub-problems); essentially we could "just" cast the lifetime to `'static`, however there's no good way to do this without making `new_surface` unsafe or depend on WGPU (having `wgpu::SurfaceTarget` in `raw-window-handle` would help).