### PR TITLE
Better handling for close/suspend/exit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
         toolchain: [stable]
         include:
           - os: ubuntu-latest
-            toolchain: "1.80.1"
+            toolchain: "1.81.0"
             variant: MSRV
           - os: ubuntu-latest
             toolchain: beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["gui"]
 categories = ["gui"]
 repository = "https://github.com/kas-gui/kas"
 exclude = ["/examples"]
-rust-version = "1.80.1"
+rust-version = "1.81.0"
 
 [package.metadata.docs.rs]
 features = ["stable"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ KAS GUI
 [![Crates.io](https://img.shields.io/crates/v/kas.svg)](https://crates.io/crates/kas)
 [![kas-text](https://img.shields.io/badge/GitHub-kas--text-blueviolet)](https://github.com/kas-gui/kas-text/)
 [![Docs](https://docs.rs/kas/badge.svg)](https://docs.rs/kas)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.80+-lightgray.svg)
 
 KAS is a stateful, pure-Rust GUI toolkit supporting:
 

--- a/crates/kas-core/src/action.rs
+++ b/crates/kas-core/src/action.rs
@@ -75,7 +75,5 @@ bitflags! {
         const UPDATE = 1 << 17;
         /// The current window should be closed
         const CLOSE = 1 << 30;
-        /// Close all windows and exit
-        const EXIT = 1 << 31;
     }
 }

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -849,21 +849,12 @@ impl<'a> EventCx<'a> {
     ///
     /// Navigation focus will return to whichever widget had focus before
     /// the popup was open.
-    pub fn close_window(&mut self, id: WindowId) {
-        if let Some(index) =
-            self.popups
-                .iter()
-                .enumerate()
-                .find_map(|(i, p)| if p.0 == id { Some(i) } else { None })
-        {
-            let (wid, popup, onf) = self.popups.remove(index);
-            self.popup_removed.push((popup.id, wid));
-            self.runner.close_window(wid);
-
-            if let Some(id) = onf {
-                self.set_nav_focus(id, FocusSource::Synthetic);
+    pub fn close_window(&mut self, mut id: WindowId) {
+        for (index, p) in self.popups.iter().enumerate() {
+            if p.0 == id {
+                id = self.close_popup(index);
+                break;
             }
-            return;
         }
 
         self.runner.close_window(id);

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -259,7 +259,7 @@ impl EventState {
     /// Terminate the GUI
     #[inline]
     pub fn exit(&mut self) {
-        self.action |= Action::EXIT;
+        self.pending_cmds.push_back((Id::ROOT, Command::Exit));
     }
 
     /// Notify that an [`Action`] should happen

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -467,7 +467,7 @@ impl<'a> EventCx<'a> {
         let opt_command = self.config.shortcuts().try_match(self.modifiers, &vkey);
 
         if Some(Command::Exit) == opt_command {
-            self.action |= Action::EXIT;
+            self.runner.exit();
             return;
         } else if Some(Command::Close) == opt_command {
             self.handle_close();

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -464,15 +464,15 @@ impl<'a> EventCx<'a> {
             widget.id()
         );
 
-        let opt_command = self.config.shortcuts().try_match(self.modifiers, &vkey);
+        let opt_cmd = self.config.shortcuts().try_match(self.modifiers, &vkey);
 
-        if Some(Command::Exit) == opt_command {
+        if Some(Command::Exit) == opt_cmd {
             self.runner.exit();
             return;
-        } else if Some(Command::Close) == opt_command {
+        } else if Some(Command::Close) == opt_cmd {
             self.handle_close();
             return;
-        } else if let Some(cmd) = opt_command {
+        } else if let Some(cmd) = opt_cmd {
             let mut targets = vec![];
             let mut send = |_self: &mut Self, id: Id, cmd| -> bool {
                 if !targets.contains(&id) {
@@ -548,10 +548,10 @@ impl<'a> EventCx<'a> {
             }
             let event = Event::Command(Command::Activate, Some(code));
             self.send_event(widget, id, event);
-        } else if self.config.nav_focus && vkey == Key::Named(NamedKey::Tab) {
+        } else if self.config.nav_focus && opt_cmd == Some(Command::Tab) {
             let shift = self.modifiers.shift_key();
             self.next_nav_focus_impl(widget.re(), None, shift, FocusSource::Key);
-        } else if vkey == Key::Named(NamedKey::Escape) {
+        } else if opt_cmd == Some(Command::Escape) {
             if let Some(id) = self.popups.last().map(|(id, _, _)| *id) {
                 self.close_window(id);
             }

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -288,6 +288,14 @@ impl EventState {
 
         std::mem::take(&mut self.action)
     }
+
+    /// Window has been closed: clean up state
+    pub(crate) fn suspended(&mut self, runner: &mut dyn RunnerT) {
+        while !self.popups.is_empty() {
+            let id = self.close_popup(self.popups.len() - 1);
+            runner.close_window(id);
+        }
+    }
 }
 
 /// Platform API

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -401,21 +401,21 @@ impl<Data: 'static> Window<Data> {
     /// Each [`crate::Popup`] is assigned a [`WindowId`]; both are passed.
     pub(crate) fn add_popup(
         &mut self,
-        cx: &mut EventCx,
+        cx: &mut ConfigCx,
         data: &Data,
         id: WindowId,
         popup: kas::PopupDescriptor,
     ) {
         let index = self.popups.len();
         self.popups.push((id, popup, Offset::ZERO));
-        self.resize_popup(&mut cx.config_cx(), data, index);
+        self.resize_popup(cx, data, index);
         cx.action(Id::ROOT, Action::REDRAW);
     }
 
     /// Trigger closure of a pop-up
     ///
     /// If the given `id` refers to a pop-up, it should be closed.
-    pub(crate) fn remove_popup(&mut self, cx: &mut EventCx, id: WindowId) {
+    pub(crate) fn remove_popup(&mut self, cx: &mut ConfigCx, id: WindowId) {
         for i in 0..self.popups.len() {
             if id == self.popups[i].0 {
                 self.popups.remove(i);

--- a/crates/kas-core/src/runner/event_loop.rs
+++ b/crates/kas-core/src/runner/event_loop.rs
@@ -108,7 +108,7 @@ where
             for window in self.windows.values_mut() {
                 match window.resume(&mut self.state, el) {
                     Ok(winit_id) => {
-                        self.id_map.insert(winit_id, window.window_id);
+                        self.id_map.insert(winit_id, window.window_id());
                     }
                     Err(e) => {
                         log::error!("Unable to create window: {}", e);
@@ -171,7 +171,7 @@ where
     pub(super) fn new(mut windows: Vec<Box<Window<A, G, T>>>, state: State<A, G, T>) -> Self {
         Loop {
             suspended: true,
-            windows: windows.drain(..).map(|w| (w.window_id, w)).collect(),
+            windows: windows.drain(..).map(|w| (w.window_id(), w)).collect(),
             popups: Default::default(),
             id_map: Default::default(),
             state,

--- a/crates/kas-core/src/runner/event_loop.rs
+++ b/crates/kas-core/src/runner/event_loop.rs
@@ -211,7 +211,7 @@ where
                         win_id = id;
                     }
                     if let Some(window) = self.windows.get_mut(&win_id) {
-                        window.send_close(&mut self.state, target);
+                        window.send_close(target);
                     }
                 }
                 Pending::Action(action) => {

--- a/crates/kas-core/src/runner/mod.rs
+++ b/crates/kas-core/src/runner/mod.rs
@@ -39,6 +39,9 @@ pub extern crate raw_window_handle;
 /// across windows). This trait must be implemented by the latter.
 ///
 /// When no top-level data is required, use `()` which implements this trait.
+///
+/// TODO: should we pass some type of interface to the runner to these methods?
+/// We could pass a `&mut dyn RunnerT` easily, but that trait is not public.
 pub trait AppData: 'static {
     /// Handle messages
     ///
@@ -46,10 +49,22 @@ pub trait AppData: 'static {
     /// the widget tree (see [kas::event] module doc), a message is left on the
     /// stack. Unhandled messages will result in warnings in the log.
     fn handle_messages(&mut self, messages: &mut MessageStack);
+
+    /// Application is being suspended
+    ///
+    /// The application should ensure any important state is saved.
+    ///
+    /// This method is called when the application has been suspended or is
+    /// about to exit (on Android/iOS/Web platforms, the application may resume
+    /// after this method is called; on other platforms this probably indicates
+    /// imminent closure). Widget state may still exist, but is not live
+    /// (widgets will not process events or messages).
+    fn suspended(&mut self) {}
 }
 
 impl AppData for () {
     fn handle_messages(&mut self, _: &mut MessageStack) {}
+    fn suspended(&mut self) {}
 }
 
 #[crate::autoimpl(Debug)]

--- a/crates/kas-core/src/runner/mod.rs
+++ b/crates/kas-core/src/runner/mod.rs
@@ -61,6 +61,7 @@ enum Pending<A: AppData, G: GraphicsBuilder, T: kas::theme::Theme<G::Shared>> {
     AddWindow(WindowId, Box<Window<A, G, T>>),
     CloseWindow(WindowId),
     Action(kas::Action),
+    Exit,
 }
 
 #[cfg(winit)]

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -152,6 +152,9 @@ pub(crate) trait RunnerT {
     /// Close a window
     fn close_window(&mut self, id: WindowId);
 
+    /// Exit the application
+    fn exit(&mut self);
+
     /// Attempt to get clipboard contents
     ///
     /// In case of failure, paste actions will simply fail. The implementation
@@ -226,6 +229,10 @@ impl<Data: AppData, G: GraphicsBuilder, T: Theme<G::Shared>> RunnerT for SharedS
 
     fn close_window(&mut self, id: WindowId) {
         self.pending.push_back(Pending::CloseWindow(id));
+    }
+
+    fn exit(&mut self) {
+        self.pending.push_back(Pending::Exit);
     }
 
     fn get_clipboard(&mut self) -> Option<String> {

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -97,7 +97,9 @@ where
         }
     }
 
-    pub(crate) fn on_exit(&self) {
+    pub(crate) fn suspended(&mut self) {
+        self.data.suspended();
+
         match self.options.write_config(&self.shared.config.borrow()) {
             Ok(()) => (),
             Err(error) => warn_about_error("Failed to save config", &error),

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -281,7 +281,7 @@ impl<A: AppData, G: GraphicsBuilder, T: Theme<G::Shared>> Window<A, G, T> {
         );
         state.handle_messages(&mut messages);
 
-        if action.contains(Action::CLOSE | Action::EXIT) {
+        if action.contains(Action::CLOSE) {
             return (action, None);
         }
         self.handle_action(state, action);

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -370,29 +370,23 @@ impl<A: AppData, G: GraphicsBuilder, T: Theme<G::Shared>> Window<A, G, T> {
             return;
         };
 
-        let mut messages = MessageStack::new();
-        self.ev_state
-            .with(&mut state.shared, window, &mut messages, |cx| {
-                self.widget.add_popup(cx, &state.data, id, popup)
-            });
-        state.handle_messages(&mut messages);
+        let size = window.theme_window.size();
+        let mut cx = ConfigCx::new(&size, &mut self.ev_state);
+        self.widget.add_popup(&mut cx, &state.data, id, popup);
     }
 
     pub(super) fn send_action(&mut self, action: Action) {
         self.ev_state.action(Id::ROOT, action);
     }
 
-    pub(super) fn send_close(&mut self, state: &mut State<A, G, T>, id: WindowId) {
+    pub(super) fn send_close(&mut self, id: WindowId) {
         if id == self.window_id {
             self.ev_state.action(Id::ROOT, Action::CLOSE);
         } else if let Some(window) = self.window.as_ref() {
             let widget = &mut self.widget;
-            let mut messages = MessageStack::new();
-            self.ev_state
-                .with(&mut state.shared, window, &mut messages, |cx| {
-                    widget.remove_popup(cx, id)
-                });
-            state.handle_messages(&mut messages);
+            let size = window.theme_window.size();
+            let mut cx = ConfigCx::new(&size, &mut self.ev_state);
+            widget.remove_popup(&mut cx, id);
         }
     }
 }

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -47,7 +47,7 @@ path = "../kas-core"
 version = "0.7.0"
 
 [dependencies.wgpu]
-version = "23.0.1"
+version = "24.0.1"
 default-features = false
 features = ["spirv"]
 

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -32,7 +32,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         mut custom: CB,
         options: &Options,
     ) -> Result<Self, Error> {
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: options.backend(),
             ..Default::default()
         });

--- a/crates/kas-wgpu/src/draw/images.rs
+++ b/crates/kas-wgpu/src/draw/images.rs
@@ -35,7 +35,7 @@ impl Image {
         assert!(!data.is_empty());
         assert_eq!(data.len(), 4 * usize::conv(size.0) * usize::conv(size.1));
         queue.write_texture(
-            wgpu::ImageCopyTexture {
+            wgpu::TexelCopyTextureInfo {
                 texture: atlas_pipe.get_texture(self.atlas),
                 mip_level: 0,
                 origin: wgpu::Origin3d {
@@ -46,7 +46,7 @@ impl Image {
                 aspect: wgpu::TextureAspect::All,
             },
             data,
-            wgpu::ImageDataLayout {
+            wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(4 * size.0),
                 rows_per_image: Some(size.1),

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -148,7 +148,7 @@ impl Pipeline {
         }
         for (atlas, origin, size, data) in self.prepare.drain(..) {
             queue.write_texture(
-                wgpu::ImageCopyTexture {
+                wgpu::TexelCopyTextureInfo {
                     texture: self.atlas_pipe.get_texture(atlas),
                     mip_level: 0,
                     origin: wgpu::Origin3d {
@@ -159,7 +159,7 @@ impl Pipeline {
                     aspect: wgpu::TextureAspect::All,
                 },
                 &data,
-                wgpu::ImageDataLayout {
+                wgpu::TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(size.0),
                     rows_per_image: Some(size.1),

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -102,9 +102,6 @@ impl_scope! {
         }
 
         /// Set text in an existing `Label`
-        ///
-        /// Note: this must not be called before fonts have been initialised
-        /// (usually done by the theme when the main loop starts).
         pub fn set_text(&mut self, cx: &mut EventState, text: T) {
             self.text.set_text(text);
             let act = self.text.reprepare_action();
@@ -252,9 +249,6 @@ impl_scope! {
         }
 
         /// Set text in an existing `Label`
-        ///
-        /// Note: this must not be called before fonts have been initialised
-        /// (usually done by the theme when the main loop starts).
         pub fn set_text(&mut self, cx: &mut EventState, text: AccessString) {
             self.text.set_text(text);
             let act = self.text.reprepare_action();

--- a/crates/kas-widgets/src/text.rs
+++ b/crates/kas-widgets/src/text.rs
@@ -140,14 +140,6 @@ impl_scope! {
     }
 }
 
-/* TODO(specialization): can we support this? min_specialization is not enough.
-impl<U, T: From<U> + FormattableText + 'static> From<U> for Text<T> {
-    default fn from(text: U) -> Self {
-        let text = T::from(text);
-        Text::new(text)
-    }
-}*/
-
 /// A [`Text`] widget which formats a value from input
 ///
 /// Examples:


### PR DESCRIPTION
Ctrl+Q was already mapped to `Command::Exit`; this is now handled.

Similarly, Alt+F4 maps to `Command::Close` which is now handled: close the popup or window if none.

Also added `AppData::suspended` to allow data saving on suspend/exit.