### PR TITLE
Replace fns for_child* with get_child* to reduce stack depth

### DIFF
--- a/crates/kas-core/src/core/collection.rs
+++ b/crates/kas-core/src/core/collection.rs
@@ -38,12 +38,7 @@ pub trait Collection {
     fn get_mut_tile(&mut self, index: usize) -> Option<&mut dyn Tile>;
 
     /// Operate on a widget as a [`Node`]
-    fn for_node(
-        &mut self,
-        data: &Self::Data,
-        index: usize,
-        closure: Box<dyn FnOnce(Node<'_>) + '_>,
-    );
+    fn child_node<'n>(&'n mut self, data: &'n Self::Data, index: usize) -> Option<Node<'n>>;
 
     /// Iterate over elements as [`Tile`] items within `range`
     ///
@@ -255,15 +250,12 @@ macro_rules! impl_slice {
             }
 
             #[inline]
-            fn for_node(
-                &mut self,
-                data: &W::Data,
+            fn child_node<'n>(
+                &'n mut self,
+                data: &'n Self::Data,
                 index: usize,
-                closure: Box<dyn FnOnce(Node<'_>) + '_>,
-            ) {
-                if let Some($pat) = self.get_mut(index) {
-                    closure($w.as_node(data));
-                }
+            ) -> Option<Node<'n>> {
+                self.get_mut(index).map(|$pat| $w.as_node(data))
             }
 
             #[inline]

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -42,10 +42,10 @@ pub fn _send<W: Events>(
         if let Some(index) = widget.find_child_index(&id) {
             let translation = widget.translation();
             let mut _found = false;
-            widget.as_node(data).for_child(index, |mut node| {
+            if let Some(mut node) = widget.as_node(data).get_child(index) {
                 is_used = node._send(cx, id.clone(), event.clone() + translation);
                 _found = true;
-            });
+            }
 
             #[cfg(debug_assertions)]
             if !_found {
@@ -81,10 +81,10 @@ pub fn _send<W: Events>(
 pub fn _replay<W: Events>(widget: &mut W, cx: &mut EventCx, data: &<W as Widget>::Data, id: Id) {
     if let Some(index) = widget.find_child_index(&id) {
         let mut _found = false;
-        widget.as_node(data).for_child(index, |mut node| {
+        if let Some(mut node) = widget.as_node(data).get_child(index) {
             node._replay(cx, id.clone());
             _found = true;
-        });
+        }
 
         #[cfg(debug_assertions)]
         if !_found {
@@ -147,7 +147,9 @@ fn nav_next(
     if let Some(index) = child {
         let mut opt_id = None;
         let out = &mut opt_id;
-        widget.for_child(index, |mut node| *out = node._nav_next(cx, focus, advance));
+        if let Some(mut node) = widget.get_child(index) {
+            *out = node._nav_next(cx, focus, advance);
+        }
         if let Some(id) = opt_id {
             return Some(id);
         }
@@ -174,7 +176,9 @@ fn nav_next(
     while let Some(index) = widget.nav_next(rev, child) {
         let mut opt_id = None;
         let out = &mut opt_id;
-        widget.for_child(index, |mut node| *out = node._nav_next(cx, focus, advance));
+        if let Some(mut node) = widget.get_child(index) {
+            *out = node._nav_next(cx, focus, advance);
+        }
         if let Some(id) = opt_id {
             return Some(id);
         }

--- a/crates/kas-core/src/core/tile.rs
+++ b/crates/kas-core/src/core/tile.rs
@@ -91,7 +91,7 @@ pub trait Tile: Layout {
     ///
     /// This method is usually implemented automatically by the `#[widget]`
     /// macro. It should be implemented directly if and only if
-    /// [`Tile::get_child`] and [`Widget::for_child_node`] are
+    /// [`Tile::get_child`] and [`Widget::child_node`] are
     /// implemented directly.
     fn num_children(&self) -> usize {
         unimplemented!() // make rustdoc show that this is a provided method

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -315,7 +315,7 @@ pub enum NavAdvance {
 /// -   **Core** methods of [`Tile`] are *always* implemented via the [`#widget`]
 ///     macro, whether or not an `impl Tile { ... }` item is present.
 /// -   **Introspection** methods [`Tile::num_children`], [`Tile::get_child`]
-///     and [`Widget::for_child_node`] are implemented by the [`#widget`] macro
+///     and [`Widget::child_node`] are implemented by the [`#widget`] macro
 ///     in most cases: child widgets embedded within a layout descriptor or
 ///     included as fields marked with `#[widget]` are enumerated.
 /// -   **Introspection** methods [`Tile::find_child_index`] and
@@ -362,13 +362,8 @@ pub trait Widget: Tile {
     ///
     /// It is recommended to use the methods on [`Node`]
     /// instead of calling this method.
-    fn for_child_node(
-        &mut self,
-        data: &Self::Data,
-        index: usize,
-        closure: Box<dyn FnOnce(Node<'_>) + '_>,
-    ) {
-        let _ = (data, index, closure);
+    fn child_node<'n>(&'n mut self, data: &'n Self::Data, index: usize) -> Option<Node<'n>> {
+        let _ = (data, index);
         unimplemented!() // make rustdoc show that this is a provided method
     }
 

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -102,8 +102,9 @@ pub trait Events: Widget + Sized {
         for index in 0..self.num_children() {
             let id = self.make_child_id(index);
             if id.is_valid() {
-                self.as_node(data)
-                    .for_child(index, |node| cx.configure(node, id));
+                if let Some(node) = self.as_node(data).get_child(index) {
+                    cx.configure(node, id);
+                }
             }
         }
     }
@@ -134,7 +135,9 @@ pub trait Events: Widget + Sized {
     /// Use [`ConfigCx::update`].
     fn update_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
         for index in 0..self.num_children() {
-            self.as_node(data).for_child(index, |node| cx.update(node));
+            if let Some(node) = self.as_node(data).get_child(index) {
+                cx.update(node);
+            }
         }
     }
 

--- a/crates/kas-macros/src/collection.rs
+++ b/crates/kas-macros/src/collection.rs
@@ -356,7 +356,7 @@ impl Collection {
                 #index => Some(&mut self.#path),
             });
             for_node_rules.append_all(quote! {
-                #index => closure(self.#path.as_node(data)),
+                #index => Some(self.#path.as_node(data)),
             });
         }
 
@@ -398,16 +398,16 @@ impl Collection {
                     _ => None,
                 }
             }
-            fn for_node(
-                &mut self,
-                data: &Self::Data,
+            #[inline]
+            fn child_node<'__n>(
+                &'__n mut self,
+                data: &'__n Self::Data,
                 index: usize,
-                closure: Box<dyn FnOnce(::kas::Node<'_>) + '_>,
-            ) {
+            ) -> Option<::kas::Node<'__n>> {
                 use ::kas::Widget;
                 match index {
                     #for_node_rules
-                    _ => (),
+                    _ => None,
                 }
             }
         };

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -37,7 +37,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
 
     let mut num_children = None;
     let mut get_child = None;
-    let mut for_child_node = None;
+    let mut child_node = None;
     let mut find_child_index = None;
     let mut make_child_id = None;
     for (index, impl_) in scope.impls.iter().enumerate() {
@@ -50,8 +50,8 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
 
                 for item in &impl_.items {
                     if let ImplItem::Fn(ref item) = item {
-                        if item.sig.ident == "for_child_node" {
-                            for_child_node = Some(item.sig.ident.clone());
+                        if item.sig.ident == "child_node" {
+                            child_node = Some(item.sig.ident.clone());
                         }
                     } else if let ImplItem::Type(ref item) = item {
                         if item.ident == "Data" {
@@ -293,11 +293,11 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
         if get_child.is_none() {
             emit_warning!(span, "fn num_children without fn get_child");
         }
-        if for_child_node.is_none() {
-            emit_warning!(span, "fn num_children without fn for_child_node");
+        if child_node.is_none() {
+            emit_warning!(span, "fn num_children without fn child_node");
         }
     }
-    if let Some(span) = get_child.as_ref().or(for_child_node.as_ref()) {
+    if let Some(span) = get_child.as_ref().or(child_node.as_ref()) {
         if num_children.is_none() {
             emit_warning!(span, "associated impl of `fn Tile::num_children` required");
         }
@@ -321,7 +321,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
         #core_path.status.require_rect(&#core_path._id);
     };
 
-    let do_impl_widget_children = get_child.is_none() && for_child_node.is_none();
+    let do_impl_widget_children = get_child.is_none() && child_node.is_none();
     let fns_get_child = if do_impl_widget_children {
         let mut get_rules = quote! {};
         for (index, child) in children.iter().enumerate() {
@@ -349,7 +349,7 @@ pub fn widget(attr_span: Span, mut args: WidgetArgs, scope: &mut Scope) -> Resul
         let item_idents = collect_idents(widget_impl);
         let has_item = |name| item_idents.iter().any(|(_, ident)| ident == name);
 
-        // If the user impls Widget, they must supply type Data and fn for_child_node
+        // If the user impls Widget, they must supply type Data and fn child_node
 
         // Always impl fn as_node
         widget_impl.items.push(Verbatim(widget_as_node()));
@@ -841,26 +841,25 @@ pub fn impl_widget(
             };
 
             get_mut_rules.append_all(if let Some(ref data) = child.data_binding {
-                quote! { #i => closure(#path.as_node(#data)), }
+                quote! { #i => Some(#path.as_node(#data)), }
             } else {
                 if let Some(ref span) = child.attr_span {
-                    quote_spanned! {*span=> #i => closure(#path.as_node(data)), }
+                    quote_spanned! {*span=> #i => Some(#path.as_node(data)), }
                 } else {
-                    quote! { #i => closure(#path.as_node(data)), }
+                    quote! { #i => Some(#path.as_node(data)), }
                 }
             });
         }
 
         quote! {
-            fn for_child_node(
-                &mut self,
-                data: &Self::Data,
+            fn child_node<'__n>(
+                &'__n mut self,
+                data: &'__n Self::Data,
                 index: usize,
-                closure: Box<dyn FnOnce(::kas::Node<'_>) + '_>,
-            ) {
+            ) -> Option<::kas::Node<'__n>> {
                 match index {
                     #get_mut_rules
-                    _ => (),
+                    _ => None,
                 }
             }
         }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -885,7 +885,7 @@ pub fn impl_widget(
 pub fn widget_as_node() -> Toks {
     quote! {
         #[inline]
-        fn as_node<'a>(&'a mut self, data: &'a Self::Data) -> ::kas::Node<'a> {
+        fn as_node<'__a>(&'__a mut self, data: &'__a Self::Data) -> ::kas::Node<'__a> {
             ::kas::Node::new(self, data)
         }
     }

--- a/crates/kas-macros/src/widget_derive.rs
+++ b/crates/kas-macros/src/widget_derive.rs
@@ -274,16 +274,15 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
 
     // Widget methods are derived. Cost: cannot override any Events methods or translation().
     let fn_as_node = widget_as_node();
-    let fn_for_child_node = quote! {
+    let fn_child_node = quote! {
         #[inline]
-        fn for_child_node(
-            &mut self,
-            data: &Self::Data,
+        fn child_node<'__n>(
+            &'__n mut self,
+            data: &'__n Self::Data,
             index: usize,
-            closure: Box<dyn FnOnce(::kas::Node<'_>) + '_>,
-        ) {
+        ) -> Option<::kas::Node<'__n>> {
             #map_data
-            self.#inner.for_child_node(data, index, closure)
+            self.#inner.child_node(data, index)
         }
     };
     let fn_configure = quote! {
@@ -358,8 +357,8 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
             widget_impl.items.push(Verbatim(fn_as_node));
         }
 
-        if !has_item("for_child_node") {
-            widget_impl.items.push(Verbatim(fn_for_child_node));
+        if !has_item("child_node") {
+            widget_impl.items.push(Verbatim(fn_child_node));
         }
 
         if !has_item("_configure") {
@@ -386,7 +385,7 @@ pub fn widget(_attr_span: Span, args: WidgetArgs, scope: &mut Scope) -> Result<(
             impl #impl_generics ::kas::Widget for #impl_target {
                 type Data = #data_ty;
                 #fn_as_node
-                #fn_for_child_node
+                #fn_child_node
                 #fn_configure
                 #fn_update
                 #fn_send

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -842,7 +842,9 @@ impl_scope! {
             if let Some(index) = child {
                 let mut opt_id = None;
                 let out = &mut opt_id;
-                self.as_node(data).for_child(index, |mut node| *out = node._nav_next(cx, focus, advance));
+                if let Some(mut node) = self.as_node(data).get_child(index) {
+                    *out = node._nav_next(cx, focus, advance);
+                }
                 if let Some(id) = opt_id {
                     return Some(id);
                 }
@@ -883,7 +885,9 @@ impl_scope! {
 
                 let mut opt_id = None;
                 let out = &mut opt_id;
-                self.as_node(data).for_child(index, |mut node| *out = node._nav_next(cx, focus, advance));
+                if let Some(mut node) = self.as_node(data).get_child(index) {
+                    *out = node._nav_next(cx, focus, advance);
+                }
                 if let Some(id) = opt_id {
                     return Some(id);
                 }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -813,19 +813,16 @@ impl_scope! {
     impl Widget for Self {
         type Data = A::Data;
 
-        fn for_child_node(
-            &mut self,
-            data: &A::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
+        fn child_node<'n>(&'n mut self, data: &'n A::Data, index: usize) -> Option<Node<'n>> {
             if let Some(w) = self.widgets.get_mut(index) {
                 if let Some(ref key) = w.key {
                     if let Some(item) = self.accessor.item(data, key) {
-                        closure(w.widget.as_node(item));
+                        return Some(w.widget.as_node(item));
                     }
                 }
             }
+
+            None
         }
 
         // Non-standard implementation to allow mapping new children

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -774,7 +774,9 @@ impl_scope! {
             if let Some(index) = child {
                 let mut opt_id = None;
                 let out = &mut opt_id;
-                self.as_node(data).for_child(index, |mut node| *out = node._nav_next(cx, focus, advance));
+                if let Some(mut node) = self.as_node(data).get_child(index) {
+                    *out = node._nav_next(cx, focus, advance);
+                }
                 if let Some(id) = opt_id {
                     return Some(id);
                 }
@@ -825,7 +827,9 @@ impl_scope! {
 
                 let mut opt_id = None;
                 let out = &mut opt_id;
-                self.as_node(data).for_child(index, |mut node| *out = node._nav_next(cx, focus, advance));
+                if let Some(mut node) = self.as_node(data).get_child(index) {
+                    *out = node._nav_next(cx, focus, advance);
+                }
                 if let Some(id) = opt_id {
                     return Some(id);
                 }

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -745,19 +745,16 @@ impl_scope! {
     impl Widget for Self {
         type Data = A::Data;
 
-        fn for_child_node(
-            &mut self,
-            data: &A::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
+        fn child_node<'n>(&'n mut self, data: &'n A::Data, index: usize) -> Option<Node<'n>> {
             if let Some(w) = self.widgets.get_mut(index) {
                 if let Some(ref key) = w.key {
                     if let Some(item) = self.accessor.item(data, key) {
-                        closure(w.widget.as_node(item));
+                        return Some(w.widget.as_node(item));
                     }
                 }
             }
+
+            None
         }
 
         // Non-standard implementation to allow mapping new children

--- a/crates/kas-widgets/src/adapt/adapt_events.rs
+++ b/crates/kas-widgets/src/adapt/adapt_events.rs
@@ -131,13 +131,8 @@ kas::impl_scope! {
         }
 
         #[inline]
-        fn for_child_node(
-            &mut self,
-            data: &Self::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            self.inner.for_child_node(data, index, closure);
+        fn child_node<'n>(&'n mut self, data: &'n Self::Data, index: usize) -> Option<Node<'n>> {
+            self.inner.child_node(data, index)
         }
 
         fn _configure(&mut self, cx: &mut ConfigCx, data: &Self::Data, id: Id) {

--- a/crates/kas-widgets/src/float.rs
+++ b/crates/kas-widgets/src/float.rs
@@ -162,13 +162,9 @@ impl_scope! {
     impl Widget for Self {
         type Data = C::Data;
 
-        fn for_child_node(
-            &mut self,
-            data: &C::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            self.widgets.for_node(data, index, closure);
+        #[inline]
+        fn child_node<'n>(&'n mut self, data: &'n Self::Data, index: usize) -> Option<Node<'n>> {
+            self.widgets.child_node(data, index)
         }
     }
 }

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -230,13 +230,8 @@ impl_scope! {
     impl Widget for Self {
         type Data = C::Data;
 
-        fn for_child_node(
-            &mut self,
-            data: &C::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            self.widgets.for_node(data, index, closure);
+        fn child_node<'n>(&'n mut self, data: &'n C::Data, index: usize) -> Option<Node<'n>> {
+            self.widgets.child_node(data, index)
         }
     }
 }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -349,13 +349,8 @@ impl_scope! {
     impl Widget for Self {
         type Data = C::Data;
 
-        fn for_child_node(
-            &mut self,
-            data: &C::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            self.widgets.for_node(data, index, closure);
+        fn child_node<'n>(&'n mut self, data: &'n C::Data, index: usize) -> Option<Node<'n>> {
+            self.widgets.child_node(data, index)
         }
     }
 

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -248,15 +248,8 @@ impl_scope! {
     impl Widget for Self {
         type Data = Data;
 
-        fn for_child_node(
-            &mut self,
-            data: &Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            if let Some(w) = self.widgets.get_mut(index) {
-                closure(w.as_node(data));
-            }
+        fn child_node<'n>(&'n mut self, data: &'n Data, index: usize) -> Option<Node<'n>> {
+            self.widgets.get_mut(index).map(|w| w.as_node(data))
         }
     }
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -361,15 +361,8 @@ impl_scope! {
     impl kas::Widget for Self {
         type Data = W::Data;
 
-        fn for_child_node(
-            &mut self,
-            data: &W::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            if let Some(w) = self.list.get_mut(index) {
-                closure(w.as_node(data));
-            }
+        fn child_node<'n>(&'n mut self, data: &'n W::Data, index: usize) -> Option<Node<'n>> {
+            self.list.get_mut(index).map(|w| w.as_node(data))
         }
     }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -306,18 +306,11 @@ impl_scope! {
     impl Widget for Self {
         type Data = C::Data;
 
-        fn for_child_node(
-            &mut self,
-            data: &C::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
+        fn child_node<'n>(&'n mut self, data: &'n C::Data, index: usize) -> Option<Node<'n>> {
             if (index & 1) != 0 {
-                if let Some(w) = self.grips.get_mut(index >> 1) {
-                    closure(w.as_node(&()));
-                }
+                self.grips.get_mut(index >> 1).map(|w| w.as_node(&()))
             } else {
-                self.widgets.for_node(data, index >> 1, closure);
+                self.widgets.child_node(data, index >> 1)
             }
         }
     }

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -58,15 +58,8 @@ impl_scope! {
     impl Widget for Self {
         type Data = W::Data;
 
-        fn for_child_node(
-            &mut self,
-            data: &W::Data,
-            index: usize,
-            closure: Box<dyn FnOnce(Node<'_>) + '_>,
-        ) {
-            if let Some((w, _)) = self.widgets.get_mut(index) {
-                closure(w.as_node(data));
-            }
+        fn child_node<'n>(&'n mut self, data: &'n W::Data, index: usize) -> Option<Node<'n>> {
+            self.widgets.get_mut(index).map(|(w, _)| w.as_node(data))
         }
     }
 


### PR DESCRIPTION
Motivation:

- Simpler fn signatures
- Reduces stack depth of an example `panic!()` placed in `Spinner::handle_event` tested in the gallery from 155 items to 99.

This locks in some of the changes from #487 since prior to that `fn ListView::child_node` would not pass the borrow checker (unable to return borrow of temporary data item).