### PR TITLE
Update kas-text: use Fontique + Swash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,4 +161,4 @@ members = [
 
 [patch.crates-io.kas-text]
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "2f52de0"
+rev = "0c2618e5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,4 +161,4 @@ members = [
 
 [patch.crates-io.kas-text]
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "8d0915b2"
+rev = "5e6720f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,4 +161,4 @@ members = [
 
 [patch.crates-io.kas-text]
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "0c2618e5"
+rev = "8d0915b2"

--- a/crates/kas-core/src/config/config.rs
+++ b/crates/kas-core/src/config/config.rs
@@ -123,6 +123,11 @@ impl WindowConfig {
         self.config.borrow()
     }
 
+    /// Get a clone of the base (unscaled) [`Config`]
+    pub fn clone_base(&self) -> Rc<RefCell<Config>> {
+        self.config.clone()
+    }
+
     /// Update the base config
     ///
     /// Since it is not known which parts of the configuration are updated, all

--- a/crates/kas-core/src/config/font.rs
+++ b/crates/kas-core/src/config/font.rs
@@ -5,7 +5,7 @@
 
 //! Font configuration
 
-use crate::text::fonts::{FontSelector, GenericFamily};
+use crate::text::fonts::FontSelector;
 use crate::theme::TextClass;
 use crate::Action;
 use std::collections::BTreeMap;
@@ -29,7 +29,9 @@ pub struct FontConfig {
     pub size: f32,
 
     /// Standard fonts
-    #[cfg_attr(feature = "serde", serde(default))]
+    ///
+    /// TODO: read/write support.
+    #[cfg_attr(feature = "serde", serde(skip, default))]
     pub fonts: BTreeMap<TextClass, FontSelector>,
 
     /// Text glyph rastering settings
@@ -161,6 +163,8 @@ impl FontConfig {
 }
 
 mod defaults {
+    use kas_text::fonts::FamilySelector;
+
     use super::*;
 
     pub fn size() -> f32 {
@@ -168,11 +172,10 @@ mod defaults {
     }
 
     pub fn fonts() -> BTreeMap<TextClass, FontSelector> {
-        let mut selector = FontSelector::new();
-        selector.set_families([GenericFamily::UiSerif, GenericFamily::Serif]);
+        let serif = FamilySelector::SERIF;
         let list = [
-            (TextClass::Edit(false), selector.clone()),
-            (TextClass::Edit(true), selector),
+            (TextClass::Edit(false), serif.into()),
+            (TextClass::Edit(true), serif.into()),
         ];
         list.iter().cloned().collect()
     }

--- a/crates/kas-core/src/theme/dimensions.rs
+++ b/crates/kas-core/src/theme/dimensions.rs
@@ -322,15 +322,6 @@ impl<D: 'static> ThemeSize for Window<D> {
         }
     }
 
-    fn line_height(&self, class: TextClass) -> i32 {
-        let font_id = self.fonts.get(&class).cloned().unwrap_or_default();
-        crate::text::fonts::library()
-            .get_first_face(font_id)
-            .expect("invalid font_id")
-            .height(self.dims.dpem)
-            .cast_ceil()
-    }
-
     fn text_configure(&self, text: &mut dyn SizableText, class: TextClass) {
         let font_id = self.fonts.get(&class).cloned().unwrap_or_default();
         let dpem = self.dims.dpem;

--- a/crates/kas-core/src/theme/dimensions.rs
+++ b/crates/kas-core/src/theme/dimensions.rs
@@ -346,28 +346,19 @@ impl<D: 'static> ThemeSize for Window<D> {
             if wrap {
                 let min = self.dims.min_line_length;
                 let limit = 2 * min;
-                let bound: i32 = text
-                    .measure_width(limit.cast())
-                    .expect("not configured")
-                    .cast_ceil();
+                let bound: i32 = text.measure_width(limit.cast()).cast_ceil();
 
                 // NOTE: using different variable-width stretch policies here can
                 // cause problems (e.g. edit boxes greedily consuming too much
                 // space). This is a hard layout problem; for now don't do this.
                 SizeRules::new(bound.min(min), bound.min(limit), margins, Stretch::Filler)
             } else {
-                let bound: i32 = text
-                    .measure_width(f32::INFINITY)
-                    .expect("not configured")
-                    .cast_ceil();
+                let bound: i32 = text.measure_width(f32::INFINITY).cast_ceil();
                 SizeRules::new(bound, bound, margins, Stretch::Filler)
             }
         } else {
             let wrap_width = axis.other().map(|w| w.cast()).unwrap_or(f32::INFINITY);
-            let bound: i32 = text
-                .measure_height(wrap_width)
-                .expect("not configured")
-                .cast_ceil();
+            let bound: i32 = text.measure_height(wrap_width).cast_ceil();
 
             let line_height = self.dims.dpem.cast_ceil();
             let min = bound.max(line_height);

--- a/crates/kas-core/src/theme/dimensions.rs
+++ b/crates/kas-core/src/theme/dimensions.rs
@@ -5,6 +5,7 @@
 
 //! A shared implementation of [`ThemeSize`]
 
+use kas_text::fonts::FontSelector;
 use linear_map::LinearMap;
 use std::any::Any;
 use std::f32;
@@ -17,7 +18,6 @@ use crate::config::WindowConfig;
 use crate::dir::Directional;
 use crate::geom::{Rect, Size, Vec2};
 use crate::layout::{AlignPair, AxisInfo, FrameRules, Margins, SizeRules, Stretch};
-use crate::text::fonts::FontId;
 
 crate::impl_scope! {
     /// Parameterisation of [`Dimensions`]
@@ -152,7 +152,7 @@ impl Dimensions {
 /// A convenient implementation of [`crate::Window`]
 pub struct Window<D> {
     pub dims: Dimensions,
-    pub fonts: Rc<LinearMap<TextClass, FontId>>,
+    pub fonts: Rc<LinearMap<TextClass, FontSelector>>,
     pub anim: AnimState<D>,
 }
 
@@ -160,7 +160,7 @@ impl<D> Window<D> {
     pub fn new(
         dims: &Parameters,
         config: &WindowConfig,
-        fonts: Rc<LinearMap<TextClass, FontId>>,
+        fonts: Rc<LinearMap<TextClass, FontSelector>>,
     ) -> Self {
         Window {
             dims: Dimensions::new(dims, config),

--- a/crates/kas-core/src/theme/dimensions.rs
+++ b/crates/kas-core/src/theme/dimensions.rs
@@ -323,10 +323,9 @@ impl<D: 'static> ThemeSize for Window<D> {
     }
 
     fn text_configure(&self, text: &mut dyn SizableText, class: TextClass) {
-        let font_id = self.fonts.get(&class).cloned().unwrap_or_default();
+        let font = self.fonts.get(&class).cloned().unwrap_or_default();
         let dpem = self.dims.dpem;
-        text.set_font(font_id, dpem);
-        text.configure().expect("invalid font_id");
+        text.set_font(font, dpem);
     }
 
     fn text_rules(

--- a/crates/kas-core/src/theme/flat_theme.rs
+++ b/crates/kas-core/src/theme/flat_theme.rs
@@ -96,8 +96,7 @@ where
 
     fn new_window(&mut self, config: &WindowConfig) -> Self::Window {
         self.base.cols = config.theme().get_active_scheme().into();
-        let fonts = self.base.fonts.as_ref().unwrap().clone();
-        dim::Window::new(&dimensions(), config, fonts)
+        dim::Window::new(&dimensions(), config)
     }
 
     fn update_window(&mut self, w: &mut Self::Window, config: &WindowConfig) {

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -5,6 +5,7 @@
 
 //! Simple theme
 
+use kas_text::fonts::FontSelector;
 use linear_map::LinearMap;
 use std::cell::RefCell;
 use std::f32;
@@ -18,7 +19,7 @@ use crate::dir::{Direction, Directional};
 use crate::draw::{color::Rgba, *};
 use crate::event::EventState;
 use crate::geom::*;
-use crate::text::{fonts, Effect, TextDisplay};
+use crate::text::{Effect, TextDisplay};
 use crate::theme::dimensions as dim;
 use crate::theme::{Background, FrameStyle, MarkStyle, TextClass};
 use crate::theme::{ColorsLinear, InputState, Theme};
@@ -35,7 +36,7 @@ use super::ColorsSrgb;
 pub struct SimpleTheme {
     pub cols: ColorsLinear,
     dims: dim::Parameters,
-    pub fonts: Option<Rc<LinearMap<TextClass, fonts::FontId>>>,
+    pub fonts: Option<Rc<LinearMap<TextClass, FontSelector>>>,
 }
 
 impl Default for SimpleTheme {
@@ -71,16 +72,12 @@ where
     type Draw<'a> = DrawHandle<'a, DS>;
 
     fn init(&mut self, config: &RefCell<Config>) {
-        let fonts = fonts::library();
-        if let Err(e) = fonts.init() {
-            panic!("Error initializing fonts: {e}");
-        }
         self.fonts = Some(Rc::new(
             config
                 .borrow()
                 .font
                 .iter_fonts()
-                .map(|(c, s)| (*c, fonts.select_font(s)))
+                .map(|(c, s)| (*c, *s))
                 .collect(),
         ));
     }

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -80,7 +80,7 @@ where
                 .borrow()
                 .font
                 .iter_fonts()
-                .filter_map(|(c, s)| fonts.select_font(s).ok().map(|id| (*c, id)))
+                .map(|(c, s)| (*c, fonts.select_font(s)))
                 .collect(),
         ));
     }

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -5,12 +5,9 @@
 
 //! Simple theme
 
-use kas_text::fonts::FontSelector;
-use linear_map::LinearMap;
 use std::cell::RefCell;
 use std::f32;
 use std::ops::Range;
-use std::rc::Rc;
 use std::time::Instant;
 
 use crate::cast::traits::*;
@@ -36,7 +33,6 @@ use super::ColorsSrgb;
 pub struct SimpleTheme {
     pub cols: ColorsLinear,
     dims: dim::Parameters,
-    pub fonts: Option<Rc<LinearMap<TextClass, FontSelector>>>,
 }
 
 impl Default for SimpleTheme {
@@ -52,7 +48,6 @@ impl SimpleTheme {
         SimpleTheme {
             cols: ColorsSrgb::LIGHT.into(), // value is unimportant
             dims: Default::default(),
-            fonts: None,
         }
     }
 }
@@ -71,21 +66,11 @@ where
     type Window = dim::Window<DS::Draw>;
     type Draw<'a> = DrawHandle<'a, DS>;
 
-    fn init(&mut self, config: &RefCell<Config>) {
-        self.fonts = Some(Rc::new(
-            config
-                .borrow()
-                .font
-                .iter_fonts()
-                .map(|(c, s)| (*c, *s))
-                .collect(),
-        ));
-    }
+    fn init(&mut self, _: &RefCell<Config>) {}
 
     fn new_window(&mut self, config: &WindowConfig) -> Self::Window {
         self.cols = config.theme().get_active_scheme().into();
-        let fonts = self.fonts.as_ref().unwrap().clone();
-        dim::Window::new(&self.dims, config, fonts)
+        dim::Window::new(&self.dims, config)
     }
 
     fn update_window(&mut self, w: &mut Self::Window, config: &WindowConfig) {

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -5,8 +5,6 @@
 
 //! "Handle" types used by themes
 
-use cast::CastFloat;
-
 use super::{Feature, FrameStyle, MarginStyle, SizableText, Text, TextClass};
 use crate::autoimpl;
 use crate::dir::Directional;
@@ -80,7 +78,6 @@ impl<'a> SizeCx<'a> {
     ///
     /// The Em is a unit of typography (variously defined as the point-size of
     /// the font, the height of the font or the width of an upper-case `M`).
-    /// The method [`Self::line_height`] returns a related but distinct value.
     ///
     /// This method returns the size of 1 Em in physical pixels, derived from
     /// the font size in use by the theme and the screen's scale factor.
@@ -156,23 +153,6 @@ impl<'a> SizeCx<'a> {
         self.0.frame(style, axis.is_vertical())
     }
 
-    /// The height of a line of text using the corresponding font
-    ///
-    /// This method looks up the font face corresponding to the given `class`,
-    /// scales this according to [`Self::dpem`], then measures the line height.
-    /// The result is typically 100% - 150% of the value returned by
-    /// [`Self::dpem`], depending on the font face.
-    ///
-    /// Prefer to use [`Self::text_line_height`] where possible.
-    pub fn line_height(&self, class: TextClass) -> i32 {
-        self.0.line_height(class)
-    }
-
-    /// Get the line-height of a configured text object
-    pub fn text_line_height<T: FormattableText>(&self, text: &Text<T>) -> i32 {
-        text.line_height().expect("not configured").cast_ceil()
-    }
-
     /// Get [`SizeRules`] for a text element
     ///
     /// The [`TextClass`] is used to select a font and controls whether line
@@ -234,11 +214,6 @@ pub trait ThemeSize {
 
     /// Size of a frame around another element
     fn frame(&self, style: FrameStyle, axis_is_vertical: bool) -> FrameRules;
-
-    /// The height of a line of text by class
-    ///
-    /// Prefer to use [`SizeCx::text_line_height`] where possible.
-    fn line_height(&self, class: TextClass) -> i32;
 
     /// Configure a text object, setting font properties
     fn text_configure(&self, text: &mut dyn SizableText, class: TextClass);

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -427,23 +427,6 @@ impl<T: FormattableText> Text<T> {
         Ok(())
     }
 
-    /// Returns the height of horizontal text
-    ///
-    /// Returns an error if called before [`Self::configure`].
-    ///
-    /// This depends on the font and font size, but is independent of the text.
-    pub fn line_height(&self) -> Result<f32, NotReady> {
-        self.check_status(Status::Configured)?;
-
-        fonts::library()
-            .get_first_face(self.font())
-            .map(|face| face.height(self.font_size()))
-            .map_err(|_| {
-                debug_assert!(false, "font_id should be validated by configure");
-                NotReady
-            })
-    }
-
     /// Measure required width, up to some `max_width`
     ///
     /// [`configure`][Self::configure] must be called before this method.

--- a/crates/kas-core/src/theme/traits.rs
+++ b/crates/kas-core/src/theme/traits.rs
@@ -36,9 +36,6 @@ pub trait Theme<DS: DrawSharedImpl> {
     ///
     /// The toolkit must call this method before [`Theme::new_window`]
     /// to allow initialisation specific to the `DrawIface`.
-    ///
-    /// At a minimum, a theme must load a font to [`crate::text::fonts`].
-    /// The first font loaded (by any theme) becomes the default font.
     fn init(&mut self, config: &RefCell<Config>);
 
     /// Construct per-window storage

--- a/crates/kas-wgpu/src/shaded_theme.rs
+++ b/crates/kas-wgpu/src/shaded_theme.rs
@@ -85,8 +85,7 @@ where
 
     fn new_window(&mut self, config: &WindowConfig) -> Self::Window {
         self.base.cols = config.theme().get_active_scheme().into();
-        let fonts = self.base.fonts.as_ref().unwrap().clone();
-        dim::Window::new(&dimensions(), config, fonts)
+        dim::Window::new(&dimensions(), config)
     }
 
     fn update_window(&mut self, w: &mut Self::Window, config: &WindowConfig) {

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -1087,7 +1087,7 @@ impl_scope! {
         /// NOTE: we could add a `set_str` variant of this method but there
         /// doesn't appear to be a need.
         pub fn set_string(&mut self, cx: &mut EventState, string: String) {
-            if !self.text.set_string(string) || self.text.prepare() != Ok(true) {
+            if !self.text.set_string(string) || !self.text.prepare() {
                 return;
             }
 
@@ -1338,13 +1338,8 @@ impl<G: EditGuard> EditField<G> {
     fn prepare_text(&mut self, cx: &mut EventCx) {
         let start = std::time::Instant::now();
 
-        match self.text.prepare() {
-            Err(NotReady) => {
-                debug_assert!(false, "text not ready");
-                return;
-            }
-            Ok(false) => return,
-            Ok(true) => (),
+        if !self.text.prepare() {
+            return;
         }
 
         self.text_size = Vec2::from(self.text.bounding_box().unwrap().1).cast_ceil();

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -608,14 +608,14 @@ impl<G: EditGuard> EditBox<G> {
 
     /// Adjust the height allocation
     #[inline]
-    pub fn set_lines(&mut self, min_lines: i32, ideal_lines: i32) {
+    pub fn set_lines(&mut self, min_lines: f32, ideal_lines: f32) {
         self.inner.set_lines(min_lines, ideal_lines);
     }
 
     /// Adjust the height allocation (inline)
     #[inline]
     #[must_use]
-    pub fn with_lines(mut self, min_lines: i32, ideal_lines: i32) -> Self {
+    pub fn with_lines(mut self, min_lines: f32, ideal_lines: f32) -> Self {
         self.set_lines(min_lines, ideal_lines);
         self
     }
@@ -740,7 +740,7 @@ impl_scope! {
         view_offset: Offset,
         editable: bool,
         width: (f32, f32),
-        lines: (i32, i32),
+        lines: (f32, f32),
         text: Text<String>,
         text_size: Size,
         selection: SelectionHelper,
@@ -761,9 +761,10 @@ impl_scope! {
                 let dpem = sizer.dpem();
                 ((self.width.0 * dpem).cast_ceil(), (self.width.1 * dpem).cast_ceil())
             } else {
-                let height = sizer.line_height(self.class());
-                (self.lines.0 * height, self.lines.1 * height)
+                let dpem = sizer.dpem();
+                ((self.lines.0 * dpem).cast_ceil(), (self.lines.1 * dpem).cast_ceil())
             };
+
             let margins = sizer.text_margins().extract(axis);
             let stretch = if axis.is_horizontal() || self.multi_line() {
                 Stretch::High
@@ -1054,7 +1055,7 @@ impl_scope! {
                 view_offset: Default::default(),
                 editable: true,
                 width: (8.0, 16.0),
-                lines: (1, 1),
+                lines: (1.0, 1.0),
                 text: Text::default().with_class(TextClass::Edit(false)),
                 text_size: Default::default(),
                 selection: Default::default(),
@@ -1254,8 +1255,8 @@ impl<G: EditGuard> EditField<G> {
     pub fn with_multi_line(mut self, multi_line: bool) -> Self {
         self.text.set_class(TextClass::Edit(multi_line));
         self.lines = match multi_line {
-            false => (1, 1),
-            true => (4, 7),
+            false => (1.0, 1.0),
+            true => (4.0, 7.0),
         };
         self
     }
@@ -1284,14 +1285,14 @@ impl<G: EditGuard> EditField<G> {
 
     /// Adjust the height allocation
     #[inline]
-    pub fn set_lines(&mut self, min_lines: i32, ideal_lines: i32) {
+    pub fn set_lines(&mut self, min_lines: f32, ideal_lines: f32) {
         self.lines = (min_lines, ideal_lines);
     }
 
     /// Adjust the height allocation (inline)
     #[inline]
     #[must_use]
-    pub fn with_lines(mut self, min_lines: i32, ideal_lines: i32) -> Self {
+    pub fn with_lines(mut self, min_lines: f32, ideal_lines: f32) -> Self {
         self.set_lines(min_lines, ideal_lines);
         self
     }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -40,7 +40,7 @@ impl_scope! {
             let mut rules = sizer.text_rules(&mut self.text, axis);
             let _ = self.bar.size_rules(sizer.re(), axis);
             if axis.is_vertical() {
-                rules.reduce_min_to(sizer.text_line_height(&self.text) * 4);
+                rules.reduce_min_to((sizer.dpem() * 4.0).cast_ceil());
             }
             rules.with_stretch(Stretch::Low)
         }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -107,7 +107,7 @@ impl_scope! {
         /// (usually done by the theme when the main loop starts).
         pub fn set_text(&mut self, cx: &mut EventState, text: T) {
             self.text.set_text(text);
-            if self.text.prepare() != Ok(true) {
+            if !self.text.prepare() {
                 return;
             }
 
@@ -198,7 +198,8 @@ impl_scope! {
     impl ScrollLabel<String> {
         /// Set text contents from a string
         pub fn set_string(&mut self, cx: &mut EventState, string: String) {
-            if self.text.set_string(string) && self.text.prepare().is_ok() {
+            if self.text.set_string(string) {
+                self.text.prepare();
                 cx.action(self, Action::SET_RECT);
             }
         }

--- a/crates/kas-widgets/src/scroll_text.rs
+++ b/crates/kas-widgets/src/scroll_text.rs
@@ -40,7 +40,7 @@ impl_scope! {
             let mut rules = sizer.text_rules(&mut self.text, axis);
             let _ = self.bar.size_rules(sizer.re(), axis);
             if axis.is_vertical() {
-                rules.reduce_min_to(sizer.text_line_height(&self.text) * 4);
+                rules.reduce_min_to((sizer.dpem() * 4.0).cast_ceil());
             }
             rules.with_stretch(Stretch::Low)
         }

--- a/crates/kas-widgets/src/scroll_text.rs
+++ b/crates/kas-widgets/src/scroll_text.rs
@@ -11,7 +11,7 @@ use kas::event::{Command, CursorIcon, FocusSource, Scroll};
 use kas::geom::Vec2;
 use kas::prelude::*;
 use kas::text::format::FormattableText;
-use kas::text::{NotReady, SelectionHelper};
+use kas::text::SelectionHelper;
 use kas::theme::{Text, TextClass};
 
 impl_scope! {
@@ -186,12 +186,8 @@ impl_scope! {
                 return;
             }
             self.text.set_text(text);
-            let action = match self.text.prepare() {
-                Err(NotReady) => Action::empty(),
-                Ok(_) => Action::SET_RECT,
-            };
-            debug_assert!(!action.is_empty(), "update before configure");
-            cx.action(self, action);
+            self.text.prepare();
+            cx.action(self, Action::SET_RECT);
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -27,7 +27,7 @@ fn calc_ui() -> Window<()> {
     // We could use kas::widget::Text, but EditBox looks better.
     let display = EditBox::string(|calc: &Calculator| calc.display())
         .with_multi_line(true)
-        .with_lines(3, 3)
+        .with_lines(3.0, 3.0)
         .with_width_em(5.0, 10.0);
 
     // We use map_any to avoid passing input data (not wanted by buttons):

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -130,9 +130,7 @@ impl_scope! {
 
         fn configure(&mut self, cx: &mut ConfigCx) {
             self.date.set_align(AlignPair::CENTER.into());
-            self.date.configure().unwrap();
             self.time.set_align(AlignPair::CENTER.into());
-            self.time.configure().unwrap();
             cx.request_timer(self.id(), TIMER, Duration::ZERO);
         }
 

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -330,7 +330,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
         Splitter::new(collection![
             EditBox::new(Guard)
                 .with_multi_line(true)
-                .with_lines(4, 12)
+                .with_lines(4.0, 12.0)
                 .with_text(DOC),
             ScrollLabel::new(Markdown::new(DOC).unwrap())
                 .on_configure(|cx, label| {


### PR DESCRIPTION
Updates kas-text for https://github.com/kas-gui/kas-text/pull/94

This implements font resolution by script, thus many more characters resolve to a valid glyph, though not all.

Some functionality is lost here:

- Read/write support for font configuration: the selector changed, is non-trivial to convert due to usage of a lookup table. TODO for later.
- `SizeCx::line_height` was removed since this depends on the font, which now depends on the text script. Instead we specify `EditField` height in `Em`s (or actual text height, whichever is greater).