### PR TITLE
Fix window sizing

### DIFF
--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -632,7 +632,7 @@ pub fn collection(input: TokenStream) -> TokenStream {
 ///
 /// For example usage, see [`Grid`](https://docs.rs/kas/latest/kas/widgets/struct.Grid.html).
 ///
-/// [`kas::Collection`]: https://docs.rs/kas/latest/kas/trait.Collection.html
+/// [`kas::CellCollection`]: https://docs.rs/kas/latest/kas/trait.CellCollection.html
 #[proc_macro_error]
 #[proc_macro]
 pub fn cell_collection(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
It turns out that the clock example wouldn't run at all on X11 due to a missing resize, so we should do that anyway (even though it may be redundant). If we had more platform-specific code here, we should be able to avoid this issue on Wayland at least. See github.com/rust-windowing/winit/issues/3192