### PR TITLE
Support Swash glyph rastering; restrict kas::text re-exports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,8 @@ markdown = ["kas-core/markdown"]
 # Enable text shaping
 shaping = ["kas-core/shaping"]
 
-# Use Swash or fontdue to raster glyphs (instead of ab_glyph)
+# Enable Swash and/or fontdue glyph rasterers
+# See field mode of struct RasterConfig for selection.
 swash = ["kas-wgpu?/swash"]
 fontdue = ["kas-wgpu?/fontdue"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,4 +156,4 @@ members = [
 
 [patch.crates-io.kas-text]
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "f226c7e"
+rev = "1f5a9a4c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,3 +153,7 @@ members = [
     "crates/kas-view",
     "examples/mandlebrot",
 ]
+
+[patch.crates-io.kas-text]
+git = "https://github.com/kas-gui/kas-text.git"
+rev = "f226c7e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,10 @@ markdown = ["kas-core/markdown"]
 # Enable text shaping
 shaping = ["kas-core/shaping"]
 
+# Use Swash or fontdue to raster glyphs (instead of ab_glyph)
+swash = ["kas-wgpu?/swash"]
+fontdue = ["kas-wgpu?/fontdue"]
+
 # Enable serde support (mainly config read/write)
 serde = ["kas-core/serde"]
 

--- a/crates/kas-core/src/config/font.rs
+++ b/crates/kas-core/src/config/font.rs
@@ -79,6 +79,13 @@ impl Default for FontConfig {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RasterConfig {
     //// Raster mode/engine (backend dependent)
+    ////
+    /// The `mode` parameter selects rendering mode (though depending on crate
+    /// features, not all options will be available):
+    ///
+    /// -   `mode == 0` (default): use `ab_glyph` for rastering
+    /// -   `mode == 1`: use `ab_glyph` and align glyphs to side bearings
+    /// -   `mode == 2`: use `fontdue` for rastering
     #[cfg_attr(feature = "serde", serde(default))]
     pub mode: u8,
     /// Scale multiplier for fixed-precision

--- a/crates/kas-core/src/config/font.rs
+++ b/crates/kas-core/src/config/font.rs
@@ -83,10 +83,12 @@ pub struct RasterConfig {
     /// The `mode` parameter selects rendering mode (though depending on crate
     /// features, not all options will be available):
     ///
-    /// -   `mode == 0` (default): use `ab_glyph` for rastering
+    /// -   `mode == 0`: use `ab_glyph` for rastering
     /// -   `mode == 1`: use `ab_glyph` and align glyphs to side bearings
     /// -   `mode == 2`: use `fontdue` for rastering
-    #[cfg_attr(feature = "serde", serde(default))]
+    /// -   `mode == 3`: use `swash` for rastering
+    /// -   `mode == 4`: use `swash` for rastering with hinting
+    #[cfg_attr(feature = "serde", serde(default = "defaults::mode"))]
     pub mode: u8,
     /// Scale multiplier for fixed-precision
     ///
@@ -223,6 +225,9 @@ mod defaults {
         list.iter().cloned().collect()
     }
 
+    pub fn mode() -> u8 {
+        4
+    }
     pub fn scale_steps() -> u8 {
         4
     }

--- a/crates/kas-core/src/config/font.rs
+++ b/crates/kas-core/src/config/font.rs
@@ -81,7 +81,9 @@ pub struct RasterConfig {
     //// Raster mode/engine (backend dependent)
     ////
     /// The `mode` parameter selects rendering mode (though depending on crate
-    /// features, not all options will be available):
+    /// features, not all options will be available). The default mode is `4`.
+    /// In case the crate is built without the required `fontdue` or `swash`
+    /// feature, the rasterer falls back to mode `0`.
     ///
     /// -   `mode == 0`: use `ab_glyph` for rastering
     /// -   `mode == 1`: use `ab_glyph` and align glyphs to side bearings

--- a/crates/kas-core/src/config/font.rs
+++ b/crates/kas-core/src/config/font.rs
@@ -126,7 +126,7 @@ pub struct RasterConfig {
 impl Default for RasterConfig {
     fn default() -> Self {
         RasterConfig {
-            mode: 0,
+            mode: defaults::mode(),
             scale_steps: defaults::scale_steps(),
             subpixel_threshold: defaults::subpixel_threshold(),
             subpixel_steps: defaults::subpixel_steps(),

--- a/crates/kas-core/src/text/mod.rs
+++ b/crates/kas-core/src/text/mod.rs
@@ -13,7 +13,10 @@
 //!
 //! [KAS Text]: https://github.com/kas-gui/kas-text/
 
-pub use kas_text::*;
+pub use kas_text::{
+    fonts, format, Align, Direction, Effect, EffectFlags, MarkerPos, MarkerPosIter, NotReady,
+    OwningVecIter, Range, Status, Text, TextDisplay, Vec2, DPU,
+};
 
 mod selection;
 pub use selection::{SelectionAction, SelectionHelper};

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -11,7 +11,7 @@ use crate::cast::Cast;
 #[allow(unused)] use crate::event::ConfigCx;
 use crate::geom::{Rect, Size};
 use crate::layout::{AlignHints, AxisInfo, SizeRules};
-use crate::text::fonts::{FaceId, FontId, InvalidFontId};
+use crate::text::fonts::{FontId, InvalidFontId};
 use crate::text::format::{EditableText, FormattableText};
 use crate::text::*;
 use crate::{Action, Layout};
@@ -600,47 +600,6 @@ impl<T: FormattableText> Text<T> {
     /// See [`TextDisplay::text_glyph_pos`].
     pub fn text_glyph_pos(&self, index: usize) -> Result<MarkerPosIter, NotReady> {
         Ok(self.display()?.text_glyph_pos(index))
-    }
-
-    /// Yield a sequence of positioned glyphs
-    ///
-    /// See [`TextDisplay::glyphs`].
-    pub fn glyphs<F: FnMut(FaceId, f32, Glyph)>(&self, f: F) -> Result<(), NotReady> {
-        Ok(self.display()?.glyphs(f))
-    }
-
-    /// Like [`TextDisplay::glyphs`] but with added effects
-    ///
-    /// See [`TextDisplay::glyphs_with_effects`].
-    pub fn glyphs_with_effects<X, F, G>(
-        &self,
-        effects: &[Effect<X>],
-        default_aux: X,
-        f: F,
-        g: G,
-    ) -> Result<(), NotReady>
-    where
-        X: Copy,
-        F: FnMut(FaceId, f32, Glyph, usize, X),
-        G: FnMut(f32, f32, f32, f32, usize, X),
-    {
-        Ok(self
-            .display()?
-            .glyphs_with_effects(effects, default_aux, f, g))
-    }
-
-    /// Yield a sequence of rectangles to highlight a given text range
-    ///
-    /// Calls `f(top_left, bottom_right)` for each highlighting rectangle.
-    pub fn highlight_range<F>(
-        &self,
-        range: std::ops::Range<usize>,
-        mut f: F,
-    ) -> Result<(), NotReady>
-    where
-        F: FnMut(Vec2, Vec2),
-    {
-        Ok(self.display()?.highlight_range(range, &mut f))
     }
 }
 

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -37,6 +37,7 @@ harfbuzz = ["kas-text/harfbuzz"]
 raster = ["ab_glyph"]
 ab_glyph = ["kas-text/ab_glyph", "dep:ab_glyph"]
 fontdue = ["kas-text/fontdue"]
+swash = ["kas-text/swash", "dep:swash"]
 
 [dependencies]
 bytemuck = "1.7.0"
@@ -55,6 +56,11 @@ path = "../kas-core"
 
 [dependencies.kas-text]
 version = "0.7.0"
+
+[dependencies.swash]
+version = "0.2.4"
+optional = true
+features = ["scale"]
 
 [dependencies.wgpu]
 version = "25.0.0"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -16,7 +16,6 @@ features = ["kas/winit", "kas/wayland"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-# WARNING: if "raster" is disabled, an alternative like "kas-text/fontdue" is required!
 default = ["shaping", "raster"]
 
 # Enables documentation of APIs for graphics library and platform backends.
@@ -34,7 +33,8 @@ metal = ["wgpu/metal"]
 shaping = ["kas-text/shaping"]
 harfbuzz = ["kas-text/harfbuzz"]
 
-raster = ["ab_glyph"]
+# Raster backends
+raster = ["ab_glyph"] # default choice
 ab_glyph = ["kas-text/ab_glyph", "dep:ab_glyph"]
 fontdue = ["kas-text/fontdue"]
 swash = ["kas-text/swash", "dep:swash"]

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -34,7 +34,8 @@ metal = ["wgpu/metal"]
 shaping = ["kas-text/shaping"]
 harfbuzz = ["kas-text/harfbuzz"]
 
-raster = ["kas-text/raster"]
+raster = ["ab_glyph"]
+ab_glyph = ["kas-text/ab_glyph", "dep:ab_glyph"]
 fontdue = ["kas-text/fontdue"]
 
 [dependencies]
@@ -44,6 +45,7 @@ log = "0.4"
 thiserror = "2.0.3"
 guillotiere = "0.6.0"
 rustc-hash = "2.0"
+ab_glyph = { version = "0.2.10", optional = true }
 
 [dependencies.kas]
 # Rename package purely for convenience:

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -33,7 +33,9 @@ metal = ["wgpu/metal"]
 
 shaping = ["kas-text/shaping"]
 harfbuzz = ["kas-text/harfbuzz"]
+
 raster = ["kas-text/raster"]
+fontdue = ["kas-text/fontdue"]
 
 [dependencies]
 bytemuck = "1.7.0"

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -11,10 +11,24 @@ use kas::config::RasterConfig;
 use kas::draw::{color::Rgba, AllocError, PassId};
 use kas::geom::{Quad, Rect, Vec2};
 use kas::text::fonts::{self, FaceId};
-use kas::text::{Effect, Glyph, TextDisplay};
-use kas_text::raster::{raster, Config, SpriteDescriptor};
+use kas::text::{Effect, Glyph, GlyphId, TextDisplay};
 use rustc_hash::FxHashMap as HashMap;
 use std::mem::size_of;
+
+kas::impl_scope! {
+    /// Raster configuration
+    #[derive(Debug, PartialEq)]
+    #[impl_default]
+    pub struct Config {
+        #[allow(unused)]
+        sb_align: bool = false,
+        #[allow(unused)]
+        fontdue: bool = false,
+        scale_steps: f32 = 4.0,
+        subpixel_threshold: f32 = 18.0,
+        subpixel_steps: u8 = 5,
+    }
+}
 
 /// Configuration read/write/format errors
 #[derive(thiserror::Error, Debug)]
@@ -26,6 +40,91 @@ pub enum RasterError {
     #[allow(unused)]
     #[error("zero-sized")]
     Zero,
+}
+
+/// A Sprite descriptor
+///
+/// This descriptor includes all important properties of a rastered glyph in a
+/// small, easily hashable value. It is thus ideal for caching rastered glyphs
+/// in a `HashMap`.
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct SpriteDescriptor(u64);
+
+impl std::fmt::Debug for SpriteDescriptor {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let dpem_steps = ((self.0 & 0x00FF_FFFF_0000_0000) >> 32) as u32;
+        let x_steps = ((self.0 & 0x0F00_0000_0000_0000) >> 56) as u8;
+        let y_steps = ((self.0 & 0xF000_0000_0000_0000) >> 60) as u8;
+        f.debug_struct("SpriteDescriptor")
+            .field("face", &self.face())
+            .field("glyph", &self.glyph())
+            .field("dpem_steps", &dpem_steps)
+            .field("offset_steps", &(x_steps, y_steps))
+            .finish()
+    }
+}
+
+impl SpriteDescriptor {
+    /// Choose a sub-pixel precision multiplier based on scale (pixels per Em)
+    ///
+    /// Must return an integer between 1 and 16.
+    fn sub_pixel_from_dpem(config: &Config, dpem: f32) -> u8 {
+        if dpem < config.subpixel_threshold {
+            config.subpixel_steps
+        } else {
+            1
+        }
+    }
+
+    /// Construct
+    ///
+    /// Most parameters come from [`TextDisplay::glyphs`] output. See also [`raster`].
+    pub fn new(config: &Config, face: FaceId, glyph: Glyph, dpem: f32) -> Self {
+        let face: u16 = face.get().cast();
+        let glyph_id: u16 = glyph.id.0;
+        let steps = Self::sub_pixel_from_dpem(config, dpem);
+        let mult = f32::conv(steps);
+        let dpem = u32::conv_trunc(dpem * config.scale_steps + 0.5);
+        let x_off = u8::conv_trunc(glyph.position.0.fract() * mult) % steps;
+        let y_off = u8::conv_trunc(glyph.position.1.fract() * mult) % steps;
+        assert!(dpem & 0xFF00_0000 == 0 && x_off & 0xF0 == 0 && y_off & 0xF0 == 0);
+        let packed = face as u64
+            | ((glyph_id as u64) << 16)
+            | ((dpem as u64) << 32)
+            | ((x_off as u64) << 56)
+            | ((y_off as u64) << 60);
+        SpriteDescriptor(packed)
+    }
+
+    /// Get `FaceId` descriptor
+    pub fn face(self) -> FaceId {
+        FaceId::from((self.0 & 0x0000_0000_0000_FFFF) as u32)
+    }
+
+    /// Get `GlyphId` descriptor
+    pub fn glyph(self) -> GlyphId {
+        GlyphId(((self.0 & 0x0000_0000_FFFF_0000) >> 16).cast())
+    }
+
+    /// Get scale (pixels per Em)
+    pub fn dpem(self, config: &Config) -> f32 {
+        let dpem_steps = ((self.0 & 0x00FF_FFFF_0000_0000) >> 32) as u32;
+        f32::conv(dpem_steps) / config.scale_steps
+    }
+
+    /// Get fractional position
+    ///
+    /// This may optionally be used (depending on [`Config`]) to improve letter
+    /// spacing at small font sizes. Returns the `(x, y)` offsets in the range
+    /// `0.0 ≤ x < 1.0` (and the same for `y`).
+    pub fn fractional_position(self, config: &Config) -> (f32, f32) {
+        let mult = 1.0 / f32::conv(Self::sub_pixel_from_dpem(config, self.dpem(config)));
+        let x_steps = ((self.0 & 0x0F00_0000_0000_0000) >> 56) as u8;
+        let y_steps = ((self.0 & 0xF000_0000_0000_0000) >> 60) as u8;
+        let x = f32::conv(x_steps) * mult;
+        let y = f32::conv(y_steps) * mult;
+        (x, y)
+    }
 }
 
 /// A Sprite
@@ -149,12 +248,14 @@ impl Pipeline {
     }
 
     pub fn set_raster_config(&mut self, config: &RasterConfig) {
-        self.config = Config::new(
-            config.mode,
-            config.scale_steps,
-            config.subpixel_threshold,
-            config.subpixel_steps,
-        )
+        self.config = Config {
+            sb_align: config.mode == 1,
+            fontdue: config.mode == 2,
+            scale_steps: config.scale_steps.cast(),
+            subpixel_threshold: config.subpixel_threshold.cast(),
+            subpixel_steps: config.subpixel_steps.clamp(1, 16),
+        };
+
         // NOTE: possibly this should force re-drawing of all glyphs, but for
         // now that is out of scope
     }
@@ -227,7 +328,7 @@ impl Pipeline {
         let result = self.raster_fontdue(desc);
 
         #[cfg(not(feature = "fontdue"))]
-        let result = self.raster_kas_text_glyph(desc);
+        let result = self.raster_ab_glyph(desc);
 
         let sprite = match result {
             Ok(sprite) => sprite,
@@ -241,17 +342,53 @@ impl Pipeline {
         sprite
     }
 
-    fn raster_kas_text_glyph(&mut self, desc: SpriteDescriptor) -> Result<Sprite, RasterError> {
-        let rs = raster(&self.config, desc).ok_or(RasterError::Failed)?;
-        let (atlas, _, origin, tex_quad) = self.atlas_pipe.allocate(rs.size)?;
+    #[cfg(not(feature = "fontdue"))]
+    fn raster_ab_glyph(&mut self, desc: SpriteDescriptor) -> Result<Sprite, RasterError> {
+        use ab_glyph::Font;
 
-        self.prepare.push((atlas, origin, rs.size, rs.data));
+        let id = desc.glyph();
+        let face = desc.face();
+        let face_store = fonts::library().get_face_store(face);
+        let dpem = desc.dpem(&self.config);
+
+        let (mut x, y) = desc.fractional_position(&self.config);
+        if self.config.sb_align && desc.dpem(&self.config) >= self.config.subpixel_threshold {
+            let sf = face_store.face_ref().scale_by_dpem(dpem);
+            x -= sf.h_side_bearing(id);
+        }
+
+        let font = face_store.ab_glyph();
+        let scale = dpem * font.height_unscaled() / font.units_per_em().unwrap();
+        let glyph = ab_glyph::Glyph {
+            id: ab_glyph::GlyphId(id.0),
+            scale: scale.into(),
+            position: ab_glyph::point(x, y),
+        };
+        let outline = font.outline_glyph(glyph).ok_or(RasterError::Failed)?;
+
+        let bounds = outline.px_bounds();
+        let offset: (i32, i32) = (bounds.min.x.cast_trunc(), bounds.min.y.cast_trunc());
+        let size = bounds.max - bounds.min;
+        let size = (u32::conv_trunc(size.x), u32::conv_trunc(size.y));
+        if size.0 == 0 || size.1 == 0 {
+            return Err(RasterError::Zero);
+        }
+
+        let mut data = vec![0; usize::conv(size.0 * size.1)];
+        outline.draw(|x, y, c| {
+            // Convert to u8 with saturating conversion, rounding down:
+            data[usize::conv((y * size.0) + x)] = (c * 256.0) as u8;
+        });
+
+        let (atlas, _, origin, tex_quad) = self.atlas_pipe.allocate(size)?;
+
+        self.prepare.push((atlas, origin, size, data));
 
         Ok(Sprite {
             atlas,
             valid: true,
-            size: Vec2(rs.size.0.cast(), rs.size.1.cast()),
-            offset: Vec2(rs.offset.0.cast(), rs.offset.1.cast()),
+            size: Vec2(size.0.cast(), size.1.cast()),
+            offset: Vec2(offset.0.cast(), offset.1.cast()),
             tex_quad,
         })
     }

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -10,8 +10,8 @@ use kas::cast::traits::*;
 use kas::config::RasterConfig;
 use kas::draw::{color::Rgba, AllocError, PassId};
 use kas::geom::{Quad, Rect, Vec2};
-use kas::text::fonts::{self, FaceId};
-use kas::text::{Effect, Glyph, GlyphId, TextDisplay};
+use kas_text::fonts::{self, FaceId};
+use kas_text::{Effect, Glyph, GlyphId, TextDisplay};
 use rustc_hash::FxHashMap as HashMap;
 use std::mem::size_of;
 

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -380,6 +380,10 @@ impl Pipeline {
 
         let sprite = match result {
             Ok(sprite) => sprite,
+            Err(RasterError::Zero) => {
+                // Ignore this common error
+                Sprite::default()
+            }
             Err(err) => {
                 log::warn!("raster_glyph failed: {err}");
                 Sprite::default()


### PR DESCRIPTION
Support using [Swash](https://github.com/dfrg/swash) for glyph rastering as an alternative over `ab_glyph` or `fontique`.

Selectively import some parts of `kas_text` into `kas::text`, hiding parts which are not of interest to `kas_core` or widgets. `kas_wgpu` thus requires some direct imports from `kas_text`.

Migrate `kas_text::raster` code into `kas_wgpu`. See also https://github.com/kas-gui/kas-text/pull/91.