### PR TITLE
Fixes + serde_yaml2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
         run: sudo apt-get install -y libxkbcommon-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
       - name: Test kas-macros
-        run: cargo test --manifest-path crates/kas-macros/Cargo.toml --all-features
+        run: cargo test --manifest-path crates/kas-macros/Cargo.toml --features log
       - name: Test kas-core
         run: cargo test --manifest-path crates/kas-core/Cargo.toml --features stable
       - name: Test kas-widgets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # about target platforms).
 #
 # Note: only some examples build in this configuration; others need view,
-# markdown, resvg. Recommended also: clipboard, yaml (or some config format).
+# markdown, resvg. Recommended also: clipboard, ron (or some config format).
 minimal = ["wgpu", "winit", "wayland"]
 # All recommended features for optimal experience
 default = ["minimal", "view", "image", "resvg", "clipboard", "markdown", "shaping", "spawn"]

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -23,7 +23,7 @@ minimal = ["winit", "wayland"]
 # All standard test target features
 stable = ["minimal", "clipboard", "markdown", "shaping", "spawn", "x11", "serde", "toml", "yaml", "json", "ron", "macros_log", "image"]
 # Enables all "recommended" features for nightly rustc
-nightly = ["stable"]
+nightly = ["stable", "kas-macros/nightly"]
 # Additional, less recommendation-worthy features
 experimental = ["dark-light", "recursive-layout-widgets", "unsafe_node"]
 

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -43,7 +43,7 @@ markdown = ["kas-text/markdown"]
 shaping = ["kas-text/shaping"]
 
 # Enable support for YAML (de)serialisation
-yaml = ["serde", "dep:serde_yaml"]
+yaml = ["serde", "dep:serde_yaml2"]
 
 # Enable support for JSON (de)serialisation
 json = ["serde", "dep:serde_json"]
@@ -100,7 +100,7 @@ linear-map = "1.2.0"
 thiserror = "2.0.3"
 serde = { version = "1.0.123", features = ["derive"], optional = true }
 serde_json = { version = "1.0.61", optional = true }
-serde_yaml = { version = "0.9.9", optional = true }
+serde_yaml2 = { version = "0.1.2", optional = true }
 ron = { version = "0.8.0", package = "ron", optional = true }
 toml = { version = "0.8.2", package = "toml", optional = true }
 num_enum = "0.7.0"

--- a/crates/kas-macros/Cargo.toml
+++ b/crates/kas-macros/Cargo.toml
@@ -22,6 +22,9 @@ log = []
 # Optimize generated layout widgets
 recursive-layout-widgets = []
 
+# Enable reporting of warnings from proc-macros
+nightly = ["proc-macro-error2/nightly"]
+
 [dependencies]
 quote = "1.0"
 proc-macro2 = { version = "1.0" }

--- a/crates/kas-macros/src/widget_derive.rs
+++ b/crates/kas-macros/src/widget_derive.rs
@@ -129,7 +129,7 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
         }
     };
 
-    let fn_size_rules = Some(quote! {
+    let fn_size_rules = quote! {
         #[inline]
         fn size_rules(&mut self,
             sizer: ::kas::theme::SizeCx,
@@ -137,7 +137,7 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
         ) -> ::kas::layout::SizeRules {
             self.#inner.size_rules(sizer, axis)
         }
-    });
+    };
     let fn_set_rect = quote! {
         #[inline]
         fn set_rect(
@@ -149,30 +149,30 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
             self.#inner.set_rect(cx, rect, hints);
         }
     };
-    let fn_nav_next = Some(quote! {
+    let fn_nav_next = quote! {
         #[inline]
         fn nav_next(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
             self.#inner.nav_next(reverse, from)
         }
-    });
-    let fn_translation = Some(quote! {
+    };
+    let fn_translation = quote! {
         #[inline]
         fn translation(&self) -> ::kas::geom::Offset {
             self.#inner.translation()
         }
-    });
+    };
     let fn_find_id = quote! {
         #[inline]
         fn find_id(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
             self.#inner.find_id(coord)
         }
     };
-    let fn_draw = Some(quote! {
+    let fn_draw = quote! {
         #[inline]
         fn draw(&mut self, draw: ::kas::theme::DrawCx) {
             self.#inner.draw(draw);
         }
-    });
+    };
 
     let data_ty: Type = 'outer: {
         for (i, field) in fields.iter_mut().enumerate() {
@@ -260,9 +260,7 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
         layout_impl.items.push(Verbatim(required_layout_methods));
 
         if !has_item("size_rules") {
-            if let Some(method) = fn_size_rules {
-                layout_impl.items.push(Verbatim(method));
-            }
+            layout_impl.items.push(Verbatim(fn_size_rules));
         }
 
         if !has_item("set_rect") {
@@ -270,9 +268,7 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
         }
 
         if !has_item("nav_next") {
-            if let Some(method) = fn_nav_next {
-                layout_impl.items.push(Verbatim(method));
-            }
+            layout_impl.items.push(Verbatim(fn_nav_next));
         }
 
         if let Some(ident) = item_idents
@@ -280,8 +276,8 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
             .find_map(|(_, ident)| (*ident == "translation").then_some(ident))
         {
             emit_error!(ident, "method not supported in derive mode");
-        } else if let Some(method) = fn_translation {
-            layout_impl.items.push(Verbatim(method));
+        } else {
+            layout_impl.items.push(Verbatim(fn_translation));
         }
 
         if !has_item("find_id") {
@@ -289,11 +285,9 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
         }
 
         if !has_item("draw") {
-            if let Some(method) = fn_draw {
-                layout_impl.items.push(Verbatim(method));
-            }
+            layout_impl.items.push(Verbatim(fn_draw));
         }
-    } else if let Some(fn_size_rules) = fn_size_rules {
+    } else {
         scope.generated.push(quote! {
             impl #impl_generics ::kas::Layout for #impl_target {
                 #required_layout_methods

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -108,6 +108,7 @@ impl_scope! {
         }
 
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
+            self.core.rect = rect;
             let dim = (self.direction, self.widgets.len());
             let mut setter = RowSetter::<D, Vec<i32>, _>::new(rect, dim, &mut self.layout);
 


### PR DESCRIPTION
This includes:
- a small fix to #460
- a `kas-macros/nightly` feature to enable reporting warnings (a workaround until https://github.com/GnomedDev/proc-macro-error-2/pull/5 lands)
- replaces the deprecated `serde_yaml` dependency
- a fix to the `List` widget