### PR TITLE
Move layout macros to kas-widgets; do not recurse internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,22 @@ wayland = ["kas-core/wayland"]
 # Support X11
 x11 = ["kas-core/x11"]
 
-# Optimise Node using unsafe code
+# Optimize generated layout widgets
+#
+# Recursive layout macros allow the generation of complex layout widgets; for
+# example `row!["a", column!["b", "c"]]` yields a single layout widget (over
+# three `StrLabel` widgets) instead of two separate layout widgets.
+# (Note that this happens anyway in custom widget layout syntax where it is
+# requried to support reference to widget fields.)
+#
+# A limited number of method calls such as `.align(AlignHints::LEFT)` and
+# `.map_any()` are supported but are not linked correctly via rust-analyzer.
+#
+# Often results in unused import warnings, hence you may want to use
+# RUSTFLAGS="-A unused_imports".
+recursive-layout-widgets = ["kas-core/recursive-layout-widgets"]
+
+# Optimize Node using unsafe code
 unsafe_node = ["kas-core/unsafe_node"]
 
 [dependencies]

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -74,7 +74,10 @@ dark-light = ["dep:dark-light"]
 # Support spawning async tasks
 spawn = ["dep:async-global-executor"]
 
-# Optimise Node using unsafe code
+# Optimize generated layout widgets
+recursive-layout-widgets = ["kas-macros/recursive-layout-widgets"]
+
+# Optimize Node using unsafe code
 unsafe_node = []
 
 [build-dependencies]

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -636,19 +636,19 @@ impl std::ops::SubAssign<Offset> for Rect {
 #[cfg_attr(doc_cfg, doc(cfg(feature = "winit")))]
 mod winit_impls {
     use super::{Coord, Size};
-    use crate::cast::{Cast, CastApprox, Conv, ConvApprox};
+    use crate::cast::{Cast, CastApprox, Conv, ConvApprox, Result};
     use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 
     impl<X: CastApprox<i32>> ConvApprox<PhysicalPosition<X>> for Coord {
         #[inline]
-        fn try_conv_approx(pos: PhysicalPosition<X>) -> cast::Result<Self> {
+        fn try_conv_approx(pos: PhysicalPosition<X>) -> Result<Self> {
             Ok(Coord(pos.x.cast_approx(), pos.y.cast_approx()))
         }
     }
 
     impl<X: Cast<i32>> Conv<PhysicalSize<X>> for Size {
         #[inline]
-        fn try_conv(size: PhysicalSize<X>) -> cast::Result<Self> {
+        fn try_conv(size: PhysicalSize<X>) -> Result<Self> {
             Ok(Size(size.width.cast(), size.height.cast()))
         }
     }

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -30,7 +30,8 @@ mod root;
 pub use crate::core::*;
 pub use action::Action;
 pub use decorations::Decorations;
-pub use kas_macros::*;
+pub use kas_macros::{autoimpl, extends, impl_default, widget};
+pub use kas_macros::{collection, impl_anon, impl_scope, widget_index};
 #[doc(inline)] pub use popup::Popup;
 #[doc(inline)] pub(crate) use popup::PopupDescriptor;
 #[doc(inline)]

--- a/crates/kas-macros/Cargo.toml
+++ b/crates/kas-macros/Cargo.toml
@@ -19,6 +19,9 @@ proc-macro = true
 # Requires that all crates using these macros depend on the log crate.
 log = []
 
+# Optimize generated layout widgets
+recursive-layout-widgets = []
+
 [dependencies]
 quote = "1.0"
 proc-macro2 = { version = "1.0" }

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -617,9 +617,11 @@ pub fn aligned_row(input: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```ignore
-/// let list = kas::widgets::List::right(kas::collection![
+/// use kas::collection;
+/// use kas::widgets::{CheckBox, List};
+/// let list = List::right(collection![
 ///     "A checkbox",
-///     kas::widgets::CheckBox::new(|_, _| false),
+///     CheckBox::new(|_, _| false),
 /// ]);
 /// ```
 ///

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -511,8 +511,11 @@ impl Parse for Tree {
 }
 
 impl Layout {
-    fn parse(input: ParseStream, gen: &mut NameGenerator, recurse: bool) -> Result<Self> {
-        let mut layout = if recurse && input.peek2(Token![!]) {
+    fn parse(input: ParseStream, gen: &mut NameGenerator, _recurse: bool) -> Result<Self> {
+        #[cfg(feature = "recursive-layout-widgets")]
+        let _recurse = true;
+
+        let mut layout = if _recurse && input.peek2(Token![!]) {
             Self::parse_macro_like(input, gen)?
         } else if input.peek(Token![self]) {
             Layout::Single(input.parse()?)

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -95,6 +95,8 @@ mod stack;
 mod tab_stack;
 mod text;
 
+pub use kas_macros::{aligned_column, aligned_row, column, float, grid, list, row};
+
 pub use crate::image::Image;
 #[cfg(feature = "image")] pub use crate::image::ImageError;
 pub use button::Button;

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -40,7 +40,7 @@ impl_scope! {
     ///
     /// [`Row`] and [`Column`] are type-defs to `List` which fix the direction `D`.
     ///
-    /// The macros [`kas::row`] and [`kas::column`] also create row/column
+    /// The macros [`row!`] and [`column!`] also create row/column
     /// layouts, but are not fully equivalent:
     ///
     /// -   `row!` and `column!` generate anonymous layout widgets (or objects).
@@ -55,6 +55,8 @@ impl_scope! {
     /// Drawing and event handling is O(log n) in the number of children (assuming
     /// only a small number are visible at any one time).
     ///
+    /// [`row!`]: crate::row
+    /// [`column!`]: crate::column
     /// [`set_direction`]: List::set_direction
     #[autoimpl(Default where C: Default, D: Default)]
     #[widget]

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -10,8 +10,7 @@ use std::str::FromStr;
 
 use kas::event::NamedKey;
 use kas::prelude::*;
-use kas::widgets::{AccessLabel, Adapt, Button, EditBox};
-use kas::{column, grid};
+use kas::widgets::{column, grid, AccessLabel, Adapt, Button, EditBox};
 
 type Key = kas::event::Key<kas::event::SmolStr>;
 

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use kas::event::NamedKey;
 use kas::prelude::*;
 use kas::widgets::{AccessLabel, Adapt, Button, EditBox};
+use kas::{column, grid};
 
 type Key = kas::event::Key<kas::event::SmolStr>;
 
@@ -31,7 +32,7 @@ fn calc_ui() -> Window<()> {
         .with_width_em(5.0, 10.0);
 
     // We use map_any to avoid passing input data (not wanted by buttons):
-    let buttons = kas::grid! {
+    let buttons = grid! {
         // Key bindings: C, Del
         (0, 0) => Button::label_msg("&clear", Key::Named(NamedKey::Clear))
             .with_access_key(NamedKey::Delete.into()),
@@ -57,7 +58,7 @@ fn calc_ui() -> Window<()> {
     }
     .map_any();
 
-    let ui = Adapt::new(kas::column![display, buttons], Calculator::new())
+    let ui = Adapt::new(column![display, buttons], Calculator::new())
         .on_message(|_, calc, key| calc.handle(key))
         .on_configure(|cx, _| {
             cx.disable_nav_focus(true);

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -7,12 +7,13 @@
 
 use kas::prelude::*;
 use kas::widgets::{format_value, Adapt, Button};
+use kas::{column, row};
 
 #[derive(Clone, Debug)]
 struct Increment(i32);
 
 fn counter() -> impl Widget<Data = ()> {
-    let tree = kas::column![
+    let tree = column![
         format_value!("{}").align(AlignHints::CENTER),
         row![
             Button::label_msg("−", Increment(-1)),

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -6,8 +6,7 @@
 //! Counter example (simple button)
 
 use kas::prelude::*;
-use kas::widgets::{format_value, Adapt, Button};
-use kas::{column, row};
+use kas::widgets::{column, format_value, row, Adapt, Button};
 
 #[derive(Clone, Debug)]
 struct Increment(i32);

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -11,9 +11,9 @@
 //! to calculate the maximum scroll offset).
 
 use kas::prelude::*;
-use kas::row;
 use kas::view::{Driver, ListData, ListView, SharedData};
 use kas::widgets::*;
+use kas::{column, row};
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -206,7 +206,7 @@ fn main() -> kas::app::Result<()> {
         let act = list.set_direction(data.dir);
         cx.action(list, act);
     });
-    let tree = kas::column![
+    let tree = column![
         "Demonstration of dynamic widget creation / deletion",
         controls.map(|data: &Data| &data.len),
         "Contents of selected entry:",

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -12,8 +12,7 @@
 
 use kas::prelude::*;
 use kas::view::{Driver, ListData, ListView, SharedData};
-use kas::widgets::*;
-use kas::{column, row};
+use kas::widgets::{column, *};
 use std::collections::HashMap;
 
 #[derive(Debug)]

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -21,8 +21,8 @@
 
 use kas::prelude::*;
 use kas::widgets::edit::{EditBox, EditField, EditGuard};
+use kas::widgets::{column, row};
 use kas::widgets::{Adapt, Button, Label, List, RadioButton, ScrollBarRegion, Separator, Text};
-use kas::{column, row};
 
 #[derive(Debug)]
 struct SelectEntry(usize);

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -20,9 +20,9 @@
 //! is still fast.
 
 use kas::prelude::*;
-use kas::row;
 use kas::widgets::edit::{EditBox, EditField, EditGuard};
 use kas::widgets::{Adapt, Button, Label, List, RadioButton, ScrollBarRegion, Separator, Text};
+use kas::{column, row};
 
 #[derive(Debug)]
 struct SelectEntry(usize);
@@ -170,7 +170,7 @@ fn main() -> kas::app::Result<()> {
         }
         cx.action(list, act);
     });
-    let tree = kas::column![
+    let tree = column![
         "Demonstration of dynamic widget creation / deletion",
         controls.map(|data: &Data| &data.len),
         "Contents of selected entry:",

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -54,6 +54,7 @@ fn widgets() -> Box<dyn Widget<Data = AppData>> {
         ("Th&ree", Entry::Three),
     ];
 
+    #[allow(unused)]
     #[derive(Clone, Debug)]
     enum Item {
         Button,

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -8,13 +8,13 @@
 //! This is a test-bed to demonstrate most toolkit functionality
 //! (excepting custom graphics).
 
+use kas::collection;
 use kas::dir::Right;
 use kas::event::Key;
 use kas::prelude::*;
 use kas::resvg::Svg;
 use kas::theme::{MarginStyle, ThemeControl};
-use kas::widgets::*;
-use kas::{aligned_column, collection, column, float, row};
+use kas::widgets::{column, *};
 
 #[derive(Debug, Default)]
 struct AppData {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -14,6 +14,7 @@ use kas::prelude::*;
 use kas::resvg::Svg;
 use kas::theme::{MarginStyle, ThemeControl};
 use kas::widgets::*;
+use kas::{aligned_column, collection, column, float, row};
 
 #[derive(Debug, Default)]
 struct AppData {
@@ -147,7 +148,7 @@ fn widgets() -> Box<dyn Widget<Data = AppData>> {
 Пример текста на нескольких языках.
 טקסט לדוגמא במספר שפות.";
 
-    let widgets = kas::aligned_column![
+    let widgets = aligned_column![
         row!["ScrollLabel", ScrollLabel::new(text).map_any()],
         row![
             "EditBox",
@@ -307,11 +308,11 @@ Demonstration of *as-you-type* formatting from **Markdown**.
 ```
 ";
 
-    let ui = kas::float![
+    let ui = float![
         Button::label_msg("↻", MsgDirection)
             .map_any()
             .pack(AlignHints::TOP_RIGHT),
-        Splitter::new(kas::collection![
+        Splitter::new(collection![
             EditBox::new(Guard)
                 .with_multi_line(true)
                 .with_lines(4, 12)
@@ -392,13 +393,13 @@ fn filter_list() -> Box<dyn Widget<Data = AppData>> {
             cx.action(list, act);
         });
 
-    let sel_buttons = kas::row![
+    let sel_buttons = row![
         "Selection:",
         RadioButton::new_value("&n&one", SelectionMode::None),
         RadioButton::new_value("s&ingle", SelectionMode::Single),
         RadioButton::new_value("&multiple", SelectionMode::Multiple),
     ];
-    let ui = kas::column![
+    let ui = column![
         sel_buttons.map(|data: &Data| &data.mode),
         ScrollBars::new(list_view),
     ];
@@ -487,7 +488,7 @@ fn canvas() -> Box<dyn Widget<Data = AppData>> {
         }
     }
 
-    let ui = kas::column![
+    let ui = column![
         Label::new(
             "Animated canvas demo (CPU-rendered, async). Note: scheduling is broken on X11."
         ),
@@ -513,7 +514,7 @@ KAS_CONFIG_MODE=readwrite
     )
     .unwrap();
 
-    let ui = kas::column![ScrollLabel::new(desc), Separator::new(), EventConfig::new(),]
+    let ui = column![ScrollLabel::new(desc), Separator::new(), EventConfig::new(),]
         .map_any()
         .on_update(|cx, _, data: &AppData| cx.set_disabled(data.disabled));
     Box::new(ui)
@@ -583,7 +584,7 @@ fn main() -> kas::app::Result<()> {
         })
         .build();
 
-    let ui = kas::column![
+    let ui = column![
         menubar,
         Separator::new(),
         TabStack::from([

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -7,7 +7,7 @@
 
 use kas::layout::AlignHints;
 use kas::widgets::{AdaptWidget, CheckBox, EditBox, ScrollLabel};
-use kas::Window;
+use kas::{grid, Window};
 
 const LIPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nunc mi, consequat eget urna ut, auctor luctus mi. Sed molestie mi est. Sed non ligula ante. Curabitur ac molestie ante, nec sodales eros. In non arcu at turpis euismod bibendum ut tincidunt eros. Suspendisse blandit maximus nisi, viverra hendrerit elit efficitur et. Morbi ut facilisis eros. Vivamus dignissim, sapien sed mattis consectetur, libero leo imperdiet turpis, ac pulvinar libero purus eu lorem. Etiam quis sollicitudin urna. Integer vitae erat vel neque gravida blandit ac non quam.";
 const CRASIT: &str = "Cras sit amet justo ipsum. Aliquam in nunc posuere leo egestas laoreet convallis eu libero. Nullam ut massa ante. Cras vitae velit pharetra, euismod nisl suscipit, feugiat nulla. Aenean consectetur, diam non tristique iaculis, nisl lectus hendrerit sapien, nec rhoncus mi sem non odio. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla a lorem eu ipsum faucibus placerat ac quis quam. Curabitur justo ligula, laoreet nec ultrices eu, scelerisque non metus. Mauris sit amet est enim. Mauris risus eros, accumsan ut iaculis sit amet, sagittis facilisis neque. Nunc venenatis risus nec purus malesuada, a tristique arcu efficitur. Nulla suscipit arcu nibh. Cras facilisis nibh a gravida aliquet. Praesent fringilla felis a tristique luctus.";
@@ -15,7 +15,7 @@ const CRASIT: &str = "Cras sit amet justo ipsum. Aliquam in nunc posuere leo ege
 fn main() -> kas::app::Result<()> {
     env_logger::init();
 
-    let ui = kas::grid! {
+    let ui = grid! {
         (1, 0) => "Layout demo",
         (2, 0) => CheckBox::new(|_, _| true),
         (0..3, 1) => ScrollLabel::new(LIPSUM),

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -6,8 +6,8 @@
 //! Demonstration of widget and text layouts
 
 use kas::layout::AlignHints;
-use kas::widgets::{AdaptWidget, CheckBox, EditBox, ScrollLabel};
-use kas::{grid, Window};
+use kas::widgets::{grid, AdaptWidget, CheckBox, EditBox, ScrollLabel};
+use kas::Window;
 
 const LIPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nunc mi, consequat eget urna ut, auctor luctus mi. Sed molestie mi est. Sed non ligula ante. Curabitur ac molestie ante, nec sodales eros. In non arcu at turpis euismod bibendum ut tincidunt eros. Suspendisse blandit maximus nisi, viverra hendrerit elit efficitur et. Morbi ut facilisis eros. Vivamus dignissim, sapien sed mattis consectetur, libero leo imperdiet turpis, ac pulvinar libero purus eu lorem. Etiam quis sollicitudin urna. Integer vitae erat vel neque gravida blandit ac non quam.";
 const CRASIT: &str = "Cras sit amet justo ipsum. Aliquam in nunc posuere leo egestas laoreet convallis eu libero. Nullam ut massa ante. Cras vitae velit pharetra, euismod nisl suscipit, feugiat nulla. Aenean consectetur, diam non tristique iaculis, nisl lectus hendrerit sapien, nec rhoncus mi sem non odio. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla a lorem eu ipsum faucibus placerat ac quis quam. Curabitur justo ligula, laoreet nec ultrices eu, scelerisque non metus. Mauris sit amet est enim. Mauris risus eros, accumsan ut iaculis sit amet, sagittis facilisis neque. Nunc venenatis risus nec purus malesuada, a tristique arcu efficitur. Nulla suscipit arcu nibh. Cras facilisis nibh a gravida aliquet. Praesent fringilla felis a tristique luctus.";

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -6,8 +6,7 @@
 //! Counter example (simple button)
 
 use kas::prelude::*;
-use kas::widgets::{Adapt, Button, EditField, Splitter};
-use kas::{column, row};
+use kas::widgets::{column, row, Adapt, Button, EditField, Splitter};
 
 #[derive(Clone, Debug)]
 enum Message {

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -7,6 +7,7 @@
 
 use kas::prelude::*;
 use kas::widgets::{Adapt, Button, EditField, Splitter};
+use kas::{column, row};
 
 #[derive(Clone, Debug)]
 enum Message {
@@ -17,7 +18,7 @@ enum Message {
 fn main() -> kas::app::Result<()> {
     env_logger::init();
 
-    let ui = kas::column![
+    let ui = column![
         row![
             Button::label_msg("−", Message::Decr),
             Button::label_msg("+", Message::Incr),

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use kas::prelude::*;
 use kas::widgets::{format_data, Adapt, Button};
-use kas::Decorations;
+use kas::{row, Decorations};
 
 #[derive(Clone, Debug)]
 struct MsgReset;
@@ -23,7 +23,7 @@ struct Timer {
 }
 
 fn make_window() -> impl Widget<Data = ()> {
-    let ui = kas::row![
+    let ui = row![
         format_data!(timer: &Timer, "{}.{:03}", timer.elapsed.as_secs(), timer.elapsed.subsec_millis()),
         Button::label_msg("&reset", MsgReset).map_any(),
         Button::label_msg("&start / &stop", MsgStart).map_any(),

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -8,8 +8,8 @@
 use std::time::{Duration, Instant};
 
 use kas::prelude::*;
-use kas::widgets::{format_data, Adapt, Button};
-use kas::{row, Decorations};
+use kas::widgets::{format_data, row, Adapt, Button};
+use kas::Decorations;
 
 #[derive(Clone, Debug)]
 struct MsgReset;

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -7,8 +7,8 @@
 //!
 //! Each window shares the counter, but has its own increment step.
 
-use kas::widgets::{format_data, label_any, Adapt, Button, Slider};
-use kas::{column, messages::MessageStack, row, Window};
+use kas::widgets::{column, format_data, label_any, row, Adapt, Button, Slider};
+use kas::{messages::MessageStack, Window};
 
 #[derive(Clone, Debug)]
 struct Increment(i32);

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -8,7 +8,7 @@
 //! Each window shares the counter, but has its own increment step.
 
 use kas::widgets::{format_data, label_any, Adapt, Button, Slider};
-use kas::{messages::MessageStack, Window};
+use kas::{column, messages::MessageStack, row, Window};
 
 #[derive(Clone, Debug)]
 struct Increment(i32);
@@ -37,7 +37,7 @@ fn counter(title: &str) -> Window<Count> {
     struct SetValue(i32);
 
     let slider = Slider::right(1..=10, |_, data: &Data| data.1).with_msg(SetValue);
-    let ui = kas::column![
+    let ui = column![
         format_data!(data: &Data, "Count: {}", data.0.0),
         row![slider, format_data!(data: &Data, "{}", data.1)],
         row![

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -2,8 +2,7 @@
 
 use kas::prelude::*;
 use kas::view::{driver, MatrixData, MatrixView, SelectionMode, SelectionMsg, SharedData};
-use kas::widgets::{Adapt, EditBox, ScrollBars};
-use kas::{column, row};
+use kas::widgets::{column, row, Adapt, EditBox, ScrollBars};
 
 #[derive(Debug)]
 struct TableSize(usize);

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -3,6 +3,7 @@
 use kas::prelude::*;
 use kas::view::{driver, MatrixData, MatrixView, SelectionMode, SelectionMsg, SharedData};
 use kas::widgets::{Adapt, EditBox, ScrollBars};
+use kas::{column, row};
 
 #[derive(Debug)]
 struct TableSize(usize);
@@ -54,7 +55,7 @@ fn main() -> kas::app::Result<()> {
     #[derive(Debug)]
     struct SetLen(usize);
 
-    let ui = kas::column![
+    let ui = column![
         row![
             "From 1 to",
             EditBox::parser(|data: &TableSize| data.0, SetLen)

--- a/tests/layout_macros.rs
+++ b/tests/layout_macros.rs
@@ -1,26 +1,27 @@
 use kas::layout::AlignHints;
 use kas::Widget;
+use kas::{aligned_column, aligned_row, column, float, grid, list, row};
 
 fn use_widget<W: Widget<Data = ()>>(_: W) {}
 
 #[test]
 fn column() {
-    use_widget(kas::column!["one", "two",])
+    use_widget(column!["one", "two",])
 }
 
 #[test]
 fn row() {
-    use_widget(kas::row!["one", "two"]);
+    use_widget(row!["one", "two"]);
 }
 
 #[test]
 fn list() {
-    use_widget(kas::list!(left, ["one", "two"]));
+    use_widget(list!(left, ["one", "two"]));
 }
 
 #[test]
 fn float() {
-    use_widget(kas::float![
+    use_widget(float![
         "one".pack(AlignHints::TOP_LEFT),
         "two".pack(AlignHints::BOTTOM_RIGHT),
         "some text\nin the\nbackground",
@@ -29,7 +30,7 @@ fn float() {
 
 #[test]
 fn grid() {
-    use_widget(kas::grid! {
+    use_widget(grid! {
         (0, 0) => "top left",
         (1, 0) => "top right",
         (0..2, 1) => "bottom row (merged)",
@@ -38,14 +39,16 @@ fn grid() {
 
 #[test]
 fn aligned_column() {
-    use_widget(kas::aligned_column![row!["one", "two"], row![
-        "three", "four"
-    ],]);
+    #[rustfmt::skip]
+    use_widget(aligned_column![
+        row!["one", "two"],
+        row!["three", "four"],
+    ]);
 }
 
 #[test]
 fn aligned_row() {
-    use_widget(kas::aligned_row![column!["one", "two"], column![
+    use_widget(aligned_row![column!["one", "two"], column![
         "three", "four"
     ],]);
 }

--- a/tests/layout_macros.rs
+++ b/tests/layout_macros.rs
@@ -1,6 +1,6 @@
 use kas::layout::AlignHints;
+use kas::widgets::{aligned_column, aligned_row, column, float, grid, list, row};
 use kas::Widget;
-use kas::{aligned_column, aligned_row, column, float, grid, list, row};
 
 fn use_widget<W: Widget<Data = ()>>(_: W) {}
 


### PR DESCRIPTION
Layout macros (`column!`, `grid!` etc.) are moved into the `kas::widgets` namespace.

These layout macros no longer recurse internally (except with feature `recursive-layout-widgets`). This is slightly less optimal but means that e.g. `column!["title", row!["a", "b"].map(|_| &())]` is now possible since the internal `row![..]` is a widget and thus supports all the usual methods. Caveat: this is incompatible with the `recursive-layout-widgets` feature, and thus we warn about it in all cases.

Note that recursive layout macros must remain a feature to support usage in custom widgets where inner layout components may refer to fields of the custom widget, so all we're really doing is turning off this feature in the common case to improve diagnostic output.

Since these macros now behave (mostly) identically both within and outside of other layout macros, we can stop prepending with `kas::` to identify non-recursive macro calls and just import the macros (explicitly, since glob import clashes with the `std` `column!` macro).