### PR TITLE
Implement batched glyph rasterising

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,4 +155,4 @@ members = [
 
 [patch.crates-io.kas-text]
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "9312d06"
+rev = "2f70ffd4"

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -44,8 +44,6 @@ impl Default for Rasterer {
 pub enum RasterError {
     #[error("allocation failed")]
     Alloc(#[from] AllocError),
-    #[error("failed")]
-    Failed,
     #[allow(unused)]
     #[error("zero-sized")]
     Zero,
@@ -333,106 +331,108 @@ impl Pipeline {
             .render(&window.atlas, pass, rpass, bg_common);
     }
 
-    /// Get a rendered sprite
-    ///
-    /// The result may not be valid; see [`Sprite::is_valid`].
-    fn get_glyph(&mut self, face: FaceId, dpem: f32, glyph: Glyph) -> Sprite {
-        let desc = SpriteDescriptor::new(&self.config, face, glyph, dpem);
-        if let Some(sprite) = self.glyphs.get(&desc).cloned() {
-            sprite
-        } else {
-            // NOTE: this branch is *rare*. We don't use HashMap::entry and push
-            // rastering to another function to optimise for the common case.
-            self.raster_glyph(desc)
-        }
-    }
-
-    fn raster_glyph(&mut self, desc: SpriteDescriptor) -> Sprite {
+    /// Raster a sequence of glyphs
+    #[inline]
+    fn raster_glyphs(
+        &mut self,
+        face_id: FaceId,
+        dpem: f32,
+        mut glyphs: impl Iterator<Item = Glyph>,
+    ) {
         // NOTE: we only need the allocation and coordinates now; the
         // rendering could be offloaded (though this may not be useful).
 
-        let result = match self.rasterer {
+        match self.rasterer {
             #[cfg(feature = "ab_glyph")]
-            Rasterer::AbGlyph => self.raster_ab_glyph(desc),
-            Rasterer::Swash => self.raster_swash(desc),
-        };
-
-        let sprite = match result {
-            Ok(sprite) => sprite,
-            Err(RasterError::Zero) => {
-                // Ignore this common error
-                Sprite::default()
-            }
-            Err(err) => {
-                log::warn!("raster_glyph failed: {err}");
-                Sprite::default()
-            }
-        };
-
-        self.glyphs.insert(desc, sprite.clone());
-        sprite
+            Rasterer::AbGlyph => self.raster_ab_glyph(face_id, dpem, &mut glyphs),
+            Rasterer::Swash => self.raster_swash(face_id, dpem, &mut glyphs),
+        }
     }
 
     #[cfg(feature = "ab_glyph")]
-    fn raster_ab_glyph(&mut self, desc: SpriteDescriptor) -> Result<Sprite, RasterError> {
+    fn raster_ab_glyph(
+        &mut self,
+        face_id: FaceId,
+        dpem: f32,
+        glyphs: &mut dyn Iterator<Item = Glyph>,
+    ) {
         use ab_glyph::Font;
 
-        let id = desc.glyph();
-        let face = desc.face();
-        let face_store = fonts::library().get_face_store(face);
-        let dpem = desc.dpem(&self.config);
+        let face_store = fonts::library().get_face_store(face_id);
 
-        let (mut x, y) = desc.fractional_position(&self.config);
-        if self.sb_align && desc.dpem(&self.config) >= self.config.subpixel_threshold {
-            let sf = face_store.face_ref().scale_by_dpem(dpem);
-            x -= sf.h_side_bearing(id);
+        for glyph in glyphs {
+            let desc = SpriteDescriptor::new(&self.config, face_id, glyph, dpem);
+            if self.glyphs.contains_key(&desc) {
+                continue;
+            }
+
+            let (mut x, y) = desc.fractional_position(&self.config);
+            if self.sb_align && desc.dpem(&self.config) >= self.config.subpixel_threshold {
+                let sf = face_store.face_ref().scale_by_dpem(dpem);
+                x -= sf.h_side_bearing(glyph.id);
+            }
+
+            let font = face_store.ab_glyph();
+            let scale = dpem * font.height_unscaled() / font.units_per_em().unwrap();
+            let glyph = ab_glyph::Glyph {
+                id: ab_glyph::GlyphId(glyph.id.0),
+                scale: scale.into(),
+                position: ab_glyph::point(x, y),
+            };
+            let Some(outline) = font.outline_glyph(glyph) else {
+                log::warn!("raster_glyphs failed: unable to outline glyph");
+                self.glyphs.insert(desc, Sprite::default());
+                continue;
+            };
+
+            let bounds = outline.px_bounds();
+            let offset: (i32, i32) = (bounds.min.x.cast_trunc(), bounds.min.y.cast_trunc());
+            let size = bounds.max - bounds.min;
+            let size = (u32::conv_trunc(size.x), u32::conv_trunc(size.y));
+            if size.0 == 0 || size.1 == 0 {
+                // Ignore this common error
+                self.glyphs.insert(desc, Sprite::default());
+                continue;
+            }
+
+            let mut data = vec![0; usize::conv(size.0 * size.1)];
+            outline.draw(|x, y, c| {
+                // Convert to u8 with saturating conversion, rounding down:
+                data[usize::conv((y * size.0) + x)] = (c * 256.0) as u8;
+            });
+
+            let Ok((atlas, _, origin, tex_quad)) = self.atlas_pipe.allocate(size) else {
+                log::warn!("raster_glyphs failed: unable to allocate");
+                self.glyphs.insert(desc, Sprite::default());
+                continue;
+            };
+
+            self.prepare.push((atlas, origin, size, data));
+
+            self.glyphs.insert(desc, Sprite {
+                atlas,
+                valid: true,
+                size: Vec2(size.0.cast(), size.1.cast()),
+                offset: Vec2(offset.0.cast(), offset.1.cast()),
+                tex_quad,
+            });
         }
-
-        let font = face_store.ab_glyph();
-        let scale = dpem * font.height_unscaled() / font.units_per_em().unwrap();
-        let glyph = ab_glyph::Glyph {
-            id: ab_glyph::GlyphId(id.0),
-            scale: scale.into(),
-            position: ab_glyph::point(x, y),
-        };
-        let outline = font.outline_glyph(glyph).ok_or(RasterError::Failed)?;
-
-        let bounds = outline.px_bounds();
-        let offset: (i32, i32) = (bounds.min.x.cast_trunc(), bounds.min.y.cast_trunc());
-        let size = bounds.max - bounds.min;
-        let size = (u32::conv_trunc(size.x), u32::conv_trunc(size.y));
-        if size.0 == 0 || size.1 == 0 {
-            return Err(RasterError::Zero);
-        }
-
-        let mut data = vec![0; usize::conv(size.0 * size.1)];
-        outline.draw(|x, y, c| {
-            // Convert to u8 with saturating conversion, rounding down:
-            data[usize::conv((y * size.0) + x)] = (c * 256.0) as u8;
-        });
-
-        let (atlas, _, origin, tex_quad) = self.atlas_pipe.allocate(size)?;
-
-        self.prepare.push((atlas, origin, size, data));
-
-        Ok(Sprite {
-            atlas,
-            valid: true,
-            size: Vec2(size.0.cast(), size.1.cast()),
-            offset: Vec2(offset.0.cast(), offset.1.cast()),
-            tex_quad,
-        })
     }
 
-    fn raster_swash(&mut self, desc: SpriteDescriptor) -> Result<Sprite, RasterError> {
+    // NOTE: using dyn Iterator over impl Iterator is slightly slower but saves 2-4kB
+    fn raster_swash(
+        &mut self,
+        face_id: FaceId,
+        dpem: f32,
+        glyphs: &mut dyn Iterator<Item = Glyph>,
+    ) {
         use swash::scale::{image::Content, Render, Source, StrikeWith};
         use swash::zeno::{Angle, Format, Transform};
 
-        // TODO: we should re-use scaler when rendering glyphs for a layout/run
-        let face = fonts::library().get_face_store(desc.face());
+        let face = fonts::library().get_face_store(face_id);
         let font = face.swash();
         let synthesis = face.synthesis();
-        let dpem = desc.dpem(&self.config);
+
         let mut scaler = self
             .scale_cx
             .builder(font)
@@ -461,36 +461,55 @@ impl Pipeline {
         // Faux bold:
         let embolden = if synthesis.embolden() { dpem * 0.02 } else { 0.0 };
 
-        let image = Render::new(sources)
-            .format(Format::Alpha)
-            .offset(desc.fractional_position(&self.config).into())
-            .transform(transform)
-            .embolden(embolden)
-            .render(&mut scaler, desc.glyph().0.into())
-            .ok_or(RasterError::Failed)?;
-
-        let offset = (image.placement.left, -image.placement.top);
-        let size = (image.placement.width, image.placement.height);
-        if size.0 == 0 || size.1 == 0 {
-            return Err(RasterError::Zero);
-        }
-
-        match image.content {
-            Content::Mask => {
-                let (atlas, _, origin, tex_quad) = self.atlas_pipe.allocate(size)?;
-
-                self.prepare.push((atlas, origin, size, image.data));
-
-                Ok(Sprite {
-                    atlas,
-                    valid: true,
-                    size: Vec2(size.0.cast(), size.1.cast()),
-                    offset: Vec2(offset.0.cast(), offset.1.cast()),
-                    tex_quad,
-                })
+        for glyph in glyphs {
+            let desc = SpriteDescriptor::new(&self.config, face_id, glyph, dpem);
+            if self.glyphs.contains_key(&desc) {
+                continue;
             }
-            Content::SubpixelMask => unimplemented!(),
-            Content::Color => unimplemented!(),
+
+            let Some(image) = Render::new(sources)
+                .format(Format::Alpha)
+                .offset(desc.fractional_position(&self.config).into())
+                .transform(transform)
+                .embolden(embolden)
+                .render(&mut scaler, desc.glyph().0.into())
+            else {
+                log::warn!("raster_glyphs failed: unable to construct renderer");
+                self.glyphs.insert(desc, Sprite::default());
+                continue;
+            };
+
+            let offset = (image.placement.left, -image.placement.top);
+            let size = (image.placement.width, image.placement.height);
+            if size.0 == 0 || size.1 == 0 {
+                // Ignore this common error
+                self.glyphs.insert(desc, Sprite::default());
+                continue;
+            }
+
+            let sprite = match image.content {
+                Content::Mask => {
+                    let Ok((atlas, _, origin, tex_quad)) = self.atlas_pipe.allocate(size) else {
+                        log::warn!("raster_glyphs failed: unable to allocate");
+                        self.glyphs.insert(desc, Sprite::default());
+                        continue;
+                    };
+
+                    self.prepare.push((atlas, origin, size, image.data));
+
+                    Sprite {
+                        atlas,
+                        valid: true,
+                        size: Vec2(size.0.cast(), size.1.cast()),
+                        offset: Vec2(offset.0.cast(), offset.1.cast()),
+                        tex_quad,
+                    }
+                }
+                Content::SubpixelMask => unimplemented!(),
+                Content::Color => unimplemented!(),
+            };
+
+            self.glyphs.insert(desc, sprite);
         }
     }
 }
@@ -526,7 +545,17 @@ impl Window {
             let face = run.face_id();
             let dpem = run.dpem();
             for glyph in run.glyphs() {
-                let sprite = pipe.get_glyph(face, dpem, glyph);
+                let desc = SpriteDescriptor::new(&pipe.config, face, glyph, dpem);
+                let sprite = match pipe.glyphs.get(&desc) {
+                    Some(sprite) => sprite,
+                    None => {
+                        pipe.raster_glyphs(face, dpem, run.glyphs());
+                        match pipe.glyphs.get(&desc) {
+                            Some(sprite) => sprite,
+                            None => continue,
+                        }
+                    }
+                };
                 if sprite.is_valid() {
                     let a = rect.a + Vec2::from(glyph.position).floor() + sprite.offset;
                     let b = a + sprite.size;
@@ -566,7 +595,17 @@ impl Window {
             let face = run.face_id();
             let dpem = run.dpem();
             let for_glyph = |glyph: Glyph, _: usize, _: ()| {
-                let sprite = pipe.get_glyph(face, dpem, glyph);
+                let desc = SpriteDescriptor::new(&pipe.config, face, glyph, dpem);
+                let sprite = match pipe.glyphs.get(&desc) {
+                    Some(sprite) => sprite,
+                    None => {
+                        pipe.raster_glyphs(face, dpem, run.glyphs());
+                        match pipe.glyphs.get(&desc) {
+                            Some(sprite) => sprite,
+                            None => return,
+                        }
+                    }
+                };
                 if sprite.is_valid() {
                     let a = rect.a + Vec2::from(glyph.position).floor() + sprite.offset;
                     let b = a + sprite.size;
@@ -617,7 +656,17 @@ impl Window {
             let face = run.face_id();
             let dpem = run.dpem();
             let for_glyph = |glyph: Glyph, _, col: Rgba| {
-                let sprite = pipe.get_glyph(face, dpem, glyph);
+                let desc = SpriteDescriptor::new(&pipe.config, face, glyph, dpem);
+                let sprite = match pipe.glyphs.get(&desc) {
+                    Some(sprite) => sprite,
+                    None => {
+                        pipe.raster_glyphs(face, dpem, run.glyphs());
+                        match pipe.glyphs.get(&desc) {
+                            Some(sprite) => sprite,
+                            None => return,
+                        }
+                    }
+                };
                 if sprite.is_valid() {
                     let a = rect.a + Vec2::from(glyph.position).floor() + sprite.offset;
                     let b = a + sprite.size;


### PR DESCRIPTION
Corresponds to https://github.com/kas-gui/kas-text/pull/96

There is some increase in code complexity and binary size, but also the decrease in raster time is significant:
```
# Old code (not batched):
Debug:
Size: 366871888 / 50474048
Raster time: 7953μs / 18847μs / 390μs / 372μs / 15790μs
Raster time: 10807μs / 20112μs / 382μs / 469μs / 16258μs
Release:
Size: 25773608 / 19200448
Raster time: 729μs / 5271μs / 136μs / 61μs / 2506μs
Raster time: 763μs / 4696μs / 132μs / 71μs / 2691μs

# New code (batched, using dyn Iterator):
Release:
Size: 25788968 (+15360) / 19212352 (+11904)
Raster time: 899μs / 2318μs / 122μs / 87μs / 472μs
Raster time: 798μs / 1996μs / 99μs / 65μs / 497μs

# Variant using impl Iterator (compared to old code):
Debug:
Size: 367115144 (+243256) / 50476864 (+2816)
Raster time: 5677μs / 6027μs / 351μs / 386μs / 2978μs
Raster time: 9194μs / 6098μs  / 398μs /　462μs　/ 3032μs
Release:
Size: 25792856 (+19248) / 19215040 (+14592)
Raster time: 670μs / 1984μs / 131μs / 60μs / 620μs
Raster time: 680μs / 2105μs / 141μs / 60μs / 407μs
```

Sizes are the binary size for `examples/gallery.rs` using nightly features on Wayland before / after strip.

Times are the total raster times to display page Widgets / Text editor / List / Canvas / Config in that order (rastering extra glyphs on demand).

The extra complexity is due to on-demand detection needing to switch to batch rendering. Ahead-of-time rastering would avoid this, but has its own drawbacks (though in theory we could drive this from `ConfigCx::text_configure`).