### PR TITLE
#[widget] macro revisions

### DIFF
--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -357,6 +357,8 @@ pub trait Widget: Tile {
     /// Type `Data` should be specified either here (`impl Widget { ... }`) or
     /// in `impl Events { ... }`. Alternatively, if the widget has no children
     /// and no explicit `impl Events` or `impl Widget`, then `Data = ()` is
+    /// assumed; or, if the prior conditions are met and `#[collection]` is used
+    /// on some field, then `Data = <#field_ty as ::kas::Collection>::Data` is
     /// assumed.
     ///
     /// [`#widget`]: macros::widget

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -21,6 +21,10 @@ use kas_macros::autoimpl;
 /// The implementation of this method may be omitted where no event-handling is
 /// required. All methods have a default implementation.
 ///
+/// Type [`Widget::Data`] may be specified in `impl Events { ... }` instead of
+/// in `impl Widget { ... }` (this is permitted since it allows may `#[widget]`
+/// definitions to omit `impl Widget { ... }` altogether).
+///
 /// # Widget lifecycle
 ///
 /// 1.  The widget is configured ([`Events::configure`],
@@ -350,8 +354,10 @@ pub trait Widget: Tile {
     /// Widget expects data of this type to be provided by reference when
     /// calling any event-handling operation on this widget.
     ///
-    /// This type may be specified using a [`#widget`] macro property in case
-    /// this trait is not explicitly implemented.
+    /// Type `Data` should be specified either here (`impl Widget { ... }`) or
+    /// in `impl Events { ... }`. Alternatively, if the widget has no children
+    /// and no explicit `impl Events` or `impl Widget`, then `Data = ()` is
+    /// assumed.
     ///
     /// [`#widget`]: macros::widget
     type Data;

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -277,6 +277,7 @@ pub fn impl_self(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///     available inputs are `self`, `data` (own input data) and `index`
 ///     (of the child).
 /// -   `#[widget = expr]`: an alternative way of writing the above
+/// -   `#[collection]`: the field is a [`Collection`] of widgets
 ///
 /// ## Examples
 ///
@@ -337,6 +338,7 @@ pub fn impl_self(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// [`Layout`]: https://docs.rs/kas/latest/kas/trait.Layout.html
 /// [`Tile`]: https://docs.rs/kas/latest/kas/trait.Tile.html
 /// [`Events`]: https://docs.rs/kas/latest/kas/trait.Events.html
+/// [`Collection`]: https://docs.rs/kas/latest/kas/trait.Collection.html
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn widget(_: TokenStream, item: TokenStream) -> TokenStream {

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -259,17 +259,7 @@ pub fn impl_self(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// See also the [`macro@layout`] attribute which assists in implementing
 /// [`Layout`].
 ///
-/// ## Syntax
-///
-/// > _WidgetAttr_ :\
-/// > &nbsp;&nbsp; `#` `[` `widget` _WidgetAttrArgs_? `]`
-/// >
-/// > _WidgetAttrArgs_ :\
-/// > &nbsp;&nbsp; `{` (_WidgetAttrArg_ `;`) * `}`
-///
-/// Supported arguments (_WidgetAttrArg_) are:
-///
-/// -   <code>Data = Type</code>: the `Widget::Data` associated type
+/// ## Fields
 ///
 /// The struct must contain a field of type `widget_core!()` (usually named
 /// `core`). The macro `widget_core!()` is a placeholder, expanded by

--- a/crates/kas-macros/src/widget_args.rs
+++ b/crates/kas-macros/src/widget_args.rs
@@ -9,7 +9,7 @@ use proc_macro2::{Span, TokenStream as Toks};
 use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;
-use syn::{Expr, Ident, Index, Member, Meta, Token};
+use syn::{Expr, Ident, Index, Member, Meta};
 
 #[allow(non_camel_case_types)]
 mod kw {
@@ -20,22 +20,11 @@ mod kw {
 }
 
 #[derive(Debug, Default)]
-pub struct WidgetArgs {
-    pub data_ty: Option<syn::Type>,
-}
+pub struct WidgetArgs {}
 
 impl Parse for WidgetArgs {
-    fn parse(content: ParseStream) -> Result<Self> {
-        let data_ty = if !content.is_empty() {
-            let _: Token![type] = content.parse()?;
-            let _ = content.parse::<kw::Data>()?;
-            let _: Token![=] = content.parse()?;
-            Some(content.parse()?)
-        } else {
-            None
-        };
-
-        Ok(WidgetArgs { data_ty })
+    fn parse(_: ParseStream) -> Result<Self> {
+        Ok(WidgetArgs {})
     }
 }
 
@@ -57,11 +46,13 @@ impl ScopeAttr for AttrImplWidget {
 
     fn apply(&self, attr: syn::Attribute, scope: &mut Scope) -> Result<()> {
         let span = attr.span();
-        let args = match &attr.meta {
-            Meta::Path(_) => WidgetArgs::default(),
-            _ => attr.parse_args()?,
+        match &attr.meta {
+            Meta::Path(_) => (),
+            _ => {
+                let _: WidgetArgs = attr.parse_args()?;
+            }
         };
-        crate::widget::widget(span, args, scope)
+        crate::widget::widget(span, scope)
     }
 }
 

--- a/crates/kas-widgets/src/adapt/with_label.rs
+++ b/crates/kas-widgets/src/adapt/with_label.rs
@@ -17,7 +17,7 @@ mod WithLabel {
     ///
     /// Mouse/touch input on the label sends events to the inner widget.
     #[derive(Clone, Default)]
-    #[widget(type Data = W::Data)]
+    #[widget]
     #[layout(list![self.inner, self.label].with_direction(self.dir))]
     pub struct WithLabel<W: Widget, D: Directional = Direction> {
         core: widget_core!(),
@@ -112,5 +112,9 @@ mod WithLabel {
         fn probe(&self, _: Coord) -> Id {
             self.inner.id()
         }
+    }
+
+    impl Events for Self {
+        type Data = W::Data;
     }
 }

--- a/crates/kas-widgets/src/filler.rs
+++ b/crates/kas-widgets/src/filler.rs
@@ -14,7 +14,7 @@ mod Filler {
     /// This widget has zero minimum size but can expand according to the given
     /// stretch priority.
     #[derive(Clone, Debug, Default)]
-    #[widget(type Data = ())]
+    #[widget]
     pub struct Filler {
         core: widget_core!(),
         horiz: Stretch,

--- a/crates/kas-widgets/src/float.rs
+++ b/crates/kas-widgets/src/float.rs
@@ -89,6 +89,7 @@ mod Float {
     #[widget]
     pub struct Float<C: Collection> {
         core: widget_core!(),
+        #[collection]
         widgets: C,
     }
 
@@ -139,15 +140,6 @@ mod Float {
     }
 
     impl Tile for Self {
-        #[inline]
-        fn num_children(&self) -> usize {
-            self.widgets.len()
-        }
-
-        fn get_child(&self, index: usize) -> Option<&dyn Tile> {
-            self.widgets.get_tile(index)
-        }
-
         fn probe(&self, coord: Coord) -> Id {
             for i in 0..self.widgets.len() {
                 if let Some(child) = self.widgets.get_tile(i) {
@@ -157,15 +149,6 @@ mod Float {
                 }
             }
             self.id()
-        }
-    }
-
-    impl Widget for Self {
-        type Data = C::Data;
-
-        #[inline]
-        fn child_node<'n>(&'n mut self, data: &'n Self::Data, index: usize) -> Option<Node<'n>> {
-            self.widgets.child_node(data, index)
         }
     }
 }

--- a/crates/kas-widgets/src/frame.rs
+++ b/crates/kas-widgets/src/frame.rs
@@ -52,7 +52,7 @@ mod Frame {
     // NOTE: this would use derive mode if that supported custom layout syntax,
     // but it does not. This would allow us to implement Deref to self.inner.
     #[derive(Clone, Default)]
-    #[widget(type Data = W::Data)]
+    #[widget]
     #[layout(frame!(self.inner).with_style(self.style))]
     pub struct Frame<W: Widget> {
         core: widget_core!(),
@@ -61,6 +61,10 @@ mod Frame {
         /// The inner widget
         #[widget]
         pub inner: W,
+    }
+
+    impl Events for Self {
+        type Data = W::Data;
     }
 
     impl Self {

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -172,6 +172,7 @@ mod Grid {
         core: widget_core!(),
         layout: DynGridStorage,
         dim: GridDimensions,
+        #[collection]
         widgets: C,
     }
 
@@ -212,14 +213,6 @@ mod Grid {
     }
 
     impl Tile for Self {
-        #[inline]
-        fn num_children(&self) -> usize {
-            self.widgets.len()
-        }
-        fn get_child(&self, index: usize) -> Option<&dyn Tile> {
-            self.widgets.get_tile(index).map(|w| w.as_tile())
-        }
-
         fn probe(&self, coord: Coord) -> Id {
             for n in 0..self.widgets.len() {
                 if let Some(child) = self.widgets.get_tile(n) {
@@ -229,14 +222,6 @@ mod Grid {
                 }
             }
             self.id()
-        }
-    }
-
-    impl Widget for Self {
-        type Data = C::Data;
-
-        fn child_node<'n>(&'n mut self, data: &'n C::Data, index: usize) -> Option<Node<'n>> {
-            self.widgets.child_node(data, index)
         }
     }
 }

--- a/crates/kas-widgets/src/image.rs
+++ b/crates/kas-widgets/src/image.rs
@@ -38,7 +38,7 @@ mod Image {
     ///
     /// May be default constructed (result is empty).
     #[derive(Clone, Debug, Default)]
-    #[widget(type Data = ())]
+    #[widget]
     pub struct Image {
         core: widget_core!(),
         scaling: PixmapScaling,

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -256,6 +256,7 @@ mod List {
     pub struct List<C: Collection, D: Directional> {
         core: widget_core!(),
         layout: DynRowStorage,
+        #[collection]
         widgets: C,
         direction: D,
         next: usize,
@@ -295,15 +296,6 @@ mod List {
     }
 
     impl Tile for Self {
-        #[inline]
-        fn num_children(&self) -> usize {
-            self.widgets.len()
-        }
-
-        fn get_child(&self, index: usize) -> Option<&dyn Tile> {
-            self.widgets.get_tile(index)
-        }
-
         fn find_child_index(&self, id: &Id) -> Option<usize> {
             id.next_key_after(self.id_ref())
                 .and_then(|k| self.id_map.get(&k).cloned())
@@ -319,6 +311,8 @@ mod List {
     }
 
     impl Events for Self {
+        type Data = C::Data;
+
         /// Make a fresh id based on `self.next` then insert into `self.id_map`
         fn make_child_id(&mut self, index: usize) -> Id {
             if let Some(child) = self.widgets.get_tile(index) {
@@ -346,14 +340,6 @@ mod List {
         fn configure(&mut self, _: &mut ConfigCx) {
             // All children will be re-configured which will rebuild id_map
             self.id_map.clear();
-        }
-    }
-
-    impl Widget for Self {
-        type Data = C::Data;
-
-        fn child_node<'n>(&'n mut self, data: &'n C::Data, index: usize) -> Option<Node<'n>> {
-            self.widgets.child_node(data, index)
         }
     }
 

--- a/crates/kas-widgets/src/mark.rs
+++ b/crates/kas-widgets/src/mark.rs
@@ -18,7 +18,7 @@ mod Mark {
     ///
     /// TODO: expand or replace.
     #[derive(Clone, Debug)]
-    #[widget(type Data = ())]
+    #[widget]
     pub struct Mark {
         core: widget_core!(),
         style: MarkStyle,

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -25,7 +25,7 @@ mod ScrollRegion {
     ///
     /// [`ScrollBarRegion`]: crate::ScrollBarRegion
     #[derive(Clone, Debug, Default)]
-    #[widget(type Data = W::Data)]
+    #[widget]
     pub struct ScrollRegion<W: Widget> {
         core: widget_core!(),
         min_child_size: Size,
@@ -136,6 +136,8 @@ mod ScrollRegion {
     }
 
     impl Events for Self {
+        type Data = W::Data;
+
         fn configure(&mut self, cx: &mut ConfigCx) {
             cx.register_nav_fallback(self.id());
         }

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -393,7 +393,7 @@ mod ScrollBars {
     /// force internal margins by wrapping contents with a (zero-sized) frame.
     /// [`ScrollRegion`] already does this.
     #[derive(Clone, Debug, Default)]
-    #[widget(type Data = W::Data)]
+    #[widget]
     pub struct ScrollBars<W: Scrollable + Widget> {
         core: widget_core!(),
         mode: ScrollBarMode,
@@ -597,6 +597,8 @@ mod ScrollBars {
     }
 
     impl Events for Self {
+        type Data = W::Data;
+
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
             let index = cx.last_child();
             if index == Some(widget_index![self.horiz_bar]) {

--- a/crates/kas-widgets/src/separator.rs
+++ b/crates/kas-widgets/src/separator.rs
@@ -15,7 +15,7 @@ mod Separator {
     ///
     /// This widget draws a bar when in a list.
     #[autoimpl(Clone, Debug, Default)]
-    #[widget(type Data = A)]
+    #[widget]
     pub struct Separator<A> {
         core: widget_core!(),
         _pd: PhantomData<A>,
@@ -40,6 +40,10 @@ mod Separator {
         fn draw(&self, mut draw: DrawCx) {
             draw.separator(self.rect());
         }
+    }
+
+    impl Events for Self {
+        type Data = A;
     }
 
     /// A separator is a valid menu widget


### PR DESCRIPTION
New `#[collection]` attribute to replace explicit `num_children` / `get_child` / `child_node` definitions on a few widgets.

Drop support for `type Data = ...` in `#[widget]` attr args; instead:

- Assume `Data = ()` without `impl Events { ... }`, `impl Widget { ... }` or children
- Assume `Data = <#field_ty as ::kas::Collection>::Data` without `impl Events { ... }`, `impl Widget { ... }` or children but with `#[collection]` attribute on some field
- Require explicit definition (on `Events` or `Widget`) otherwise