### PR TITLE
Support drawing RGBA glyphs

### DIFF
--- a/crates/kas-core/src/config/config.rs
+++ b/crates/kas-core/src/config/config.rs
@@ -119,7 +119,7 @@ impl WindowConfig {
     }
 
     /// Access base (unscaled) [`Config`]
-    pub fn base(&self) -> Ref<Config> {
+    pub fn base(&self) -> Ref<'_, Config> {
         self.config.borrow()
     }
 
@@ -157,7 +157,7 @@ impl WindowConfig {
     }
 
     /// Access event config
-    pub fn event(&self) -> EventWindowConfig {
+    pub fn event(&self) -> EventWindowConfig<'_> {
         EventWindowConfig(self)
     }
 
@@ -172,7 +172,7 @@ impl WindowConfig {
     }
 
     /// Access font config
-    pub fn font(&self) -> Ref<FontConfig> {
+    pub fn font(&self) -> Ref<'_, FontConfig> {
         Ref::map(self.config.borrow(), |c| &c.font)
     }
 
@@ -193,12 +193,12 @@ impl WindowConfig {
     }
 
     /// Access shortcut config
-    pub fn shortcuts(&self) -> Ref<Shortcuts> {
+    pub fn shortcuts(&self) -> Ref<'_, Shortcuts> {
         Ref::map(self.config.borrow(), |c| &c.shortcuts)
     }
 
     /// Access theme config
-    pub fn theme(&self) -> Ref<ThemeConfig> {
+    pub fn theme(&self) -> Ref<'_, ThemeConfig> {
         Ref::map(self.config.borrow(), |c| &c.theme)
     }
 

--- a/crates/kas-core/src/config/event.rs
+++ b/crates/kas-core/src/config/event.rs
@@ -146,7 +146,7 @@ pub struct EventWindowConfig<'a>(pub(super) &'a super::WindowConfig);
 impl<'a> EventWindowConfig<'a> {
     /// Access base (unscaled) event [`EventConfig`]
     #[inline]
-    pub fn base(&self) -> Ref<EventConfig> {
+    pub fn base(&self) -> Ref<'_, EventConfig> {
         Ref::map(self.0.config.borrow(), |c| &c.event)
     }
 

--- a/crates/kas-core/src/config/shortcuts.rs
+++ b/crates/kas-core/src/config/shortcuts.rs
@@ -327,10 +327,8 @@ mod common {
             let mut state = ModifiersState::empty();
 
             let adv_dash_if_not_empty = |v: &mut &str| {
-                if !v.is_empty() {
-                    if v.starts_with('-') {
-                        *v = &v[1..];
-                    }
+                if !v.is_empty() && v.starts_with('-') {
+                    *v = &v[1..];
                 }
             };
 

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -95,7 +95,7 @@ impl IntOrPtr {
         u
     }
 
-    fn get(&self) -> Variant {
+    fn get(&self) -> Variant<'_> {
         if let Some(p) = self.get_ptr() {
             unsafe {
                 let len = *p.offset(1);
@@ -323,7 +323,7 @@ impl Id {
     }
 
     /// Iterate over path components
-    pub fn iter(&self) -> WidgetPathIter {
+    pub fn iter(&self) -> WidgetPathIter<'_> {
         match self.0.get() {
             Variant::Invalid => panic!("Id::iter: invalid"),
             Variant::Int(x) => WidgetPathIter(PathIter::Bits(BitsIter::new(x))),
@@ -381,7 +381,7 @@ impl Id {
         r
     }
 
-    pub fn iter_keys_after(&self, id: &Self) -> WidgetPathIter {
+    pub fn iter_keys_after(&self, id: &Self) -> WidgetPathIter<'_> {
         let mut self_iter = self.iter();
         for v in id.iter() {
             if self_iter.next() != Some(v) {

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -113,7 +113,7 @@ impl<'a, DS: DrawSharedImpl> DrawIface<'a, DS> {
     /// Case `class == PassType::Overlay`: the new pass is derived from the
     /// base pass (i.e. the window). Draw operations still happen after those in
     /// `parent_pass`.
-    pub fn new_pass(&mut self, rect: Rect, offset: Offset, class: PassType) -> DrawIface<DS> {
+    pub fn new_pass(&mut self, rect: Rect, offset: Offset, class: PassType) -> DrawIface<'_, DS> {
         let pass = self.draw.new_pass(self.pass, rect, offset, class);
         DrawIface {
             draw: &mut *self.draw,

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -117,7 +117,7 @@ impl<'a> DrawCx<'a> {
     }
 
     /// Access a [`SizeCx`]
-    pub fn size_cx(&mut self) -> SizeCx {
+    pub fn size_cx(&mut self) -> SizeCx<'_> {
         SizeCx::new(self.h.components().0)
     }
 
@@ -145,7 +145,7 @@ impl<'a> DrawCx<'a> {
     /// Access the low-level draw device (implementation type)
     ///
     /// The implementing type must be specified. See [`DrawIface::downcast_from`].
-    pub fn draw_iface<DS: DrawSharedImpl>(&mut self) -> Option<DrawIface<DS>> {
+    pub fn draw_iface<DS: DrawSharedImpl>(&mut self) -> Option<DrawIface<'_, DS>> {
         DrawIface::downcast_from(self.draw_device())
     }
 

--- a/crates/kas-wgpu/src/draw/mod.rs
+++ b/crates/kas-wgpu/src/draw/mod.rs
@@ -49,7 +49,6 @@ pub struct DrawPipe<C> {
     flat_round: flat_round::Pipeline,
     round_2col: round_2col::Pipeline,
     custom: C,
-    pub(crate) text: text_pipe::Pipeline,
 }
 
 kas::impl_scope! {
@@ -65,6 +64,5 @@ kas::impl_scope! {
         flat_round: flat_round::Window,
         round_2col: round_2col::Window,
         custom: CW,
-        pub(crate) text: text_pipe::Window,
     }
 }

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -320,7 +320,7 @@ impl Pipeline {
             .variations(
                 synthesis
                     .variation_settings()
-                    .into_iter()
+                    .iter()
                     .map(|(tag, value)| (swash::tag_from_bytes(&tag.to_be_bytes()), *value)),
             )
             .build();
@@ -351,7 +351,7 @@ impl Pipeline {
                 .offset(desc.fractional_position(&self.text.config).into())
                 .transform(transform)
                 .embolden(embolden)
-                .render(&mut scaler, desc.glyph().0.into())
+                .render(&mut scaler, desc.glyph().0)
             else {
                 log::warn!("raster_glyphs failed: unable to construct renderer");
                 self.text.glyphs.insert(desc, Sprite::default());
@@ -430,8 +430,11 @@ impl Window {
         let mut a = rect.a + glyph_pos.floor() + sprite.offset;
         let mut b = a + sprite.size;
 
-        if !sprite.is_valid()
-            || !(a.0 < rect.b.0 && a.1 < rect.b.1 && b.0 > rect.a.0 && b.1 > rect.a.1)
+        if !(sprite.is_valid()
+            && a.0 < rect.b.0
+            && a.1 < rect.b.1
+            && b.0 > rect.a.0
+            && b.1 > rect.a.1)
         {
             return;
         }

--- a/crates/kas-wgpu/src/options.rs
+++ b/crates/kas-wgpu/src/options.rs
@@ -109,7 +109,7 @@ impl Options {
         }
     }
 
-    pub(crate) fn adapter_options(&self) -> wgpu::RequestAdapterOptions {
+    pub(crate) fn adapter_options(&self) -> wgpu::RequestAdapterOptions<'_, '_> {
         wgpu::RequestAdapterOptions {
             power_preference: self.power_preference,
             force_fallback_adapter: self.backends.is_empty(),

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -91,7 +91,7 @@ impl_scope! {
     }
 
     impl Menu for Self {
-        fn sub_items(&mut self) -> Option<SubItems> {
+        fn sub_items(&mut self) -> Option<SubItems<'_>> {
             Some(SubItems {
                 label: Some(&mut self.label),
                 ..Default::default()
@@ -146,7 +146,7 @@ impl_scope! {
     }
 
     impl Menu for Self {
-        fn sub_items(&mut self) -> Option<SubItems> {
+        fn sub_items(&mut self) -> Option<SubItems<'_>> {
             Some(SubItems {
                 label: Some(&mut self.label),
                 toggle: Some(&mut self.checkbox),

--- a/crates/kas-widgets/src/menu/mod.rs
+++ b/crates/kas-widgets/src/menu/mod.rs
@@ -76,7 +76,7 @@ pub trait Menu: Widget {
     /// # }
     /// ```
     // TODO: adding frame spacing like this is quite hacky. Find a better approach?
-    fn sub_items(&mut self) -> Option<SubItems> {
+    fn sub_items(&mut self) -> Option<SubItems<'_>> {
         None
     }
 
@@ -110,7 +110,7 @@ pub trait Menu: Widget {
 }
 
 impl<A, W: Menu<Data = ()>> Menu for MapAny<A, W> {
-    fn sub_items(&mut self) -> Option<SubItems> {
+    fn sub_items(&mut self) -> Option<SubItems<'_>> {
         self.inner.sub_items()
     }
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -151,7 +151,7 @@ impl_scope! {
     }
 
     impl Menu for Self {
-        fn sub_items(&mut self) -> Option<SubItems> {
+        fn sub_items(&mut self) -> Option<SubItems<'_>> {
             Some(SubItems {
                 label: Some(&mut self.label),
                 submenu: Some(&mut self.mark),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -207,13 +207,13 @@ where
 {
     /// Access config
     #[inline]
-    pub fn config(&self) -> Ref<Config> {
+    pub fn config(&self) -> Ref<'_, Config> {
         self.state.config().borrow()
     }
 
     /// Access config mutably
     #[inline]
-    pub fn config_mut(&mut self) -> RefMut<Config> {
+    pub fn config_mut(&mut self) -> RefMut<'_, Config> {
         self.state.config().borrow_mut()
     }
 


### PR DESCRIPTION
This should support drawing colour emojis, except that the font system (kas-text + fontique) always finds a simple outline first.

Possibly the best way to fix that is to via [this](https://github.com/linebender/parley/issues/371#issuecomment-2934501589) (i.e. modify `fontique::Query` to limit results to those supporting the matching `Block` or unicode range).