### PR TITLE
Update impl-tools: use `#[impl_self]`

### DIFF
--- a/crates/kas-core/src/core/collection.rs
+++ b/crates/kas-core/src/core/collection.rs
@@ -7,7 +7,7 @@
 
 use crate::layout::{GridCellInfo, GridDimensions};
 use crate::{Node, Tile, Widget};
-use kas_macros::impl_scope;
+use kas_macros::impl_self;
 use std::ops::RangeBounds;
 
 /// A collection of (child) widgets
@@ -155,7 +155,8 @@ pub trait CellCollection: Collection {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod CollectionIterTile {
     /// An iterator over a [`Collection`] as [`Tile`] elements
     pub struct CollectionIterTile<'a, C: Collection + ?Sized> {
         start: usize,
@@ -192,7 +193,8 @@ impl_scope! {
     impl ExactSizeIterator for Self {}
 }
 
-impl_scope! {
+#[impl_self]
+mod CollectionIterCellInfo {
     /// An iterator over a [`Collection`] as [`GridCellInfo`] elements
     pub struct CollectionIterCellInfo<'a, C: CellCollection + ?Sized> {
         start: usize,

--- a/crates/kas-core/src/core/layout.rs
+++ b/crates/kas-core/src/core/layout.rs
@@ -27,7 +27,7 @@ use kas_macros::autoimpl;
 ///
 /// The [`#widget`] macro will, when its `layout` property is specified,
 /// generate an implementation of this trait (if omitted from the surrounding
-/// `impl_scope!`) or provide default implementations of its methods (if an
+/// `#[impl_self]`) or provide default implementations of its methods (if an
 /// explicit impl of `Layout` is found but some methods are missing).
 ///
 /// [`#widget`]: macros::widget

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -292,7 +292,8 @@ pub enum NavAdvance {
 ///
 /// Synopsis:
 /// ```ignore
-/// impl_scope! {
+/// #[impl_self]
+/// mod MyWidget {
 ///     #[widget {
 ///         // macro properties (all optional)
 ///         Data = T;

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -283,8 +283,9 @@ pub enum NavAdvance {
 /// # Implementing Widget
 ///
 /// To implement a widget, use the [`#widget`] macro within an
-/// [`impl_scope`](macros::impl_scope). **This is the only supported method of
-/// implementing `Widget`.**
+/// [`impl_self`](macros::impl_self), [`impl_scope!`](macros::impl_scope) or
+/// [`impl_anon!`](macros::impl_anon) macro.
+/// **This is the only supported method of implementing `Widget`.**
 ///
 /// Explicit (partial) implementations of [`Widget`], [`Layout`], [`Tile`] and [`Events`]
 /// are optional. The [`#widget`] macro completes implementations.

--- a/crates/kas-core/src/decorations.rs
+++ b/crates/kas-core/src/decorations.rs
@@ -11,7 +11,7 @@ use crate::event::{CursorIcon, ResizeDirection};
 use crate::prelude::*;
 use crate::theme::MarkStyle;
 use crate::theme::{Text, TextClass};
-use kas_macros::impl_scope;
+use kas_macros::impl_self;
 use std::fmt::Debug;
 
 /// Available decoration modes
@@ -40,7 +40,8 @@ pub enum Decorations {
     Server,
 }
 
-impl_scope! {
+#[impl_self]
+mod Border {
     /// A border region
     ///
     /// Does not draw anything; used solely for event handling.
@@ -98,7 +99,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Label {
     /// A simple label
     #[derive(Clone, Debug, Default)]
     #[widget {
@@ -123,7 +125,8 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            self.text.set_rect(cx, rect, hints.combine(AlignHints::CENTER));
+            self.text
+                .set_rect(cx, rect, hints.combine(AlignHints::CENTER));
         }
     }
 
@@ -143,7 +146,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod MarkButton {
     /// A mark which is also a button
     ///
     /// This button is not keyboard navigable; only mouse/touch interactive.
@@ -201,7 +205,8 @@ enum TitleBarButton {
     Close,
 }
 
-impl_scope! {
+#[impl_self]
+mod TitleBarButtons {
     /// A set of title-bar buttons
     ///
     /// Currently, this consists of minimise, maximise and close buttons.
@@ -233,13 +238,15 @@ impl_scope! {
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
             if let Some(msg) = cx.try_pop() {
                 match msg {
-                    TitleBarButton::Minimize => {
+                    TitleBarButton::Minimize =>
+                    {
                         #[cfg(winit)]
                         if let Some(w) = cx.winit_window() {
                             w.set_minimized(true);
                         }
                     }
-                    TitleBarButton::Maximize => {
+                    TitleBarButton::Maximize =>
+                    {
                         #[cfg(winit)]
                         if let Some(w) = cx.winit_window() {
                             w.set_maximized(!w.is_maximized());
@@ -252,7 +259,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod TitleBar {
     /// A window's title bar (part of decoration)
     #[derive(Clone, Default)]
     #[widget{

--- a/crates/kas-core/src/hidden.rs
+++ b/crates/kas-core/src/hidden.rs
@@ -15,9 +15,10 @@ use crate::layout::{AlignHints, AxisInfo, SizeRules};
 use crate::theme::{SizeCx, Text, TextClass};
 #[allow(unused)] use crate::Action;
 use crate::{Events, Layout, Widget};
-use kas_macros::{autoimpl, impl_scope};
+use kas_macros::{autoimpl, impl_self};
 
-impl_scope! {
+#[impl_self]
+mod StrLabel {
     /// A simple text label
     ///
     /// Vertical alignment defaults to centred, horizontal
@@ -51,7 +52,8 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
+            self.text
+                .set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
         }
     }
 
@@ -62,7 +64,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod MapAny {
     /// Map any input data to `()`
     ///
     /// This is a generic data-mapping widget-wrapper with fixed `()` input
@@ -96,7 +99,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Align {
     /// Apply an alignment hint
     ///
     /// The inner widget chooses how to apply (or ignore) this hint.
@@ -127,7 +131,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Pack {
     /// Apply an alignment hint, squash and align the result
     ///
     /// The inner widget chooses how to apply (or ignore) this hint.
@@ -150,7 +155,11 @@ impl_scope! {
         /// Construct
         #[inline]
         pub fn new(inner: W, hints: AlignHints) -> Self {
-            Pack { inner, hints, size: Size::ZERO }
+            Pack {
+                inner,
+                hints,
+                size: Size::ZERO,
+            }
         }
     }
 

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -8,7 +8,7 @@
 //! Re-exports:
 //!
 //! -   [`kas::cast`] is a re-export of [`easy-cast`](https://crates.io/crates/easy-cast)
-//! -   [`impl_scope!`], [`impl_anon!`], [`autoimpl`] and [`impl_default`] are
+//! -   [`impl_self`], [`impl_scope!`], [`impl_anon!`], [`autoimpl`] and [`impl_default`] are
 //!     re-implementations of [`impl-tools`](https://crates.io/crates/impl-tools) macros
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -31,7 +31,7 @@ mod root;
 pub use crate::core::*;
 pub use action::Action;
 pub use kas_macros::{autoimpl, extends, impl_default};
-pub use kas_macros::{cell_collection, collection, impl_anon, impl_scope};
+pub use kas_macros::{cell_collection, collection, impl_anon, impl_scope, impl_self};
 pub use kas_macros::{widget, widget_index, widget_set_rect};
 #[doc(inline)] pub use popup::Popup;
 #[doc(inline)] pub(crate) use popup::PopupDescriptor;

--- a/crates/kas-core/src/popup.rs
+++ b/crates/kas-core/src/popup.rs
@@ -8,7 +8,7 @@
 use crate::dir::Direction;
 use crate::event::{ConfigCx, Event, EventCx, IsUsed, Scroll, Unused, Used};
 use crate::{Events, Id, Tile, TileExt, Widget, WindowId};
-use kas_macros::{impl_scope, widget_index};
+use kas_macros::{impl_self, widget_index};
 
 #[allow(unused)] use crate::event::EventState;
 
@@ -19,7 +19,8 @@ pub(crate) struct PopupDescriptor {
     pub direction: Direction,
 }
 
-impl_scope! {
+#[impl_self]
+mod Popup {
     /// A popup (e.g. menu or tooltip)
     ///
     /// A pop-up is a box used for things like tool-tips and menus which escapes
@@ -69,7 +70,12 @@ impl_scope! {
         fn handle_event(&mut self, cx: &mut EventCx, _: &W::Data, event: Event) -> IsUsed {
             match event {
                 Event::PressStart { press } => {
-                    if press.id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
+                    if press
+                        .id
+                        .as_ref()
+                        .map(|id| self.is_ancestor_of(id))
+                        .unwrap_or(false)
+                    {
                         Unused
                     } else {
                         self.close(cx);

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -21,7 +21,7 @@ pub use crate::layout::{Align, AlignHints, AlignPair, AxisInfo, SizeRules, Stret
 #[doc(no_inline)] pub use crate::theme::{DrawCx, SizeCx};
 #[doc(no_inline)] pub use crate::Action;
 #[doc(no_inline)]
-pub use crate::{autoimpl, impl_anon, impl_default, impl_scope};
+pub use crate::{autoimpl, impl_anon, impl_default, impl_scope, impl_self};
 #[doc(no_inline)]
 pub use crate::{widget, widget_index, widget_set_rect};
 #[doc(no_inline)]

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -13,7 +13,7 @@ use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::{self, AlignHints, AxisInfo, SizeRules};
 use crate::theme::{DrawCx, FrameStyle, SizeCx};
 use crate::{Action, Events, Icon, Id, Layout, Tile, TileExt, Widget};
-use kas_macros::{impl_scope, widget_set_rect};
+use kas_macros::{impl_self, widget_set_rect};
 use smallvec::SmallVec;
 use std::num::NonZeroU32;
 
@@ -56,7 +56,8 @@ pub enum WindowCommand {
     SetIcon(Option<Icon>),
 }
 
-impl_scope! {
+#[impl_self]
+mod Window {
     /// The window widget
     ///
     /// This widget is the root of any UI tree used as a window. It manages
@@ -76,14 +77,22 @@ impl_scope! {
         inner: Box<dyn Widget<Data = Data>>,
         #[widget(&())]
         title_bar: TitleBar,
-        #[widget(&())] b_w: Border,
-        #[widget(&())] b_e: Border,
-        #[widget(&())] b_n: Border,
-        #[widget(&())] b_s: Border,
-        #[widget(&())] b_nw: Border,
-        #[widget(&())] b_ne: Border,
-        #[widget(&())] b_sw: Border,
-        #[widget(&())] b_se: Border,
+        #[widget(&())]
+        b_w: Border,
+        #[widget(&())]
+        b_e: Border,
+        #[widget(&())]
+        b_n: Border,
+        #[widget(&())]
+        b_s: Border,
+        #[widget(&())]
+        b_nw: Border,
+        #[widget(&())]
+        b_ne: Border,
+        #[widget(&())]
+        b_sw: Border,
+        #[widget(&())]
+        b_se: Border,
         bar_h: i32,
         dec_offset: Offset,
         dec_size: Size,
@@ -136,18 +145,43 @@ impl_scope! {
             let mut p_in = p_nw + self.dec_offset;
             let p_se = p_in + s_in;
 
-            self.b_w.set_rect(cx, Rect::new(Coord(p_nw.0, p_in.1), Size(s_nw.0, s_in.1)), hints);
-            self.b_e.set_rect(cx, Rect::new(Coord(p_se.0, p_in.1), Size(s_se.0, s_in.1)), hints);
-            self.b_n.set_rect(cx, Rect::new(Coord(p_in.0, p_nw.1), Size(s_in.0, s_nw.1)), hints);
-            self.b_s.set_rect(cx, Rect::new(Coord(p_in.0, p_se.1), Size(s_in.0, s_se.1)), hints);
+            self.b_w.set_rect(
+                cx,
+                Rect::new(Coord(p_nw.0, p_in.1), Size(s_nw.0, s_in.1)),
+                hints,
+            );
+            self.b_e.set_rect(
+                cx,
+                Rect::new(Coord(p_se.0, p_in.1), Size(s_se.0, s_in.1)),
+                hints,
+            );
+            self.b_n.set_rect(
+                cx,
+                Rect::new(Coord(p_in.0, p_nw.1), Size(s_in.0, s_nw.1)),
+                hints,
+            );
+            self.b_s.set_rect(
+                cx,
+                Rect::new(Coord(p_in.0, p_se.1), Size(s_in.0, s_se.1)),
+                hints,
+            );
             self.b_nw.set_rect(cx, Rect::new(p_nw, s_nw), hints);
-            self.b_ne.set_rect(cx, Rect::new(Coord(p_se.0, p_nw.1), Size(s_se.0, s_nw.1)), hints);
+            self.b_ne.set_rect(
+                cx,
+                Rect::new(Coord(p_se.0, p_nw.1), Size(s_se.0, s_nw.1)),
+                hints,
+            );
             self.b_se.set_rect(cx, Rect::new(p_se, s_se), hints);
-            self.b_sw.set_rect(cx, Rect::new(Coord(p_nw.0, p_se.1), Size(s_nw.0, s_se.1)), hints);
+            self.b_sw.set_rect(
+                cx,
+                Rect::new(Coord(p_nw.0, p_se.1), Size(s_nw.0, s_se.1)),
+                hints,
+            );
 
             if self.bar_h > 0 {
                 let bar_size = Size(s_in.0, self.bar_h);
-                self.title_bar.set_rect(cx, Rect::new(p_in, bar_size), hints);
+                self.title_bar
+                    .set_rect(cx, Rect::new(p_in, bar_size), hints);
                 p_in.1 += self.bar_h;
                 s_in -= Size(0, self.bar_h);
             }
@@ -176,7 +210,8 @@ impl_scope! {
                     return Some(id);
                 }
             }
-            self.inner.try_probe(coord)
+            self.inner
+                .try_probe(coord)
                 .or_else(|| self.b_w.try_probe(coord))
                 .or_else(|| self.b_e.try_probe(coord))
                 .or_else(|| self.b_n.try_probe(coord))

--- a/crates/kas-macros/Cargo.toml
+++ b/crates/kas-macros/Cargo.toml
@@ -30,7 +30,7 @@ proc-macro-error2 = { version = "2.0", default-features = false }
 bitflags = "2.3.3"
 
 [dependencies.impl-tools-lib]
-version = "0.11.0" # version used in doc links
+version = "0.11.2" # version used in doc links
 
 [dependencies.syn]
 version = "2.0.22"

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -118,7 +118,12 @@ fn find_attr(path: &syn::Path) -> Option<&'static dyn scope::ScopeAttr> {
 /// [rustfmt#5254](https://github.com/rust-lang/rustfmt/issues/5254),
 /// [rustfmt#5538](https://github.com/rust-lang/rustfmt/pull/5538)).
 ///
-/// See [`impl_tools::impl_scope`](https://docs.rs/impl-tools/0.6/impl_tools/macro.impl_scope.html)
+/// Note: prefer [`macro@impl_self`] over this macro unless using
+/// [`macro@impl_default`]. This macro will be removed once
+/// [RFC 3681](https://github.com/rust-lang/rfcs/pull/3681) (default field
+/// values) is stable in this crate's MSRV.
+///
+/// See [`impl_tools::impl_scope`](https://docs.rs/impl-tools/latest/impl_tools/macro.impl_scope.html)
 /// for full documentation.
 ///
 /// ## Special attribute macros
@@ -138,6 +143,96 @@ fn find_attr(path: &syn::Path) -> Option<&'static dyn scope::ScopeAttr> {
 pub fn impl_scope(input: TokenStream) -> TokenStream {
     let mut scope = parse_macro_input!(input as scope::Scope);
     scope.apply_attrs(find_attr);
+    scope.expand().into()
+}
+
+fn find_impl_self_attrs(path: &syn::Path) -> Option<&'static dyn scope::ScopeAttr> {
+    use scope::ScopeAttr;
+    if widget_args::AttrImplWidget.path().matches(path) {
+        Some(&widget_args::AttrImplWidget)
+    } else {
+        None
+    }
+}
+
+/// Implement a type with `impl Self` syntax
+///
+/// This attribute macro supports a type (struct, enum, type alias or union)
+/// definition plus associated `impl` items within a `mod`.
+///
+/// Macro expansion discards the `mod` entirely, placing all contents into the
+/// outer scope. This simplifies privacy rules in many use-cases, and highlights
+/// that the usage of `mod` is purely a hack to make the macro input valid Rust
+/// syntax (and thus compatible with `rustfmt`).
+///
+/// ## Special attribute macros
+///
+/// Additionally, `#[impl_self]` supports special attribute macros evaluated
+/// within its scope:
+///
+/// -   [`#[widget]`](macro@widget): implement `kas::Widget` trait family
+///
+/// ## Syntax
+///
+/// > _ImplSelf_ :\
+/// > &nbsp;&nbsp; `#[impl_self]` `mod` _Name_ `{` _ScopeItem_ _ItemImpl_ * `}`
+/// >
+/// > _ScopeItem_ :\
+/// > &nbsp;&nbsp; _ItemEnum_ | _ItemStruct_ | _ItemType_ | _ItemUnion_
+///
+/// Here, _ItemEnum_, _ItemStruct_, _ItemType_ and _ItemUnion_ are `enum`,
+/// `struct`, `type` alias and `union` definitions respectively. Whichever of
+/// these is used, it must match the module name _Name_.
+///
+/// _ItemImpl_ is an `impl` item. It may use the standard implementation syntax
+/// (e.g. `impl Debug for MyType { .. }`) or `impl Self` syntax (see below).
+///
+/// The `mod` may not contain any other items, except `doc` items (documentation
+/// on the module itself is ignored in favour of documentation on the defined
+/// type) and attributes (which apply as usual).
+///
+/// ### `impl Self` syntax
+///
+/// `impl Self` "syntax" is syntactically-valid (but not semantically-valid)
+/// Rust syntax for writing inherent and trait `impl` blocks:
+///
+/// -   `impl Self { ... }` — an inherent `impl` item on the defined type
+/// -   `impl Debug for Self { ... }` — a trait `impl` item on the defined type
+///
+/// Generic parameters and bounds are copied from the type definition.
+/// Additional generic parameters may be specified; these extend the list of
+/// generic parameters on the type itself, and thus must have distinct names.
+/// Additional bounds (where clauses) may be specified; these extend the list of
+/// bounds on the type itself.
+///
+/// ## Example
+///
+/// ```
+/// #[impl_tools::impl_self]
+/// mod Pair {
+///     /// A pair of values of type `T`
+///     pub struct Pair<T>(T, T);
+///
+///     impl Self {
+///         pub fn new(a: T, b: T) -> Self {
+///             Pair(a, b)
+///         }
+///     }
+///
+///     impl Self where T: Clone {
+///         pub fn splat(a: T) -> Self {
+///             let b = a.clone();
+///             Pair(a, b)
+///         }
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+#[proc_macro_error]
+pub fn impl_self(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let _ = parse_macro_input!(attr as scope::ScopeModAttrs);
+    let mut scope = parse_macro_input!(input as scope::ScopeMod).contents;
+    scope.apply_attrs(find_impl_self_attrs);
     scope.expand().into()
 }
 

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -238,7 +238,8 @@ pub fn impl_self(attr: TokenStream, input: TokenStream) -> TokenStream {
 
 /// Attribute to implement the `kas::Widget` family of traits
 ///
-/// This may *only* be used within the [`impl_scope!`] macro.
+/// This may *only* be used within the [`macro@impl_self`], [`impl_scope!`]
+/// and [`impl_anon!`] macros.
 ///
 /// Assists implementation of the [`Widget`], [`Events`], [`Layout`] and [`Tile`] traits.
 /// Implementations of these traits are generated if missing or augmented with
@@ -336,7 +337,8 @@ pub fn impl_self(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// [`Frame`](https://docs.rs/kas-widgets/latest/kas_widgets/struct.Frame.html) widget:
 ///
 /// ```ignore
-/// impl_scope! {
+/// #[impl_self]
+/// mod Frame {
 ///     /// A frame around content
 ///     #[derive(Clone, Default)]
 ///     #[widget{
@@ -367,7 +369,8 @@ pub fn impl_self(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// It is possible to derive from a field which is itself a widget, e.g.:
 /// ```ignore
-/// impl_scope! {
+/// #[impl_self]
+/// mod ScrollBarRegion {
 ///     #[autoimpl(Deref, DerefMut using self.0)]
 ///     #[derive(Clone, Default)]
 ///     #[widget{ derive = self.0; }]
@@ -429,7 +432,7 @@ pub fn impl_self(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn widget(_: TokenStream, item: TokenStream) -> TokenStream {
-    emit_call_site_error!("must be used within impl_scope! { ... }");
+    emit_call_site_error!("must be used within scope of #[impl_self], impl_scope! or impl_anon!");
     item
 }
 
@@ -496,8 +499,8 @@ pub fn impl_anon(input: TokenStream) -> TokenStream {
 
 /// Index of a child widget
 ///
-/// This macro is usable only within an [`impl_scope!`]  macro using the
-/// [`widget`](macro@widget) attribute.
+/// This macro is usable only within an [`macro@impl_self`], [`impl_scope!`] or
+/// [`impl_anon!`] macro using the [`macro@widget`] attribute.
 ///
 /// Example usage: `widget_index![self.a]`. If `a` is a child widget (a field
 /// marked with the `#[widget]` attribute), then this expands to the child
@@ -517,7 +520,8 @@ pub fn widget_index(input: TokenStream) -> TokenStream {
 /// to implement method [`Layout::rect`]. This macro assigns to that field.
 ///
 /// This macro is usable only within the definition of `Layout::set_rect` within
-/// an [`impl_scope!`] macro using the [`widget`](macro@widget) attribute.
+/// an [`macro@impl_self`], [`impl_scope!`] or [`impl_anon!`] macro using the
+/// [`macro@widget`] attribute.
 ///
 /// The method `Layout::rect` will be generated if this macro is used by the
 /// widget, otherwise a definition of the method must be provided.

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -26,7 +26,7 @@ mod widget_derive;
 
 /// Implement `Default`
 ///
-/// See [`impl_tools::impl_default`](https://docs.rs/impl-tools/0.6/impl_tools/attr.impl_default.html)
+/// See [`impl_tools::impl_default`](https://docs.rs/impl-tools/latest/impl_tools/attr.impl_default.html)
 /// for full documentation.
 #[proc_macro_attribute]
 #[proc_macro_error]
@@ -45,7 +45,7 @@ pub fn impl_default(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// A variant of the standard `derive` macro
 ///
-/// See [`impl_tools::autoimpl`](https://docs.rs/impl-tools/0.6/impl_tools/attr.autoimpl.html)
+/// See [`impl_tools::autoimpl`](https://docs.rs/impl-tools/latest/impl_tools/attr.autoimpl.html)
 /// for full documentation.
 ///
 /// The following traits are supported:
@@ -131,7 +131,7 @@ fn find_attr(path: &syn::Path) -> Option<&'static dyn scope::ScopeAttr> {
 /// -   [`#[widget]`](macro@widget): implement `kas::Widget` trait family
 ///
 /// Note: matching these macros within `impl_scope!` does not use path
-/// resolution. Using `#[impl_tools::impl_default]` would resolve the variant
+/// resolution. Using `#[kas_macros::impl_default]` would resolve the variant
 /// of this macro which *doesn't support* field initializers.
 #[proc_macro_error]
 #[proc_macro]

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -208,7 +208,7 @@ fn find_impl_self_attrs(path: &syn::Path) -> Option<&'static dyn scope::ScopeAtt
 /// ## Example
 ///
 /// ```
-/// #[impl_tools::impl_self]
+/// #[kas_macros::impl_self]
 /// mod Pair {
 ///     /// A pair of values of type `T`
 ///     pub struct Pair<T>(T, T);

--- a/crates/kas-macros/src/visitors.rs
+++ b/crates/kas-macros/src/visitors.rs
@@ -28,7 +28,7 @@ impl Parse for UnscopedInput {
             let _ = input.parse::<kw::error_emitted>()?;
             Ok(UnscopedInput(input.parse()?))
         } else {
-            let msg = "usage invalid outside of `impl_scope!` macro with `#[widget]` attribute";
+            let msg = "usage invalid outside of #[impl_self], impl_scope! or impl_anon! macro with #[widget] attribute";
             Err(Error::new(Span::call_site(), msg))
         }
     }

--- a/crates/kas-resvg/src/canvas.rs
+++ b/crates/kas-resvg/src/canvas.rs
@@ -88,7 +88,8 @@ impl<P: CanvasProgram> State<P> {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Canvas {
     /// A canvas widget over the `tiny-skia` library
     ///
     /// The widget is essentially a cached image drawn from a [`Pixmap`]

--- a/crates/kas-resvg/src/svg.rs
+++ b/crates/kas-resvg/src/svg.rs
@@ -130,13 +130,13 @@ impl State {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Svg {
     /// An SVG image loaded from a path
     ///
     /// May be default constructed (result is empty).
     #[autoimpl(Debug ignore self.inner)]
-    #[impl_default]
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     #[widget]
     pub struct Svg {
         core: widget_core!(),
@@ -295,9 +295,9 @@ impl_scope! {
                 cx.redraw(&self);
                 self.inner = match std::mem::take(&mut self.inner) {
                     State::None => State::None,
-                    State::Initial(source) |
-                    State::Rendering(source) |
-                    State::Ready(source, _) => State::Ready(source, pixmap),
+                    State::Initial(source) | State::Rendering(source) | State::Ready(source, _) => {
+                        State::Ready(source, pixmap)
+                    }
                 };
 
                 let own_size: (u32, u32) = self.rect().size.cast();

--- a/crates/kas-view/src/filter/filter_list.rs
+++ b/crates/kas-view/src/filter/filter_list.rs
@@ -9,7 +9,7 @@ use super::Filter;
 use crate::{DataClerk, Driver, ListView};
 use kas::dir::{Direction, Directional};
 use kas::event::{EventCx, EventState};
-use kas::{autoimpl, impl_scope, Events, Widget};
+use kas::{autoimpl, impl_self, Events, Widget};
 use kas_widgets::edit::{EditBox, EditField, EditGuard};
 use kas_widgets::{ScrollBarMode, ScrollBars};
 use std::fmt::Debug;
@@ -42,7 +42,8 @@ impl EditGuard for AflGuard {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod FilterBoxListView {
     /// An [`EditBox`] above a filtered [`ListView`]
     ///
     /// This is essentially just two widgets with "glue" to handle a

--- a/crates/kas-widgets/src/adapt/adapt.rs
+++ b/crates/kas-widgets/src/adapt/adapt.rs
@@ -12,7 +12,8 @@ use linear_map::LinearMap;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-impl_scope! {
+#[impl_self]
+mod Adapt {
     /// Data adaption node
     ///
     /// Where [`Map`] allows mapping to a sub-set of input data, `Adapt` allows
@@ -177,7 +178,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Map {
     /// Data mapping
     ///
     /// This is a generic data-mapping widget-wrapper.

--- a/crates/kas-widgets/src/adapt/adapt_events.rs
+++ b/crates/kas-widgets/src/adapt/adapt_events.rs
@@ -6,13 +6,14 @@
 //! Event adapters
 
 use super::{AdaptConfigCx, AdaptEventCx};
-use kas::autoimpl;
 use kas::event::{ConfigCx, Event, EventCx, IsUsed};
 #[allow(unused)] use kas::Events;
+use kas::{autoimpl, impl_self};
 use kas::{Id, Node, Widget};
 use std::fmt::Debug;
 
-kas::impl_scope! {
+#[impl_self]
+mod AdaptEvents {
     /// Wrapper with configure / update / message handling callbacks.
     ///
     /// This type is constructed by some [`AdaptWidget`](super::AdaptWidget) methods.

--- a/crates/kas-widgets/src/adapt/reserve.rs
+++ b/crates/kas-widgets/src/adapt/reserve.rs
@@ -9,7 +9,8 @@ use kas::dir::Directions;
 use kas::prelude::*;
 use kas::theme::MarginStyle;
 
-impl_scope! {
+#[impl_self]
+mod Reserve {
     /// A generic widget for size reservations
     ///
     /// In a few cases it is desirable to reserve more space for a widget than
@@ -57,7 +58,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Margins {
     /// Specify margins
     ///
     /// This replaces a widget's margins.

--- a/crates/kas-widgets/src/adapt/with_label.rs
+++ b/crates/kas-widgets/src/adapt/with_label.rs
@@ -8,7 +8,8 @@
 use crate::AccessLabel;
 use kas::prelude::*;
 
-impl_scope! {
+#[impl_self]
+mod WithLabel {
     /// A wrapper widget with a label
     ///
     /// The label supports access keys, which activate `self.inner` on
@@ -31,7 +32,10 @@ impl_scope! {
 
     impl Self {
         /// Construct a wrapper around `inner` placing a `label` in the given `direction`
-        pub fn new<T: Into<AccessString>>(inner: W, label: T) -> Self where D: Default {
+        pub fn new<T: Into<AccessString>>(inner: W, label: T) -> Self
+        where
+            D: Default,
+        {
             Self::new_dir(inner, D::default(), label)
         }
     }

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -11,7 +11,8 @@ use kas::prelude::*;
 use kas::theme::{Background, FrameStyle};
 use std::fmt::Debug;
 
-impl_scope! {
+#[impl_self]
+mod Button {
     /// A push-button with a generic label
     ///
     /// Default alignment of content is centered.

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -11,7 +11,8 @@ use kas::theme::Feature;
 use std::fmt::Debug;
 use std::time::Instant;
 
-impl_scope! {
+#[impl_self]
+mod CheckBox {
     /// A bare check box (no label)
     ///
     /// See also [`CheckButton`] which includes a label.
@@ -169,7 +170,8 @@ pub(crate) fn shrink_to_text(rect: &mut Rect, direction: Direction, label: &Acce
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod CheckButton {
     /// A check button with label
     ///
     /// This is a [`CheckBox`] with a label.

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -17,7 +17,8 @@ use std::fmt::Debug;
 #[derive(Clone, Debug)]
 struct IndexMsg(usize);
 
-impl_scope! {
+#[impl_self]
+mod ComboBox {
     /// A pop-up multiple choice menu
     ///
     /// # Messages
@@ -63,7 +64,8 @@ impl_scope! {
 
         fn update(&mut self, cx: &mut ConfigCx, data: &A) {
             let msg = (self.state_fn)(cx, data);
-            let opt_index = self.popup
+            let opt_index = self
+                .popup
                 .inner
                 .inner
                 .iter()
@@ -126,7 +128,9 @@ impl_scope! {
                         let index = if y > 0 {
                             self.active.saturating_sub(y as usize)
                         } else {
-                            self.active.saturating_add((-y) as usize).min(self.len().saturating_sub(1))
+                            self.active
+                                .saturating_add((-y) as usize)
+                                .min(self.len().saturating_sub(1))
                         };
                         self.set_active(cx, index);
                         Used
@@ -135,9 +139,16 @@ impl_scope! {
                     }
                 }
                 Event::PressStart { press } => {
-                    if press.id.as_ref().map(|id| self.is_ancestor_of(id)).unwrap_or(false) {
+                    if press
+                        .id
+                        .as_ref()
+                        .map(|id| self.is_ancestor_of(id))
+                        .unwrap_or(false)
+                    {
                         if press.is_primary() {
-                            press.grab(self.id(), kas::event::GrabMode::Grab).complete(cx);
+                            press
+                                .grab(self.id(), kas::event::GrabMode::Grab)
+                                .complete(cx);
                             cx.set_grab_depress(*press, press.id);
                             self.opening = !self.popup.is_open();
                         }

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -21,7 +21,8 @@ use kas::text::format::FormattableText;
 #[derive(Copy, Clone, Debug)]
 struct MessageBoxOk;
 
-impl_scope! {
+#[impl_self]
+mod MessageBox {
     /// A simple message box.
     #[widget{
         layout = column! [self.label, self.button];
@@ -47,10 +48,8 @@ impl_scope! {
 
         /// Build a [`Window`]
         pub fn into_window<A: 'static>(self, title: impl ToString) -> Window<A> {
-            Window::new(self.map_any(), title)
-                .with_restrictions(true, true)
+            Window::new(self.map_any(), title).with_restrictions(true, true)
         }
-
     }
 
     impl Events for Self {
@@ -78,7 +77,8 @@ pub enum TextEditResult {
 #[derive(Clone, Debug)]
 struct MsgClose(bool);
 
-impl_scope! {
+#[impl_self]
+mod TextEdit {
     #[widget{
         layout = grid! {
             (0..3, 0) => self.edit,

--- a/crates/kas-widgets/src/event_config.rs
+++ b/crates/kas-widgets/src/event_config.rs
@@ -9,7 +9,8 @@ use crate::{Button, CheckButton, ComboBox, Spinner};
 use kas::config::{ConfigMsg, EventConfigMsg, MousePan};
 use kas::prelude::*;
 
-impl_scope! {
+#[impl_self]
+mod EventConfig {
     /// A widget for configuring event config
     ///
     /// This only needs to be added to a UI to be functional.
@@ -117,27 +118,41 @@ impl_scope! {
                 menu_delay: Spinner::new(0..=5_000, |cx, _| cx.config().base().event.menu_delay_ms)
                     .with_step(50)
                     .with_msg(EventConfigMsg::MenuDelay),
-                touch_select_delay: Spinner::new(0..=5_000, |cx: &ConfigCx, _| cx.config().base().event.touch_select_delay_ms)
-                    .with_step(50)
-                    .with_msg(EventConfigMsg::TouchSelectDelay),
-                kinetic_timeout: Spinner::new(0..=500, |cx: &ConfigCx, _| cx.config().base().event.kinetic_timeout_ms)
-                    .with_step(5)
-                    .with_msg(EventConfigMsg::KineticTimeout),
-                kinetic_decay_mul: Spinner::new(0.0..=1.0, |cx: &ConfigCx, _| cx.config().base().event.kinetic_decay_mul)
-                    .with_step(0.0625)
-                    .with_msg(EventConfigMsg::KineticDecayMul),
-                kinetic_decay_sub: Spinner::new(0.0..=1.0e4, |cx: &ConfigCx, _| cx.config().base().event.kinetic_decay_sub)
-                    .with_step(10.0)
-                    .with_msg(EventConfigMsg::KineticDecaySub),
-                kinetic_grab_sub: Spinner::new(0.0..=1.0e4, |cx: &ConfigCx, _| cx.config().base().event.kinetic_grab_sub)
-                    .with_step(5.0)
-                    .with_msg(EventConfigMsg::KineticGrabSub),
-                scroll_dist_em: Spinner::new(0.125..=125.0, |cx: &ConfigCx, _| cx.config().base().event.scroll_dist_em)
-                    .with_step(0.125)
-                    .with_msg(EventConfigMsg::ScrollDistEm),
-                pan_dist_thresh: Spinner::new(0.25..=25.0, |cx: &ConfigCx, _| cx.config().base().event.pan_dist_thresh)
-                    .with_step(0.25)
-                    .with_msg(EventConfigMsg::PanDistThresh),
+                touch_select_delay: Spinner::new(0..=5_000, |cx: &ConfigCx, _| {
+                    cx.config().base().event.touch_select_delay_ms
+                })
+                .with_step(50)
+                .with_msg(EventConfigMsg::TouchSelectDelay),
+                kinetic_timeout: Spinner::new(0..=500, |cx: &ConfigCx, _| {
+                    cx.config().base().event.kinetic_timeout_ms
+                })
+                .with_step(5)
+                .with_msg(EventConfigMsg::KineticTimeout),
+                kinetic_decay_mul: Spinner::new(0.0..=1.0, |cx: &ConfigCx, _| {
+                    cx.config().base().event.kinetic_decay_mul
+                })
+                .with_step(0.0625)
+                .with_msg(EventConfigMsg::KineticDecayMul),
+                kinetic_decay_sub: Spinner::new(0.0..=1.0e4, |cx: &ConfigCx, _| {
+                    cx.config().base().event.kinetic_decay_sub
+                })
+                .with_step(10.0)
+                .with_msg(EventConfigMsg::KineticDecaySub),
+                kinetic_grab_sub: Spinner::new(0.0..=1.0e4, |cx: &ConfigCx, _| {
+                    cx.config().base().event.kinetic_grab_sub
+                })
+                .with_step(5.0)
+                .with_msg(EventConfigMsg::KineticGrabSub),
+                scroll_dist_em: Spinner::new(0.125..=125.0, |cx: &ConfigCx, _| {
+                    cx.config().base().event.scroll_dist_em
+                })
+                .with_step(0.125)
+                .with_msg(EventConfigMsg::ScrollDistEm),
+                pan_dist_thresh: Spinner::new(0.25..=25.0, |cx: &ConfigCx, _| {
+                    cx.config().base().event.pan_dist_thresh
+                })
+                .with_step(0.25)
+                .with_msg(EventConfigMsg::PanDistThresh),
                 mouse_pan: ComboBox::new_msg(
                     pan_options,
                     |cx: &ConfigCx, _| cx.config().base().event.mouse_pan,

--- a/crates/kas-widgets/src/filler.rs
+++ b/crates/kas-widgets/src/filler.rs
@@ -7,7 +7,8 @@
 
 use kas::prelude::*;
 
-impl_scope! {
+#[impl_self]
+mod Filler {
     /// A space filler
     ///
     /// This widget has zero minimum size but can expand according to the given

--- a/crates/kas-widgets/src/float.rs
+++ b/crates/kas-widgets/src/float.rs
@@ -70,7 +70,8 @@ macro_rules! float {
     };
 }
 
-impl_scope! {
+#[impl_self]
+mod Float {
     /// A float widget
     ///
     /// All widgets occupy the same space with the first child on top.

--- a/crates/kas-widgets/src/frame.rs
+++ b/crates/kas-widgets/src/frame.rs
@@ -42,7 +42,8 @@ macro_rules! frame {
     };
 }
 
-impl_scope! {
+#[impl_self]
+mod Frame {
     /// A frame around content
     ///
     /// This widget provides a simple abstraction: drawing a frame around its

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -128,7 +128,8 @@ macro_rules! aligned_row {
     };
 }
 
-impl_scope! {
+#[impl_self]
+mod Grid {
     /// A generic grid widget
     ///
     /// Child widgets are displayed in a grid, according to each child's
@@ -178,7 +179,9 @@ impl_scope! {
         fn size_rules(&mut self, sizer: SizeCx, axis: AxisInfo) -> SizeRules {
             let mut solver = GridSolver::<Vec<_>, Vec<_>, _>::new(axis, self.dim, &mut self.layout);
             for n in 0..self.widgets.len() {
-                if let Some((info, child)) = self.widgets.cell_info(n).zip(self.widgets.get_mut_tile(n)) {
+                if let Some((info, child)) =
+                    self.widgets.cell_info(n).zip(self.widgets.get_mut_tile(n))
+                {
                     solver.for_child(&mut self.layout, info, |axis| {
                         child.size_rules(sizer.re(), axis)
                     });
@@ -191,7 +194,9 @@ impl_scope! {
             widget_set_rect!(rect);
             let mut setter = GridSetter::<Vec<_>, Vec<_>, _>::new(rect, self.dim, &mut self.layout);
             for n in 0..self.widgets.len() {
-                if let Some((info, child)) = self.widgets.cell_info(n).zip(self.widgets.get_mut_tile(n)) {
+                if let Some((info, child)) =
+                    self.widgets.cell_info(n).zip(self.widgets.get_mut_tile(n))
+                {
                     child.set_rect(cx, setter.child_rect(&mut self.layout, info), hints);
                 }
             }

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -31,7 +31,8 @@ pub enum GripMsg {
     PressEnd(bool),
 }
 
-impl_scope! {
+#[impl_self]
+mod GripPart {
     /// A draggable grip part
     ///
     /// [`Slider`](crate::Slider), [`ScrollBar`](crate::ScrollBar) and
@@ -102,7 +103,8 @@ impl_scope! {
             match event {
                 Event::PressStart { press, .. } => {
                     cx.push(GripMsg::PressStart);
-                    press.grab(self.id(), kas::event::GrabMode::Grab)
+                    press
+                        .grab(self.id(), kas::event::GrabMode::Grab)
                         .with_icon(CursorIcon::Grabbing)
                         .complete(cx);
 

--- a/crates/kas-widgets/src/image.rs
+++ b/crates/kas-widgets/src/image.rs
@@ -32,7 +32,8 @@ impl From<kas::draw::AllocError> for ImageError {
 #[cfg(feature = "image")]
 pub type Result<T> = std::result::Result<T, ImageError>;
 
-impl_scope! {
+#[impl_self]
+mod Image {
     /// An image with margins
     ///
     /// May be default constructed (result is empty).

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -10,7 +10,8 @@ use kas::prelude::*;
 use kas::text::format::FormattableText;
 use kas::theme::{Text, TextClass};
 
-impl_scope! {
+#[impl_self]
+mod Label {
     /// A text label
     ///
     /// `Label` derives its contents from input data. Use [`Text`](crate::Text)
@@ -22,8 +23,7 @@ impl_scope! {
     ///
     /// This type is generic over the text type.
     /// See also: [`AccessLabel`].
-    #[impl_default(where T: Default)]
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Default)]
     #[widget {
         Data = ();
         layout = self.text;
@@ -116,7 +116,8 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
+            self.text
+                .set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
         }
     }
 
@@ -159,7 +160,8 @@ impl<'a> From<&'a str> for Label<String> {
 // NOTE: AccessLabel requires a different text class. Once specialization is
 // stable we can simply replace the `draw` method, but for now we use a whole
 // new type.
-impl_scope! {
+#[impl_self]
+mod AccessLabel {
     /// A label supporting an access key
     ///
     /// An `AccessLabel` is a variant of [`Label`] supporting [`AccessString`],
@@ -170,8 +172,7 @@ impl_scope! {
     /// A text label. Vertical alignment defaults to centred, horizontal
     /// alignment depends on the script direction if not specified.
     /// Line-wrapping is enabled by default.
-    #[impl_default]
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Default)]
     #[widget {
         layout = self.text;
     }]
@@ -257,7 +258,8 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
+            self.text
+                .set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
         }
     }
 
@@ -278,7 +280,7 @@ impl_scope! {
                     cx.push(kas::messages::Activate(code));
                     Used
                 }
-                _ => Unused
+                _ => Unused,
             }
         }
     }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -204,7 +204,8 @@ pub type Row<C> = List<C, Right>;
 /// See documentation of [`List`] type.
 pub type Column<C> = List<C, Down>;
 
-impl_scope! {
+#[impl_self]
+mod List {
     /// A generic row/column widget
     ///
     /// A linear widget over a [`Collection`] of widgets.
@@ -267,7 +268,9 @@ impl_scope! {
             let mut solver = RowSolver::new(axis, dim, &mut self.layout);
             for n in 0..self.widgets.len() {
                 if let Some(child) = self.widgets.get_mut_tile(n) {
-                    solver.for_child(&mut self.layout, n, |axis| child.size_rules(sizer.re(), axis));
+                    solver.for_child(&mut self.layout, n, |axis| {
+                        child.size_rules(sizer.re(), axis)
+                    });
                 }
             }
             solver.finish(&mut self.layout)

--- a/crates/kas-widgets/src/mark.rs
+++ b/crates/kas-widgets/src/mark.rs
@@ -9,7 +9,8 @@ use kas::prelude::*;
 use kas::theme::MarkStyle;
 use std::fmt::Debug;
 
-impl_scope! {
+#[impl_self]
+mod Mark {
     /// A mark
     ///
     /// These are small theme-defined "glyphs"; see [`MarkStyle`]. They may be
@@ -56,7 +57,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod MarkButton {
     /// A mark which is also a button
     ///
     /// A clickable button over a [`Mark`].

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -11,7 +11,8 @@ use kas::prelude::*;
 use kas::theme::{FrameStyle, TextClass};
 use std::fmt::Debug;
 
-impl_scope! {
+#[impl_self]
+mod MenuEntry {
     /// A standard menu entry
     ///
     /// # Messages
@@ -99,7 +100,10 @@ impl_scope! {
         }
     }
 
-    impl PartialEq<M> for Self where M: PartialEq {
+    impl PartialEq<M> for Self
+    where
+        M: PartialEq,
+    {
         #[inline]
         fn eq(&self, rhs: &M) -> bool {
             self.msg == *rhs
@@ -107,7 +111,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod MenuToggle {
     /// A menu entry which can be toggled
     #[widget {
         layout = row! [self.checkbox, self.label];

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -13,7 +13,8 @@ use kas::theme::FrameStyle;
 
 const TIMER_SHOW: TimerHandle = TimerHandle::new(0, false);
 
-impl_scope! {
+#[impl_self]
+mod MenuBar {
     /// A menu-bar
     ///
     /// This widget houses a sequence of menu buttons, allowing input actions across
@@ -38,7 +39,10 @@ impl_scope! {
 
         /// Construct a menu builder
         pub fn builder() -> MenuBuilder<Data, D> {
-            MenuBuilder { menus: vec![], direction: D::default() }
+            MenuBuilder {
+                menus: vec![],
+                direction: D::default(),
+            }
         }
     }
     impl<Data> MenuBar<Data, kas::dir::Right> {
@@ -135,7 +139,8 @@ impl_scope! {
                     Used
                 }
                 Event::PressStart { press } => {
-                    if press.id
+                    if press
+                        .id
                         .as_ref()
                         .map(|id| self.is_ancestor_of(id))
                         .unwrap_or(false)
@@ -145,7 +150,9 @@ impl_scope! {
                             let press_in_the_bar = self.rect().contains(press.coord);
 
                             if !press_in_the_bar || !any_menu_open {
-                                press.grab(self.id(), kas::event::GrabMode::Grab).complete(cx);
+                                press
+                                    .grab(self.id(), kas::event::GrabMode::Grab)
+                                    .complete(cx);
                             }
                             cx.set_grab_depress(*press, press.id.clone());
                             if press_in_the_bar {
@@ -195,11 +202,7 @@ impl_scope! {
                     }
                     Used
                 }
-                Event::PressEnd {
-                    press,
-                    success,
-                    ..
-                } if success => {
+                Event::PressEnd { press, success, .. } if success => {
                     let id = match press.id {
                         Some(x) => x,
                         None => return Used,

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -13,7 +13,8 @@ use kas::prelude::*;
 use kas::theme::{FrameStyle, MarkStyle, TextClass};
 use kas::Popup;
 
-impl_scope! {
+#[impl_self]
+mod SubMenu {
     /// A sub-menu
     #[widget {
         layout = self.label;
@@ -198,7 +199,8 @@ const fn menu_view_row_info(row: u32) -> layout::GridCellInfo {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod MenuView {
     /// A menu view
     #[widget]
     struct MenuView<W: Menu> {

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -7,7 +7,8 @@
 
 use kas::prelude::*;
 
-impl_scope! {
+#[impl_self]
+mod NavFrame {
     /// Navigation Frame wrapper
     ///
     /// This widget is a wrapper that can be used to make a static widget such as a

--- a/crates/kas-widgets/src/progress.rs
+++ b/crates/kas-widgets/src/progress.rs
@@ -8,7 +8,8 @@
 use kas::prelude::*;
 use kas::theme::Feature;
 
-impl_scope! {
+#[impl_self]
+mod ProgressBar {
     /// A progress bar
     ///
     /// The "progress" value may range from 0.0 to 1.0.

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -11,7 +11,8 @@ use kas::theme::Feature;
 use std::fmt::Debug;
 use std::time::Instant;
 
-impl_scope! {
+#[impl_self]
+mod RadioBox {
     /// A bare radio box (no label)
     ///
     /// See also [`RadioButton`] which includes a label.
@@ -99,8 +100,7 @@ impl_scope! {
             state_fn: impl Fn(&ConfigCx, &A) -> bool + 'static,
             msg_fn: impl Fn() -> M + 'static,
         ) -> Self {
-            RadioBox::new(state_fn)
-                .with(move |cx, _| cx.push(msg_fn()))
+            RadioBox::new(state_fn).with(move |cx, _| cx.push(msg_fn()))
         }
 
         /// Construct a radio box
@@ -114,8 +114,7 @@ impl_scope! {
             A: Clone + Debug + Eq + 'static,
         {
             let v2 = value.clone();
-            Self::new(move |_, data| *data == value)
-                .with(move |cx, _| cx.push(v2.clone()))
+            Self::new(move |_, data| *data == value).with(move |cx, _| cx.push(v2.clone()))
         }
 
         fn select(&mut self, cx: &mut EventCx, data: &A) {
@@ -130,7 +129,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod RadioButton {
     /// A radio button with label
     ///
     /// See also [`RadioBox`] which excludes the label.
@@ -215,8 +215,7 @@ impl_scope! {
             state_fn: impl Fn(&ConfigCx, &A) -> bool + 'static,
             msg_fn: impl Fn() -> M + 'static,
         ) -> Self {
-            RadioButton::new(label, state_fn)
-                .with(move |cx, _| cx.push(msg_fn()))
+            RadioButton::new(label, state_fn).with(move |cx, _| cx.push(msg_fn()))
         }
 
         /// Construct a radio button
@@ -230,8 +229,7 @@ impl_scope! {
             A: Clone + Debug + Eq + 'static,
         {
             let v2 = value.clone();
-            Self::new(label, move |_, data| *data == value)
-                .with(move |cx, _| cx.push(v2.clone()))
+            Self::new(label, move |_, data| *data == value).with(move |cx, _| cx.push(v2.clone()))
         }
 
         fn direction(&self) -> Direction {

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -9,7 +9,8 @@ use kas::event::{components::ScrollComponent, Scroll};
 use kas::prelude::*;
 use std::fmt::Debug;
 
-impl_scope! {
+#[impl_self]
+mod ScrollRegion {
     /// A scrollable region
     ///
     /// This region supports scrolling via mouse wheel and click/touch drag.
@@ -130,7 +131,8 @@ impl_scope! {
         }
 
         fn probe(&self, coord: Coord) -> Id {
-            self.inner.try_probe(coord + self.translation())
+            self.inner
+                .try_probe(coord + self.translation())
                 .unwrap_or_else(|| self.id())
         }
     }
@@ -141,7 +143,8 @@ impl_scope! {
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
-            self.scroll.scroll_by_event(cx, event, self.id(), self.rect())
+            self.scroll
+                .scroll_by_event(cx, event, self.id(), self.rect())
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx, _: &Self::Data, scroll: Scroll) {

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -39,7 +39,8 @@ pub struct ScrollMsg(pub i32);
 
 const TIMER_HIDE: TimerHandle = TimerHandle::new(0, false);
 
-impl_scope! {
+#[impl_self]
+mod ScrollBar {
     /// A scroll bar
     ///
     /// Scroll bars allow user-input of a value between 0 and a defined maximum,
@@ -59,7 +60,7 @@ impl_scope! {
         direction: D,
         // Terminology assumes vertical orientation:
         min_grip_len: i32, // units: px
-        grip_len: i32, // units: px
+        grip_len: i32,     // units: px
         // grip_size, max_value and value are all in arbitrary (user-provided) units:
         grip_size: i32, // contract: > 0; relative to max_value
         max_value: i32,
@@ -378,7 +379,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod ScrollBars {
     /// Scroll bar controls
     ///
     /// This is a wrapper adding scroll bar controls around a child. Note that this
@@ -388,8 +390,7 @@ impl_scope! {
     /// the result looks poor when content is scrolled. Instead the content should
     /// force internal margins by wrapping contents with a (zero-sized) frame.
     /// [`ScrollRegion`] already does this.
-    #[impl_default(where W: trait)]
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Default)]
     #[widget {
         Data = W::Data;
     }]
@@ -552,8 +553,10 @@ impl_scope! {
             if self.show_bars.0 {
                 let pos = Coord(pos.0, rect.pos2().1 - bar_width);
                 let size = Size::new(child_size.0, bar_width);
-                self.horiz_bar.set_rect(cx, Rect { pos, size }, AlignHints::NONE);
-                self.horiz_bar.set_limits(cx, max_scroll_offset.0, rect.size.0);
+                self.horiz_bar
+                    .set_rect(cx, Rect { pos, size }, AlignHints::NONE);
+                self.horiz_bar
+                    .set_limits(cx, max_scroll_offset.0, rect.size.0);
             } else {
                 self.horiz_bar.set_rect(cx, Rect::ZERO, AlignHints::NONE);
             }
@@ -561,8 +564,10 @@ impl_scope! {
             if self.show_bars.1 {
                 let pos = Coord(rect.pos2().0 - bar_width, pos.1);
                 let size = Size::new(bar_width, self.rect().size.1);
-                self.vert_bar.set_rect(cx, Rect { pos, size }, AlignHints::NONE);
-                self.vert_bar.set_limits(cx, max_scroll_offset.1, rect.size.1);
+                self.vert_bar
+                    .set_rect(cx, Rect { pos, size }, AlignHints::NONE);
+                self.vert_bar
+                    .set_limits(cx, max_scroll_offset.1, rect.size.1);
             } else {
                 self.vert_bar.set_rect(cx, Rect::ZERO, AlignHints::NONE);
             }
@@ -583,7 +588,8 @@ impl_scope! {
 
     impl Tile for Self {
         fn probe(&self, coord: Coord) -> Id {
-            self.vert_bar.try_probe(coord)
+            self.vert_bar
+                .try_probe(coord)
                 .or_else(|| self.horiz_bar.try_probe(coord))
                 .or_else(|| self.inner.try_probe(coord))
                 .unwrap_or_else(|| self.id())
@@ -615,7 +621,8 @@ impl_scope! {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod ScrollBarRegion {
     /// A scrollable region with bars
     ///
     /// This is essentially a `ScrollBars<ScrollRegion<W>>`:

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -14,7 +14,8 @@ use kas::text::format::FormattableText;
 use kas::text::SelectionHelper;
 use kas::theme::{Text, TextClass};
 
-impl_scope! {
+#[impl_self]
+mod ScrollLabel {
     /// A static text label supporting scrolling and selection
     ///
     /// Line-wrapping is enabled; default alignment is derived from the script
@@ -248,9 +249,7 @@ impl_scope! {
                     cx.redraw(self);
                     Used
                 }
-                Event::Scroll(delta) => {
-                    self.pan_delta(cx, delta.as_offset(cx), false)
-                }
+                Event::Scroll(delta) => self.pan_delta(cx, delta.as_offset(cx), false),
                 event => match self.input_handler.handle(cx, self.id(), event) {
                     TextInputAction::Used | TextInputAction::Finish => Used,
                     TextInputAction::Unused => Unused,

--- a/crates/kas-widgets/src/scroll_text.rs
+++ b/crates/kas-widgets/src/scroll_text.rs
@@ -14,7 +14,8 @@ use kas::text::format::FormattableText;
 use kas::text::SelectionHelper;
 use kas::theme::{Text, TextClass};
 
-impl_scope! {
+#[impl_self]
+mod ScrollText {
     /// A dynamic text label supporting scrolling and selection
     ///
     /// Line-wrapping is enabled; default alignment is derived from the script
@@ -226,9 +227,7 @@ impl_scope! {
                     cx.redraw(self);
                     Used
                 }
-                Event::Scroll(delta) => {
-                    self.pan_delta(cx, delta.as_offset(cx), false)
-                }
+                Event::Scroll(delta) => self.pan_delta(cx, delta.as_offset(cx), false),
                 event => match self.input_handler.handle(cx, self.id(), event) {
                     TextInputAction::Used | TextInputAction::Finish => Used,
                     TextInputAction::Unused => Unused,

--- a/crates/kas-widgets/src/separator.rs
+++ b/crates/kas-widgets/src/separator.rs
@@ -9,7 +9,8 @@ use crate::menu::Menu;
 use kas::prelude::*;
 use std::marker::PhantomData;
 
-impl_scope! {
+#[impl_self]
+mod Separator {
     /// A separator
     ///
     /// This widget draws a bar when in a list.

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -102,7 +102,8 @@ impl SliderValue for Duration {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Slider {
     /// A slider
     ///
     /// Sliders allow user input of a value from a fixed range.
@@ -139,28 +140,40 @@ impl_scope! {
         /// To make the slider interactive, assign an event handler with
         /// [`Self::with`] or [`Self::with_msg`].
         #[inline]
-        pub fn new(range: RangeInclusive<T>, state_fn: impl Fn(&ConfigCx, &A) -> T + 'static) -> Self {
+        pub fn new(
+            range: RangeInclusive<T>,
+            state_fn: impl Fn(&ConfigCx, &A) -> T + 'static,
+        ) -> Self {
             Slider::new_dir(range, state_fn, D::default())
         }
     }
     impl<A, T: SliderValue> Slider<A, T, kas::dir::Left> {
         /// Construct with fixed direction
         #[inline]
-        pub fn left(range: RangeInclusive<T>, state_fn: impl Fn(&ConfigCx, &A) -> T + 'static) -> Self {
+        pub fn left(
+            range: RangeInclusive<T>,
+            state_fn: impl Fn(&ConfigCx, &A) -> T + 'static,
+        ) -> Self {
             Slider::new(range, state_fn)
         }
     }
     impl<A, T: SliderValue> Slider<A, T, kas::dir::Right> {
         /// Construct with fixed direction
         #[inline]
-        pub fn right(range: RangeInclusive<T>, state_fn: impl Fn(&ConfigCx, &A) -> T + 'static) -> Self {
+        pub fn right(
+            range: RangeInclusive<T>,
+            state_fn: impl Fn(&ConfigCx, &A) -> T + 'static,
+        ) -> Self {
             Slider::new(range, state_fn)
         }
     }
     impl<A, T: SliderValue> Slider<A, T, kas::dir::Up> {
         /// Construct with fixed direction
         #[inline]
-        pub fn up(range: RangeInclusive<T>, state_fn: impl Fn(&ConfigCx, &A) -> T + 'static) -> Self {
+        pub fn up(
+            range: RangeInclusive<T>,
+            state_fn: impl Fn(&ConfigCx, &A) -> T + 'static,
+        ) -> Self {
             Slider::new(range, state_fn)
         }
     }
@@ -168,7 +181,10 @@ impl_scope! {
     impl<A, T: SliderValue> Slider<A, T, kas::dir::Down> {
         /// Construct with fixed direction
         #[inline]
-        pub fn down(range: RangeInclusive<T>, state_fn: impl Fn(&ConfigCx, &A) -> T + 'static) -> Self {
+        pub fn down(
+            range: RangeInclusive<T>,
+            state_fn: impl Fn(&ConfigCx, &A) -> T + 'static,
+        ) -> Self {
             Slider::new(range, state_fn)
         }
     }
@@ -311,7 +327,8 @@ impl_scope! {
 
             // Set the grip size (we could instead call set_size but the widget
             // model requires we call set_rect anyway):
-            rect.size.set_component(self.direction, cx.size_cx().grip_len());
+            rect.size
+                .set_component(self.direction, cx.size_cx().grip_len());
             self.grip.set_rect(cx, rect, AlignHints::NONE);
             // Correct the position:
             self.grip.set_offset(cx, self.offset());

--- a/crates/kas-widgets/src/spinner.rs
+++ b/crates/kas-widgets/src/spinner.rs
@@ -151,7 +151,8 @@ impl<A, T: SpinnerValue> EditGuard for SpinnerGuard<A, T> {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Spinner {
     /// A numeric entry widget with up/down arrows
     ///
     /// The value is constrained to a given `range`. Increment and decrement
@@ -183,7 +184,10 @@ impl_scope! {
         /// Values vary within the given `range`. The default step size is
         /// 1 for common types (see [`SpinnerValue::default_step`]).
         #[inline]
-        pub fn new(range: RangeInclusive<T>, state_fn: impl Fn(&ConfigCx, &A) -> T + 'static) -> Self {
+        pub fn new(
+            range: RangeInclusive<T>,
+            state_fn: impl Fn(&ConfigCx, &A) -> T + 'static,
+        ) -> Self {
             Spinner {
                 core: Default::default(),
                 edit: EditField::new(SpinnerGuard::new(range, Box::new(state_fn)))
@@ -289,7 +293,8 @@ impl_scope! {
 
     impl Tile for Self {
         fn probe(&self, coord: Coord) -> Id {
-            self.b_up.try_probe(coord)
+            self.b_up
+                .try_probe(coord)
                 .or_else(|| self.b_down.try_probe(coord))
                 .unwrap_or_else(|| self.edit.id())
         }
@@ -314,7 +319,7 @@ impl_scope! {
                         _ => return Unused,
                     };
                     value = self.edit.guard.handle_btn(cx, data, btn);
-                },
+                }
                 Event::Scroll(delta) => {
                     if let Some(y) = delta.as_wheel_action(cx) {
                         let (count, btn) = if y > 0 {

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -14,7 +14,8 @@ use kas::prelude::*;
 use kas::theme::Feature;
 use kas::Collection;
 
-impl_scope! {
+#[impl_self]
+mod Splitter {
     /// A resizable row/column widget
     ///
     /// Similar to [`crate::List`] but with draggable grips between items.
@@ -33,7 +34,10 @@ impl_scope! {
         id_map: HashMap<usize, usize>, // map key of Id to index
     }
 
-    impl Self where D: Default {
+    impl Self
+    where
+        D: Default,
+    {
         /// Construct a new instance with default-constructed direction
         #[inline]
         pub fn new(widgets: C) -> Self {

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -29,7 +29,8 @@ impl State {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod Stack {
     /// A stack of widgets
     ///
     /// A stack consists a set of child widgets, "pages", all of equal size.
@@ -42,7 +43,6 @@ impl_scope! {
     /// By default, all pages are configured and sized. To avoid configuring
     /// hidden pages (thus preventing these pages from affecting size)
     /// call [`Self::set_size_limit`] or [`Self::with_size_limit`].
-    #[impl_default]
     #[derive(Clone, Debug)]
     #[widget]
     pub struct Stack<W: Widget> {
@@ -50,9 +50,23 @@ impl_scope! {
         align_hints: AlignHints,
         widgets: Vec<(W, State)>,
         active: usize,
-        size_limit: usize = usize::MAX,
+        size_limit: usize,
         next: usize,
         id_map: HashMap<usize, usize>, // map key of Id to index
+    }
+
+    impl Default for Self {
+        fn default() -> Self {
+            Stack {
+                core: Default::default(),
+                align_hints: AlignHints::NONE,
+                widgets: Vec::new(),
+                active: 0,
+                size_limit: usize::MAX,
+                next: 0,
+                id_map: HashMap::new(),
+            }
+        }
     }
 
     impl Widget for Self {
@@ -141,7 +155,10 @@ impl_scope! {
         fn make_child_id(&mut self, index: usize) -> Id {
             if let Some((child, state)) = self.widgets.get(index) {
                 // Use the widget's existing identifier, if valid
-                if state.is_configured() && child.id_ref().is_valid() && self.id_ref().is_ancestor_of(child.id_ref()) {
+                if state.is_configured()
+                    && child.id_ref().is_valid()
+                    && self.id_ref().is_ancestor_of(child.id_ref())
+                {
                     if let Some(key) = child.id_ref().next_key_after(self.id_ref()) {
                         if let Entry::Vacant(entry) = self.id_map.entry(key) {
                             entry.insert(index);

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -15,7 +15,8 @@ use std::fmt::Debug;
 #[derive(Clone, Debug)]
 struct MsgSelectIndex(usize);
 
-impl_scope! {
+#[impl_self]
+mod Tab {
     /// A tab
     ///
     /// This is a special variant of `Button` which sends a [`Select`] on press.
@@ -81,7 +82,8 @@ impl_scope! {
 /// This is a parametrisation of [`TabStack`].
 pub type BoxTabStack<Data> = TabStack<Box<dyn Widget<Data = Data>>>;
 
-impl_scope! {
+#[impl_self]
+mod TabStack {
     /// A tabbed stack of widgets
     ///
     /// A stack consists a set of child widgets, "pages", all of equal size.

--- a/crates/kas-widgets/src/text.rs
+++ b/crates/kas-widgets/src/text.rs
@@ -9,7 +9,8 @@ use kas::prelude::*;
 use kas::text::format::FormattableText;
 use kas::theme::{self, TextClass};
 
-impl_scope! {
+#[impl_self]
+mod Text {
     /// A text label (derived from data)
     ///
     /// `Text` derives its contents from input data. Use [`Label`](crate::Label)
@@ -31,7 +32,10 @@ impl_scope! {
         text_fn: Box<dyn Fn(&ConfigCx, &A) -> T>,
     }
 
-    impl Default for Self where for<'a> &'a A: Into<T> {
+    impl Default for Self
+    where
+        for<'a> &'a A: Into<T>,
+    {
         fn default() -> Self {
             Text {
                 core: Default::default(),
@@ -107,7 +111,8 @@ impl_scope! {
 
     impl Layout for Self {
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
-            self.text.set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
+            self.text
+                .set_rect(cx, rect, hints.combine(AlignHints::VERT_CENTER));
         }
     }
 

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -30,7 +30,8 @@ type DrawShared = <Runner as runner::RunnerInherent>::DrawShared;
 
 const TIMER: TimerHandle = TimerHandle::new(0, true);
 
-impl_scope! {
+#[impl_self]
+mod Clock {
     #[derive(Clone)]
     #[widget]
     struct Clock {

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -9,7 +9,8 @@ use kas::event::CursorIcon;
 use kas::prelude::*;
 use kas::widgets::{Column, Label};
 
-impl_scope! {
+#[impl_self]
+mod CursorWidget {
     #[widget{
         Data = ();
         layout = self.label;

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -109,7 +109,8 @@ impl EditGuard for ListEntryGuard {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod ListEntry {
     // The list entry
     #[widget{
         layout = column! [

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -93,7 +93,8 @@ impl EditGuard for ListEntryGuard {
     }
 }
 
-impl_scope! {
+#[impl_self]
+mod ListEntry {
     // The list entry
     #[widget{
         layout = column! [

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -47,7 +47,8 @@ fn main() -> kas::runner::Result<()> {
     app.with(window).run()
 }
 
-impl_scope! {
+#[impl_self]
+mod ColourSquare {
     // A custom widget incorporating "Loading..." text, drawing and layout.
     #[widget]
     struct ColourSquare {
@@ -71,7 +72,8 @@ impl_scope! {
 
         fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints) {
             widget_set_rect!(rect);
-            self.loading_text.set_rect(cx, rect, hints.combine(AlignHints::CENTER));
+            self.loading_text
+                .set_rect(cx, rect, hints.combine(AlignHints::CENTER));
         }
 
         fn draw(&self, mut draw: DrawCx) {


### PR DESCRIPTION
Update to `impl-tools-lib` v0.11.2 and use the new `#[impl_self]` macro instead of `impl_scope!` where possible. This allows usage of `cargo fmt` within widget definitions.

See: https://github.com/kas-gui/impl-tools/pull/53

Several usages of `impl_scope!` remain to support `#[impl_default]`. These should be replaced using RFC 3681 (default field values) later.