### PR TITLE
Fix freezes during pan events, add click-click-drag gesture

### DIFF
--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -95,6 +95,7 @@ pub struct EventState {
     popup_removed: SmallVec<[(Id, WindowId); 16]>,
     time_updates: Vec<(Instant, Id, TimerHandle)>,
     frame_updates: LinearSet<(Id, TimerHandle)>,
+    need_frame_update: bool,
     // Set of messages awaiting sending
     send_queue: VecDeque<(Id, Erased)>,
     // Set of futures of messages together with id of sending widget

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -35,6 +35,7 @@ impl EventState {
             popup_removed: Default::default(),
             time_updates: vec![],
             frame_updates: Default::default(),
+            need_frame_update: false,
             send_queue: Default::default(),
             fut_messages: vec![],
             pending_update: None,
@@ -85,8 +86,8 @@ impl EventState {
         self.time_updates.last().map(|time| time.0)
     }
 
-    pub(crate) fn have_pending(&self) -> bool {
-        !self.frame_updates.is_empty() || !self.fut_messages.is_empty()
+    pub(crate) fn need_frame_update(&self) -> bool {
+        self.need_frame_update || !self.frame_updates.is_empty() || !self.fut_messages.is_empty()
     }
 
     /// Construct a [`EventCx`] referring to this state
@@ -205,6 +206,7 @@ impl<'a> EventCx<'a> {
     /// This method should be called once per frame as well as after the last
     /// frame before a long sleep.
     pub(crate) fn frame_update(&mut self, mut widget: Node<'_>) {
+        self.need_frame_update = false;
         log::debug!(target: "kas_core::event", "Processing frame update");
         if let Some((target, event)) = self.mouse.frame_update() {
             self.send_event(widget.re(), target, event);

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -236,7 +236,7 @@ impl EventState {
         }
         if self
             .mouse
-            .mouse_grab
+            .grab
             .as_ref()
             .map(|grab| *w_id == grab.depress)
             .unwrap_or(false)
@@ -259,7 +259,7 @@ impl EventState {
     /// Get whether the widget is under the mouse cursor
     #[inline]
     pub fn is_hovered(&self, w_id: &Id) -> bool {
-        self.mouse.mouse_grab.is_none() && *w_id == self.mouse.hover
+        self.mouse.grab.is_none() && *w_id == self.mouse.hover
     }
 
     /// Set the cursor icon
@@ -298,7 +298,7 @@ impl EventState {
         let mut redraw = false;
         match source {
             PressSource::Mouse(_, _) => {
-                if let Some(grab) = self.mouse.mouse_grab.as_mut() {
+                if let Some(grab) = self.mouse.grab.as_mut() {
                     redraw = grab.depress != target;
                     old = grab.depress.take();
                     grab.depress = target.clone();
@@ -324,7 +324,7 @@ impl EventState {
     pub fn any_grab_on(&self, id: &Id) -> bool {
         if self
             .mouse
-            .mouse_grab
+            .grab
             .as_ref()
             .map(|grab| grab.start_id == id)
             .unwrap_or(false)
@@ -342,7 +342,7 @@ impl<'a> EventCx<'a> {
     /// [`Press::grab`]). The cursor will be reset when the mouse-grab
     /// ends.
     pub fn set_grab_cursor(&mut self, id: &Id, icon: CursorIcon) {
-        if let Some(ref grab) = self.mouse.mouse_grab {
+        if let Some(ref grab) = self.mouse.grab {
             if grab.start_id == *id {
                 self.window.set_cursor_icon(icon);
             }

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -284,6 +284,7 @@ impl<'a> EventCx<'a> {
                 }
                 GrabDetails::Pan(details) => {
                     details.c1 = coord;
+                    self.need_frame_update = true;
                 }
             }
         } else if let Some(popup_id) = self.popups.last().map(|(_, p, _)| p.id.clone()) {

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -147,7 +147,10 @@ impl Mouse {
                     unreachable!()
                 }
 
-                if alpha != DVec2(1.0, 0.0) || delta != DVec2::ZERO {
+                if alpha.is_finite()
+                    && delta.is_finite()
+                    && (alpha != DVec2(1.0, 0.0) || delta != DVec2::ZERO)
+                {
                     let id = grab.start_id.clone();
                     let event = Event::Pan { alpha, delta };
                     return Some((id, event));

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -341,8 +341,9 @@ impl<'a> EventCx<'a> {
                 }
 
                 if redraw {
-                    self.action(Id::ROOT, Action::REDRAW);
+                    self.window_action(Action::REDRAW);
                 } else if let Some(pan_grab) = pan_grab {
+                    self.need_frame_update = true;
                     if usize::conv(pan_grab.1) < MAX_PAN_GRABS {
                         if let Some(pan) = self.touch.pan_grab.get_mut(usize::conv(pan_grab.0)) {
                             pan.coords[usize::conv(pan_grab.1)].1 = coord;

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -272,7 +272,10 @@ impl<'a> EventCx<'a> {
             }
 
             let id = grab.id.clone();
-            if alpha != DVec2(1.0, 0.0) || delta != DVec2::ZERO {
+            if alpha.is_finite()
+                && delta.is_finite()
+                && (alpha != DVec2(1.0, 0.0) || delta != DVec2::ZERO)
+            {
                 let event = Event::Pan { alpha, delta };
                 self.send_event(node.re(), id, event);
             }

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -48,6 +48,16 @@ impl Quad {
         }
     }
 
+    /// Construct with center and radius
+    #[inline]
+    pub fn from_center(pos: Vec2, r: f32) -> Self {
+        let v = Vec2::splat(r);
+        Quad {
+            a: pos - v,
+            b: pos + v,
+        }
+    }
+
     /// Get the size
     #[inline]
     pub fn size(&self) -> Vec2 {

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -349,6 +349,18 @@ macro_rules! impl_vec2 {
                     true => self.1,
                 }
             }
+
+            /// Returns `true` if all components are neither infinite nor NaN
+            #[inline]
+            pub fn is_finite(self) -> bool {
+                self.0.is_finite() && self.1.is_finite()
+            }
+
+            /// Returns `true` if no components are zero, infinite, submormal or NaN
+            #[inline]
+            pub fn is_normal(self) -> bool {
+                self.0.is_normal() && self.1.is_normal()
+            }
         }
 
         impl Neg for $T {

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -415,6 +415,9 @@ pub trait ThemeDraw {
     /// This may be used to cull hidden items from lists inside a scrollable view.
     fn get_clip_rect(&mut self) -> Rect;
 
+    /// Draw [`EventState`] overlay
+    fn event_state_overlay(&mut self);
+
     /// Draw a frame inside the given `rect`
     ///
     /// The frame dimensions are given by [`ThemeSize::frame`].

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -252,6 +252,20 @@ where
         self.draw.get_clip_rect()
     }
 
+    fn event_state_overlay(&mut self) {
+        if let Some((coord, used)) = self.ev.mouse_pin() {
+            // let r = self.w.dims.scale * 6.0;
+            // let inner = if used { 0.0 } else { 0.6 };
+            let (r, inner) = match used {
+                false => (self.w.dims.scale * 3.6, 0.0),
+                true => (self.w.dims.scale * 6.0, 0.6),
+            };
+            let c = self.cols.accent;
+            self.draw
+                .circle(Quad::from_center(coord.cast(), r), inner, c);
+        }
+    }
+
     fn frame(&mut self, id: &Id, rect: Rect, style: FrameStyle, bg: Background) {
         let outer = Quad::conv(rect);
         match style {

--- a/crates/kas-macros/src/extends.rs
+++ b/crates/kas-macros/src/extends.rs
@@ -64,6 +64,10 @@ impl Extends {
                 (#base).get_clip_rect()
             }
 
+            fn event_state_overlay(&mut self) {
+                (#base).event_state_overlay();
+            }
+
             fn frame(&mut self, id: &Id, rect: Rect, style: ::kas::theme::FrameStyle, bg: Background) {
                 (#base).frame(id, rect, style, bg);
             }


### PR DESCRIPTION
Revised from #491: update need-frame-update which now appears to have fixed all freezes during pan operations (i.e click+drag).

Copied from #491: add click-click-drag gesture, used to enable scale and rotate "panning" by mouse: click to set a fixed point, then click+drag to move a second point. Draw a marker for the fixed point. This only applies to panning operations supporting scaling and/or rotation (test with `examples/mandlebrot`).