### PR TITLE
Rename try_observe -> try_peek

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -233,7 +233,7 @@ pub trait Events: Widget + Sized {
     /// This is the secondary event handler (see [documentation](crate::event)).
     ///
     /// It is implied that the stack contains at least one message.
-    /// Use [`EventCx::try_pop`] and/or [`EventCx::try_observe`].
+    /// Use [`EventCx::try_pop`] and/or [`EventCx::try_peek`].
     ///
     /// [`EventCx::last_child`] may be called to find the message's sender.
     /// This may return [`None`] (if no child was visited, which implies that

--- a/crates/kas-core/src/event/cx/config.rs
+++ b/crates/kas-core/src/event/cx/config.rs
@@ -94,28 +94,6 @@ impl<'a> ConfigCx<'a> {
         widget._update(self);
     }
 
-    /* TODO: can we support these (i.e. track `id`)?
-    /// Push a message (replay)
-    ///
-    /// Unlike [`EventCx::push`], this is not handled while unwinding
-    /// from event sending, but via a fresh traversal of the widget tree.
-    pub fn push<M: Debug + 'static>(&mut self, msg: M) {
-        self.send(id, msg);
-    }
-
-    /// Push a type-erased message (replay)
-    ///
-    /// Unlike [`EventCx::push_erased`], this is not handled while unwinding
-    /// from event sending, but via a fresh traversal of the widget tree.
-    ///
-    /// The message may be [popped](EventCx::try_pop) or
-    /// [observed](EventCx::try_observe) from [`Events::handle_messages`]
-    /// by the widget itself, its parent, or any ancestor.
-    pub fn push_erased(&mut self, msg: Erased) {
-        self.send_erased(id, msg);
-    }
-    */
-
     /// Align a feature's rect
     ///
     /// In case the input `rect` is larger than desired on either axis, it is

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -600,7 +600,7 @@ impl EventState {
     /// Similar to [`EventCx::push`], the message is sent as part of a widget
     /// tree traversal.
     /// The message may be [popped](EventCx::try_pop) or
-    /// [observed](EventCx::try_observe) from [`Events::handle_messages`]
+    /// [peeked](EventCx::try_peek) from [`Events::handle_messages`]
     /// by the widget itself, its parent, or any ancestor.
     pub fn send<M: Debug + 'static>(&mut self, id: Id, msg: M) {
         self.send_erased(id, Erased::new(msg));
@@ -730,7 +730,7 @@ impl<'a> EventCx<'a> {
     /// then pushed to the stack.
     ///
     /// The message may be [popped](EventCx::try_pop) or
-    /// [observed](EventCx::try_observe) from [`Events::handle_messages`]
+    /// [peeked](EventCx::try_peek) from [`Events::handle_messages`]
     /// by the widget itself, its parent, or any ancestor.
     pub fn push<M: Debug + 'static>(&mut self, msg: M) {
         self.push_erased(Erased::new(msg));
@@ -741,7 +741,7 @@ impl<'a> EventCx<'a> {
     /// This is a lower-level variant of [`Self::push`].
     ///
     /// The message may be [popped](EventCx::try_pop) or
-    /// [observed](EventCx::try_observe) from [`Events::handle_messages`]
+    /// [peeked](EventCx::try_peek) from [`Events::handle_messages`]
     /// by the widget itself, its parent, or any ancestor.
     pub fn push_erased(&mut self, msg: Erased) {
         self.messages.push_erased(msg);
@@ -762,8 +762,8 @@ impl<'a> EventCx<'a> {
     /// Try observing the last message on the stack without popping
     ///
     /// This method may be called from [`Events::handle_messages`].
-    pub fn try_observe<M: Debug + 'static>(&self) -> Option<&M> {
-        self.messages.try_observe()
+    pub fn try_peek<M: Debug + 'static>(&self) -> Option<&M> {
+        self.messages.try_peek()
     }
 
     /// Try getting a debug representation of the last message on the stack

--- a/crates/kas-core/src/messages.rs
+++ b/crates/kas-core/src/messages.rs
@@ -186,7 +186,7 @@ impl MessageStack {
     /// Try observing the last message on the stack without popping
     ///
     /// This method may be called from [`Events::handle_messages`].
-    pub fn try_observe<M: Debug + 'static>(&self) -> Option<&M> {
+    pub fn try_peek<M: Debug + 'static>(&self) -> Option<&M> {
         if self.has_any() {
             self.stack.last().and_then(|m| m.downcast_ref::<M>())
         } else {

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -234,7 +234,7 @@ impl<A, V: Clone + Debug + Eq + 'static> ComboBox<A, V> {
             mark: Mark::new(MarkStyle::Point(Direction::Down)),
             popup: Popup::new(
                 AdaptEvents::new(Column::new(entries)).on_messages(|cx, _, _| {
-                    if let Some(_) = cx.try_observe::<V>() {
+                    if let Some(_) = cx.try_peek::<V>() {
                         if let Some(index) = cx.last_child() {
                             cx.push(IndexMsg(index));
                         }


### PR DESCRIPTION
Use common nomenclature.

Also remove a note about an intended TODO item: there is not good motivation to add `fn ConfigCx::push` as sugar for `cx.send(self.id(), msg)`.