### PR TITLE
Update winit, wgpu, resvg

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -121,7 +121,7 @@ version = "0.5.0" # used in doc links
 
 [dependencies.winit]
 # Provides translations for several winit types
-version = "0.29.2"
+version = "0.30.0"
 optional = true
 default-features = false
 features = ["rwh_06"]

--- a/crates/kas-core/src/app/app.rs
+++ b/crates/kas-core/src/app/app.rs
@@ -13,7 +13,7 @@ use crate::util::warn_about_error;
 use crate::{impl_scope, Window, WindowId};
 use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
-use winit::event_loop::{EventLoop, EventLoopBuilder, EventLoopProxy};
+use winit::event_loop::{EventLoop, EventLoopProxy};
 
 pub struct Application<Data: AppData, G: AppGraphicsBuilder, T: Theme<G::Shared>> {
     el: EventLoop<ProxyAction>,
@@ -83,7 +83,7 @@ impl_scope! {
             });
             config.borrow_mut().init();
 
-            let el = EventLoopBuilder::with_user_event().build()?;
+            let el = EventLoop::with_user_event().build()?;
 
             let mut draw_shared = self.graphical.build()?;
             draw_shared.set_raster_config(config.borrow().font.raster());
@@ -237,8 +237,8 @@ impl<'a> PlatformWrapper<'a> {
         {
             cfg_if::cfg_if! {
                 if #[cfg(all(feature = "wayland", feature = "x11"))] {
-                    use winit::platform::wayland::EventLoopWindowTargetExtWayland;
-                    return if self.0.is_wayland() {
+                    use winit::platform::wayland::ActiveEventLoopExtWayland;
+                    return if true /*FIXME: self.0.is_wayland()*/ {
                         Platform::Wayland
                     } else {
                         Platform::X11

--- a/crates/kas-core/src/app/app.rs
+++ b/crates/kas-core/src/app/app.rs
@@ -211,8 +211,8 @@ where
     /// Run the main loop.
     #[inline]
     pub fn run(self) -> Result<()> {
-        let mut el = super::EventLoop::new(self.windows, self.state);
-        self.el.run(move |event, elwt| el.handle(event, elwt))?;
+        let mut l = super::Loop::new(self.windows, self.state);
+        self.el.run_app(&mut l)?;
         Ok(())
     }
 }

--- a/crates/kas-core/src/app/event_loop.rs
+++ b/crates/kas-core/src/app/event_loop.rs
@@ -11,7 +11,8 @@ use crate::theme::Theme;
 use crate::{Action, WindowId};
 use std::collections::HashMap;
 use std::time::Instant;
-use winit::event::{Event, StartCause};
+use winit::application::ApplicationHandler;
+use winit::event::StartCause;
 use winit::event_loop::{ActiveEventLoop, ControlFlow};
 use winit::window as ww;
 
@@ -33,6 +34,136 @@ where
     resumes: Vec<(Instant, WindowId)>,
 }
 
+impl<A: AppData, G, T> ApplicationHandler<ProxyAction> for Loop<A, G, T>
+where
+    G: AppGraphicsBuilder,
+    T: Theme<G::Shared>,
+    T::Window: kas::theme::Window,
+{
+    fn new_events(&mut self, el: &ActiveEventLoop, cause: StartCause) {
+        // MainEventsCleared will reset control_flow (but not when it is Poll)
+        el.set_control_flow(ControlFlow::Wait);
+
+        match cause {
+            StartCause::ResumeTimeReached {
+                requested_resume, ..
+            } => {
+                let item = self
+                    .resumes
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| panic!("timer wakeup without resume"));
+                assert_eq!(item.0, requested_resume);
+                log::trace!("Wakeup: timer (window={:?})", item.1);
+
+                let resume = if let Some(w) = self.windows.get_mut(&item.1) {
+                    w.update_timer(&mut self.state)
+                } else {
+                    // presumably, some window with active timers was removed
+                    None
+                };
+
+                if let Some(instant) = resume {
+                    self.resumes[0].0 = instant;
+                } else {
+                    self.resumes.remove(0);
+                }
+            }
+            StartCause::WaitCancelled { .. } => {
+                // This event serves no purpose?
+                // log::debug!("Wakeup: WaitCancelled (ignoring)");
+            }
+            StartCause::Poll => (),
+            StartCause::Init => (),
+        }
+    }
+
+    fn user_event(&mut self, _: &ActiveEventLoop, event: ProxyAction) {
+        match event {
+            ProxyAction::Close(id) => {
+                if let Some(window) = self.windows.get_mut(&id) {
+                    window.send_action(Action::CLOSE);
+                }
+            }
+            ProxyAction::CloseAll => {
+                for window in self.windows.values_mut() {
+                    window.send_action(Action::CLOSE);
+                }
+            }
+            ProxyAction::Message(msg) => {
+                let mut stack = crate::messages::MessageStack::new();
+                stack.push_erased(msg.into_erased());
+                self.state.handle_messages(&mut stack);
+            }
+            ProxyAction::WakeAsync => {
+                // We don't need to do anything: MainEventsCleared will
+                // automatically be called after, which automatically calls
+                // window.update(..), which calls EventState::Update.
+            }
+        }
+    }
+
+    fn resumed(&mut self, el: &ActiveEventLoop) {
+        if self.suspended {
+            for window in self.windows.values_mut() {
+                match window.resume(&mut self.state, el) {
+                    Ok(winit_id) => {
+                        self.id_map.insert(winit_id, window.window_id);
+                    }
+                    Err(e) => {
+                        log::error!("Unable to create window: {}", e);
+                    }
+                }
+            }
+            self.suspended = false;
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        el: &ActiveEventLoop,
+        window_id: ww::WindowId,
+        event: winit::event::WindowEvent,
+    ) {
+        self.flush_pending(el);
+
+        if let Some(id) = self.id_map.get(&window_id) {
+            if let Some(window) = self.windows.get_mut(id) {
+                if window.handle_event(&mut self.state, event) {
+                    el.set_control_flow(ControlFlow::Poll);
+                }
+            }
+        }
+    }
+
+    fn about_to_wait(&mut self, el: &ActiveEventLoop) {
+        self.flush_pending(el);
+        self.resumes.sort_by_key(|item| item.0);
+
+        if self.windows.is_empty() {
+            el.exit();
+        } else if matches!(el.control_flow(), ControlFlow::Poll) {
+        } else if let Some((instant, _)) = self.resumes.first() {
+            el.set_control_flow(ControlFlow::WaitUntil(*instant));
+        } else {
+            el.set_control_flow(ControlFlow::Wait);
+        };
+    }
+
+    fn suspended(&mut self, _: &ActiveEventLoop) {
+        if !self.suspended {
+            for window in self.windows.values_mut() {
+                window.suspend();
+            }
+            self.suspended = true;
+        }
+    }
+
+    fn exiting(&mut self, _: &ActiveEventLoop) {
+        self.state.on_exit();
+    }
+}
+
 impl<A: AppData, G: AppGraphicsBuilder, T: Theme<G::Shared>> Loop<A, G, T>
 where
     T::Window: kas::theme::Window,
@@ -45,127 +176,6 @@ where
             id_map: Default::default(),
             state,
             resumes: vec![],
-        }
-    }
-
-    pub(super) fn handle(&mut self, event: Event<ProxyAction>, el: &ActiveEventLoop) {
-        match event {
-            Event::NewEvents(cause) => {
-                // MainEventsCleared will reset control_flow (but not when it is Poll)
-                el.set_control_flow(ControlFlow::Wait);
-
-                match cause {
-                    StartCause::ResumeTimeReached {
-                        requested_resume, ..
-                    } => {
-                        let item = self
-                            .resumes
-                            .first()
-                            .cloned()
-                            .unwrap_or_else(|| panic!("timer wakeup without resume"));
-                        assert_eq!(item.0, requested_resume);
-                        log::trace!("Wakeup: timer (window={:?})", item.1);
-
-                        let resume = if let Some(w) = self.windows.get_mut(&item.1) {
-                            w.update_timer(&mut self.state)
-                        } else {
-                            // presumably, some window with active timers was removed
-                            None
-                        };
-
-                        if let Some(instant) = resume {
-                            self.resumes[0].0 = instant;
-                        } else {
-                            self.resumes.remove(0);
-                        }
-                    }
-                    StartCause::WaitCancelled { .. } => {
-                        // This event serves no purpose?
-                        // log::debug!("Wakeup: WaitCancelled (ignoring)");
-                    }
-                    StartCause::Poll => (),
-                    StartCause::Init => (),
-                }
-            }
-
-            Event::WindowEvent { window_id, event } => {
-                self.flush_pending(el);
-
-                if let Some(id) = self.id_map.get(&window_id) {
-                    if let Some(window) = self.windows.get_mut(id) {
-                        if window.handle_event(&mut self.state, event) {
-                            el.set_control_flow(ControlFlow::Poll);
-                        }
-                    }
-                }
-            }
-            Event::DeviceEvent { .. } => {
-                // windows handle local input; we do not handle global input
-            }
-            Event::UserEvent(action) => match action {
-                ProxyAction::Close(id) => {
-                    if let Some(window) = self.windows.get_mut(&id) {
-                        window.send_action(Action::CLOSE);
-                    }
-                }
-                ProxyAction::CloseAll => {
-                    for window in self.windows.values_mut() {
-                        window.send_action(Action::CLOSE);
-                    }
-                }
-                ProxyAction::Message(msg) => {
-                    let mut stack = crate::messages::MessageStack::new();
-                    stack.push_erased(msg.into_erased());
-                    self.state.handle_messages(&mut stack);
-                }
-                ProxyAction::WakeAsync => {
-                    // We don't need to do anything: MainEventsCleared will
-                    // automatically be called after, which automatically calls
-                    // window.update(..), which calls EventState::Update.
-                }
-            },
-
-            Event::Suspended if !self.suspended => {
-                for window in self.windows.values_mut() {
-                    window.suspend();
-                }
-                self.suspended = true;
-            }
-            Event::Suspended => (),
-            Event::Resumed if self.suspended => {
-                for window in self.windows.values_mut() {
-                    match window.resume(&mut self.state, el) {
-                        Ok(winit_id) => {
-                            self.id_map.insert(winit_id, window.window_id);
-                        }
-                        Err(e) => {
-                            log::error!("Unable to create window: {}", e);
-                        }
-                    }
-                }
-                self.suspended = false;
-            }
-            Event::Resumed => (),
-
-            Event::AboutToWait => {
-                self.flush_pending(el);
-                self.resumes.sort_by_key(|item| item.0);
-
-                if self.windows.is_empty() {
-                    el.exit();
-                } else if matches!(el.control_flow(), ControlFlow::Poll) {
-                } else if let Some((instant, _)) = self.resumes.first() {
-                    el.set_control_flow(ControlFlow::WaitUntil(*instant));
-                } else {
-                    el.set_control_flow(ControlFlow::Wait);
-                };
-            }
-
-            Event::LoopExiting => {
-                self.state.on_exit();
-            }
-
-            Event::MemoryWarning => (), // TODO ?
         }
     }
 

--- a/crates/kas-core/src/app/mod.rs
+++ b/crates/kas-core/src/app/mod.rs
@@ -14,7 +14,7 @@ mod common;
 use crate::messages::MessageStack;
 #[cfg(winit)] use crate::WindowId;
 #[cfg(winit)] use app::PlatformWrapper;
-#[cfg(winit)] use event_loop::Loop as EventLoop;
+#[cfg(winit)] use event_loop::Loop;
 #[cfg(winit)] pub(crate) use shared::{AppShared, AppState};
 #[cfg(winit)]
 pub(crate) use window::{Window, WindowDataErased};

--- a/crates/kas-core/src/app/shared.rs
+++ b/crates/kas-core/src/app/shared.rs
@@ -217,7 +217,7 @@ impl<Data: AppData, G: AppGraphicsBuilder, T: Theme<G::Shared>> AppShared
         // By far the simplest way to implement this is to let our call
         // anscestor, event::Loop::handle, do the work.
         //
-        // In theory we could pass the EventLoopWindowTarget for *each* event
+        // In theory we could pass the `ActiveEventLoop` for *each* event
         // handled to create the winit window here or use statics to generate
         // errors now, but user code can't do much with this error anyway.
         let id = self.next_window_id();

--- a/crates/kas-resvg/Cargo.toml
+++ b/crates/kas-resvg/Cargo.toml
@@ -26,8 +26,8 @@ svg = ["dep:resvg", "dep:usvg"]
 
 [dependencies]
 tiny-skia = { version = "0.11.0" }
-resvg = { version = "0.38.0", optional = true }
-usvg = { version = "0.38.0", optional = true }
+resvg = { version = "0.41.0", optional = true }
+usvg = { version = "0.41.0", optional = true }
 once_cell = "1.17.0"
 thiserror = "1.0.23"
 

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -47,7 +47,7 @@ path = "../kas-core"
 version = "0.6.0"
 
 [dependencies.wgpu]
-version = "0.19.1"
+version = "0.20.0"
 default-features = false
 features = ["spirv"]
 

--- a/crates/kas-wgpu/src/draw/flat_round.rs
+++ b/crates/kas-wgpu/src/draw/flat_round.rs
@@ -68,6 +68,7 @@ impl Pipeline {
             vertex: wgpu::VertexState {
                 module: &shaders.vert_flat_round,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -94,6 +95,7 @@ impl Pipeline {
             fragment: Some(wgpu::FragmentState {
                 module: &shaders.frag_flat_round,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: super::RENDER_TEX_FORMAT,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),

--- a/crates/kas-wgpu/src/draw/images.rs
+++ b/crates/kas-wgpu/src/draw/images.rs
@@ -95,6 +95,7 @@ impl Images {
             wgpu::VertexState {
                 module: &shaders.vert_image,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: size_of::<Instance>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Instance,
@@ -109,6 +110,7 @@ impl Images {
             wgpu::FragmentState {
                 module: &shaders.frag_image,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: super::RENDER_TEX_FORMAT,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),

--- a/crates/kas-wgpu/src/draw/round_2col.rs
+++ b/crates/kas-wgpu/src/draw/round_2col.rs
@@ -57,6 +57,7 @@ impl Pipeline {
             vertex: wgpu::VertexState {
                 module: &shaders.vert_round_2col,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -82,6 +83,7 @@ impl Pipeline {
             fragment: Some(wgpu::FragmentState {
                 module: &shaders.frag_round_2col,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: super::RENDER_TEX_FORMAT,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),

--- a/crates/kas-wgpu/src/draw/shaded_round.rs
+++ b/crates/kas-wgpu/src/draw/shaded_round.rs
@@ -63,6 +63,7 @@ impl Pipeline {
             vertex: wgpu::VertexState {
                 module: &shaders.vert_shaded_round,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -89,6 +90,7 @@ impl Pipeline {
             fragment: Some(wgpu::FragmentState {
                 module: &shaders.frag_shaded_round,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: super::RENDER_TEX_FORMAT,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),

--- a/crates/kas-wgpu/src/draw/shaded_square.rs
+++ b/crates/kas-wgpu/src/draw/shaded_square.rs
@@ -50,6 +50,7 @@ impl Pipeline {
             vertex: wgpu::VertexState {
                 module: &shaders.vert_shaded_square,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -74,6 +75,7 @@ impl Pipeline {
             fragment: Some(wgpu::FragmentState {
                 module: &shaders.frag_shaded_square,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: super::RENDER_TEX_FORMAT,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -96,6 +96,7 @@ impl Pipeline {
             wgpu::VertexState {
                 module: &shaders.vert_glyph,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: size_of::<Instance>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Instance,
@@ -111,6 +112,7 @@ impl Pipeline {
             wgpu::FragmentState {
                 module: &shaders.frag_glyph,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: super::RENDER_TEX_FORMAT,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4"
 smallvec = "1.6.1"
 unicode-segmentation = "1.7"
 thiserror = "1.0.23"
-image = { version = "0.24.1", optional = true }
+image = { version = "0.25.1", optional = true }
 kas-macros = { version = "0.14.1", path = "../kas-macros" }
 linear-map = "1.2.0"
 

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -132,6 +132,7 @@ impl CustomPipeBuilder for PipeBuilder {
             vertex: wgpu::VertexState {
                 module: &shaders.vertex,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
@@ -152,6 +153,7 @@ impl CustomPipeBuilder for PipeBuilder {
             fragment: Some(wgpu::FragmentState {
                 module: &shaders.fragment,
                 entry_point: "main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: tex_format,
                     blend: None,


### PR DESCRIPTION
Regression: this always reports `Platform::Wayland` on Linux (https://github.com/rust-windowing/winit/pull/3672). This may affect decorations on X11, but it's not worth blocking the PR or finding a workaround for now.

Migrates to winit's new `ApplicationHandler` (straightforward).