### PR TITLE
Remove input data from widget layout syntax items

### DIFF
--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -208,27 +208,33 @@ pub fn impl_scope(input: TokenStream) -> TokenStream {
 /// implementation of `Tile::nav_next`, with a couple of exceptions
 /// (where macro-time analysis is insufficient to implement this method).
 ///
-/// > [_Column_], [_Row_], [_List_] [_AlignedColumn_], [_AlignedRow_], [_Grid_], [_Float_], [_Frame_] :\
+/// > [_Column_], [_Row_], [_List_] [_AlignedColumn_], [_AlignedRow_], [_Grid_],
+/// > [_Float_], [_Frame_] :\
 /// > &nbsp;&nbsp; These stand-alone macros are explicitly supported in this position.\
-///
+/// >
 /// > _Single_ :\
 /// > &nbsp;&nbsp; `self` `.` _Member_\
-/// > &nbsp;&nbsp; A named child: `self.foo` (more precisely, this matches any expression starting `self`, and uses `&mut (#expr)`)
+/// > &nbsp;&nbsp; A named child: `self.foo` (more precisely, this matches any
+/// > expression starting `self`, and uses `&mut (#expr)`).
 /// >
 /// > _WidgetConstructor_ :\
 /// > &nbsp;&nbsp; _Expr_\
-/// > &nbsp;&nbsp; An expression yielding a widget, e.g. `Label::new("Hello world")`. The result must be an object of some type `W: Widget`.
+/// > &nbsp;&nbsp; An expression yielding a widget, e.g.
+/// > `Label::new("Hello world")`. The result must be an object of some type
+/// > `W: Widget<Data = ()>`. This widget will be stored in a hidden field and
+/// > is accessible through `Tile::get_child` but does not receive input data.
 /// >
 /// > _LabelLit_ :\
 /// > &nbsp;&nbsp; _StrLit_\
-/// > &nbsp;&nbsp; A string literal generates a label widget, e.g. "Hello world". This is an internal type without text wrapping.
-/// >
+/// > &nbsp;&nbsp; A string literal generates a label widget, e.g. "Hello
+/// > world". This is an internal type without text wrapping.
+///
 /// Additional syntax rules (not layout items):
 ///
 /// > _Member_ :\
 /// > &nbsp;&nbsp; _Ident_ | _Index_\
 /// > &nbsp;&nbsp; The name of a struct field or an index into a tuple struct.
-/// >
+///
 /// ## Examples
 ///
 /// A simple example is the

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -21,23 +21,12 @@ mod kw {
     custom_keyword!(pack);
     custom_keyword!(column);
     custom_keyword!(row);
-    custom_keyword!(right);
-    custom_keyword!(left);
-    custom_keyword!(down);
-    custom_keyword!(up);
-    custom_keyword!(center);
-    custom_keyword!(stretch);
     custom_keyword!(frame);
     custom_keyword!(list);
     custom_keyword!(grid);
-    custom_keyword!(default);
-    custom_keyword!(top);
-    custom_keyword!(bottom);
     custom_keyword!(aligned_column);
     custom_keyword!(aligned_row);
     custom_keyword!(float);
-    custom_keyword!(px);
-    custom_keyword!(em);
     custom_keyword!(with_direction);
     custom_keyword!(with_style);
     custom_keyword!(with_background);
@@ -145,6 +134,7 @@ struct ExprMember {
     member: Member,
 }
 
+#[allow(unused)]
 #[derive(Debug)]
 enum Direction {
     Left,
@@ -478,24 +468,7 @@ impl ToTokens for ExprMember {
 
 impl Parse for Direction {
     fn parse(input: ParseStream) -> Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(kw::right) {
-            let _: kw::right = input.parse()?;
-            Ok(Direction::Right)
-        } else if lookahead.peek(kw::down) {
-            let _: kw::down = input.parse()?;
-            Ok(Direction::Down)
-        } else if lookahead.peek(kw::left) {
-            let _: kw::left = input.parse()?;
-            Ok(Direction::Left)
-        } else if lookahead.peek(kw::up) {
-            let _: kw::up = input.parse()?;
-            Ok(Direction::Up)
-        } else if lookahead.peek(Token![self]) {
-            Ok(Direction::Expr(input.parse()?))
-        } else {
-            Err(lookahead.error())
-        }
+        Ok(Direction::Expr(input.parse()?))
     }
 }
 

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -632,7 +632,7 @@ impl Layout {
                 children.push(Child::new_core(ident.clone().into()));
                 fields
                     .ty_toks
-                    .append_all(quote! { #ident: Box<dyn ::kas::Widget<Data = #data_ty>>, });
+                    .append_all(quote! { #ident: Box<dyn ::kas::Widget<Data = ()>>, });
                 let span = expr.span();
                 fields
                     .def_toks
@@ -684,22 +684,12 @@ impl Layout {
             Layout::Label(ident, text) => {
                 children.push(Child::new_core(ident.clone().into()));
                 let span = text.span();
-                if *data_ty == syn::parse_quote! { () } {
-                    fields
-                        .ty_toks
-                        .append_all(quote! { #ident: ::kas::hidden::StrLabel, });
-                    fields.def_toks.append_all(
-                        quote_spanned! {span=> #ident: ::kas::hidden::StrLabel::new(#text), },
-                    );
-                } else {
-                    fields.ty_toks.append_all(
-                        quote! { #ident: ::kas::hidden::MapAny<#data_ty, ::kas::hidden::StrLabel>, },
-                    );
-                    fields.def_toks.append_all(
-                        quote_spanned! {span=> #ident: ::kas::hidden::MapAny::new(::kas::hidden::StrLabel::new(#text)), },
-                    );
-                    fields.used_data_ty = true;
-                }
+                fields
+                    .ty_toks
+                    .append_all(quote! { #ident: ::kas::hidden::StrLabel, });
+                fields.def_toks.append_all(
+                    quote_spanned! {span=> #ident: ::kas::hidden::StrLabel::new(#text), },
+                );
             }
             Layout::MapAny(layout, map_any) => {
                 let start = children.len();

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -184,7 +184,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
 
             let mut stor_defs = Default::default();
             if let Some(Layout { ref tree, .. }) = args.layout {
-                stor_defs = tree.storage_fields(&mut children, &data_ty);
+                stor_defs = tree.storage_fields(&mut children);
             }
             if !stor_defs.ty_toks.is_empty() {
                 let name = format!("_{name}CoreTy");

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -796,11 +796,6 @@ pub fn impl_widget(
                 ChildIdent::Field(ident) => quote! { self.#ident },
                 ChildIdent::CoreField(ident) => quote! { #core_path.#ident },
             };
-            // TODO: incorrect or unconstrained data type of child causes a poor error
-            // message here. Add a constaint like this (assuming no mapping fn):
-            // <#ty as WidgetNode::Data> == Self::Data
-            // But this is unsupported: rust#20041
-            // predicates.push(..);
 
             get_mut_rules.append_all(if let Some(ref data) = child.data_binding {
                 quote! { #i => closure(#path.as_node(#data)), }

--- a/crates/kas-macros/src/widget_args.rs
+++ b/crates/kas-macros/src/widget_args.rs
@@ -238,7 +238,7 @@ impl Child {
         Child {
             ident: ChildIdent::CoreField(ident),
             attr_span: None,
-            data_binding: None,
+            data_binding: Some(syn::parse_quote! { &() }),
         }
     }
 }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -29,7 +29,7 @@ impl_scope! {
     /// when selected. If a handler is specified via [`Self::with`] or
     /// [`Self::with_msg`] then this message is passed to the handler and not emitted.
     #[widget {
-        layout = frame!(row! [self.label, self.mark])
+        layout = frame!(row! [self.label, Mark::new(MarkStyle::Point(Direction::Down))])
             .with_style(FrameStyle::Button)
             .align(AlignHints::CENTER);
         navigable = true;
@@ -39,8 +39,6 @@ impl_scope! {
         core: widget_core!(),
         #[widget(&())]
         label: Label<String>,
-        #[widget(&())]
-        mark: Mark,
         #[widget(&())]
         popup: Popup<AdaptEvents<Column<Vec<MenuEntry<V>>>>>,
         active: usize,
@@ -233,7 +231,6 @@ impl<A, V: Clone + Debug + Eq + 'static> ComboBox<A, V> {
         ComboBox {
             core: Default::default(),
             label,
-            mark: Mark::new(MarkStyle::Point(Direction::Down)),
             popup: Popup::new(
                 AdaptEvents::new(Column::new(entries)).on_messages(|cx, _, _| {
                     if let Some(_) = cx.try_peek::<V>() {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -107,12 +107,13 @@ fn widgets() -> Box<dyn Widget<Data = AppData>> {
     let popup_edit_box = impl_anon! {
         #[widget{
             layout = row! [
-                format_data!(data: &Data, "{}", &data.text),
-                Button::label_msg("&Edit", MsgEdit).map_any(),
+                self.text,
+                Button::label_msg("&Edit", MsgEdit),
             ];
         }]
         struct {
             core: widget_core!(),
+            #[widget] text: Text<Data, String> = format_data!(data: &Data, "{}", &data.text),
             #[widget(&())] popup: Popup<TextEdit> = Popup::new(TextEdit::new("", true), Direction::Down),
         }
         impl Events for Self {


### PR DESCRIPTION
Previously, widgets embedded in input data could support input data. This was rarely ever used within custom widgets but commonly used as part of "widget constructor macros" like `column!`, until #476 made those return named widgets (like `Column`).

We can now remove this feature. Motivation (aside from some simpler code) is that this avoids some confusing errors. For example, the last commit here simply in-lines a widget field which is never accessed nor uses input data:
```diff
diff --git a/crates/kas-widgets/src/combobox.rs b/crates/kas-widgets/src/combobox.rs
index b7a2f49d..c8074527 100644
--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -29,7 +29,7 @@ impl_scope! {
     /// when selected. If a handler is specified via [`Self::with`] or
     /// [`Self::with_msg`] then this message is passed to the handler and not emitted.
     #[widget {
-        layout = frame!(row! [self.label, self.mark])
+        layout = frame!(row! [self.label, Mark::new(MarkStyle::Point(Direction::Down))])
             .with_style(FrameStyle::Button)
             .align(AlignHints::CENTER);
         navigable = true;
@@ -40,8 +40,6 @@ impl_scope! {
         #[widget(&())]
         label: Label<String>,
         #[widget(&())]
-        mark: Mark,
-        #[widget(&())]
         popup: Popup<AdaptEvents<Column<Vec<MenuEntry<V>>>>>,
         active: usize,
         opening: bool,
@@ -233,7 +231,6 @@ impl<A, V: Clone + Debug + Eq + 'static> ComboBox<A, V> {
         ComboBox {
             core: Default::default(),
             label,
-            mark: Mark::new(MarkStyle::Point(Direction::Down)),
             popup: Popup::new(
                 AdaptEvents::new(Column::new(entries)).on_messages(|cx, _, _| {
                     if let Some(_) = cx.try_peek::<V>() {
```
Without the removal of this feature, that diff results in the following error:
```
error[E0412]: cannot find type `A` in this scope
  --> crates/kas-widgets/src/combobox.rs:62:21
   |
62 |         type Data = A;
   |                     ^ not found in this scope

For more information about this error, try `rustc --explain E0412`.
error: could not compile `kas-widgets` (lib) due to 1 previous error
```
Why? Because widgets declared in-line in layout syntax for *custom* widgets are placed in the `widget_core!()` struct and expected to support the custom widget's data type; in this case, the field is expected to implement `Widget<Data = A>` — but here `A` is a generic of the (outer) widget type, not the core. We *could* solve that error by copying all generics from the outer widget to the core (or attempt to infer which generics are actually required), but this solution is cleaner. (It's also cleaner because we didn't want to use this input data anyway, and usually don't for widgets declared in layout syntax because these are usually static.)