### PR TITLE
Revise GripPart position/size setting

### DIFF
--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -47,12 +47,11 @@ impl_scope! {
     /// to determine the grip's size.
     /// (Calling `size_rules` is still required to comply with widget model.)
     ///
-    /// [`Layout::set_rect`] sets the grip's rect, clamping the position to the
-    /// track (it is assumed that the size does not exceed that of the track).
+    /// [`Layout::set_rect`] sets the grip's rect directly.
     /// [`Self::set_track`] must be called first.
     ///
-    /// Often it is preferable to use [`Self::set_size`] and
-    /// [`Self::set_offset`] to set the grip's size and position.
+    /// Often it is preferable to use [`Self::set_size`] to set the grip's size
+    /// then [`Self::set_offset`] to set the position.
     /// (Calling `set_rect` is still required to comply with widget model.)
     ///
     /// [`Layout::draw`] does nothing. The parent should handle all drawing.
@@ -81,11 +80,6 @@ impl_scope! {
     impl Layout for GripPart {
         fn size_rules(&mut self, _: SizeCx, _axis: AxisInfo) -> SizeRules {
             SizeRules::EMPTY
-        }
-
-        fn set_rect(&mut self, _: &mut ConfigCx, rect: Rect, _: AlignHints) {
-            self.core.rect = rect;
-            let _ = self.set_offset(self.offset()); // clamp
         }
 
         fn draw(&mut self, _: DrawCx) {}

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -218,12 +218,9 @@ impl_scope! {
             let grip_len = i64::from(self.grip_size) * i64::conv(len) / total;
             self.grip_len = i32::conv(grip_len).max(self.min_grip_len).min(len);
             let mut size = self.core.rect.size;
-            if self.direction.is_horizontal() {
-                size.0 = self.grip_len;
-            } else {
-                size.1 = self.grip_len;
-            }
-            self.grip.set_size_and_offset(size, self.offset())
+            size.set_component(self.direction, self.grip_len);
+            self.grip.set_size(size);
+            self.grip.set_offset(self.offset()).1
         }
 
         // translate value to offset in local coordinates
@@ -285,7 +282,11 @@ impl_scope! {
             };
             let rect = cx.align_feature(Feature::ScrollBar(self.direction()), rect, align);
             self.core.rect = rect;
-            self.grip.set_rect(cx, rect, AlignHints::NONE);
+            self.grip.set_track(rect);
+
+            // We call grip.set_rect only for compliance with the widget model:
+            self.grip.set_rect(cx, Rect::ZERO, AlignHints::NONE);
+
             self.min_grip_len = cx.size_cx().grip_len();
             let _ = self.update_widgets();
         }

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -299,16 +299,21 @@ impl_scope! {
         }
 
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
+            eprintln!("Slider::set_rect({rect:?}");
             let align = match self.direction.is_vertical() {
                 false => AlignPair::new(Align::Stretch, hints.vert.unwrap_or(Align::Center)),
                 true => AlignPair::new(hints.horiz.unwrap_or(Align::Center), Align::Stretch),
             };
-            let rect = cx.align_feature(Feature::Slider(self.direction()), rect, align);
+            let mut rect = cx.align_feature(Feature::Slider(self.direction()), rect, align);
             self.core.rect = rect;
+            self.grip.set_track(rect);
+
+            // Set the grip size (we could instead call set_size but the widget
+            // model requires we call set_rect anyway):
+            rect.size.set_component(self.direction, cx.size_cx().grip_len());
             self.grip.set_rect(cx, rect, AlignHints::NONE);
-            let mut size = rect.size;
-            size.set_component(self.direction, cx.size_cx().grip_len());
-            let _ = self.grip.set_size_and_offset(size, self.offset());
+            // Correct the position:
+            let _ = self.grip.set_offset(self.offset());
         }
 
         fn probe(&mut self, coord: Coord) -> Id {

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -205,9 +205,9 @@ impl_scope! {
                 // TODO(opt): calculate all maximal sizes simultaneously
                 let index = (n << 1) + 1;
                 let track = setter.maximal_rect_of(&mut self.data, index);
-                self.grips[n].set_rect(cx, track, AlignHints::NONE);
-                let grip = setter.child_rect(&mut self.data, index);
-                let _ = self.grips[n].set_size_and_offset(grip.size, grip.pos - track.pos);
+                self.grips[n].set_track(track);
+                let rect = setter.child_rect(&mut self.data, index);
+                self.grips[n].set_rect(cx, rect, AlignHints::NONE);
 
                 n += 1;
             }
@@ -336,9 +336,9 @@ impl<C: Collection, D: Directional> Splitter<C, D> {
 
             let index = (n << 1) + 1;
             let track = self.grips[n].track();
-            self.grips[n].set_rect(cx, track, AlignHints::NONE);
-            let grip = setter.child_rect(&mut self.data, index);
-            let _ = self.grips[n].set_size_and_offset(grip.size, grip.pos - track.pos);
+            self.grips[n].set_track(track);
+            let rect = setter.child_rect(&mut self.data, index);
+            let _ = self.grips[n].set_rect(cx, rect, AlignHints::NONE);
 
             n += 1;
         }


### PR DESCRIPTION
This corrects a subtle bug in the initial position of a `Slider` and tries to make the code more robust.

The caveat here is that the widget model works against us by requiring that `set_rect` be called instead of only calling `set_size`.