### PR TITLE
Revise kinetic scrolling

### DIFF
--- a/crates/kas-core/src/config/config.rs
+++ b/crates/kas-core/src/config/config.rs
@@ -90,7 +90,7 @@ impl Config {
 pub struct WindowConfig {
     pub(super) config: Rc<RefCell<Config>>,
     pub(super) scale_factor: f32,
-    pub(super) scroll_flick_sub: f32,
+    pub(super) kinetic_decay_sub: f32,
     pub(super) scroll_dist: f32,
     pub(super) pan_dist_thresh: f32,
     /// Whether navigation focus is enabled for this application window
@@ -106,7 +106,7 @@ impl WindowConfig {
         WindowConfig {
             config,
             scale_factor: f32::NAN,
-            scroll_flick_sub: f32::NAN,
+            kinetic_decay_sub: f32::NAN,
             scroll_dist: f32::NAN,
             pan_dist_thresh: f32::NAN,
             nav_focus: true,
@@ -118,7 +118,7 @@ impl WindowConfig {
     pub(crate) fn update(&mut self, scale_factor: f32) {
         let base = self.config.borrow();
         self.scale_factor = scale_factor;
-        self.scroll_flick_sub = base.event.scroll_flick_sub * scale_factor;
+        self.kinetic_decay_sub = base.event.kinetic_decay_sub * scale_factor;
         let dpem = base.font.size() * scale_factor;
         self.scroll_dist = base.event.scroll_dist_em * dpem;
         self.pan_dist_thresh = base.event.pan_dist_thresh * scale_factor;

--- a/crates/kas-core/src/config/event.rs
+++ b/crates/kas-core/src/config/event.rs
@@ -27,6 +27,7 @@ pub enum EventConfigMsg {
     PanDistThresh(f32),
     MousePan(MousePan),
     MouseTextPan(MousePan),
+    MouseWheelActions(bool),
     MouseNavFocus(bool),
     TouchNavFocus(bool),
     /// Reset all config values to default (not saved) values
@@ -81,6 +82,9 @@ pub struct EventConfig {
     #[cfg_attr(feature = "serde", serde(default = "defaults::mouse_text_pan"))]
     pub mouse_text_pan: MousePan,
 
+    #[cfg_attr(feature = "serde", serde(default = "defaults::mouse_wheel_actions"))]
+    pub mouse_wheel_actions: bool,
+
     #[cfg_attr(feature = "serde", serde(default = "defaults::mouse_nav_focus"))]
     pub mouse_nav_focus: bool,
     #[cfg_attr(feature = "serde", serde(default = "defaults::touch_nav_focus"))]
@@ -99,6 +103,7 @@ impl Default for EventConfig {
             pan_dist_thresh: defaults::pan_dist_thresh(),
             mouse_pan: defaults::mouse_pan(),
             mouse_text_pan: defaults::mouse_text_pan(),
+            mouse_wheel_actions: defaults::mouse_wheel_actions(),
             mouse_nav_focus: defaults::mouse_nav_focus(),
             touch_nav_focus: defaults::touch_nav_focus(),
         }
@@ -117,6 +122,7 @@ impl EventConfig {
             EventConfigMsg::PanDistThresh(v) => self.pan_dist_thresh = v,
             EventConfigMsg::MousePan(v) => self.mouse_pan = v,
             EventConfigMsg::MouseTextPan(v) => self.mouse_text_pan = v,
+            EventConfigMsg::MouseWheelActions(v) => self.mouse_wheel_actions = v,
             EventConfigMsg::MouseNavFocus(v) => self.mouse_nav_focus = v,
             EventConfigMsg::TouchNavFocus(v) => self.touch_nav_focus = v,
             EventConfigMsg::ResetToDefault => *self = EventConfig::default(),
@@ -196,6 +202,12 @@ impl<'a> EventWindowConfig<'a> {
     #[inline]
     pub fn pan_dist_thresh(&self) -> f32 {
         self.0.pan_dist_thresh
+    }
+
+    /// Whether the mouse wheel may trigger actions such as switching to the next item in a list
+    #[inline]
+    pub fn mouse_wheel_actions(&self) -> bool {
+        self.base().mouse_wheel_actions
     }
 
     /// When to pan general widgets (unhandled events) with the mouse
@@ -281,6 +293,9 @@ mod defaults {
     }
     pub fn pan_dist_thresh() -> f32 {
         5.0
+    }
+    pub fn mouse_wheel_actions() -> bool {
+        true
     }
     pub fn mouse_pan() -> MousePan {
         MousePan::Always

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -87,21 +87,19 @@ impl Glide {
 
     fn step(&mut self, cx: &EventState) -> Option<Offset> {
         let evc = cx.config().event();
-        let (decay_mul, decay_sub) = evc.scroll_flick_decay();
-
         let now = Instant::now();
         let dur = (now - self.t_step).as_secs_f32();
         self.t_step = now;
 
         if let Some(source) = self.press {
-            let grab_mul = 50.0;
-            let decay_sub = decay_sub * grab_mul;
+            let decay_sub = evc.kinetic_grab_sub();
             let grab_vel = cx.press_velocity(source).unwrap_or_default() + self.vel;
 
             let v = self.vel - grab_vel;
             self.vel -= v.abs().min(Vec2::splat(decay_sub * dur)) * v.sign();
         }
 
+        let (decay_mul, decay_sub) = evc.kinetic_decay();
         let v = self.vel * decay_mul.powf(dur);
         self.vel = v - v.abs().min(Vec2::splat(decay_sub * dur)) * v.sign();
 

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -497,7 +497,7 @@ impl TextInput {
                 self.glide.press_start(press.source);
                 action
             }
-            Event::PressMove { press, delta } if press.is_primary() => {
+            Event::PressMove { press, delta, .. } if press.is_primary() => {
                 self.glide.press_move(press.source, delta);
                 match press.source {
                     PressSource::Touch(touch_id) => match self.touch_phase {

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -322,7 +322,7 @@ impl<'a> EventCx<'a> {
 
     pub(crate) fn post_send(&mut self, index: usize) -> Option<Scroll> {
         self.last_child = Some(index);
-        (self.scroll != Scroll::None).then_some(self.scroll)
+        (self.scroll != Scroll::None).then_some(self.scroll.clone())
     }
 
     /// Replay a message as if it was pushed by `id`

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -268,7 +268,6 @@ impl<'a> EventCx<'a> {
         data: &A,
         event: winit::event::WindowEvent,
     ) {
-        use cast::CastApprox;
         use winit::event::WindowEvent::*;
 
         match event {
@@ -335,9 +334,7 @@ impl<'a> EventCx<'a> {
                 }
                 self.modifiers = state;
             }
-            CursorMoved { position, .. } => {
-                self.handle_cursor_moved(win, data, position.cast_approx())
-            }
+            CursorMoved { position, .. } => self.handle_cursor_moved(win, data, position.into()),
             CursorEntered { .. } => self.handle_cursor_entered(),
             CursorLeft { .. } => self.handle_cursor_left(win.as_node(data)),
             MouseWheel { delta, .. } => self.handle_mouse_wheel(win.as_node(data), delta),

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -349,9 +349,7 @@ impl EventState {
     pub fn press_velocity(&self, press: PressSource) -> Option<Vec2> {
         let evc = self.config().event();
         match press {
-            PressSource::Mouse(_, _) => {
-                Some(self.mouse.samples.velocity(evc.scroll_flick_timeout()))
-            }
+            PressSource::Mouse(_, _) => Some(self.mouse.samples.velocity(evc.kinetic_timeout())),
             PressSource::Touch(id) => self.touch.velocity(id, evc),
         }
     }

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -228,7 +228,7 @@ impl Touch {
             .unwrap_or(u16::MAX);
         self.velocity
             .get(v as usize)
-            .map(|sampler| sampler.velocity(evc.scroll_flick_timeout()))
+            .map(|sampler| sampler.velocity(evc.kinetic_timeout()))
     }
 }
 

--- a/crates/kas-core/src/event/cx/press/velocity.rs
+++ b/crates/kas-core/src/event/cx/press/velocity.rs
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Event handling: mouse / touch velocity sampling
+//!
+//! The goal here is to yield estimates of velocity (in pixels per second) for
+//! mouse motion and touch swipe events. Estimates should be smooth (ideally at
+//! least two delta samples) and responsive (ideally no longer than the period
+//! of one frame).
+//!
+//! From a cursory web search and some tests on available devices:
+//!
+//! - Common (basic) mice usually report at 125 Hz while gaming mice commonly
+//!   report at 1 kHz (potentially up to 8 kHz)
+//! - Some touchscreens report at ~100 Hz while modern phone touchscreens often
+//!   report at twice the screen refresh rate (with some gaming phones using
+//!   ~1-2 kHz).
+//! - A Windows Precision Touchpad is required to report at 125 Hz; my Elan
+//!   touchpad reports at 150 Hz.
+//! - Troubleshooting requests attest that rates are sometimes much lower (as
+//!   low as 30 Hz).
+//!
+//! A sample period of `3500 / screen_refresh_hz` ms should allow at least 3
+//! (delta) samples while providing 7 in the common 125 Hz mouse, 60 Hz screen
+//! case. Provided we ignore deltas of zero, we may limit our sample buffer to
+//! a relatively small size (e.g. 8 samples) without making results too jittery;
+//! this also improves responsiveness when the sample rate is high.
+
+use crate::geom::Vec2;
+use smallvec::SmallVec;
+use std::time::{Duration, Instant};
+
+const MAX_SAMPLES: usize = 8;
+
+/// A buffer of recent delta samples used to estimate velocity
+#[derive(Clone, Debug, Default)]
+pub(super) struct Samples {
+    samples: SmallVec<[(Instant, Vec2); MAX_SAMPLES]>,
+    next: usize, // index of next insert
+}
+
+impl Samples {
+    /// Clear all samples
+    pub(super) fn clear(&mut self) {
+        self.samples.clear();
+        self.next = 0;
+    }
+
+    /// Push a new sample
+    pub(super) fn push_delta(&mut self, delta: Vec2) {
+        let now = Instant::now();
+        if self.samples.len() < MAX_SAMPLES {
+            self.samples.push((now, delta));
+        } else {
+            self.samples[self.next] = (now, delta);
+            self.next = (self.next + 1) % MAX_SAMPLES;
+        }
+    }
+
+    /// Calculate average velocity over a given sample `period`
+    ///
+    /// Units: pixels per second.
+    pub(super) fn velocity(&self, period: Duration) -> Vec2 {
+        let now = Instant::now();
+        let start = now - period; // saturating_sub
+
+        let mut delta = Vec2::ZERO;
+        for sample in &self.samples {
+            if sample.0 > start {
+                delta += sample.1;
+            }
+        }
+
+        delta / period.as_secs_f32()
+    }
+}

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -5,6 +5,7 @@
 
 //! Event handling: events
 
+use cast::CastApprox;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -748,6 +749,21 @@ impl ScrollDelta {
             Ok(self.as_factor(cx))
         } else {
             Err(self.as_offset(cx))
+        }
+    }
+
+    /// Attempt to interpret as a mouse wheel action
+    ///
+    /// Infers the "scroll delta" as an integral step, if appropriate.
+    /// This may be used e.g. to change the selected value of a `ComboBox`.
+    ///
+    /// Positive values indicate scrolling up.
+    pub fn as_wheel_action(self, cx: &EventState) -> Option<i32> {
+        match self {
+            ScrollDelta::Lines(_, y) if cx.config().event().mouse_wheel_actions() => {
+                y.try_cast_approx().ok()
+            }
+            _ => None,
         }
     }
 }

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -285,7 +285,7 @@ impl Event {
             Event::PressStart { press, .. } if press.is_primary() => {
                 press.grab(id, GrabMode::Click).complete(cx)
             }
-            Event::PressEnd { press, success } => {
+            Event::PressEnd { press, success, .. } => {
                 if success && id == press.id {
                     f(cx)
                 } else {

--- a/crates/kas-core/src/event/response.rs
+++ b/crates/kas-core/src/event/response.rs
@@ -9,6 +9,8 @@ use crate::geom::{Offset, Rect};
 
 pub use IsUsed::{Unused, Used};
 
+use super::components::GlideStart;
+
 /// Return type of event-handling methods
 ///
 /// This type is convertible to/from `bool` and supports the expected bit-wise
@@ -71,7 +73,7 @@ impl std::ops::Not for IsUsed {
 /// Request to / notification of scrolling from a child
 ///
 /// See: [`EventCx::set_scroll`](super::EventCx::set_scroll).
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[must_use]
 pub enum Scroll {
     /// No scrolling
@@ -91,6 +93,8 @@ pub enum Scroll {
     /// With the usual scroll offset conventions, this delta must be subtracted
     /// from the scroll offset.
     Offset(Offset),
+    /// Start glide scrolling
+    Glide(GlideStart),
     /// Focus the given rect
     Rect(Rect),
 }

--- a/crates/kas-core/src/event/response.rs
+++ b/crates/kas-core/src/event/response.rs
@@ -9,7 +9,7 @@ use crate::geom::{Offset, Rect};
 
 pub use IsUsed::{Unused, Used};
 
-use super::components::GlideStart;
+use super::components::KineticStart;
 
 /// Return type of event-handling methods
 ///
@@ -93,8 +93,8 @@ pub enum Scroll {
     /// With the usual scroll offset conventions, this delta must be subtracted
     /// from the scroll offset.
     Offset(Offset),
-    /// Start glide scrolling
-    Glide(GlideStart),
+    /// Start kinetic scrolling
+    Kinetic(KineticStart),
     /// Focus the given rect
     Rect(Rect),
 }

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -348,6 +348,18 @@ macro_rules! impl_vec2 {
                 self.0 * self.0 + self.1 * self.1
             }
 
+            /// Return the L1 (rectilinear / taxicab) distance
+            #[inline]
+            pub fn distance_l1(self) -> $f {
+                self.0.abs() + self.1.abs()
+            }
+
+            /// Return the L-inf (max) distance
+            #[inline]
+            pub fn distance_l_inf(self) -> $f {
+                self.0.abs().max(self.1.abs())
+            }
+
             /// Extract one component, based on a direction
             ///
             /// This merely extracts the horizontal or vertical component.
@@ -516,6 +528,22 @@ macro_rules! impl_vec2 {
             #[inline]
             fn try_conv(v: $T) -> Result<Self> {
                 Ok(Self::conv(v))
+            }
+        }
+
+        #[cfg(winit)]
+        impl From<winit::dpi::PhysicalPosition<$f>> for $T {
+            #[inline]
+            fn from(pos: winit::dpi::PhysicalPosition<$f>) -> Self {
+                $T(pos.x, pos.y)
+            }
+        }
+
+        #[cfg(winit)]
+        impl From<winit::dpi::PhysicalSize<$f>> for $T {
+            #[inline]
+            fn from(size: winit::dpi::PhysicalSize<$f>) -> Self {
+                $T(size.width, size.height)
             }
         }
     };

--- a/crates/kas-core/src/messages.rs
+++ b/crates/kas-core/src/messages.rs
@@ -169,7 +169,7 @@ impl MessageStack {
 impl Drop for MessageStack {
     fn drop(&mut self) {
         for msg in self.stack.drain(..) {
-            if msg.is::<crate::event::components::GlideStart>() {
+            if msg.is::<crate::event::components::KineticStart>() {
                 // We can safely ignore this message
                 continue;
             }

--- a/crates/kas-core/src/messages.rs
+++ b/crates/kas-core/src/messages.rs
@@ -169,6 +169,11 @@ impl MessageStack {
 impl Drop for MessageStack {
     fn drop(&mut self) {
         for msg in self.stack.drain(..) {
+            if msg.is::<crate::event::components::GlideStart>() {
+                // We can safely ignore this message
+                continue;
+            }
+
             log::warn!(target: "kas_core::erased", "unhandled: {msg:?}");
         }
     }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -798,9 +798,8 @@ impl_scope! {
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx, data: &C::Data, scroll: Scroll) {
-            let act = self.scroll.scroll(cx, self.rect(), scroll);
+            self.scroll.scroll(cx, self.id(), self.rect(), scroll);
             self.update_widgets(&mut cx.config_cx(), data, false);
-            cx.action(self, act);
         }
     }
 

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -729,7 +729,7 @@ impl_scope! {
                         let w = &mut self.widgets[index];
                         if success
                             && !matches!(self.sel_mode, SelectionMode::None)
-                            && !self.scroll.is_gliding()
+                            && !self.scroll.is_kinetic_scrolling()
                             && w.key.as_ref().map(|k| k == key).unwrap_or(false)
                             && w.widget.rect().contains(press.coord + self.scroll.offset())
                         {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -662,7 +662,7 @@ impl_scope! {
         fn update_recurse(&mut self, _: &mut ConfigCx, _: &Self::Data) {}
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &C::Data, event: Event) -> IsUsed {
-            let is_used = match event {
+            let mut is_used = match event {
                 Event::Command(cmd, _) => {
                     let last = self.clerk.len(data).wrapping_sub(1);
                     if last == usize::MAX {
@@ -745,15 +745,14 @@ impl_scope! {
                 _ => Unused, // fall through to scroll handler
             };
 
-            let (moved, used_by_sber) = self
-                .scroll
-                .scroll_by_event(cx, event, self.id(), self.rect());
-            if moved {
+            let offset = self.scroll.offset();
+            is_used |= self.scroll.scroll_by_event(cx, event, self.id(), self.rect());
+            if offset != self.scroll.offset() {
                 // We may process multiple 'moved' events per frame; TIMER_UPDATE_WIDGETS will only
                 // be processed once per frame.
                 cx.request_frame_timer(self.id(), TIMER_UPDATE_WIDGETS);
             }
-            is_used | used_by_sber
+            is_used
         }
 
         fn handle_messages(&mut self, cx: &mut EventCx, data: &C::Data) {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -772,9 +772,8 @@ impl_scope! {
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx, data: &C::Data, scroll: Scroll) {
-            let act = self.scroll.scroll(cx, self.rect(), scroll);
+            self.scroll.scroll(cx, self.id(), self.rect(), scroll);
             self.update_widgets(&mut cx.config_cx(), data, false);
-            cx.action(self, act);
         }
     }
 

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -623,7 +623,7 @@ impl_scope! {
         fn update_recurse(&mut self, _: &mut ConfigCx, _: &Self::Data) {}
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &C::Data, event: Event) -> IsUsed {
-            let is_used = match event {
+            let mut is_used = match event {
                 Event::Command(cmd, _) => {
                     if self.data_len == Size::ZERO {
                         return Unused;
@@ -719,15 +719,14 @@ impl_scope! {
                 _ => Unused, // fall through to scroll handler
             };
 
-            let (moved, used_by_sber) = self
-                .scroll
-                .scroll_by_event(cx, event, self.id(), self.rect());
-            if moved {
+            let offset = self.scroll.offset();
+            is_used |= self.scroll.scroll_by_event(cx, event, self.id(), self.rect());
+            if offset != self.scroll.offset() {
                 // We may process multiple 'moved' events per frame; TIMER_UPDATE_WIDGETS will only
                 // be processed once per frame.
                 cx.request_frame_timer(self.id(), TIMER_UPDATE_WIDGETS);
             }
-            is_used | used_by_sber
+            is_used
         }
 
         fn handle_messages(&mut self, cx: &mut EventCx, data: &C::Data) {

--- a/crates/kas-view/src/matrix_view.rs
+++ b/crates/kas-view/src/matrix_view.rs
@@ -703,7 +703,7 @@ impl_scope! {
                         let w = &mut self.widgets[index];
                         if success
                             && !matches!(self.sel_mode, SelectionMode::None)
-                            && !self.scroll.is_gliding()
+                            && !self.scroll.is_kinetic_scrolling()
                             && w.key.as_ref().map(|k| k == key).unwrap_or(false)
                             && w.widget.rect().contains(press.coord + self.scroll.offset())
                         {

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -906,7 +906,7 @@ impl_scope! {
                 event => match self.input_handler.handle(cx, self.id(), event) {
                     TextInputAction::None => Used,
                     TextInputAction::Unused => Unused,
-                    TextInputAction::Pan(delta, glide) => self.pan_delta(cx, delta, glide),
+                    TextInputAction::Pan(delta, kinetic) => self.pan_delta(cx, delta, kinetic),
                     TextInputAction::Focus { coord, action } => {
                         if let Some(coord) = coord {
                             self.set_edit_pos_from_coord(cx, coord);
@@ -1620,7 +1620,7 @@ impl<G: EditGuard> EditField<G> {
     }
 
     // Pan by given delta.
-    fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset, glide: bool) -> IsUsed {
+    fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset, kinetic: bool) -> IsUsed {
         let new_offset = (self.view_offset - delta)
             .min(self.max_scroll_offset())
             .max(Offset::ZERO);
@@ -1629,7 +1629,7 @@ impl<G: EditGuard> EditField<G> {
             self.view_offset = new_offset;
         }
 
-        self.input_handler.set_scroll_residual(cx, delta, glide);
+        self.input_handler.set_scroll_residual(cx, delta, kinetic);
         Used
     }
 

--- a/crates/kas-widgets/src/event_config.rs
+++ b/crates/kas-widgets/src/event_config.rs
@@ -50,12 +50,14 @@ impl_scope! {
             (0, 8) => "Mouse text pan:",
             (1..3, 8) => self.mouse_text_pan,
 
-            (1..3, 9) => self.mouse_nav_focus,
+            (1..3, 9) => self.mouse_wheel_actions,
 
-            (1..3, 10) => self.touch_nav_focus,
+            (1..3, 10) => self.mouse_nav_focus,
 
-            (0, 11) => "Restore default values:",
-            (1..3, 11) => Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
+            (1..3, 11) => self.touch_nav_focus,
+
+            (0, 12) => "Restore default values:",
+            (1..3, 12) => Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
         };
     }]
     #[impl_default(EventConfig::new())]
@@ -79,6 +81,8 @@ impl_scope! {
         mouse_pan: ComboBox<(), MousePan>,
         #[widget]
         mouse_text_pan: ComboBox<(), MousePan>,
+        #[widget]
+        mouse_wheel_actions: CheckButton<()>,
         #[widget]
         mouse_nav_focus: CheckButton<()>,
         #[widget]
@@ -135,6 +139,11 @@ impl_scope! {
                     pan_options,
                     |cx: &ConfigCx, _| cx.config().base().event.mouse_text_pan,
                     EventConfigMsg::MouseTextPan,
+                ),
+                mouse_wheel_actions: CheckButton::new_msg(
+                    "Mouse &wheel actions",
+                    |cx: &ConfigCx, _| cx.config().base().event.mouse_wheel_actions,
+                    EventConfigMsg::MouseWheelActions,
                 ),
                 mouse_nav_focus: CheckButton::new_msg(
                     "&Mouse navigation focus",

--- a/crates/kas-widgets/src/event_config.rs
+++ b/crates/kas-widgets/src/event_config.rs
@@ -28,36 +28,39 @@ impl_scope! {
             (1, 1) => self.touch_select_delay,
             (2, 1) => "ms",
 
-            (0, 2) => "Scroll flick timeout:",
-            (1, 2) => self.scroll_flick_timeout,
+            (0, 2) => "Kinetic scrolling timeout:",
+            (1, 2) => self.kinetic_timeout,
             (2, 2) => "ms",
 
-            (0, 3) => "Scroll flick multiply:",
-            (1, 3) => self.scroll_flick_mul,
+            (0, 3) => "Kinetic decay (relative):",
+            (1, 3) => self.kinetic_decay_mul,
 
-            (0, 4) => "Scroll flick subtract:",
-            (1, 4) => self.scroll_flick_sub,
+            (0, 4) => "Kinetic decay (absolute):",
+            (1, 4) => self.kinetic_decay_sub,
 
-            (0, 5) => "Scroll wheel distance:",
-            (1, 5) => self.scroll_dist_em, (2, 5) => "em",
+            (0, 5) => "Kinetic decay when grabbed:",
+            (1, 5) => self.kinetic_grab_sub,
 
-            (0, 6) => "Pan distance threshold:",
-            (1, 6) => self.pan_dist_thresh,
+            (0, 6) => "Scroll wheel distance:",
+            (1, 6) => self.scroll_dist_em, (2, 6) => "em",
 
-            (0, 7) => "Mouse pan:",
-            (1..3, 7) => self.mouse_pan,
+            (0, 7) => "Pan distance threshold:",
+            (1, 7) => self.pan_dist_thresh,
 
-            (0, 8) => "Mouse text pan:",
-            (1..3, 8) => self.mouse_text_pan,
+            (0, 8) => "Mouse pan:",
+            (1..3, 8) => self.mouse_pan,
 
-            (1..3, 9) => self.mouse_wheel_actions,
+            (0, 9) => "Mouse text pan:",
+            (1..3, 9) => self.mouse_text_pan,
 
-            (1..3, 10) => self.mouse_nav_focus,
+            (1..3, 10) => self.mouse_wheel_actions,
 
-            (1..3, 11) => self.touch_nav_focus,
+            (1..3, 11) => self.mouse_nav_focus,
 
-            (0, 12) => "Restore default values:",
-            (1..3, 12) => Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
+            (1..3, 12) => self.touch_nav_focus,
+
+            (0, 13) => "Restore default values:",
+            (1..3, 13) => Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
         };
     }]
     #[impl_default(EventConfig::new())]
@@ -68,11 +71,13 @@ impl_scope! {
         #[widget]
         touch_select_delay: Spinner<(), u32>,
         #[widget]
-        scroll_flick_timeout: Spinner<(), u32>,
+        kinetic_timeout: Spinner<(), u32>,
         #[widget]
-        scroll_flick_mul: Spinner<(), f32>,
+        kinetic_decay_mul: Spinner<(), f32>,
         #[widget]
-        scroll_flick_sub: Spinner<(), f32>,
+        kinetic_decay_sub: Spinner<(), f32>,
+        #[widget]
+        kinetic_grab_sub: Spinner<(), f32>,
         #[widget]
         scroll_dist_em: Spinner<(), f32>,
         #[widget]
@@ -115,15 +120,18 @@ impl_scope! {
                 touch_select_delay: Spinner::new(0..=5_000, |cx: &ConfigCx, _| cx.config().base().event.touch_select_delay_ms)
                     .with_step(50)
                     .with_msg(EventConfigMsg::TouchSelectDelay),
-                scroll_flick_timeout: Spinner::new(0..=500, |cx: &ConfigCx, _| cx.config().base().event.scroll_flick_timeout_ms)
+                kinetic_timeout: Spinner::new(0..=500, |cx: &ConfigCx, _| cx.config().base().event.kinetic_timeout_ms)
                     .with_step(5)
-                    .with_msg(EventConfigMsg::ScrollFlickTimeout),
-                scroll_flick_mul: Spinner::new(0.0..=1.0, |cx: &ConfigCx, _| cx.config().base().event.scroll_flick_mul)
+                    .with_msg(EventConfigMsg::KineticTimeout),
+                kinetic_decay_mul: Spinner::new(0.0..=1.0, |cx: &ConfigCx, _| cx.config().base().event.kinetic_decay_mul)
                     .with_step(0.0625)
-                    .with_msg(EventConfigMsg::ScrollFlickMul),
-                scroll_flick_sub: Spinner::new(0.0..=1.0e4, |cx: &ConfigCx, _| cx.config().base().event.scroll_flick_sub)
+                    .with_msg(EventConfigMsg::KineticDecayMul),
+                kinetic_decay_sub: Spinner::new(0.0..=1.0e4, |cx: &ConfigCx, _| cx.config().base().event.kinetic_decay_sub)
                     .with_step(10.0)
-                    .with_msg(EventConfigMsg::ScrollFlickSub),
+                    .with_msg(EventConfigMsg::KineticDecaySub),
+                kinetic_grab_sub: Spinner::new(0.0..=1.0e4, |cx: &ConfigCx, _| cx.config().base().event.kinetic_grab_sub)
+                    .with_step(5.0)
+                    .with_msg(EventConfigMsg::KineticGrabSub),
                 scroll_dist_em: Spinner::new(0.125..=125.0, |cx: &ConfigCx, _| cx.config().base().event.scroll_dist_em)
                     .with_step(0.125)
                     .with_msg(EventConfigMsg::ScrollDistEm),

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -141,9 +141,7 @@ impl_scope! {
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
-            self.scroll
-                .scroll_by_event(cx, event, self.id(), self.rect())
-                .1
+            self.scroll.scroll_by_event(cx, event, self.id(), self.rect())
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx, _: &Self::Data, scroll: Scroll) {

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -145,8 +145,7 @@ impl_scope! {
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx, _: &Self::Data, scroll: Scroll) {
-            let action = self.scroll.scroll(cx, self.rect(), scroll);
-            cx.action(self, action);
+            self.scroll.scroll(cx, self.id(), self.rect(), scroll);
         }
     }
 }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -141,7 +141,7 @@ impl_scope! {
         }
 
         // Pan by given delta.
-        fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset, glide: bool) -> IsUsed {
+        fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset, kinetic: bool) -> IsUsed {
             let new_offset = (self.view_offset - delta)
                 .min(self.max_scroll_offset())
                 .max(Offset::ZERO);
@@ -150,7 +150,7 @@ impl_scope! {
                 self.set_offset(cx, new_offset);
             }
 
-            self.input_handler.set_scroll_residual(cx, delta, glide);
+            self.input_handler.set_scroll_residual(cx, delta, kinetic);
             Used
         }
 
@@ -253,7 +253,7 @@ impl_scope! {
                 event => match self.input_handler.handle(cx, self.id(), event) {
                     TextInputAction::None => Used,
                     TextInputAction::Unused => Unused,
-                    TextInputAction::Pan(delta, glide) => self.pan_delta(cx, delta, glide),
+                    TextInputAction::Pan(delta, kinetic) => self.pan_delta(cx, delta, kinetic),
                     TextInputAction::Focus { coord, action } => {
                         if let Some(coord) = coord {
                             self.set_edit_pos_from_coord(cx, coord);

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -141,7 +141,7 @@ impl_scope! {
         }
 
         // Pan by given delta.
-        fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset) -> IsUsed {
+        fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset, glide: bool) -> IsUsed {
             let new_offset = (self.view_offset - delta)
                 .min(self.max_scroll_offset())
                 .max(Offset::ZERO);
@@ -150,11 +150,7 @@ impl_scope! {
                 self.set_offset(cx, new_offset);
             }
 
-            cx.set_scroll(if delta == Offset::ZERO {
-                Scroll::Scrolled
-            } else {
-                Scroll::Offset(delta)
-            });
+            self.input_handler.set_scroll_residual(cx, delta, glide);
             Used
         }
 
@@ -252,12 +248,12 @@ impl_scope! {
                     Used
                 }
                 Event::Scroll(delta) => {
-                    self.pan_delta(cx, delta.as_offset(cx))
+                    self.pan_delta(cx, delta.as_offset(cx), false)
                 }
                 event => match self.input_handler.handle(cx, self.id(), event) {
                     TextInputAction::None => Used,
                     TextInputAction::Unused => Unused,
-                    TextInputAction::Pan(delta) => self.pan_delta(cx, delta),
+                    TextInputAction::Pan(delta, glide) => self.pan_delta(cx, delta, glide),
                     TextInputAction::Focus { coord, action } => {
                         if let Some(coord) = coord {
                             self.set_edit_pos_from_coord(cx, coord);

--- a/crates/kas-widgets/src/scroll_text.rs
+++ b/crates/kas-widgets/src/scroll_text.rs
@@ -122,7 +122,7 @@ impl_scope! {
         }
 
         // Pan by given delta.
-        fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset) -> IsUsed {
+        fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset, glide: bool) -> IsUsed {
             let new_offset = (self.view_offset - delta)
                 .min(self.max_scroll_offset())
                 .max(Offset::ZERO);
@@ -131,11 +131,7 @@ impl_scope! {
                 self.set_offset(cx, new_offset);
             }
 
-            cx.set_scroll(if delta == Offset::ZERO {
-                Scroll::Scrolled
-            } else {
-                Scroll::Offset(delta)
-            });
+            self.input_handler.set_scroll_residual(cx, delta, glide);
             Used
         }
 
@@ -235,12 +231,12 @@ impl_scope! {
                     Used
                 }
                 Event::Scroll(delta) => {
-                    self.pan_delta(cx, delta.as_offset(cx))
+                    self.pan_delta(cx, delta.as_offset(cx), false)
                 }
                 event => match self.input_handler.handle(cx, self.id(), event) {
                     TextInputAction::None => Used,
                     TextInputAction::Unused => Unused,
-                    TextInputAction::Pan(delta) => self.pan_delta(cx, delta),
+                    TextInputAction::Pan(delta, glide) => self.pan_delta(cx, delta, glide),
                     TextInputAction::Focus { coord, action } => {
                         if let Some(coord) = coord {
                             self.set_edit_pos_from_coord(cx, coord);

--- a/crates/kas-widgets/src/scroll_text.rs
+++ b/crates/kas-widgets/src/scroll_text.rs
@@ -122,7 +122,7 @@ impl_scope! {
         }
 
         // Pan by given delta.
-        fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset, glide: bool) -> IsUsed {
+        fn pan_delta(&mut self, cx: &mut EventCx, mut delta: Offset, kinetic: bool) -> IsUsed {
             let new_offset = (self.view_offset - delta)
                 .min(self.max_scroll_offset())
                 .max(Offset::ZERO);
@@ -131,7 +131,7 @@ impl_scope! {
                 self.set_offset(cx, new_offset);
             }
 
-            self.input_handler.set_scroll_residual(cx, delta, glide);
+            self.input_handler.set_scroll_residual(cx, delta, kinetic);
             Used
         }
 
@@ -236,7 +236,7 @@ impl_scope! {
                 event => match self.input_handler.handle(cx, self.id(), event) {
                     TextInputAction::None => Used,
                     TextInputAction::Unused => Unused,
-                    TextInputAction::Pan(delta, glide) => self.pan_delta(cx, delta, glide),
+                    TextInputAction::Pan(delta, kinetic) => self.pan_delta(cx, delta, kinetic),
                     TextInputAction::Focus { coord, action } => {
                         if let Some(coord) = coord {
                             self.set_edit_pos_from_coord(cx, coord);

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -496,7 +496,6 @@ fn filter_list() -> Box<dyn Widget<Data = AppData>> {
             }
 
             if filter != edit.guard.0 {
-                eprintln!("New filter: {filter:?}");
                 edit.guard.0 = filter;
                 cx.push(FilterUpdate);
             }


### PR DESCRIPTION
Mouse cursor and touch velocity is now always sampled and available through `fn EventState::press_velocity`.

"Glide scrolling" is rebranded under the more common name "kinetic scrolling" and significantly improved.