### PR TITLE
Non-mut Layout::{rect, try_probe, draw}

### DIFF
--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -5,7 +5,7 @@
 
 //! Widget method implementations
 
-use crate::event::{ConfigCx, Event, EventCx, FocusSource, IsUsed, Scroll, Unused, Used};
+use crate::event::{ConfigCx, Event, EventCx, FocusSource, IsUsed, Scroll, Unused};
 #[cfg(debug_assertions)] use crate::util::IdentifyWidget;
 use crate::{Events, Id, NavAdvance, Node, Tile, Widget};
 
@@ -25,14 +25,14 @@ pub fn _send<W: Events>(
             return is_used;
         }
 
+        // Side-effects of receiving events at the target widget.
+        // These actions do not affect is_used or event propagation.
         match &event {
             Event::MouseHover(state) => {
                 widget.handle_hover(cx, *state);
-                return Used;
             }
             Event::NavFocus(FocusSource::Key) => {
                 cx.set_scroll(Scroll::Rect(widget.rect()));
-                is_used |= Used;
             }
             _ => (),
         }

--- a/crates/kas-core/src/core/layout.rs
+++ b/crates/kas-core/src/core/layout.rs
@@ -156,7 +156,7 @@ pub trait Layout {
     ///
     /// Non-widgets do not have an [`Id`], and therefore should use the default
     /// implementation which simply returns `None`.
-    fn try_probe(&mut self, coord: Coord) -> Option<Id> {
+    fn try_probe(&self, coord: Coord) -> Option<Id> {
         let _ = coord;
         None
     }
@@ -208,7 +208,7 @@ pub trait MacroDefinedLayout {
     fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints);
 
     /// Probe a coordinate for a widget's [`Id`]
-    fn try_probe(&mut self, coord: Coord) -> Option<Id>;
+    fn try_probe(&self, coord: Coord) -> Option<Id>;
 
     /// Draw a widget and its children
     fn draw(&self, draw: DrawCx);

--- a/crates/kas-core/src/core/layout.rs
+++ b/crates/kas-core/src/core/layout.rs
@@ -51,6 +51,14 @@ use kas_macros::autoimpl;
 /// [`#widget`]: macros::widget
 #[autoimpl(for<T: trait + ?Sized> &'_ mut T, Box<T>)]
 pub trait Layout {
+    /// Get the widget's region
+    ///
+    /// Coordinates are relative to the parent's coordinate space.
+    ///
+    /// This method is usually implemented by the `#[widget]` macro.
+    /// See also [`kas::widget_set_rect`].
+    fn rect(&self) -> Rect;
+
     /// Get size rules for the given axis
     ///
     /// # Calling
@@ -201,6 +209,9 @@ pub trait Layout {
 ///
 /// TODO: add an example
 pub trait MacroDefinedLayout {
+    /// Get the widget's region
+    fn rect(&self) -> Rect;
+
     /// Get size rules for the given axis
     fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules;
 

--- a/crates/kas-core/src/core/layout.rs
+++ b/crates/kas-core/src/core/layout.rs
@@ -189,7 +189,7 @@ pub trait Layout {
     /// This method modification should never cause issues (besides the implied
     /// limitation that widgets cannot easily detect a parent's state while
     /// being drawn).
-    fn draw(&mut self, draw: DrawCx);
+    fn draw(&self, draw: DrawCx);
 }
 
 /// Macro-defined layout
@@ -211,5 +211,5 @@ pub trait MacroDefinedLayout {
     fn try_probe(&mut self, coord: Coord) -> Option<Id>;
 
     /// Draw a widget and its children
-    fn draw(&mut self, draw: DrawCx);
+    fn draw(&self, draw: DrawCx);
 }

--- a/crates/kas-core/src/core/node.rs
+++ b/crates/kas-core/src/core/node.rs
@@ -7,7 +7,7 @@
 
 use super::Widget;
 use crate::event::{ConfigCx, Event, EventCx, IsUsed};
-use crate::geom::{Coord, Rect};
+use crate::geom::Rect;
 use crate::layout::{AlignHints, AxisInfo, SizeRules};
 use crate::theme::SizeCx;
 use crate::{Id, NavAdvance, Tile};
@@ -28,7 +28,6 @@ trait NodeT {
     fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints);
 
     fn nav_next(&self, reverse: bool, from: Option<usize>) -> Option<usize>;
-    fn try_probe(&mut self, coord: Coord) -> Option<Id>;
 
     fn _configure(&mut self, cx: &mut ConfigCx, id: Id);
     fn _update(&mut self, cx: &mut ConfigCx);
@@ -78,9 +77,6 @@ impl<'a, T> NodeT for (&'a mut dyn Widget<Data = T>, &'a T) {
 
     fn nav_next(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
         self.0.nav_next(reverse, from)
-    }
-    fn try_probe(&mut self, coord: Coord) -> Option<Id> {
-        self.0.try_probe(coord)
     }
 
     fn _configure(&mut self, cx: &mut ConfigCx, id: Id) {
@@ -296,11 +292,6 @@ impl<'a> Node<'a> {
     /// Navigation in spatial order
     pub(crate) fn nav_next(&self, reverse: bool, from: Option<usize>) -> Option<usize> {
         self.0.nav_next(reverse, from)
-    }
-
-    /// Translate a coordinate to an [`Id`]
-    pub(crate) fn try_probe(&mut self, coord: Coord) -> Option<Id> {
-        self.0.try_probe(coord)
     }
 
     /// Internal method: configure recursively

--- a/crates/kas-core/src/core/node.rs
+++ b/crates/kas-core/src/core/node.rs
@@ -9,7 +9,7 @@ use super::Widget;
 use crate::event::{ConfigCx, Event, EventCx, IsUsed};
 use crate::geom::{Coord, Rect};
 use crate::layout::{AlignHints, AxisInfo, SizeRules};
-use crate::theme::{DrawCx, SizeCx};
+use crate::theme::SizeCx;
 use crate::{Id, NavAdvance, Tile};
 
 #[cfg(not(feature = "unsafe_node"))]
@@ -29,7 +29,6 @@ trait NodeT {
 
     fn nav_next(&self, reverse: bool, from: Option<usize>) -> Option<usize>;
     fn try_probe(&mut self, coord: Coord) -> Option<Id>;
-    fn _draw(&mut self, draw: DrawCx);
 
     fn _configure(&mut self, cx: &mut ConfigCx, id: Id);
     fn _update(&mut self, cx: &mut ConfigCx);
@@ -82,9 +81,6 @@ impl<'a, T> NodeT for (&'a mut dyn Widget<Data = T>, &'a T) {
     }
     fn try_probe(&mut self, coord: Coord) -> Option<Id> {
         self.0.try_probe(coord)
-    }
-    fn _draw(&mut self, mut draw: DrawCx) {
-        self.0.draw(draw.re());
     }
 
     fn _configure(&mut self, cx: &mut ConfigCx, id: Id) {
@@ -305,20 +301,6 @@ impl<'a> Node<'a> {
     /// Translate a coordinate to an [`Id`]
     pub(crate) fn try_probe(&mut self, coord: Coord) -> Option<Id> {
         self.0.try_probe(coord)
-    }
-
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "unsafe_node")] {
-            /// Draw a widget and its children
-            pub(crate) fn _draw(&mut self, mut draw: DrawCx) {
-                self.0.draw(draw.re());
-            }
-        } else {
-            /// Draw a widget and its children
-            pub(crate) fn _draw(&mut self, draw: DrawCx) {
-                self.0._draw(draw);
-            }
-        }
     }
 
     /// Internal method: configure recursively

--- a/crates/kas-core/src/core/tile.rs
+++ b/crates/kas-core/src/core/tile.rs
@@ -5,7 +5,7 @@
 
 //! Layout, Tile and TileExt traits
 
-use crate::geom::{Coord, Offset, Rect};
+use crate::geom::{Coord, Offset};
 use crate::util::IdentifyWidget;
 use crate::{HasId, Id, Layout};
 use kas_macros::autoimpl;
@@ -21,7 +21,7 @@ use kas_macros::autoimpl;
 ///
 /// -   Has no [`Data`](Widget::Data) parameter
 /// -   Supports read-only tree reflection: [`Self::get_child`]
-/// -   Provides some basic operations: [`Self::id_ref`], [`Self::rect`]
+/// -   Provides some basic operations: [`Self::id_ref`]
 /// -   Covers sizing and drawing operations from [`Layout`]
 ///
 /// `Tile` may not be implemented directly; it will be implemented by the
@@ -73,12 +73,6 @@ pub trait Tile: Layout {
     fn id(&self) -> Id {
         self.id_ref().clone()
     }
-
-    /// Get the widget's region, relative to its parent.
-    ///
-    /// This method is usually implemented by the `#[widget]` macro.
-    /// See also [`kas::widget_set_rect`].
-    fn rect(&self) -> Rect;
 
     /// Get the name of the widget struct
     ///

--- a/crates/kas-core/src/core/tile.rs
+++ b/crates/kas-core/src/core/tile.rs
@@ -197,7 +197,7 @@ pub trait Tile: Layout {
     /// let coord = coord + self.translation();
     /// MacroDefinedLayout::try_probe(self, coord).unwrap_or_else(|| self.id())
     /// ```
-    fn probe(&mut self, coord: Coord) -> Id
+    fn probe(&self, coord: Coord) -> Id
     where
         Self: Sized,
     {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -7,7 +7,7 @@
 
 #[allow(unused)] use super::Layout;
 use super::{Node, Tile};
-#[allow(unused)] use crate::event::Used;
+#[allow(unused)] use crate::event::EventState;
 use crate::event::{ConfigCx, Event, EventCx, IsUsed, Scroll, Unused};
 use crate::Id;
 #[allow(unused)] use kas_macros as macros;
@@ -150,13 +150,13 @@ pub trait Events: Widget + Sized {
     /// default implementation of this method does nothing.
     ///
     /// Note: to implement `hover_highlight`, simply request a redraw on
-    /// focus gain and loss. To implement `cursor_icon`, call
-    /// `cx.set_hover_cursor(EXPR);` on focus gain.
+    /// hover gain and loss. To implement `cursor_icon`, call
+    /// [`EventState::set_hover_cursor`] on hover gain only.
     ///
     /// [`#widget`]: macros::widget
     #[inline]
-    fn handle_hover(&mut self, cx: &mut EventCx, state: bool) {
-        let _ = (cx, state);
+    fn handle_hover(&mut self, cx: &mut EventCx, is_hovered: bool) {
+        let _ = (cx, is_hovered);
     }
 
     /// Handle an [`Event`]

--- a/crates/kas-core/src/decorations.rs
+++ b/crates/kas-core/src/decorations.rs
@@ -80,7 +80,7 @@ impl_scope! {
             SizeRules::EMPTY
         }
 
-        fn draw(&mut self, _: DrawCx) {}
+        fn draw(&self, _: DrawCx) {}
     }
 
     impl Events for Self {
@@ -178,7 +178,7 @@ impl_scope! {
             sizer.feature(self.style.into(), axis)
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.mark(self.rect(), self.style);
         }
     }

--- a/crates/kas-core/src/decorations.rs
+++ b/crates/kas-core/src/decorations.rs
@@ -123,7 +123,6 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            widget_set_rect!(rect);
             self.text.set_rect(cx, rect, hints.combine(AlignHints::CENTER));
         }
     }

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -29,7 +29,7 @@ use std::time::Instant;
 /// #     _pd: std::marker::PhantomData<DS>,
 /// # }
 /// impl CircleWidget {
-///     fn draw(&mut self, mut draw: DrawCx) {
+///     fn draw(&self, mut draw: DrawCx) {
 ///         // This type assumes usage of kas_wgpu without a custom draw pipe:
 ///         type DrawIface = DrawIface<kas_wgpu::draw::DrawPipe<()>>;
 ///         if let Some(mut draw) = DrawIface::downcast_from(draw.draw_device()) {

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -15,8 +15,8 @@ use crate::{Action, Id};
 use kas_macros::impl_default;
 use std::time::{Duration, Instant};
 
-const TIMER_SELECT: u64 = 1 << 60;
-const TIMER_GLIDE: u64 = (1 << 60) + 1;
+const TIMER_SELECT: TimerHandle = TimerHandle::new(1 << 60, true);
+const TIMER_GLIDE: TimerHandle = TimerHandle::new((1 << 60) + 1, true);
 const GLIDE_POLL_MS: u64 = 3;
 const GLIDE_MAX_SAMPLES: usize = 8;
 
@@ -336,7 +336,7 @@ impl ScrollComponent {
                 let timeout = cx.config().event().scroll_flick_timeout();
                 let pan_dist_thresh = cx.config().event().pan_dist_thresh();
                 if self.glide.press_end(timeout, pan_dist_thresh) {
-                    cx.request_timer(id.clone(), TIMER_GLIDE, Duration::new(0, 0));
+                    cx.request_timer(id.clone(), TIMER_GLIDE, Duration::ZERO);
                 }
             }
             Event::Timer(pl) if pl == TIMER_GLIDE => {
@@ -484,7 +484,7 @@ impl TextInput {
                         || matches!(press.source, PressSource::Mouse(..) if cx.config_enable_mouse_text_pan()))
                 {
                     self.touch_phase = TouchPhase::None;
-                    cx.request_timer(w_id, TIMER_GLIDE, Duration::new(0, 0));
+                    cx.request_timer(w_id, TIMER_GLIDE, Duration::ZERO);
                 }
                 Action::None
             }

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -67,17 +67,6 @@ impl EventState {
         self.mouse_grab.is_none() && *w_id == self.hover
     }
 
-    /// Get whether widget `id` or any of its descendants are under the mouse cursor
-    #[inline]
-    pub fn is_hovered_recursive(&self, id: &Id) -> bool {
-        self.mouse_grab.is_none()
-            && self
-                .hover
-                .as_ref()
-                .map(|h| id.is_ancestor_of(h))
-                .unwrap_or(false)
-    }
-
     /// Check whether the given widget is visually depressed
     pub fn is_depressed(&self, w_id: &Id) -> bool {
         for (_, id) in &self.key_depress {

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -878,7 +878,6 @@ impl<'a> EventCx<'a> {
     ///
     /// In case of failure, paste actions will simply fail. The implementation
     /// may wish to log an appropriate warning message.
-    #[inline]
     pub fn get_clipboard(&mut self) -> Option<String> {
         #[cfg(all(wayland_platform, feature = "clipboard"))]
         if let Some(cb) = self.window.wayland_clipboard() {
@@ -895,7 +894,6 @@ impl<'a> EventCx<'a> {
     }
 
     /// Attempt to set clipboard contents
-    #[inline]
     pub fn set_clipboard(&mut self, content: String) {
         #[cfg(all(wayland_platform, feature = "clipboard"))]
         if let Some(cb) = self.window.wayland_clipboard() {
@@ -922,7 +920,6 @@ impl<'a> EventCx<'a> {
     ///
     /// Linux has a "primary buffer" with implicit copy on text selection and
     /// paste on middle-click. This method does nothing on other platforms.
-    #[inline]
     pub fn get_primary(&mut self) -> Option<String> {
         #[cfg(all(wayland_platform, feature = "clipboard"))]
         if let Some(cb) = self.window.wayland_clipboard() {
@@ -942,7 +939,6 @@ impl<'a> EventCx<'a> {
     ///
     /// Linux has a "primary buffer" with implicit copy on text selection and
     /// paste on middle-click. This method does nothing on other platforms.
-    #[inline]
     pub fn set_primary(&mut self, content: String) {
         #[cfg(all(wayland_platform, feature = "clipboard"))]
         if let Some(cb) = self.window.wayland_clipboard() {

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -209,7 +209,7 @@ pub struct EventState {
     // For each: (WindowId of popup, popup descriptor, old nav focus)
     popups: SmallVec<[(WindowId, crate::PopupDescriptor, Option<Id>); 16]>,
     popup_removed: SmallVec<[(Id, WindowId); 16]>,
-    time_updates: Vec<(Instant, Id, u64)>,
+    time_updates: Vec<(Instant, Id, TimerHandle)>,
     // Set of messages awaiting sending
     send_queue: VecDeque<(Id, Erased)>,
     // Set of futures of messages together with id of sending widget

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -272,11 +272,11 @@ impl EventState {
                 cx.action.remove(Action::REGION_MOVED);
 
                 // Update hovered widget
-                let hover = win.try_probe(data, cx.last_mouse_coord);
+                let hover = win.try_probe(cx.last_mouse_coord);
                 cx.set_hover(win.as_node(data), hover);
 
                 for grab in cx.touch_grab.iter_mut() {
-                    grab.cur_id = win.try_probe(data, grab.coord);
+                    grab.cur_id = win.try_probe(grab.coord);
                 }
             }
         });
@@ -422,7 +422,7 @@ impl<'a> EventCx<'a> {
                 let coord = position.cast_approx();
 
                 // Update hovered win
-                let id = win.try_probe(data, coord);
+                let id = win.try_probe(coord);
                 self.set_hover(win.as_node(data), id.clone());
 
                 if let Some(grab) = self.state.mouse_grab.as_mut() {
@@ -541,7 +541,7 @@ impl<'a> EventCx<'a> {
                 let coord = touch.location.cast_approx();
                 match touch.phase {
                     TouchPhase::Started => {
-                        let start_id = win.try_probe(data, coord);
+                        let start_id = win.try_probe(coord);
                         if let Some(id) = start_id.as_ref() {
                             if self.config.event().touch_nav_focus() {
                                 if let Some(id) =
@@ -561,7 +561,7 @@ impl<'a> EventCx<'a> {
                         }
                     }
                     TouchPhase::Moved => {
-                        let cur_id = win.try_probe(data, coord);
+                        let cur_id = win.try_probe(coord);
 
                         let mut redraw = false;
                         let mut pan_grab = None;

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -306,8 +306,8 @@ impl Event {
             CursorMove { .. } | PressStart { .. } => false,
             Pan { .. } | PressMove { .. } | PressEnd { .. } => true,
             Timer(_) | PopupClosed(_) => true,
-            NavFocus { .. } | SelFocus(_) | KeyFocus | MouseHover(_) => false,
-            LostNavFocus | LostKeyFocus | LostSelFocus => true,
+            NavFocus { .. } | SelFocus(_) | KeyFocus | MouseHover(true) => false,
+            LostNavFocus | LostKeyFocus | LostSelFocus | MouseHover(false) => true,
         }
     }
 
@@ -346,7 +346,7 @@ impl Event {
             NavFocus { .. } | LostNavFocus => false,
             SelFocus(_) | LostSelFocus => false,
             KeyFocus | LostKeyFocus => false,
-            MouseHover(_) => false,
+            MouseHover(_) => true,
         }
     }
 }

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -174,9 +174,7 @@ pub enum Event {
     ///
     /// This event is received after requesting timed wake-up(s)
     /// (see [`EventState::request_timer`]).
-    ///
-    /// The `u64` payload is copied from [`EventState::request_timer`].
-    Timer(u64),
+    Timer(TimerHandle),
     /// Notification that a popup has been closed
     ///
     /// This is sent to the popup when closed.
@@ -613,6 +611,33 @@ impl Command {
             Command::Down => Some(Direction::Down),
             _ => None,
         }
+    }
+}
+
+/// A timer handle
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct TimerHandle(i64);
+impl TimerHandle {
+    /// Construct a new handle
+    ///
+    /// The code must be positive. If a widget uses multiple timers, each must
+    /// have a unique code.
+    ///
+    /// When a timer update is requested multiple times before delivery using
+    /// the same `TimerHandle`, these requests are merged, choosing the
+    /// earliest time if `earliest`, otherwise the latest time.
+    pub const fn new(code: i64, earliest: bool) -> Self {
+        assert!(code >= 0);
+        if earliest {
+            TimerHandle(-code - 1)
+        } else {
+            TimerHandle(code)
+        }
+    }
+
+    /// Check whether this timer chooses the earliest time when merging
+    pub fn earliest(self) -> bool {
+        self.0 < 0
     }
 }
 

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -94,7 +94,6 @@ impl Quad {
     }
 
     /// Calculate the intersection of two quads
-    #[inline]
     pub fn intersection(&self, rhs: &Quad) -> Option<Quad> {
         let a = Vec2(self.a.0.max(rhs.a.0), self.a.1.max(rhs.a.1));
         let x = (self.b.0.min(rhs.b.0) - a.0).max(0.0);

--- a/crates/kas-core/src/hidden.rs
+++ b/crates/kas-core/src/hidden.rs
@@ -15,7 +15,7 @@ use crate::layout::{AlignHints, AxisInfo, SizeRules};
 use crate::theme::{SizeCx, Text, TextClass};
 #[allow(unused)] use crate::Action;
 use crate::{Events, Layout, Widget};
-use kas_macros::{autoimpl, impl_scope, widget_set_rect};
+use kas_macros::{autoimpl, impl_scope};
 
 impl_scope! {
     /// A simple text label
@@ -51,7 +51,6 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            widget_set_rect!(rect);
             self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
         }
     }

--- a/crates/kas-core/src/layout/row_solver.rs
+++ b/crates/kas-core/src/layout/row_solver.rs
@@ -329,9 +329,9 @@ impl<D: Directional> RowPositionSolver<D> {
     }
 
     /// Call `f` on each child intersecting the given `rect`
-    pub fn for_children_mut<C: Collection + ?Sized, F: FnMut(&mut dyn Tile)>(
+    pub fn for_children<C: Collection + ?Sized, F: FnMut(&dyn Tile)>(
         self,
-        widgets: &mut C,
+        widgets: &C,
         rect: Rect,
         mut f: F,
     ) {
@@ -360,7 +360,7 @@ impl<D: Directional> RowPositionSolver<D> {
         };
 
         for i in start..widgets.len() {
-            if let Some(child) = widgets.get_mut_tile(i) {
+            if let Some(child) = widgets.get_tile(i) {
                 let do_break = match self.direction.as_direction() {
                     Direction::Right => child.rect().pos.0 >= end.0,
                     Direction::Down => child.rect().pos.1 >= end.1,

--- a/crates/kas-core/src/layout/size_rules.rs
+++ b/crates/kas-core/src/layout/size_rules.rs
@@ -224,7 +224,6 @@ impl SizeRules {
     }
 
     /// Use the maximum size of `self` and `rhs`.
-    #[inline]
     #[must_use = "method does not modify self but returns a new value"]
     pub fn max(self, rhs: Self) -> SizeRules {
         SizeRules {
@@ -279,7 +278,6 @@ impl SizeRules {
     ///
     /// Note also that appending [`SizeRules::EMPTY`] does include interior
     /// margins (those between `EMPTY` and the other rules) within the result.
-    #[inline]
     #[must_use = "method does not modify self but returns a new value"]
     pub fn appended(self, rhs: SizeRules) -> Self {
         let c: i32 = self.m.1.max(rhs.m.0).into();
@@ -371,7 +369,6 @@ impl SizeRules {
         clippy::needless_range_loop,
         clippy::needless_return
     )]
-    #[inline]
     pub fn solve_seq_total(out: &mut [i32], rules: &[Self], total: Self, target: i32) {
         type Targets = SmallVec<[i32; 16]>;
         #[allow(non_snake_case)]

--- a/crates/kas-core/src/layout/size_types.rs
+++ b/crates/kas-core/src/layout/size_types.rs
@@ -238,6 +238,8 @@ impl_scope! {
         ///
         /// If is `None`, max size is limited to ideal size.
         pub stretch: Stretch,
+        /// The assigned [`Rect`]
+        pub rect: Rect,
     }
 }
 
@@ -260,7 +262,7 @@ impl PixmapScaling {
     /// Constrains and aligns within `rect`
     ///
     /// The resulting size is then aligned using the `align` hints, defaulting to centered.
-    pub fn align_rect(&mut self, rect: Rect, align: AlignPair, scale_factor: f32) -> Rect {
+    pub fn set_rect(&mut self, rect: Rect, align: AlignPair, scale_factor: f32) {
         let mut size = rect.size;
 
         if self.stretch == Stretch::None {
@@ -280,7 +282,7 @@ impl PixmapScaling {
             }
         }
 
-        align.aligned_rect(size, rect)
+        self.rect = align.aligned_rect(size, rect);
     }
 }
 

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -152,13 +152,15 @@ impl_scope! {
     }
 
     impl Self {
-        pub(crate) fn try_probe(&mut self, data: &Data, coord: Coord) -> Option<Id> {
+        pub(crate) fn try_probe(&self, coord: Coord) -> Option<Id> {
             if !self.rect().contains(coord) {
                 return None;
             }
             for (_, popup, translation) in self.popups.iter().rev() {
-                if let Some(Some(id)) = self.inner.as_node(data).find_node(&popup.id, |mut node| node.try_probe(coord + *translation)) {
-                    return Some(id);
+                if let Some(widget) = self.inner.find_widget(&popup.id) {
+                    if let Some(id) = widget.try_probe(coord + *translation) {
+                        return Some(id);
+                    }
                 }
             }
             if self.bar_h > 0 {

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -146,7 +146,7 @@ impl_scope! {
             self.inner.set_rect(cx, Rect::new(p_in, s_in), hints);
         }
 
-        fn draw(&mut self, _: DrawCx) {
+        fn draw(&self, _: DrawCx) {
             unimplemented!()
         }
     }
@@ -179,7 +179,7 @@ impl_scope! {
         }
 
         #[cfg(winit)]
-        pub(crate) fn draw(&mut self, data: &Data, mut draw: DrawCx) {
+        pub(crate) fn draw(&self, mut draw: DrawCx) {
             if self.dec_size != Size::ZERO {
                 draw.frame(self.rect(), FrameStyle::Window, Default::default());
                 if self.bar_h > 0 {
@@ -188,12 +188,12 @@ impl_scope! {
             }
             self.inner.draw(draw.re());
             for (_, popup, translation) in &self.popups {
-                self.inner.as_node(data).find_node(&popup.id, |mut node| {
-                    let clip_rect = node.rect() - *translation;
+                if let Some(child) = self.inner.find_widget(&popup.id) {
+                    let clip_rect = child.rect() - *translation;
                     draw.with_overlay(clip_rect, *translation, |draw| {
-                        node._draw(draw);
+                        child.draw(draw);
                     });
-                });
+                }
             }
         }
     }

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -84,7 +84,6 @@ where
         })
     }
 
-    #[inline]
     pub(crate) fn handle_messages(&mut self, messages: &mut MessageStack) {
         if messages.reset_and_has_any() {
             let count = messages.get_op_count();

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -491,7 +491,7 @@ impl<A: AppData, G: GraphicsBuilder, T: Theme<G::Shared>> Window<A, G, T> {
                     .theme
                     .draw(draw, &mut self.ev_state, &mut window.theme_window);
             let draw_cx = DrawCx::new(&mut draw, self.widget.id());
-            self.widget.draw(&state.data, draw_cx);
+            self.widget.draw(draw_cx);
         }
         let time2 = Instant::now();
 

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -409,7 +409,6 @@ impl<T: FormattableText> Text<T> {
         Ok(())
     }
 
-    #[inline]
     fn prepare_runs(&mut self) -> Result<(), NotReady> {
         match self.status {
             Status::New => return Err(NotReady),
@@ -521,7 +520,6 @@ impl<T: FormattableText> Text<T> {
     ///     [`Action::empty()`] is returned without updating `self`.
     ///
     /// This is typically called after updating a `Text` object in a widget.
-    #[inline]
     pub fn reprepare_action(&mut self) -> Action {
         match self.prepare() {
             Err(NotReady) => Action::empty(),

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -83,7 +83,7 @@ impl<T: FormattableText> Layout for Text<T> {
         self.prepare().expect("not configured");
     }
 
-    fn draw(&mut self, mut draw: DrawCx) {
+    fn draw(&self, mut draw: DrawCx) {
         draw.text(self.rect, self);
     }
 }

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -66,6 +66,10 @@ impl<T: Default + FormattableText> Default for Text<T> {
 
 /// Implement [`Layout`], using default alignment where alignment is not provided
 impl<T: FormattableText> Layout for Text<T> {
+    fn rect(&self) -> Rect {
+        self.rect
+    }
+
     fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
         sizer.text_rules(self, axis)
     }

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -419,12 +419,12 @@ pub fn widget_index(input: TokenStream) -> TokenStream {
 /// Macro to set the `rect` stored in the widget core
 ///
 /// Widgets have a hidden field of type [`Rect`] in their `widget_core!()`, used
-/// to implement method [`Tile::rect`]. This macro assigns to that field.
+/// to implement method [`Layout::rect`]. This macro assigns to that field.
 ///
 /// This macro is usable only within the definition of `Layout::set_rect` within
 /// an [`impl_scope!`] macro using the [`widget`](macro@widget) attribute.
 ///
-/// The method `Tile::rect` will be generated if this macro is used by the
+/// The method `Layout::rect` will be generated if this macro is used by the
 /// widget, otherwise a definition of the method must be provided.
 ///
 /// Example usage:
@@ -435,7 +435,7 @@ pub fn widget_index(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// [`Rect`]: https://docs.rs/kas/latest/kas/geom/struct.Rect.html
-/// [`Tile::rect`]: https://docs.rs/kas/latest/kas/trait.Tile.html#method.rect
+/// [`Layout::rect`]: https://docs.rs/kas/latest/kas/trait.Layout.html#method.rect
 #[proc_macro_error]
 #[proc_macro]
 pub fn widget_set_rect(input: TokenStream) -> TokenStream {

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -64,7 +64,7 @@ impl Tree {
         let mut toks = Toks::new();
         for target in &targets {
             toks.append_all(quote! {
-                if let Some(id) = ::kas::Layout::try_probe(&mut #target, coord) {
+                if let Some(id) = ::kas::Layout::try_probe(&#target, coord) {
                     Some(id)
                 } else
             });

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -818,10 +818,10 @@ impl Layout {
         match self {
             Layout::Align(layout, _) | Layout::Pack(layout, _) => layout.draw(core_path),
             Layout::Single(expr) => quote! {
-                ::kas::Layout::draw(&mut #expr, draw.re());
+                ::kas::Layout::draw(&#expr, draw.re());
             },
             Layout::Widget(stor, _) | Layout::Label(stor, _) => quote! {
-                ::kas::Layout::draw(&mut #core_path.#stor, draw.re());
+                ::kas::Layout::draw(&#core_path.#stor, draw.re());
             },
             Layout::Frame(stor, layout, style, bg) => {
                 let mut toks = quote! {

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -47,6 +47,11 @@ impl Tree {
         fields
     }
 
+    /// Yield an implementation of `fn rect`, if easy
+    pub fn rect(&self, core_path: &Toks) -> Option<Toks> {
+        self.0.rect(core_path)
+    }
+
     /// Yield an implementation of `fn size_rules`
     pub fn size_rules(&self, core_path: &Toks) -> Toks {
         self.0.size_rules(core_path)
@@ -621,6 +626,19 @@ impl Layout {
                     quote_spanned! {span=> #ident: ::kas::hidden::StrLabel::new(#text), },
                 );
             }
+        }
+    }
+
+    /// Yield an implementation of `fn rect`, if easy
+    fn rect(&self, core_path: &Toks) -> Option<Toks> {
+        match self {
+            Layout::Align(layout, _) | Layout::Pack(layout, _) => layout.rect(core_path),
+            Layout::Single(expr) => Some(quote! { ::kas::Layout::rect(&#expr) }),
+            Layout::Widget(stor, _) | Layout::Label(stor, _) => {
+                Some(quote! { ::kas::Layout::rect(&#core_path.#stor) })
+            }
+            Layout::Frame(stor, _, _, _) => Some(quote! { #core_path.#stor.rect }),
+            Layout::List(_, _, _) | Layout::Float(_) | Layout::Grid(_, _, _) => None,
         }
     }
 

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -417,7 +417,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                 }
 
                 #[inline]
-                fn draw(&mut self, mut draw: ::kas::theme::DrawCx) {
+                fn draw(&self, mut draw: ::kas::theme::DrawCx) {
                     draw.set_id(::kas::Tile::id(self));
                     #draw
                 }
@@ -461,7 +461,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
         };
 
         fn_draw = Some(quote! {
-            fn draw(&mut self, draw: ::kas::theme::DrawCx) {
+            fn draw(&self, draw: ::kas::theme::DrawCx) {
                 #[cfg(debug_assertions)]
                 #core_path.status.require_rect(&#core_path._id);
 

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -412,7 +412,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
                 }
 
                 #[inline]
-                fn try_probe(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
+                fn try_probe(&self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
                     #try_probe
                 }
 
@@ -452,7 +452,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
         };
 
         fn_try_probe = quote! {
-            fn try_probe(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
+            fn try_probe(&self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
                 #[cfg(debug_assertions)]
                 self.#core.status.require_rect(&self.#core._id);
 
@@ -490,7 +490,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
         };
 
         fn_try_probe = quote! {
-            fn try_probe(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
+            fn try_probe(&self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
                 #[cfg(debug_assertions)]
                 self.#core.status.require_rect(&self.#core._id);
 
@@ -507,7 +507,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
 
     let fn_probe = quote! {
         #[inline]
-        fn probe(&mut self, coord: ::kas::geom::Coord) -> ::kas::Id {
+        fn probe(&self, coord: ::kas::geom::Coord) -> ::kas::Id {
             #probe
         }
     };

--- a/crates/kas-macros/src/widget_derive.rs
+++ b/crates/kas-macros/src/widget_derive.rs
@@ -191,7 +191,7 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
     };
     let fn_try_probe = quote! {
         #[inline]
-        fn try_probe(&mut self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
+        fn try_probe(&self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
             self.#inner.try_probe(coord)
         }
     };

--- a/crates/kas-macros/src/widget_derive.rs
+++ b/crates/kas-macros/src/widget_derive.rs
@@ -145,10 +145,6 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
         fn id_ref(&self) -> &::kas::Id {
             self.#inner.id_ref()
         }
-        #[inline]
-        fn rect(&self) -> ::kas::geom::Rect {
-            self.#inner.rect()
-        }
 
         #[inline]
         fn widget_name(&self) -> &'static str {
@@ -169,6 +165,12 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
         }
     };
 
+    let fn_rect = quote! {
+        #[inline]
+        fn rect(&self) -> ::kas::geom::Rect {
+            self.#inner.rect()
+        }
+    };
     let fn_size_rules = quote! {
         #[inline]
         fn size_rules(&mut self,
@@ -207,6 +209,10 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
         let item_idents = collect_idents(layout_impl);
         let has_item = |name| item_idents.iter().any(|(_, ident)| ident == name);
 
+        if !has_item("rect") {
+            layout_impl.items.push(Verbatim(fn_rect));
+        }
+
         if !has_item("size_rules") {
             layout_impl.items.push(Verbatim(fn_size_rules));
         }
@@ -225,6 +231,7 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
     } else {
         scope.generated.push(quote! {
             impl #impl_generics ::kas::Layout for #impl_target {
+                #fn_rect
                 #fn_size_rules
                 #fn_set_rect
                 #fn_try_probe

--- a/crates/kas-macros/src/widget_derive.rs
+++ b/crates/kas-macros/src/widget_derive.rs
@@ -197,7 +197,7 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
     };
     let fn_draw = quote! {
         #[inline]
-        fn draw(&mut self, draw: ::kas::theme::DrawCx) {
+        fn draw(&self, draw: ::kas::theme::DrawCx) {
             self.#inner.draw(draw);
         }
     };

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -24,7 +24,7 @@ pub trait CanvasProgram: std::fmt::Debug + Send + 'static {
     ///
     /// Note that [`Layout::draw`] does not call this method, but instead draws
     /// from a copy of the `pixmap` (updated each time this method completes).
-    fn draw(&mut self, pixmap: &mut Pixmap);
+    fn draw(&self, pixmap: &mut Pixmap);
 
     /// This method is called each time a frame is drawn. Note that since
     /// redrawing is async and non-blocking, the result is expected to be at
@@ -36,7 +36,7 @@ pub trait CanvasProgram: std::fmt::Debug + Send + 'static {
     }
 }
 
-async fn draw<P: CanvasProgram>(mut program: P, mut pixmap: Pixmap) -> (P, Pixmap) {
+async fn draw<P: CanvasProgram>(program: P, mut pixmap: Pixmap) -> (P, Pixmap) {
     pixmap.fill(Color::TRANSPARENT);
     program.draw(&mut pixmap);
     (program, pixmap)
@@ -175,7 +175,7 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             if let Ok(mut state) = self.inner.try_borrow_mut() {
                 if let Some(fut) = state.maybe_redraw() {
                     draw.ev_state().push_spawn(self.id(), fut);

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -160,6 +160,10 @@ impl_scope! {
     }
 
     impl Layout for Self {
+        fn rect(&self) -> Rect {
+            self.scaling.rect
+        }
+
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             self.scaling.size_rules(sizer, axis)
         }
@@ -167,9 +171,9 @@ impl_scope! {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
             let align = hints.complete_default();
             let scale_factor = cx.size_cx().scale_factor();
-            widget_set_rect!(self.scaling.align_rect(rect, align, scale_factor));
-            let size = self.rect().size.cast();
+            self.scaling.set_rect(rect, align, scale_factor);
 
+            let size = self.rect().size.cast();
             if let Some(fut) = self.inner.get_mut().resize(size) {
                 cx.push_spawn(self.id(), fut);
             }

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -242,6 +242,10 @@ impl_scope! {
     }
 
     impl Layout for Self {
+        fn rect(&self) -> Rect {
+            self.scaling.rect
+        }
+
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             self.scaling.size_rules(sizer, axis)
         }
@@ -249,9 +253,9 @@ impl_scope! {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
             let align = hints.complete_default();
             let scale_factor = cx.size_cx().scale_factor();
-            widget_set_rect!(self.scaling.align_rect(rect, align, scale_factor));
-            let size: (u32, u32) = self.rect().size.cast();
+            self.scaling.set_rect(rect, align, scale_factor);
 
+            let size: (u32, u32) = self.rect().size.cast();
             if let Some(fut) = self.inner.resize(size) {
                 cx.push_spawn(self.id(), fut);
             }

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -257,7 +257,7 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             if let Some(id) = self.image.as_ref().map(|h| h.id()) {
                 draw.image(self.rect(), id);
             }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -565,9 +565,9 @@ impl_scope! {
             self.scroll_offset()
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             let coord = coord + self.scroll.offset();
-            for child in &mut self.widgets[..self.cur_len.cast()] {
+            for child in &self.widgets[..self.cur_len.cast()] {
                 if child.key.is_some() {
                     if let Some(id) = child.widget.try_probe(coord) {
                         return id;

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -406,7 +406,6 @@ impl_scope! {
             self.scroll.offset()
         }
 
-        #[inline]
         fn set_scroll_offset(&mut self, cx: &mut EventCx, offset: Offset) -> Offset {
             let act = self.scroll.set_offset(offset);
             cx.action(&self, act);

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -524,10 +524,10 @@ impl_scope! {
             debug_assert!(self.widgets.len() >= req_widgets);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let offset = self.scroll_offset();
             draw.with_clip_region(self.rect(), offset, |mut draw| {
-                for child in &mut self.widgets[..self.cur_len.cast()] {
+                for child in &self.widgets[..self.cur_len.cast()] {
                     if let Some(ref key) = child.key {
                         if self.selection.contains(key) {
                             draw.selection(child.widget.rect(), self.sel_style);

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -459,12 +459,12 @@ impl_scope! {
             debug_assert!(self.widgets.len() >= req_widgets);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let offset = self.scroll_offset();
             let rect = self.rect() + offset;
             let num = self.num_children();
             draw.with_clip_region(self.rect(), offset, |mut draw| {
-                for child in &mut self.widgets[..num] {
+                for child in &self.widgets[..num] {
                     if let Some(ref key) = child.key {
                         // Note: we don't know which widgets within 0..num are
                         // visible, so check intersection before drawing:

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -507,10 +507,10 @@ impl_scope! {
             self.scroll_offset()
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             let num = self.num_children();
             let coord = coord + self.scroll.offset();
-            for child in &mut self.widgets[..num] {
+            for child in &self.widgets[..num] {
                 if child.key.is_some() {
                     if let Some(id) = child.widget.try_probe(coord) {
                         return id;

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -350,7 +350,6 @@ impl_scope! {
             self.scroll.offset()
         }
 
-        #[inline]
         fn set_scroll_offset(&mut self, cx: &mut EventCx, offset: Offset) -> Offset {
             let action = self.scroll.set_offset(offset);
             cx.action(&self, action);

--- a/crates/kas-widgets/src/adapt/adapt.rs
+++ b/crates/kas-widgets/src/adapt/adapt.rs
@@ -6,6 +6,7 @@
 //! Adapt widget
 
 use super::{AdaptConfigCx, AdaptEventCx};
+use kas::event::TimerHandle;
 use kas::prelude::*;
 use linear_map::LinearMap;
 use std::fmt::Debug;
@@ -47,7 +48,7 @@ impl_scope! {
         inner: W,
         configure_handler: Option<Box<dyn Fn(&mut AdaptConfigCx, &mut W::Data)>>,
         update_handler: Option<Box<dyn Fn(&mut AdaptConfigCx, &mut W::Data, &A)>>,
-        timer_handlers: LinearMap<u64, Box<dyn Fn(&mut AdaptEventCx, &mut W::Data, &A)>>,
+        timer_handlers: LinearMap<TimerHandle, Box<dyn Fn(&mut AdaptEventCx, &mut W::Data, &A)>>,
         message_handlers: Vec<Box<dyn Fn(&mut AdaptEventCx, &mut W::Data, &A)>>,
     }
 
@@ -93,7 +94,7 @@ impl_scope! {
         /// It is assumed that state is modified by this timer. Frequent usage
         /// of timers which don't do anything may be inefficient; prefer usage
         /// of [`EventState::push_async`](kas::event::EventState::push_async).
-        pub fn on_timer<H>(mut self, timer_id: u64, handler: H) -> Self
+        pub fn on_timer<H>(mut self, timer_id: TimerHandle, handler: H) -> Self
         where
             H: Fn(&mut AdaptEventCx, &mut W::Data, &A) + 'static,
         {

--- a/crates/kas-widgets/src/adapt/adapt_cx.rs
+++ b/crates/kas-widgets/src/adapt/adapt_cx.rs
@@ -5,6 +5,7 @@
 
 //! Adapted contexts
 
+use kas::event::TimerHandle;
 use kas::prelude::*;
 use std::time::Duration;
 
@@ -46,10 +47,10 @@ impl<'a: 'b, 'b> AdaptEventCx<'a, 'b> {
     /// Requesting an update with `delay == 0` is valid except from a timer
     /// handler where it might cause an infinite loop.
     ///
-    /// Multiple timer requests with the same `timer_id` are merged
-    /// (choosing the earliest time).
+    /// Multiple timer requests with the same `id` and `handle` are merged
+    /// (see [`TimerHandle`] documentation).
     #[inline]
-    pub fn request_timer(&mut self, timer_id: u64, delay: Duration) {
+    pub fn request_timer(&mut self, timer_id: TimerHandle, delay: Duration) {
         self.cx.request_timer(self.id.clone(), timer_id, delay);
     }
 }
@@ -103,10 +104,10 @@ impl<'a: 'b, 'b> AdaptConfigCx<'a, 'b> {
     /// Requesting an update with `delay == 0` is valid except from a timer
     /// handler where it might cause an infinite loop.
     ///
-    /// Multiple timer requests with the same `timer_id` are merged
-    /// (choosing the earliest time).
+    /// Multiple timer requests with the same `id` and `handle` are merged
+    /// (see [`TimerHandle`] documentation).
     #[inline]
-    pub fn request_timer(&mut self, timer_id: u64, delay: Duration) {
+    pub fn request_timer(&mut self, timer_id: TimerHandle, delay: Duration) {
         self.cx.request_timer(self.id.clone(), timer_id, delay);
     }
 }

--- a/crates/kas-widgets/src/adapt/adapt_events.rs
+++ b/crates/kas-widgets/src/adapt/adapt_events.rs
@@ -140,7 +140,6 @@ kas::impl_scope! {
             self.inner.for_child_node(data, index, closure);
         }
 
-        #[inline]
         fn _configure(&mut self, cx: &mut ConfigCx, data: &Self::Data, id: Id) {
             self.inner._configure(cx, data, id);
 
@@ -163,7 +162,6 @@ kas::impl_scope! {
             }
         }
 
-        #[inline]
         fn _send(&mut self, cx: &mut EventCx, data: &Self::Data, id: Id, event: Event) -> IsUsed {
             let is_used = self.inner._send(cx, data, id, event);
 
@@ -177,7 +175,6 @@ kas::impl_scope! {
             is_used
         }
 
-        #[inline]
         fn _replay(&mut self, cx: &mut EventCx, data: &Self::Data, id: Id) {
             self.inner._replay(cx, data, id);
 

--- a/crates/kas-widgets/src/adapt/with_label.rs
+++ b/crates/kas-widgets/src/adapt/with_label.rs
@@ -107,7 +107,7 @@ impl_scope! {
             from.xor(Some(widget_index!(self.inner)))
         }
 
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.inner.id()
         }
     }

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -95,7 +95,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.id()
         }
     }

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -59,7 +59,7 @@ impl_scope! {
             widget_set_rect!(rect);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.check_box(self.rect(), self.state, self.last_change);
         }
     }

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -198,7 +198,7 @@ impl_scope! {
             from.xor(Some(widget_index!(self.inner)))
         }
 
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.inner.id()
         }
     }

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -186,7 +186,6 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            widget_set_rect!(rect);
             kas::MacroDefinedLayout::set_rect(self, cx, rect, hints);
             let dir = self.direction();
             shrink_to_text(&mut self.rect(), dir, &self.label);

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -53,7 +53,7 @@ impl_scope! {
             None
         }
 
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.id()
         }
     }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -396,7 +396,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             if self.inner.max_scroll_offset().1 > 0 {
                 if let Some(id) = self.bar.try_probe(coord) {
                     return id;
@@ -780,7 +780,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.id()
         }
     }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -387,7 +387,7 @@ impl_scope! {
             self.update_scroll_bar(cx);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             self.inner.draw(draw.re());
             if self.inner.max_scroll_offset().1 > 0 {
                 self.bar.draw(draw.re());
@@ -745,7 +745,7 @@ impl_scope! {
             self.view_offset = self.view_offset.min(self.max_scroll_offset());
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let bg = if self.has_error() {
                 Background::Error
             } else {

--- a/crates/kas-widgets/src/filler.rs
+++ b/crates/kas-widgets/src/filler.rs
@@ -28,7 +28,7 @@ impl_scope! {
             SizeRules::empty(stretch)
         }
 
-        fn draw(&mut self, _: DrawCx) {}
+        fn draw(&self, _: DrawCx) {}
     }
 }
 

--- a/crates/kas-widgets/src/float.rs
+++ b/crates/kas-widgets/src/float.rs
@@ -122,15 +122,15 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let mut iter = (0..self.widgets.len()).rev();
             if let Some(first) = iter.next() {
-                if let Some(child) = self.widgets.get_mut_tile(first) {
+                if let Some(child) = self.widgets.get_tile(first) {
                     child.draw(draw.re());
                 }
             }
             for i in iter {
-                if let Some(child) = self.widgets.get_mut_tile(i) {
+                if let Some(child) = self.widgets.get_tile(i) {
                     draw.with_pass(|draw| child.draw(draw));
                 }
             }

--- a/crates/kas-widgets/src/float.rs
+++ b/crates/kas-widgets/src/float.rs
@@ -147,9 +147,9 @@ impl_scope! {
             self.widgets.get_tile(index)
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             for i in 0..self.widgets.len() {
-                if let Some(child) = self.widgets.get_mut_tile(i) {
+                if let Some(child) = self.widgets.get_tile(i) {
                     if let Some(id) = child.try_probe(coord) {
                         return id;
                     }

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -215,9 +215,9 @@ impl_scope! {
             self.widgets.get_tile(index).map(|w| w.as_tile())
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             for n in 0..self.widgets.len() {
-                if let Some(child) = self.widgets.get_mut_tile(n) {
+                if let Some(child) = self.widgets.get_tile(n) {
                     if let Some(id) = child.try_probe(coord) {
                         return id;
                     }

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -197,9 +197,9 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             for n in 0..self.widgets.len() {
-                if let Some(child) = self.widgets.get_mut_tile(n) {
+                if let Some(child) = self.widgets.get_tile(n) {
                     child.draw(draw.re());
                 }
             }

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -80,6 +80,10 @@ impl_scope! {
 
     /// This implementation is unusual (see [`GripPart`] documentation).
     impl Layout for GripPart {
+        fn rect(&self) -> Rect {
+            self.rect
+        }
+
         fn size_rules(&mut self, _: SizeCx, _axis: AxisInfo) -> SizeRules {
             SizeRules::EMPTY
         }
@@ -89,12 +93,6 @@ impl_scope! {
         }
 
         fn draw(&self, _: DrawCx) {}
-    }
-
-    impl Tile for Self {
-        fn rect(&self) -> Rect {
-            self.rect
-        }
     }
 
     impl Events for GripPart {

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -175,7 +175,7 @@ impl_scope! {
         /// between [`Offset::ZERO`] and [`Self::max_offset`].
         #[inline]
         pub fn offset(&self) -> Offset {
-            self.rect().pos - self.track.pos
+            self.rect.pos - self.track.pos
         }
 
         /// Get the maximum allowed offset
@@ -184,7 +184,7 @@ impl_scope! {
         /// track minus the size of the grip.
         #[inline]
         pub fn max_offset(&self) -> Offset {
-            Offset::conv(self.track.size) - Offset::conv(self.rect().size)
+            Offset::conv(self.track.size) - Offset::conv(self.rect.size)
         }
 
         /// Set a new grip position
@@ -199,7 +199,7 @@ impl_scope! {
         pub fn set_offset(&mut self, cx: &mut EventState, offset: Offset) -> Offset {
             let offset = offset.min(self.max_offset()).max(Offset::ZERO);
             let grip_pos = self.track.pos + offset;
-            if grip_pos != self.rect().pos {
+            if grip_pos != self.rect.pos {
                 self.rect.pos = grip_pos;
                 cx.redraw(self);
             }
@@ -223,7 +223,7 @@ impl_scope! {
                 .with_icon(CursorIcon::Grabbing)
                 .with_cx(cx);
 
-            let offset = press.coord - self.track.pos - Offset::conv(self.rect().size / 2);
+            let offset = press.coord - self.track.pos - Offset::conv(self.rect.size / 2);
             let offset = offset.clamp(Offset::ZERO, self.max_offset());
             self.press_coord = press.coord - offset;
             offset

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -88,7 +88,7 @@ impl_scope! {
             self.rect = rect;
         }
 
-        fn draw(&mut self, _: DrawCx) {}
+        fn draw(&self, _: DrawCx) {}
     }
 
     impl Tile for Self {

--- a/crates/kas-widgets/src/image.rs
+++ b/crates/kas-widgets/src/image.rs
@@ -167,6 +167,10 @@ impl_scope! {
     }
 
     impl Layout for Image {
+        fn rect(&self) -> Rect {
+            self.scaling.rect
+        }
+
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             self.scaling.size_rules(sizer, axis)
         }
@@ -174,7 +178,7 @@ impl_scope! {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
             let align = hints.complete_default();
             let scale_factor = cx.size_cx().scale_factor();
-            widget_set_rect!(self.scaling.align_rect(rect, align, scale_factor));
+            self.scaling.set_rect(rect, align, scale_factor);
         }
 
         fn draw(&self, mut draw: DrawCx) {

--- a/crates/kas-widgets/src/image.rs
+++ b/crates/kas-widgets/src/image.rs
@@ -177,7 +177,7 @@ impl_scope! {
             widget_set_rect!(self.scaling.align_rect(rect, align, scale_factor));
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             if let Some(id) = self.handle.as_ref().map(|h| h.id()) {
                 draw.image(self.rect(), id);
             }

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -116,7 +116,6 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            widget_set_rect!(rect);
             self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
         }
     }
@@ -258,7 +257,6 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            widget_set_rect!(rect);
             self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
         }
     }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -306,10 +306,10 @@ impl_scope! {
                 .and_then(|k| self.id_map.get(&k).cloned())
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             let solver = RowPositionSolver::new(self.direction);
             solver
-                .find_child_mut(&mut self.widgets, coord)
+                .find_child(&self.widgets, coord)
                 .and_then(|child| child.try_probe(coord))
                 .unwrap_or_else(|| self.id())
         }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -285,9 +285,9 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let solver = RowPositionSolver::new(self.direction);
-            solver.for_children_mut(&mut self.widgets, draw.get_clip_rect(), |w| w.draw(draw.re()));
+            solver.for_children(&self.widgets, draw.get_clip_rect(), |w| w.draw(draw.re()));
         }
     }
 

--- a/crates/kas-widgets/src/mark.rs
+++ b/crates/kas-widgets/src/mark.rs
@@ -50,7 +50,7 @@ impl_scope! {
             sizer.feature(self.style.into(), axis)
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.mark(self.rect(), self.style);
         }
     }
@@ -91,7 +91,7 @@ impl_scope! {
             sizer.feature(self.style.into(), axis)
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.mark(self.rect(), self.style);
         }
     }

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -38,7 +38,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.id()
         }
     }
@@ -129,7 +129,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.checkbox.id()
         }
     }

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -31,7 +31,7 @@ impl_scope! {
     }
 
     impl Layout for Self {
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.frame(self.rect(), FrameStyle::MenuEntry, Default::default());
             self.label.draw(draw.re());
         }
@@ -121,7 +121,7 @@ impl_scope! {
     }
 
     impl Layout for Self {
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.set_id(self.checkbox.id());
             draw.frame(self.rect(), FrameStyle::MenuEntry, Default::default());
             kas::MacroDefinedLayout::draw(self, draw);

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -110,10 +110,10 @@ impl_scope! {
             self.widgets.get(index).map(|w| w.as_tile())
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             let solver = RowPositionSolver::new(self.direction);
             solver
-                .find_child_mut(&mut self.widgets, coord)
+                .find_child(&self.widgets, coord)
                 .and_then(|child| child.try_probe(coord))
                 .unwrap_or_else(|| self.id())
         }

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -94,10 +94,10 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let solver = RowPositionSolver::new(self.direction);
             let rect = self.rect();
-            solver.for_children_mut(&mut self.widgets, rect, |w| w.draw(draw.re()));
+            solver.for_children(&self.widgets, rect, |w| w.draw(draw.re()));
         }
     }
 

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -6,10 +6,12 @@
 //! Menubar
 
 use super::{Menu, SubMenu, SubMenuBuilder};
-use kas::event::{Command, FocusSource};
+use kas::event::{Command, FocusSource, TimerHandle};
 use kas::layout::{self, RowPositionSolver, RowSetter, RowSolver, RulesSetter, RulesSolver};
 use kas::prelude::*;
 use kas::theme::FrameStyle;
+
+const TIMER_SHOW: TimerHandle = TimerHandle::new(0, false);
 
 impl_scope! {
     /// A menu-bar
@@ -120,11 +122,9 @@ impl_scope! {
     impl Events for Self {
         fn handle_event(&mut self, cx: &mut EventCx, data: &Data, event: Event) -> IsUsed {
             match event {
-                Event::Timer(id_code) => {
+                Event::Timer(TIMER_SHOW) => {
                     if let Some(id) = self.delayed_open.clone() {
-                        if id.as_u64() == id_code {
-                            self.set_menu_path(cx, data, Some(&id), false);
-                        }
+                        self.set_menu_path(cx, data, Some(&id), false);
                     }
                     Used
                 }
@@ -181,7 +181,7 @@ impl_scope! {
                         } else if id != self.delayed_open {
                             cx.set_nav_focus(id.clone(), FocusSource::Pointer);
                             let delay = cx.config().event().menu_delay();
-                            cx.request_timer(self.id(), id.as_u64(), delay);
+                            cx.request_timer(self.id(), TIMER_SHOW, delay);
                             self.delayed_open = Some(id);
                         }
                     } else {

--- a/crates/kas-widgets/src/menu/mod.rs
+++ b/crates/kas-widgets/src/menu/mod.rs
@@ -69,7 +69,7 @@ pub trait Menu: Widget {
     /// # struct S;
     /// # impl S {
     /// # fn rect(&self) -> Rect { Rect::ZERO }
-    /// fn draw(&mut self, mut draw: DrawCx) {
+    /// fn draw(&self, mut draw: DrawCx) {
     ///     draw.frame(self.rect(), FrameStyle::MenuEntry, Default::default());
     ///     // draw children here
     /// }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -101,7 +101,7 @@ impl_scope! {
     }
 
     impl kas::Layout for Self {
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.frame(self.rect(), FrameStyle::MenuEntry, Default::default());
             self.label.draw(draw.re());
             if self.mark.rect().size != Size::ZERO {
@@ -332,8 +332,8 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
-            for child in self.list.iter_mut() {
+        fn draw(&self, mut draw: DrawCx) {
+            for child in self.list.iter() {
                 child.draw(draw.re());
             }
         }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -116,7 +116,7 @@ impl_scope! {
             None
         }
 
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.id()
         }
     }
@@ -348,8 +348,8 @@ impl_scope! {
             self.list.get(index).map(|w| w.as_tile())
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
-            for child in self.list.iter_mut() {
+        fn probe(&self, coord: Coord) -> Id {
+            for child in self.list.iter() {
                 if let Some(id) = child.try_probe(coord) {
                     return id;
                 }

--- a/crates/kas-widgets/src/progress.rs
+++ b/crates/kas-widgets/src/progress.rs
@@ -81,7 +81,7 @@ impl_scope! {
             widget_set_rect!(rect);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let dir = self.direction.as_direction();
             draw.progress_bar(self.rect(), dir, self.value);
         }

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -147,7 +147,6 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            widget_set_rect!(rect);
             kas::MacroDefinedLayout::set_rect(self, cx, rect, hints);
             let dir = self.direction();
             crate::check_box::shrink_to_text(&mut self.rect(), dir, &self.label);

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -159,7 +159,7 @@ impl_scope! {
             from.xor(Some(widget_index!(self.inner)))
         }
 
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.inner.id()
         }
     }

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -59,7 +59,7 @@ impl_scope! {
             widget_set_rect!(rect);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.radio_box(self.rect(), self.state, self.last_change);
         }
     }

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -129,7 +129,7 @@ impl_scope! {
             self.scroll_offset()
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             self.inner.try_probe(coord + self.translation())
                 .unwrap_or_else(|| self.id())
         }

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -116,7 +116,7 @@ impl_scope! {
                 .set_sizes(rect.size, child_size + self.frame_size);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.with_clip_region(self.rect(), self.scroll_offset(), |mut draw| {
                 self.inner.draw(draw.re());
             });

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -6,7 +6,7 @@
 //! `ScrollBar` control
 
 use super::{GripMsg, GripPart, ScrollRegion};
-use kas::event::Scroll;
+use kas::event::{Scroll, TimerHandle};
 use kas::prelude::*;
 use kas::theme::Feature;
 use std::fmt::Debug;
@@ -36,6 +36,8 @@ pub enum ScrollBarMode {
 /// Message from a [`ScrollBar`]
 #[derive(Copy, Clone, Debug)]
 pub struct ScrollMsg(pub i32);
+
+const TIMER_HIDE: TimerHandle = TimerHandle::new(0, false);
 
 impl_scope! {
     /// A scroll bar
@@ -226,7 +228,7 @@ impl_scope! {
         fn force_visible(&mut self, cx: &mut EventState) {
             self.force_visible = true;
             let delay = cx.config().event().touch_select_delay();
-            cx.request_timer(self.id(), 0, delay);
+            cx.request_timer(self.id(), TIMER_HIDE, delay);
         }
 
         #[inline]
@@ -344,7 +346,7 @@ impl_scope! {
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
-                Event::Timer(_) => {
+                Event::Timer(TIMER_HIDE) => {
                     self.force_visible = false;
                     cx.redraw(self);
                     Used

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -329,7 +329,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             if self.invisible && self.max_value == 0 {
                 return self.id();
             }
@@ -582,7 +582,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             self.vert_bar.try_probe(coord)
                 .or_else(|| self.horiz_bar.try_probe(coord))
                 .or_else(|| self.inner.try_probe(coord))

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -317,7 +317,7 @@ impl_scope! {
             self.update_widgets(cx);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             if !self.invisible
                 || (self.max_value != 0 && self.force_visible)
                 || draw.ev_state().is_depressed(self.grip.id_ref())
@@ -568,7 +568,7 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             self.inner.draw(draw.re());
             draw.with_pass(|mut draw| {
                 if self.show_bars.0 {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -61,7 +61,7 @@ impl_scope! {
             self.bar.set_value(cx, self.view_offset.1);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let rect = Rect::new(self.rect().pos, self.text_size);
             draw.with_clip_region(self.rect(), self.view_offset, |mut draw| {
                 if self.selection.is_empty() {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -80,7 +80,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             self.bar.try_probe(coord).unwrap_or_else(|| self.id())
         }
     }

--- a/crates/kas-widgets/src/scroll_text.rs
+++ b/crates/kas-widgets/src/scroll_text.rs
@@ -61,7 +61,7 @@ impl_scope! {
             self.bar.set_value(cx, self.view_offset.1);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let rect = Rect::new(self.rect().pos, self.text_size);
             draw.with_clip_region(self.rect(), self.view_offset, |mut draw| {
                 if self.selection.is_empty() {

--- a/crates/kas-widgets/src/scroll_text.rs
+++ b/crates/kas-widgets/src/scroll_text.rs
@@ -80,7 +80,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             self.bar.try_probe(coord).unwrap_or_else(|| self.id())
         }
     }

--- a/crates/kas-widgets/src/separator.rs
+++ b/crates/kas-widgets/src/separator.rs
@@ -38,7 +38,7 @@ impl_scope! {
             sizer.feature(kas::theme::Feature::Separator, axis)
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.separator(self.rect());
         }
     }

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -324,7 +324,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             if self.on_move.is_some() {
                 if let Some(id) = self.grip.try_probe(coord) {
                     return id;

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -317,7 +317,7 @@ impl_scope! {
             self.grip.set_offset(cx, self.offset());
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let dir = self.direction.as_direction();
             draw.slider(self.rect(), &self.grip, dir);
         }

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -281,7 +281,7 @@ impl_scope! {
             self.edit.set_outer_rect(rect, FrameStyle::EditBox);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             self.edit.draw(draw.re());
             self.b_up.draw(draw.re());
             self.b_down.draw(draw.re());

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -276,7 +276,6 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            widget_set_rect!(rect);
             kas::MacroDefinedLayout::set_rect(self, cx, rect, hints);
             self.edit.set_outer_rect(rect, FrameStyle::EditBox);
         }

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -289,7 +289,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             self.b_up.try_probe(coord)
                 .or_else(|| self.b_down.try_probe(coord))
                 .unwrap_or_else(|| self.edit.id())

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -235,7 +235,7 @@ impl_scope! {
                 .and_then(|k| self.id_map.get(&k).cloned())
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
+        fn probe(&self, coord: Coord) -> Id {
             if !self.size_solved {
                 debug_assert!(false);
                 return self.id();
@@ -246,12 +246,12 @@ impl_scope! {
             // calling it twice.
 
             let solver = layout::RowPositionSolver::new(self.direction);
-            if let Some(child) = solver.find_child_mut(&mut self.widgets, coord) {
+            if let Some(child) = solver.find_child(&self.widgets, coord) {
                 return child.try_probe(coord).unwrap_or_else(|| self.id());
             }
 
             let solver = layout::RowPositionSolver::new(self.direction);
-            if let Some(child) = solver.find_child_mut(&mut self.grips, coord) {
+            if let Some(child) = solver.find_child(&self.grips, coord) {
                 return child.try_probe(coord).unwrap_or_else(|| self.id());
             }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -196,7 +196,7 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             if !self.size_solved {
                 debug_assert!(false);
                 return;
@@ -206,12 +206,12 @@ impl_scope! {
             // calling it twice.
 
             let solver = layout::RowPositionSolver::new(self.direction);
-            solver.for_children_mut(&mut self.widgets, draw.get_clip_rect(), |w| {
+            solver.for_children(&self.widgets, draw.get_clip_rect(), |w| {
                 w.draw(draw.re());
             });
 
             let solver = layout::RowPositionSolver::new(self.direction);
-            solver.for_children_mut(&mut self.grips, draw.get_clip_rect(), |w| {
+            solver.for_children(&self.grips, draw.get_clip_rect(), |w| {
                 draw.separator(w.rect())
             });
         }

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -136,8 +136,8 @@ impl_scope! {
             }
         }
 
-        fn probe(&mut self, coord: Coord) -> Id {
-            if let Some(entry) = self.widgets.get_mut(self.active) {
+        fn probe(&self, coord: Coord) -> Id {
+            if let Some(entry) = self.widgets.get(self.active) {
                 debug_assert_eq!(entry.1, State::Sized);
                 if let Some(id) = entry.0.try_probe(coord) {
                     return id;

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -106,8 +106,8 @@ impl_scope! {
             }
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
-            if let Some(entry) = self.widgets.get_mut(self.active) {
+        fn draw(&self, mut draw: DrawCx) {
+            if let Some(entry) = self.widgets.get(self.active) {
                 debug_assert_eq!(entry.1, State::Sized);
                 entry.0.draw(draw.re());
             }

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -48,7 +48,7 @@ impl_scope! {
     }
 
     impl Tile for Self {
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             self.id()
         }
     }

--- a/crates/kas-widgets/src/text.rs
+++ b/crates/kas-widgets/src/text.rs
@@ -110,7 +110,6 @@ impl_scope! {
         }
 
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            widget_set_rect!(rect);
             self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
         }
 

--- a/crates/kas-widgets/src/text.rs
+++ b/crates/kas-widgets/src/text.rs
@@ -22,7 +22,9 @@ impl_scope! {
     /// Vertical alignment defaults to centred, horizontal alignment depends on
     /// the script direction if not specified. Line-wrapping is enabled by
     /// default.
-    #[widget]
+    #[widget {
+        layout = self.text;
+    }]
     pub struct Text<A, T: Default + FormattableText + 'static> {
         core: widget_core!(),
         text: theme::Text<T>,
@@ -104,17 +106,8 @@ impl_scope! {
     }
 
     impl Layout for Self {
-        #[inline]
-        fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
-            sizer.text_rules(&mut self.text, axis)
-        }
-
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
             self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
-        }
-
-        fn draw(&self, mut draw: DrawCx) {
-            draw.text(self.rect(), &self.text);
         }
     }
 

--- a/crates/kas-widgets/src/text.rs
+++ b/crates/kas-widgets/src/text.rs
@@ -114,7 +114,7 @@ impl_scope! {
             self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             draw.text(self.rect(), &self.text);
         }
     }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -71,7 +71,7 @@ impl_scope! {
             self.time_rect = Rect::new(time_pos, text_size);
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let accent: Rgba = Rgba8Srgb::parse("d7916f").into();
             let col_back = Rgba::ga(0.0, 0.5);
             let col_face = accent.multiply(0.4);

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -48,7 +48,6 @@ impl_scope! {
                 .with_stretch(Stretch::High)
         }
 
-        #[inline]
         fn set_rect(&mut self, _: &mut ConfigCx, rect: Rect, _: AlignHints) {
             // Force to square
             let size = rect.size.0.min(rect.size.1);

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -22,7 +22,7 @@ impl_scope! {
         cursor: CursorIcon,
     }
     impl Tile for Self {
-        fn probe(&mut self, _: Coord) -> Id {
+        fn probe(&self, _: Coord) -> Id {
             // Steal mouse focus: hover points to self, not self.label
             self.id()
         }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -433,7 +433,7 @@ fn canvas() -> Box<dyn Widget<Data = AppData>> {
     #[derive(Debug)]
     struct Program(Instant);
     impl CanvasProgram for Program {
-        fn draw(&mut self, pixmap: &mut Pixmap) {
+        fn draw(&self, pixmap: &mut Pixmap) {
             let size = (200.0, 200.0);
             let scale = Transform::from_scale(
                 f32::conv(pixmap.width()) / size.0,

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -350,7 +350,7 @@ impl_scope! {
             self.rel_width = rel_width.0 as f32;
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             let draw = draw.draw_device();
             let draw = DrawIface::<DrawPipe<Pipe>>::downcast_from(draw).unwrap();
             let p = (self.alpha, self.delta, self.rel_width, self.iters);

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -340,7 +340,6 @@ impl_scope! {
                 .with_stretch(Stretch::High)
         }
 
-        #[inline]
         fn set_rect(&mut self, _: &mut ConfigCx, rect: Rect, _: AlignHints) {
             widget_set_rect!(rect);
             let size = DVec2::conv(rect.size);

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -74,7 +74,7 @@ impl_scope! {
             self.loading_text.set_rect(cx, rect, hints.combine(AlignHints::CENTER));
         }
 
-        fn draw(&mut self, mut draw: DrawCx) {
+        fn draw(&self, mut draw: DrawCx) {
             if let Some(color) = self.color {
                 let draw = draw.draw_device();
                 draw.rect((self.rect()).cast(), color);

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -8,6 +8,7 @@
 use std::time::{Duration, Instant};
 
 use kas::decorations::Decorations;
+use kas::event::TimerHandle;
 use kas::prelude::*;
 use kas::widgets::{format_data, row, Button};
 
@@ -21,6 +22,8 @@ struct Timer {
     elapsed: Duration,
     last: Option<Instant>,
 }
+
+const TIMER: TimerHandle = TimerHandle::new(0, true);
 
 fn make_window() -> impl Widget<Data = ()> {
     let ui = row![
@@ -38,15 +41,15 @@ fn make_window() -> impl Widget<Data = ()> {
                 timer.elapsed += now - last;
             } else {
                 timer.last = Some(now);
-                cx.request_timer(0, Duration::new(0, 0));
+                cx.request_timer(TIMER, Duration::ZERO);
             }
         })
-        .on_timer(0, |cx, timer, _| {
+        .on_timer(TIMER, |cx, timer, _| {
             if let Some(last) = timer.last {
                 let now = Instant::now();
                 timer.elapsed += now - last;
                 timer.last = Some(now);
-                cx.request_timer(0, Duration::new(0, 1));
+                cx.request_timer(TIMER, Duration::from_nanos(1));
             }
         })
 }


### PR DESCRIPTION
Building on #479, we can now support non-mut methods in `Layout`.

Move `Tile::rect` to `Layout`, where arguably it should be. Adjust macro-generation of this method.

Add `TimerHandle`, replacing `payload: u64` of timers. This also allows control over how timers get merged.

I considered removing `widget_set_rect!` (a few usages were removed here; a few more could be replaced through `PixmapScaling` or layout storage), but there are still 19 usages which would require an explicit `rect: Rect` field and `fn rect` definition. Is this enough justification to keep the feature?