### PR TITLE
AccessKit integration (mark 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,9 @@ internal_doc = ["kas-core/internal_doc", "kas-wgpu?/internal_doc"]
 # Enables clipboard read/write
 clipboard = ["kas-core/clipboard"]
 
+# Enable AccessKit integration
+accesskit = ["kas-core/accesskit"]
+
 # Enable Markdown parsing
 markdown = ["kas-core/markdown"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # markdown, resvg. Recommended also: clipboard, ron (or some config format).
 minimal = ["wgpu", "wayland", "vulkan", "dx12", "metal"]
 # All recommended features for optimal experience
-default = ["minimal", "view", "image", "resvg", "clipboard", "markdown", "shaping", "spawn"]
+default = ["minimal", "view", "image", "resvg", "clipboard", "markdown", "shaping", "spawn", "accesskit"]
 # All standard test target features
 stable = ["default", "x11", "serde", "toml", "yaml", "json", "ron", "macros_log"]
 # Enables all "recommended" features for nightly rustc

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -58,6 +58,9 @@ toml = ["serde", "dep:toml"]
 # Enables clipboard read/write
 clipboard = ["dep:arboard", "dep:smithay-clipboard"]
 
+# Enable AccessKit integration
+accesskit = ["dep:accesskit", "dep:accesskit_winit"]
+
 # Inject logging into macro-generated code.
 # Requires that all crates using these macros depend on the log crate.
 macros_log = ["kas-macros/log"]
@@ -106,6 +109,8 @@ cfg-if = "1.0.0"
 smol_str = "0.2.0"
 image = { version = "0.25.1", optional = true }
 hash_hasher = "2.0.4"
+accesskit = { version = "0.21.0", optional = true }
+accesskit_winit = { version = "0.29.0", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
 smithay-clipboard = { version = "0.7.0", optional = true }

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # about target platforms).
 minimal = ["wayland"]
 # All standard test target features
-stable = ["minimal", "clipboard", "markdown", "spawn", "x11", "serde", "toml", "yaml", "json", "ron", "macros_log", "image"]
+stable = ["minimal", "clipboard", "markdown", "spawn", "x11", "serde", "toml", "yaml", "json", "ron", "macros_log", "image", "accesskit"]
 # Enables all "recommended" features for nightly rustc
 nightly = ["stable", "nightly-diagnostics"]
 # Additional, less recommendation-worthy features

--- a/crates/kas-core/src/accesskit.rs
+++ b/crates/kas-core/src/accesskit.rs
@@ -1,0 +1,86 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! AccessKit widget integration
+
+use crate::{RoleCx, TextOrSource, Tile, TileExt, Window};
+use accesskit::{Node, NodeId};
+
+#[derive(Default)]
+struct WalkCx {
+    label: Option<String>,
+    labelled_by: Option<NodeId>,
+}
+
+impl RoleCx for WalkCx {
+    fn set_label_impl(&mut self, label: TextOrSource<'_>) {
+        match label {
+            TextOrSource::Borrowed(s) => self.label = Some(s.to_string()),
+            TextOrSource::Owned(s) => self.label = Some(s),
+            TextOrSource::Source(id) => self.labelled_by = Some(id.into()),
+        }
+    }
+}
+
+fn push_child(parent: &dyn Tile, index: usize, nodes: &mut Vec<(NodeId, Node)>) -> Option<NodeId> {
+    if let Some(child) = parent.get_child(index) {
+        let mut cx = WalkCx::default();
+        let mut node = child.role(&mut cx).as_accesskit_node();
+        parent.role_child_properties(&mut cx, index);
+
+        if let Some(label) = cx.label.take() {
+            node.set_label(label);
+        } else if let Some(id) = cx.labelled_by.take() {
+            node.set_labelled_by(vec![id]);
+        }
+
+        let children = push_all_children(child, nodes);
+        if !children.is_empty() {
+            node.set_children(children);
+        }
+
+        let id = child.id_ref().into();
+        nodes.push((id, node));
+        Some(id)
+    } else {
+        None
+    }
+}
+
+fn push_all_children(tile: &dyn Tile, nodes: &mut Vec<(NodeId, Node)>) -> Vec<NodeId> {
+    tile.child_indices()
+        .into_iter()
+        .flat_map(|index| push_child(tile, index, nodes))
+        .collect()
+}
+
+/// Returns a list of nodes and the root node's identifier
+pub(crate) fn window_nodes<Data: 'static>(root: &Window<Data>) -> (Vec<(NodeId, Node)>, NodeId) {
+    let mut nodes = vec![];
+    let mut children = push_all_children(root.as_tile(), &mut nodes);
+
+    for popup in root.iter_popups() {
+        if let Some(tile) = root.find_tile(&popup.parent)
+            && let Some(index) = tile.find_child_index(&popup.id)
+            && let Some(id) = push_child(tile, index, &mut nodes)
+        {
+            children.push(id);
+        }
+    }
+
+    let mut cx = WalkCx::default();
+    let mut node = root.role(&mut cx).as_accesskit_node();
+    node.set_children(children);
+
+    if let Some(label) = cx.label.take() {
+        node.set_label(label);
+    } else if let Some(id) = cx.labelled_by.take() {
+        node.set_labelled_by(vec![id]);
+    }
+
+    let root_id = root.id_ref().into();
+    nodes.push((root_id, node));
+    (nodes, root_id)
+}

--- a/crates/kas-core/src/accesskit.rs
+++ b/crates/kas-core/src/accesskit.rs
@@ -27,7 +27,7 @@ impl RoleCx for WalkCx {
 fn push_child(parent: &dyn Tile, index: usize, nodes: &mut Vec<(NodeId, Node)>) -> Option<NodeId> {
     if let Some(child) = parent.get_child(index) {
         let mut cx = WalkCx::default();
-        let mut node = child.role(&mut cx).as_accesskit_node();
+        let mut node = child.role(&mut cx).as_accesskit_node(child);
         parent.role_child_properties(&mut cx, index);
 
         if let Some(label) = cx.label.take() {
@@ -71,7 +71,7 @@ pub(crate) fn window_nodes<Data: 'static>(root: &Window<Data>) -> (Vec<(NodeId, 
     }
 
     let mut cx = WalkCx::default();
-    let mut node = root.role(&mut cx).as_accesskit_node();
+    let mut node = root.role(&mut cx).as_accesskit_node(root);
     node.set_children(children);
 
     if let Some(label) = cx.label.take() {

--- a/crates/kas-core/src/accesskit.rs
+++ b/crates/kas-core/src/accesskit.rs
@@ -62,11 +62,11 @@ pub(crate) fn window_nodes<Data: 'static>(root: &Window<Data>) -> (Vec<(NodeId, 
     let mut children = push_all_children(root.as_tile(), &mut nodes);
 
     for popup in root.iter_popups() {
-        if let Some(tile) = root.find_tile(&popup.parent)
-            && let Some(index) = tile.find_child_index(&popup.id)
-            && let Some(id) = push_child(tile, index, &mut nodes)
-        {
-            children.push(id);
+        if let Some(tile) = root.find_tile(&popup.id) {
+            let index = crate::POPUP_INNER_INDEX;
+            if let Some(id) = push_child(tile, index, &mut nodes) {
+                children.push(id);
+            }
         }
     }
 

--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -91,8 +91,9 @@ pub enum Role<'a> {
     ///
     /// ### Messages
     ///
-    /// [`kas::messages::SetValueString`] may be used to replace the entire
-    /// text.
+    /// [`kas::messages::SetValueText`] may be used to replace the entire
+    /// text. [`kas::messages::ReplaceSelectedText`] may be used to insert text
+    /// at `edit_pos`, replacing all text between `edit_pos` and `sel_pos`.
     TextInput {
         /// Text contents
         ///

--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -266,10 +266,11 @@ impl<'a> Role<'a> {
     /// Construct an AccessKit [`Node`] from self
     ///
     /// This will set node properties as provided by self, but not those provided by the parent.
-    pub(crate) fn as_accesskit_node(&self) -> accesskit::Node {
+    pub(crate) fn as_accesskit_node(&self, tile: &dyn Tile) -> accesskit::Node {
         use crate::cast::Cast;
 
         let mut node = accesskit::Node::new(self.as_accesskit_role());
+        node.set_bounds(tile.rect().cast());
 
         match *self {
             Role::Unknown | Role::Button | Role::Tab | Role::Border => (),

--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -9,6 +9,7 @@ use crate::Id;
 #[allow(unused)] use crate::Tile;
 use crate::dir::Direction;
 #[allow(unused)] use crate::event::EventState;
+use crate::event::Key;
 use crate::geom::Offset;
 
 /// Describes a widget's purpose and capabilities
@@ -27,6 +28,8 @@ pub enum Role<'a> {
     Unknown,
     /// A text label with the given contents, usually (but not necessarily) short and fixed
     Label(&'a str),
+    /// A text label with an access key
+    AccessLabel(&'a str, Key),
     /// A push button
     ///
     /// ### Messages
@@ -67,22 +70,13 @@ pub enum Role<'a> {
     Image,
     /// A canvas
     Canvas,
-    /// Text
-    ///
-    /// ### Messages
-    ///
-    /// If (but only if) `editable`, this item supports:
-    ///
-    /// [`kas::messages::SetValueString`] may be used to replace the entire
-    /// text.
-    Text {
+    /// A text label supporting selection
+    TextLabel {
         /// Text contents
         ///
         /// NOTE: it is likely that the representation here changes to
         /// accomodate more complex texts and potentially other details.
         text: &'a str,
-        /// Whether the text is editable
-        editable: bool,
         /// The cursor index within `contents`
         edit_pos: usize,
         /// The selection index. Equals `cursor` if the selection is empty.
@@ -90,6 +84,54 @@ pub enum Role<'a> {
         /// call this the selection anchor but Kas does not; see
         /// [`kas::text::SelectionHelper`].)
         sel_pos: usize,
+    },
+    /// Editable text
+    ///
+    /// ### Messages
+    ///
+    /// [`kas::messages::SetValueString`] may be used to replace the entire
+    /// text.
+    TextInput {
+        /// Text contents
+        ///
+        /// NOTE: it is likely that the representation here changes to
+        /// accomodate more complex texts and potentially other details.
+        text: &'a str,
+        /// Whether the text input supports multi-line text
+        multi_line: bool,
+        /// The cursor index within `contents`
+        edit_pos: usize,
+        /// The selection index. Equals `cursor` if the selection is empty.
+        /// May be less than or greater than `cursor`. (Aside: some toolkits
+        /// call this the selection anchor but Kas does not; see
+        /// [`kas::text::SelectionHelper`].)
+        sel_pos: usize,
+    },
+    /// A slider input
+    ///
+    /// Note that values may not be finite; for example `max: f64::INFINITY`.
+    Slider {
+        /// Minimum value
+        min: f64,
+        /// Maximum value
+        max: f64,
+        /// Step
+        step: f64,
+        /// Current value
+        value: f64,
+    },
+    /// A spinner: numeric edit box with up and down buttons
+    ///
+    /// Note that values may not be finite; for example `max: f64::INFINITY`.
+    SpinButton {
+        /// Minimum value
+        min: f64,
+        /// Maximum value
+        max: f64,
+        /// Step
+        step: f64,
+        /// Current value
+        value: f64,
     },
     /// A progress bar
     ///
@@ -102,7 +144,10 @@ pub enum Role<'a> {
     /// # Messages
     ///
     /// [`kas::messages::Activate`] may be used to open the menu.
-    Menu,
+    Menu {
+        /// True if the menu is open
+        expanded: bool,
+    },
     /// A drop-down combination box
     ///
     /// Includes the index and text of the active entry
@@ -110,7 +155,14 @@ pub enum Role<'a> {
     /// # Messages
     ///
     /// [`kas::messages::SetIndex`] may be used to set the selected entry.
-    ComboBox(usize, &'a str),
+    ComboBox {
+        /// Index of the current choice
+        active: usize,
+        /// Text of the current choice
+        text: &'a str,
+        /// True if the menu is open
+        expanded: bool,
+    },
     /// A window
     Window,
     /// The special bar at the top of a window titling contents and usually embedding window controls
@@ -126,7 +178,7 @@ pub enum TextOrSource<'a> {
     /// A reference to another widget able to a text value
     ///
     /// It is expected that the given [`Id`] refers to a widget with role
-    /// [`Role::Label`] or [`Role::Text`].
+    /// [`Role::Label`] or [`Role::TextLabel`].
     Source(Id),
 }
 

--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -11,6 +11,8 @@ use crate::dir::Direction;
 #[allow(unused)] use crate::event::EventState;
 use crate::event::Key;
 use crate::geom::Offset;
+#[allow(unused)]
+use crate::messages::{DecrementStep, IncrementStep, SetValueF64};
 
 /// Describes a widget's purpose and capabilities
 ///
@@ -110,6 +112,12 @@ pub enum Role<'a> {
     /// A slider input
     ///
     /// Note that values may not be finite; for example `max: f64::INFINITY`.
+    ///
+    /// ### Messages
+    ///
+    /// [`SetValueF64`] may be used to set the input value.
+    ///
+    /// [`IncrementStep`] and [`DecrementStep`] change the value by one step.
     Slider {
         /// Minimum value
         min: f64,
@@ -123,6 +131,12 @@ pub enum Role<'a> {
     /// A spinner: numeric edit box with up and down buttons
     ///
     /// Note that values may not be finite; for example `max: f64::INFINITY`.
+    ///
+    /// ### Messages
+    ///
+    /// [`SetValueF64`] may be used to set the input value.
+    ///
+    /// [`IncrementStep`] and [`DecrementStep`] change the value by one step.
     SpinButton {
         /// Minimum value
         min: f64,

--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -167,6 +167,9 @@ pub enum Role<'a> {
     /// # Messages
     ///
     /// [`kas::messages::Activate`] may be used to open the menu.
+    ///
+    /// [`kas::messages::Expand`] and [`kas::messages::Collapse`] may be used to
+    /// open and close the menu.
     Menu {
         /// True if the menu is open
         expanded: bool,
@@ -178,6 +181,9 @@ pub enum Role<'a> {
     /// # Messages
     ///
     /// [`kas::messages::SetIndex`] may be used to set the selected entry.
+    ///
+    /// [`kas::messages::Expand`] and [`kas::messages::Collapse`] may be used to
+    /// open and close the menu.
     ComboBox {
         /// Index of the current choice
         active: usize,
@@ -358,6 +364,8 @@ impl<'a> Role<'a> {
                 node.set_numeric_value(value.cast());
             }
             Role::ComboBox { expanded, .. } | Role::Menu { expanded } => {
+                node.add_action(Action::Expand);
+                node.add_action(Action::Collapse);
                 node.set_expanded(expanded);
             }
         }

--- a/crates/kas-core/src/core/tile.rs
+++ b/crates/kas-core/src/core/tile.rs
@@ -15,14 +15,14 @@ use kas_macros::autoimpl;
 #[allow(unused)] use crate::theme::DrawCx;
 #[allow(unused)] use kas_macros as macros;
 
-/// Positioning and drawing routines for [`Widget`]s
+/// A sizable, drawable, identifiable, introspectible 2D tree object
 ///
 /// `Tile` is a super-trait of [`Widget`] which:
 ///
-/// -   Has no [`Data`](Widget::Data) parameter
-/// -   Supports read-only tree reflection: [`Self::get_child`]
-/// -   Provides some basic operations: [`Self::id_ref`]
-/// -   Covers sizing and drawing operations from [`Layout`]
+/// -   Is a sub-trait of [`Layout`]: is sizable and drawable
+/// -   Has no [`Data`](Widget::Data) parameter or event-handling methods
+/// -   Has an [identifier](Self::identify) and [`Self::role`]
+/// -   Supports read-only tree reflection: [`Self::child_indices`], [`Self::get_child`]
 ///
 /// `Tile` may not be implemented directly; it will be implemented by the
 /// [`#widget`] macro.
@@ -296,9 +296,9 @@ pub trait TileExt: Tile {
     ///
     /// Since `id` represents a path, this operation is normally `O(d)` where
     /// `d` is the depth of the path (depending on widget implementations).
-    fn find_widget(&self, id: &Id) -> Option<&dyn Tile> {
+    fn find_tile(&self, id: &Id) -> Option<&dyn Tile> {
         if let Some(child) = self.find_child_index(id).and_then(|i| self.get_child(i)) {
-            child.find_widget(id)
+            child.find_tile(id)
         } else if self.eq_id(id) {
             Some(self.as_tile())
         } else {
@@ -311,7 +311,7 @@ pub trait TileExt: Tile {
     /// The [`Rect`] is returned in the widgets own coordinate space where this
     /// space is translated by the [`Offset`] returned. The result is thus
     /// `rect + translation` in the caller's coordinate space.
-    fn find_widget_rect(&self, id: &Id) -> Option<(Rect, Offset)> {
+    fn find_tile_rect(&self, id: &Id) -> Option<(Rect, Offset)> {
         let mut widget = self.as_tile();
         let mut translation = Offset::ZERO;
         loop {

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -737,6 +737,28 @@ impl fmt::Display for Id {
     }
 }
 
+/// Convert to a `NodeId` using [`Id::to_nzu64`]
+///
+/// Use [`Id::try_from_u64`] for the inverse conversion.
+#[cfg(feature = "accesskit")]
+impl From<Id> for accesskit::NodeId {
+    #[inline]
+    fn from(id: Id) -> Self {
+        accesskit::NodeId(id.to_nzu64().get())
+    }
+}
+
+/// Convert to a `NodeId` using [`Id::to_nzu64`]
+///
+/// Use [`Id::try_from_u64`] for the inverse conversion.
+#[cfg(feature = "accesskit")]
+impl From<&Id> for accesskit::NodeId {
+    #[inline]
+    fn from(id: &Id) -> Self {
+        accesskit::NodeId(id.to_nzu64().get())
+    }
+}
+
 /// Types supporting conversion to [`Id`]
 ///
 /// A method taking an `id: impl HasId` parameter supports an [`Id`],

--- a/crates/kas-core/src/dir.rs
+++ b/crates/kas-core/src/dir.rs
@@ -151,6 +151,17 @@ bitflags! {
     }
 }
 
+#[cfg(feature = "accesskit")]
+impl From<Direction> for accesskit::Orientation {
+    #[inline]
+    fn from(dir: Direction) -> Self {
+        match dir {
+            Direction::Right | Direction::Left => accesskit::Orientation::Horizontal,
+            Direction::Down | Direction::Up => accesskit::Orientation::Vertical,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -32,6 +32,13 @@ impl EventState {
         self.window_has_focus
     }
 
+    /// True if [AccessKit](https://accesskit.dev/) is enabled
+    #[cfg(feature = "accesskit")]
+    #[inline]
+    pub(crate) fn accesskit_is_enabled(&self) -> bool {
+        self.accesskit_is_enabled
+    }
+
     /// True when access key labels should be shown
     ///
     /// (True when Alt is held and no widget has character focus.)

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -78,6 +78,8 @@ pub struct EventState {
     platform: Platform,
     disabled: Vec<Id>,
     window_has_focus: bool,
+    #[cfg(feature = "accesskit")]
+    accesskit_is_enabled: bool,
     modifiers: ModifiersState,
     /// Key (and IME) focus is on same widget as sel_focus; otherwise its value is ignored
     key_focus: bool,

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -224,7 +224,7 @@ impl<'a> EventCx<'a> {
         };
 
         // TODO: implement remaining actions
-        use crate::messages::{Erased, SetValueF64, SetValueString};
+        use crate::messages::{self, Erased, SetValueF64, SetValueString};
         use accesskit::{Action as AKA, ActionData};
         match request.action {
             AKA::Click => {
@@ -234,7 +234,12 @@ impl<'a> EventCx<'a> {
             AKA::Blur => (),
             AKA::Collapse | AKA::Expand => (), // TODO: open/close menus
             AKA::CustomAction => (),
-            AKA::Decrement | AKA::Increment => (),
+            AKA::Decrement => {
+                self.send_or_replay(widget, id, Erased::new(messages::DecrementStep));
+            }
+            AKA::Increment => {
+                self.send_or_replay(widget, id, Erased::new(messages::IncrementStep));
+            }
             AKA::HideTooltip | AKA::ShowTooltip => (),
             AKA::ReplaceSelectedText => (),
             AKA::ScrollDown | AKA::ScrollLeft | AKA::ScrollRight | AKA::ScrollUp => {

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -22,6 +22,8 @@ impl EventState {
             platform,
             disabled: vec![],
             window_has_focus: false,
+            #[cfg(feature = "accesskit")]
+            accesskit_is_enabled: false,
             modifiers: ModifiersState::empty(),
             key_focus: false,
             ime: None,
@@ -47,6 +49,22 @@ impl EventState {
             pending_nav_focus: PendingNavFocus::None,
             action: Action::empty(),
         }
+    }
+
+    #[cfg(feature = "accesskit")]
+    pub(crate) fn accesskit_tree_update<A>(&mut self, root: &Window<A>) -> accesskit::TreeUpdate {
+        self.accesskit_is_enabled = true;
+        let (nodes, root_id) = crate::accesskit::window_nodes(root);
+        accesskit::TreeUpdate {
+            nodes,
+            tree: Some(accesskit::Tree::new(root_id)),
+            focus: self.nav_focus().map(|id| id.into()).unwrap_or(root_id),
+        }
+    }
+
+    #[cfg(feature = "accesskit")]
+    pub(crate) fn disable_accesskit(&mut self) {
+        self.accesskit_is_enabled = false;
     }
 
     /// Update scale factor

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 use crate::theme::ThemeSize;
-use crate::{TileExt, Window};
+use crate::{Tile, TileExt, Window};
 use std::task::Poll;
 
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
@@ -289,7 +289,7 @@ impl<'a> EventCx<'a> {
         use winit::event::WindowEvent::*;
 
         match event {
-            CloseRequested => self.action(Id::ROOT, Action::CLOSE),
+            CloseRequested => self.action(win.id(), Action::CLOSE),
             /* Not yet supported: see #98
             DroppedFile(path) => ,
             HoveredFile(path) => ,
@@ -299,7 +299,7 @@ impl<'a> EventCx<'a> {
                 self.window_has_focus = state;
                 if state {
                     // Required to restart theme animations
-                    self.action(Id::ROOT, Action::REDRAW);
+                    self.action(win.id(), Action::REDRAW);
                 } else {
                     // Window focus lost: close all popups
                     while let Some(id) = self.popups.last().map(|(id, _, _)| *id) {
@@ -348,7 +348,7 @@ impl<'a> EventCx<'a> {
                 let state = modifiers.state();
                 if state.alt_key() != self.modifiers.alt_key() {
                     // This controls drawing of access key indicators
-                    self.action(Id::ROOT, Action::REDRAW);
+                    self.action(win.id(), Action::REDRAW);
                 }
                 self.modifiers = state;
             }

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -207,7 +207,7 @@ impl<'a> EventCx<'a> {
         // Set IME cursor area, if moved.
         if self.ime.is_some()
             && let Some(target) = self.sel_focus.as_ref()
-            && let Some((mut rect, translation)) = widget.as_tile().find_widget_rect(target)
+            && let Some((mut rect, translation)) = widget.as_tile().find_tile_rect(target)
         {
             if self.ime_cursor_area.size != Size::ZERO {
                 rect = self.ime_cursor_area;

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -224,7 +224,7 @@ impl<'a> EventCx<'a> {
         };
 
         // TODO: implement remaining actions
-        use crate::messages::{self, Erased, SetValueF64, SetValueString};
+        use crate::messages::{self, Erased, SetValueF64, SetValueText};
         use accesskit::{Action as AKA, ActionData};
         match request.action {
             AKA::Click => {
@@ -282,7 +282,7 @@ impl<'a> EventCx<'a> {
             AKA::SetSequentialFocusNavigationStartingPoint => (),
             AKA::SetValue => {
                 let msg = match request.data {
-                    Some(ActionData::Value(text)) => Erased::new(SetValueString(text.into())),
+                    Some(ActionData::Value(text)) => Erased::new(SetValueText(text.into())),
                     Some(ActionData::NumericValue(n)) => Erased::new(SetValueF64(n)),
                     _ => return,
                 };

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -212,6 +212,55 @@ impl EventState {
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(docsrs, doc(cfg(internal_doc)))]
 impl<'a> EventCx<'a> {
+    #[cfg(feature = "accesskit")]
+    pub(crate) fn handle_accesskit_action(
+        &mut self,
+        widget: Node<'_>,
+        request: accesskit::ActionRequest,
+    ) {
+        let Some(id) = Id::try_from_u64(request.target.0) else {
+            return;
+        };
+
+        // TODO: implement remaining actions
+        use crate::messages::{Erased, SetValueF64, SetValueString};
+        use accesskit::{Action as AKA, ActionData};
+        match request.action {
+            AKA::Click => {
+                self.send_event(widget, id, Event::Command(Command::Activate, None));
+            }
+            AKA::Focus => self.set_nav_focus(id, FocusSource::Synthetic),
+            AKA::Blur => (),
+            AKA::Collapse | AKA::Expand => (), // TODO: open/close menus
+            AKA::CustomAction => (),
+            AKA::Decrement | AKA::Increment => (),
+            AKA::HideTooltip | AKA::ShowTooltip => (),
+            AKA::ReplaceSelectedText => (),
+            AKA::ScrollDown | AKA::ScrollLeft | AKA::ScrollRight | AKA::ScrollUp => {
+                let delta = match request.action {
+                    AKA::ScrollDown => ScrollDelta::Lines(0.0, 1.0),
+                    AKA::ScrollLeft => ScrollDelta::Lines(-1.0, 0.0),
+                    AKA::ScrollRight => ScrollDelta::Lines(1.0, 0.0),
+                    AKA::ScrollUp => ScrollDelta::Lines(0.0, -1.0),
+                    _ => unreachable!(),
+                };
+                self.send_event(widget, id, Event::Scroll(delta));
+            }
+            AKA::ScrollIntoView | AKA::ScrollToPoint | AKA::SetScrollOffset => (),
+            AKA::SetTextSelection => (),
+            AKA::SetSequentialFocusNavigationStartingPoint => (),
+            AKA::SetValue => {
+                let msg = match request.data {
+                    Some(ActionData::Value(text)) => Erased::new(SetValueString(text.into())),
+                    Some(ActionData::NumericValue(n)) => Erased::new(SetValueF64(n)),
+                    _ => return,
+                };
+                self.send_or_replay(widget, id, msg);
+            }
+            AKA::ShowContextMenu => (),
+        }
+    }
+
     /// Pre-draw / pre-sleep
     ///
     /// This method should be called once per frame as well as after the last

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -246,7 +246,7 @@ impl EventState {
         );
         self.opt_action(grab.depress.clone(), Action::REDRAW);
         self.touch.remove_pan_grab(grab.pan_grab);
-        self.action(Id::ROOT, grab.flush_click_move());
+        self.window_action(grab.flush_click_move());
         grab
     }
 }

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -643,6 +643,40 @@ impl std::ops::SubAssign<Offset> for Rect {
     }
 }
 
+#[cfg(feature = "accesskit")]
+mod accesskit_impls {
+    use super::{Coord, Rect};
+    use crate::cast::{Cast, CastApprox, Conv, ConvApprox, Result};
+
+    impl ConvApprox<accesskit::Point> for Coord {
+        fn try_conv_approx(p: accesskit::Point) -> Result<Self> {
+            Ok(Coord(p.x.try_cast_approx()?, p.y.try_cast_approx()?))
+        }
+    }
+
+    impl Conv<Rect> for accesskit::Rect {
+        fn try_conv(rect: Rect) -> Result<Self> {
+            let p = rect.pos;
+            let p2 = rect.pos2();
+            Ok(accesskit::Rect {
+                x0: p.0.try_cast()?,
+                y0: p.1.try_cast()?,
+                x1: p2.0.try_cast()?,
+                y1: p2.1.try_cast()?,
+            })
+        }
+    }
+
+    impl ConvApprox<accesskit::Rect> for Rect {
+        fn try_conv_approx(rect: accesskit::Rect) -> Result<Self> {
+            let pos = Coord(rect.x0.try_cast_approx()?, rect.y0.try_cast_approx()?);
+            let p2 = Coord(rect.x1.try_cast_approx()?, rect.y1.try_cast_approx()?);
+            let size = (p2 - pos).cast();
+            Ok(Rect { pos, size })
+        }
+    }
+}
+
 mod winit_impls {
     use super::{Coord, Size};
     use crate::cast::{Cast, CastApprox, Conv, ConvApprox, Result};
@@ -651,7 +685,7 @@ mod winit_impls {
     impl<X: CastApprox<i32>> ConvApprox<PhysicalPosition<X>> for Coord {
         #[inline]
         fn try_conv_approx(pos: PhysicalPosition<X>) -> Result<Self> {
-            Ok(Coord(pos.x.cast_approx(), pos.y.cast_approx()))
+            Ok(Coord(pos.x.try_cast_approx()?, pos.y.try_cast_approx()?))
         }
     }
 

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -34,6 +34,9 @@ pub use action::Action;
 pub use kas_macros::{autoimpl, extends, impl_default};
 pub use kas_macros::{cell_collection, collection, impl_anon, impl_scope, impl_self};
 pub use kas_macros::{layout, widget, widget_index, widget_set_rect};
+#[cfg(feature = "accesskit")]
+#[doc(inline)]
+pub(crate) use popup::POPUP_INNER_INDEX;
 #[doc(inline)] pub use popup::Popup;
 #[doc(inline)] pub(crate) use popup::PopupDescriptor;
 #[doc(inline)] pub(crate) use root::WindowIdFactory;

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -22,6 +22,7 @@ extern crate self as kas;
 #[doc(inline)] pub extern crate easy_cast as cast;
 
 // internal modules:
+#[cfg(feature = "accesskit")] pub(crate) mod accesskit;
 mod action;
 mod core;
 pub mod decorations;

--- a/crates/kas-core/src/messages.rs
+++ b/crates/kas-core/src/messages.rs
@@ -27,6 +27,14 @@ use crate::event::PhysicalKey;
 #[derive(Copy, Clone, Debug)]
 pub struct Activate(pub Option<PhysicalKey>);
 
+/// Increment value by one step
+#[derive(Copy, Clone, Debug)]
+pub struct IncrementStep;
+
+/// Decrement value by one step
+#[derive(Copy, Clone, Debug)]
+pub struct DecrementStep;
+
 /// Set an input value from `f64`
 ///
 /// This message may be used to set a numeric value to an input field.

--- a/crates/kas-core/src/messages.rs
+++ b/crates/kas-core/src/messages.rs
@@ -45,7 +45,14 @@ pub struct SetValueF64(pub f64);
 ///
 /// This message may be used to set a text value to an input field.
 #[derive(Clone, Debug)]
-pub struct SetValueString(pub String);
+pub struct SetValueText(pub String);
+
+/// Replace selected text in an input value
+///
+/// This acts the same as typing or pasting the text: replace an existing
+/// selection or insert at the cursor position.
+#[derive(Clone, Debug)]
+pub struct ReplaceSelectedText(pub String);
 
 /// Set an index
 #[derive(Clone, Debug)]

--- a/crates/kas-core/src/messages.rs
+++ b/crates/kas-core/src/messages.rs
@@ -58,6 +58,14 @@ pub struct ReplaceSelectedText(pub String);
 #[derive(Clone, Debug)]
 pub struct SetIndex(pub usize);
 
+/// Expand a collapsible list or open a menu
+#[derive(Clone, Debug)]
+pub struct Expand;
+
+/// Collapse a collapsible list or close a menu
+#[derive(Clone, Debug)]
+pub struct Collapse;
+
 /// Request selection of the sender
 ///
 /// This is only useful when pushed by a child widget or sent to a child widget

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -457,7 +457,7 @@ impl<Data: 'static> Window<Data> {
         let index = self.popups.len();
         self.popups.push((id, popup, Offset::ZERO));
         self.resize_popup(cx, data, index);
-        cx.action(Id::ROOT, Action::REGION_MOVED);
+        cx.action(self.id(), Action::REGION_MOVED);
     }
 
     /// Trigger closure of a pop-up
@@ -467,7 +467,7 @@ impl<Data: 'static> Window<Data> {
         for i in 0..self.popups.len() {
             if id == self.popups[i].0 {
                 self.popups.remove(i);
-                cx.action(Id::ROOT, Action::REGION_MOVED);
+                cx.action(self.id(), Action::REGION_MOVED);
                 return;
             }
         }

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -199,7 +199,7 @@ mod Window {
                 return None;
             }
             for (_, popup, translation) in self.popups.iter().rev() {
-                if let Some(widget) = self.inner.find_widget(&popup.id)
+                if let Some(widget) = self.inner.find_tile(&popup.id)
                     && let Some(id) = widget.try_probe(coord + *translation)
                 {
                     return Some(id);
@@ -232,7 +232,7 @@ mod Window {
             }
             self.inner.draw(draw.re());
             for (_, popup, translation) in &self.popups {
-                if let Some(child) = self.inner.find_widget(&popup.id) {
+                if let Some(child) = self.inner.find_tile(&popup.id) {
                     let clip_rect = child.rect() - *translation;
                     draw.with_overlay(clip_rect, *translation, |draw| {
                         child.draw(draw);
@@ -517,7 +517,7 @@ impl<Data: 'static> Window<Data> {
             (pos, size)
         };
 
-        let Some((c, t)) = self.inner.as_tile().find_widget_rect(&popup.parent) else {
+        let Some((c, t)) = self.inner.as_tile().find_tile_rect(&popup.parent) else {
             return;
         };
         *translation = t;

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -482,6 +482,12 @@ impl<Data: 'static> Window<Data> {
             self.resize_popup(cx, data, i);
         }
     }
+
+    /// Iterate over popups
+    #[cfg(feature = "accesskit")]
+    pub(crate) fn iter_popups(&self) -> impl Iterator<Item = &kas::PopupDescriptor> {
+        self.popups.iter().map(|(_, popup, _)| popup)
+    }
 }
 
 impl<Data: 'static> Window<Data> {

--- a/crates/kas-core/src/runner/event_loop.rs
+++ b/crates/kas-core/src/runner/event_loop.rs
@@ -84,6 +84,14 @@ where
             ProxyAction::WakeAsync => {
                 // We don't need to do anything here since about_to_wait will poll all futures.
             }
+            #[cfg(feature = "accesskit")]
+            ProxyAction::AccessKit(window_id, event) => {
+                if let Some(id) = self.id_map.get(&window_id) {
+                    if let Some(window) = self.windows.get_mut(id) {
+                        window.accesskit_event(event);
+                    }
+                }
+            }
         }
     }
 

--- a/crates/kas-core/src/runner/event_loop.rs
+++ b/crates/kas-core/src/runner/event_loop.rs
@@ -86,10 +86,10 @@ where
             }
             #[cfg(feature = "accesskit")]
             ProxyAction::AccessKit(window_id, event) => {
-                if let Some(id) = self.id_map.get(&window_id) {
-                    if let Some(window) = self.windows.get_mut(id) {
-                        window.accesskit_event(event);
-                    }
+                if let Some(id) = self.id_map.get(&window_id)
+                    && let Some(window) = self.windows.get_mut(id)
+                {
+                    window.accesskit_event(&mut self.state, event);
                 }
             }
         }

--- a/crates/kas-core/src/runner/mod.rs
+++ b/crates/kas-core/src/runner/mod.rs
@@ -186,6 +186,15 @@ enum ProxyAction {
     Close(WindowId),
     Message(kas::messages::SendErased),
     WakeAsync,
+    #[cfg(feature = "accesskit")]
+    AccessKit(winit::window::WindowId, accesskit_winit::WindowEvent),
+}
+
+#[cfg(feature = "accesskit")]
+impl From<accesskit_winit::Event> for ProxyAction {
+    fn from(event: accesskit_winit::Event) -> Self {
+        ProxyAction::AccessKit(event.window_id, event.window_event)
+    }
 }
 
 #[cfg(test)]

--- a/crates/kas-core/src/runner/runner.rs
+++ b/crates/kas-core/src/runner/runner.rs
@@ -84,6 +84,8 @@ impl PreLaunchState {
             self.config,
             self.config_writer,
             create_waker(&self.el),
+            #[cfg(feature = "accesskit")]
+            Proxy(self.el.create_proxy()),
             self.window_id_factory,
         )?;
 
@@ -195,7 +197,8 @@ fn create_waker(el: &EventLoop<ProxyAction>) -> std::task::Waker {
 /// A proxy allowing control of a UI from another thread.
 ///
 /// Created by [`Runner::create_proxy`](https://docs.rs/kas/latest/kas/runner/struct.Runner.html#method.create_proxy).
-pub struct Proxy(EventLoopProxy<ProxyAction>);
+#[derive(Clone)]
+pub struct Proxy(pub(super) EventLoopProxy<ProxyAction>);
 
 /// Error type returned by [`Proxy`] functions.
 ///

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -31,6 +31,8 @@ pub(super) struct SharedState<Data: AppData, G: GraphicsInstance, T: Theme<G::Sh
     pub(super) theme: T,
     pub(super) pending: VecDeque<Pending<Data, G, T>>,
     pub(super) waker: Waker,
+    #[cfg(feature = "accesskit")]
+    pub(super) proxy: super::Proxy,
     window_id_factory: WindowIdFactory,
 }
 
@@ -55,6 +57,7 @@ where
         config: Rc<RefCell<Config>>,
         config_writer: Option<Box<dyn FnMut(&Config)>>,
         waker: Waker,
+        #[cfg(feature = "accesskit")] proxy: super::Proxy,
         window_id_factory: WindowIdFactory,
     ) -> Result<Self, Error> {
         #[cfg(feature = "clipboard")]
@@ -77,6 +80,8 @@ where
                 theme,
                 pending: Default::default(),
                 waker,
+                #[cfg(feature = "accesskit")]
+                proxy,
                 window_id_factory,
             },
             data,

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -17,7 +17,7 @@ use crate::event::{ConfigCx, CursorIcon, EventState};
 use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::SolveCache;
 use crate::theme::{DrawCx, SizeCx, Theme, ThemeDraw, ThemeSize, Window as _};
-use crate::{Action, Id, Tile, Widget, WindowId, autoimpl};
+use crate::{Action, Tile, Widget, WindowId, autoimpl};
 use std::cell::RefCell;
 use std::mem::take;
 use std::rc::Rc;
@@ -433,12 +433,12 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
     }
 
     pub(super) fn send_action(&mut self, action: Action) {
-        self.ev_state.action(Id::ROOT, action);
+        self.ev_state.action(self.widget.id(), action);
     }
 
     pub(super) fn send_close(&mut self, id: WindowId) {
         if id == self.ev_state.window_id {
-            self.ev_state.action(Id::ROOT, Action::CLOSE);
+            self.ev_state.action(self.widget.id(), Action::CLOSE);
         } else if let Some(window) = self.window.as_ref() {
             let widget = &mut self.widget;
             let size = window.theme_window.size();

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -36,6 +36,8 @@ struct WindowData<G: GraphicsInstance, T: Theme<G::Shared>> {
     surface: G::Surface<'static>,
     /// Frame rate counter
     frame_count: (Instant, u32),
+    #[cfg(feature = "accesskit")]
+    accesskit: accesskit_winit::Adapter,
 
     // NOTE: cached components could be here or in Window
     window_id: WindowId,
@@ -191,6 +193,11 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
 
         let winit_id = window.id();
 
+        #[cfg(feature = "accesskit")]
+        let proxy = state.shared.proxy.0.clone();
+        #[cfg(feature = "accesskit")]
+        let accesskit = accesskit_winit::Adapter::with_event_loop_proxy(el, &window, proxy);
+
         self.window = Some(WindowData {
             window,
             #[cfg(all(wayland_platform, feature = "clipboard"))]
@@ -198,11 +205,16 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
             surface,
             frame_count: (Instant::now(), 0),
 
+            #[cfg(feature = "accesskit")]
+            accesskit,
+
             window_id: self.ev_state.window_id,
             solve_cache,
             theme_window,
             need_redraw: true,
         });
+
+        // TODO: construct accesskit adapter
 
         self.apply_size(state, true);
 
@@ -241,6 +253,9 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         let Some(ref mut window) = self.window else {
             return false;
         };
+
+        #[cfg(feature = "accesskit")]
+        window.accesskit.process_event(&window.window, &event);
 
         match event {
             WindowEvent::Moved(_) | WindowEvent::Destroyed => false,
@@ -361,6 +376,20 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
             && let Some(ref mut window) = self.window
         {
             window.need_redraw = true;
+        }
+    }
+
+    #[cfg(feature = "accesskit")]
+    pub(super) fn accesskit_event(&mut self, event: accesskit_winit::WindowEvent) {
+        let Some(ref mut window) = self.window else {
+            return;
+        };
+
+        use accesskit_winit::WindowEvent as WE;
+        match event {
+            WE::InitialTreeRequested => (),     // TODO
+            WE::ActionRequested(action) => (),  // TODO
+            WE::AccessibilityDeactivated => (), // TODO
         }
     }
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -51,7 +51,11 @@ mod ComboBox {
 
     impl Tile for Self {
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
-            Role::ComboBox(self.active, self.label.as_str())
+            Role::ComboBox {
+                active: self.active,
+                text: self.label.as_str(),
+                expanded: self.popup.is_open(),
+            }
         }
 
         fn nav_next(&self, _: bool, _: Option<usize>) -> Option<usize> {

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -9,7 +9,7 @@ use crate::adapt::AdaptEvents;
 use crate::{Column, Label, Mark, menu::MenuEntry};
 use kas::Popup;
 use kas::event::{Command, FocusSource};
-use kas::messages::SetIndex;
+use kas::messages::{Collapse, Expand, SetIndex};
 use kas::prelude::*;
 use kas::theme::FrameStyle;
 use kas::theme::{MarkStyle, TextClass};
@@ -31,6 +31,9 @@ mod ComboBox {
     /// # Messages
     ///
     /// [`kas::messages::SetIndex`] may be used to set the selected entry.
+    ///
+    /// [`kas::messages::Expand`] and [`kas::messages::Collapse`] may be used to
+    /// open and close the menu.
     #[widget]
     #[layout(
         frame!(row! [self.label, Mark::new(MarkStyle::Chevron(Direction::Down), "Expand")])
@@ -91,14 +94,6 @@ mod ComboBox {
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &A, event: Event) -> IsUsed {
-            let open_popup = |s: &mut Self, cx: &mut EventCx, source: FocusSource| {
-                if s.popup.open(cx, &(), s.id()) {
-                    if let Some(w) = s.popup.inner.inner.get_child(s.active) {
-                        cx.next_nav_focus(w.id(), false, source);
-                    }
-                }
-            };
-
             match event {
                 Event::Command(cmd, code) => {
                     if self.popup.is_open() {
@@ -123,7 +118,7 @@ mod ComboBox {
                         let last = self.len().saturating_sub(1);
                         match cmd {
                             cmd if cmd.is_activate() => {
-                                open_popup(self, cx, FocusSource::Key);
+                                self.open_popup(cx, FocusSource::Key);
                                 cx.depress_with_key(self.id(), code);
                             }
                             Command::Up => self.set_active(cx, self.active.saturating_sub(1)),
@@ -170,7 +165,7 @@ mod ComboBox {
                     }
                 }
                 Event::CursorMove { press } | Event::PressMove { press, .. } => {
-                    open_popup(self, cx, FocusSource::Pointer);
+                    self.open_popup(cx, FocusSource::Pointer);
                     let cond = self.popup.rect().contains(press.coord);
                     let target = if cond { press.id } else { None };
                     cx.set_grab_depress(press.source, target.clone());
@@ -183,7 +178,7 @@ mod ComboBox {
                     if let Some(id) = press.id {
                         if self.eq_id(&id) {
                             if self.opening {
-                                open_popup(self, cx, FocusSource::Pointer);
+                                self.open_popup(cx, FocusSource::Pointer);
                                 return Used;
                             }
                         } else if self.popup.is_open() && self.popup.is_ancestor_of(&id) {
@@ -206,6 +201,20 @@ mod ComboBox {
                     if let Some(msg) = cx.try_pop() {
                         (f)(cx, msg);
                     }
+                }
+            } else if let Some(Expand) = cx.try_pop() {
+                self.open_popup(cx, FocusSource::Synthetic);
+            } else if let Some(Collapse) = cx.try_pop() {
+                self.popup.close(cx);
+            }
+        }
+    }
+
+    impl Self {
+        fn open_popup(&mut self, cx: &mut EventCx, source: FocusSource) {
+            if self.popup.open(cx, &(), self.id()) {
+                if let Some(w) = self.popup.inner.inner.get_child(self.active) {
+                    cx.next_nav_focus(w.id(), false, source);
                 }
             }
         }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -9,7 +9,7 @@ use crate::{ScrollBar, ScrollMsg};
 use kas::event::components::{ScrollComponent, TextInput, TextInputAction};
 use kas::event::{Command, CursorIcon, ElementState, FocusSource, ImePurpose, PhysicalKey, Scroll};
 use kas::geom::Vec2;
-use kas::messages::SetValueString;
+use kas::messages::{ReplaceSelectedText, SetValueText};
 use kas::prelude::*;
 use kas::text::{NotReady, SelectionHelper};
 use kas::theme::{Background, FrameStyle, Text, TextClass};
@@ -340,7 +340,8 @@ mod EditBox {
     ///
     /// ### Messages
     ///
-    /// [`SetValueString`] may be used to replace the entire text, where
+    /// [`SetValueText`] may be used to replace the entire text and
+    /// [`ReplaceSelectedText`] may be used to replace selected text, where
     /// [`Self::is_editable`]. This triggers the action handlers
     /// [`EditGuard::edit`] followed by [`EditGuard::activate`].
     #[autoimpl(Clone, Default, Debug where G: trait)]
@@ -465,12 +466,13 @@ mod EditBox {
             }
 
             if self.is_editable()
-                && let Some(SetValueString(string)) = cx.try_pop()
+                && let Some(SetValueText(string)) = cx.try_pop()
             {
                 self.set_string(cx, string);
                 G::edit(&mut self.inner, cx, data);
                 G::activate(&mut self.inner, cx, data);
             }
+            // TODO: pass ReplaceSelectedText to inner widget?
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx<'_>, _: &G::Data, scroll: Scroll) {
@@ -797,7 +799,8 @@ mod EditField {
     ///
     /// ### Messages
     ///
-    /// [`SetValueString`] may be used to replace the entire text, where
+    /// [`SetValueText`] may be used to replace the entire text and
+    /// [`ReplaceSelectedText`] may be used to replace selected text, where
     /// [`Self::is_editable`]. This triggers the action handlers
     /// [`EditGuard::edit`] followed by [`EditGuard::activate`].
     #[autoimpl(Clone, Debug where G: trait)]
@@ -970,7 +973,9 @@ mod EditField {
                 },
                 Event::Key(event, false) if event.state == ElementState::Pressed => {
                     if let Some(text) = &event.text {
-                        self.received_text(cx, data, text)
+                        let used = self.received_text(cx, text);
+                        G::edit(self, cx, data);
+                        used
                     } else {
                         let opt_cmd = cx
                             .config()
@@ -1082,8 +1087,12 @@ mod EditField {
                 return;
             }
 
-            if let Some(SetValueString(string)) = cx.try_pop() {
+            if let Some(SetValueText(string)) = cx.try_pop() {
                 self.set_string(cx, string);
+                G::edit(self, cx, data);
+                G::activate(self, cx, data);
+            } else if let Some(ReplaceSelectedText(text)) = cx.try_pop() {
+                self.received_text(cx, &text);
                 G::edit(self, cx, data);
                 G::activate(self, cx, data);
             }
@@ -1152,6 +1161,13 @@ mod EditField {
                 self.set_ime_cursor_area(cx);
             }
             self.set_error_state(cx, false);
+        }
+
+        /// Replace selected text
+        ///
+        /// This method does not call action handlers on the [`EditGuard`].
+        pub fn replace_selection(&mut self, cx: &mut EventCx, text: &str) {
+            self.received_text(cx, text);
         }
 
         // Call only if self.ime_focus
@@ -1392,7 +1408,7 @@ impl<G: EditGuard> EditField<G> {
         0..end
     }
 
-    fn received_text(&mut self, cx: &mut EventCx, data: &G::Data, text: &str) -> IsUsed {
+    fn received_text(&mut self, cx: &mut EventCx, text: &str) -> IsUsed {
         if !self.editable || self.current.is_active_ime() {
             return Unused;
         }
@@ -1420,8 +1436,6 @@ impl<G: EditGuard> EditField<G> {
         self.edit_x_coord = None;
 
         self.prepare_text(cx);
-
-        G::edit(self, cx, data);
         Used
     }
 

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -881,9 +881,9 @@ mod EditField {
     impl Tile for Self {
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             // TODO: this is also a ScrollRegion!
-            Role::Text {
+            Role::TextInput {
                 text: self.text.as_str(),
-                editable: self.editable,
+                multi_line: self.multi_line(),
                 edit_pos: self.selection.edit_pos(),
                 sel_pos: self.selection.sel_pos(),
             }

--- a/crates/kas-widgets/src/label.rs
+++ b/crates/kas-widgets/src/label.rs
@@ -271,7 +271,11 @@ mod AccessLabel {
 
     impl Tile for Self {
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
-            Role::Label(self.text.as_str())
+            if let Some(key) = self.text.text().key() {
+                Role::AccessLabel(self.text.as_str(), key.clone())
+            } else {
+                Role::Label(self.text.as_str())
+            }
         }
     }
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -10,6 +10,7 @@ use crate::{AccessLabel, Mark};
 use kas::Popup;
 use kas::event::{Command, FocusSource};
 use kas::layout::{self, RulesSetter, RulesSolver};
+use kas::messages::{Activate, Collapse, Expand};
 use kas::prelude::*;
 use kas::theme::{FrameStyle, MarkStyle, TextClass};
 
@@ -20,6 +21,9 @@ mod SubMenu {
     /// # Messages
     ///
     /// [`kas::messages::Activate`] may be used to open the sub-menu.
+    ///
+    /// [`kas::messages::Expand`] and [`kas::messages::Collapse`] may be used to
+    /// open and close the menu.
     #[widget]
     #[layout(self.label)]
     pub struct SubMenu<const TOP_LEVEL: bool, Data> {
@@ -147,9 +151,13 @@ mod SubMenu {
         }
 
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Data) {
-            if let Some(kas::messages::Activate(code)) = cx.try_pop() {
+            if let Some(Activate(code)) = cx.try_pop() {
                 self.popup.open(cx, data, self.id());
                 cx.depress_with_key(self.id(), code);
+            } else if let Some(Expand) = cx.try_pop() {
+                self.popup.open(cx, data, self.id());
+            } else if let Some(Collapse) = cx.try_pop() {
+                self.popup.close(cx);
             } else {
                 self.popup.close(cx);
             }

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -114,7 +114,9 @@ mod SubMenu {
 
     impl Tile for Self {
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
-            Role::Menu
+            Role::Menu {
+                expanded: self.popup.is_open(),
+            }
         }
 
         fn nav_next(&self, _: bool, _: Option<usize>) -> Option<usize> {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -45,9 +45,8 @@ mod SelectableText {
 
     impl Tile for Self {
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
-            Role::Text {
+            Role::TextLabel {
                 text: self.text.as_str(),
-                editable: false,
                 edit_pos: self.selection.edit_pos(),
                 sel_pos: self.selection.sel_pos(),
             }

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -301,6 +301,15 @@ mod Slider {
     }
 
     impl Tile for Self {
+        fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
+            Role::Slider {
+                min: self.range.0.cast(),
+                max: self.range.1.cast(),
+                step: self.step.cast(),
+                value: self.value.cast(),
+            }
+        }
+
         fn probe(&self, coord: Coord) -> Id {
             if self.on_move.is_some() {
                 if let Some(id) = self.grip.try_probe(coord) {

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -366,6 +366,15 @@ mod SpinBox {
     }
 
     impl Tile for Self {
+        fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
+            Role::SpinButton {
+                min: self.edit.guard.start.cast(),
+                max: self.edit.guard.end.cast(),
+                step: self.edit.guard.step.cast(),
+                value: self.edit.guard.value.cast(),
+            }
+        }
+
         fn probe(&self, coord: Coord) -> Id {
             self.b_up
                 .try_probe(coord)

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -7,7 +7,7 @@
 
 use crate::{EditField, EditGuard, MarkButton};
 use kas::event::Command;
-use kas::messages::{DecrementStep, IncrementStep, SetValueF64, SetValueString};
+use kas::messages::{DecrementStep, IncrementStep, ReplaceSelectedText, SetValueF64, SetValueText};
 use kas::prelude::*;
 use kas::theme::{Background, FrameStyle, MarkStyle, Text, TextClass};
 use std::ops::RangeInclusive;
@@ -201,7 +201,8 @@ mod SpinBox {
     ///
     /// [`IncrementStep`] and [`DecrementStep`] change the value by one step.
     ///
-    /// [`SetValueString`] may be used to set the input as a text value.
+    /// [`SetValueText`] may be used to set the input as a text value.
+    /// [`ReplaceSelectedText`] may be used to replace the selected text.
     #[widget]
     #[layout(
         frame!(row![self.edit, self.unit, column! [self.b_up, self.b_down]])
@@ -451,8 +452,12 @@ mod SpinBox {
                 Some(self.edit.guard.value.add_step(self.edit.guard.step))
             } else if let Some(DecrementStep) = cx.try_pop() {
                 Some(self.edit.guard.value.sub_step(self.edit.guard.step))
-            } else if let Some(SetValueString(string)) = cx.try_pop() {
+            } else if let Some(SetValueText(string)) = cx.try_pop() {
                 self.edit.set_string(cx, string);
+                SpinGuard::edit(&mut self.edit, cx, data);
+                self.edit.guard.parsed
+            } else if let Some(ReplaceSelectedText(text)) = cx.try_pop() {
+                self.edit.replace_selection(cx, &text);
                 SpinGuard::edit(&mut self.edit, cx, data);
                 self.edit.guard.parsed
             } else {

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -7,7 +7,7 @@
 
 use crate::{EditField, EditGuard, MarkButton};
 use kas::event::Command;
-use kas::messages::{SetValueF64, SetValueString};
+use kas::messages::{DecrementStep, IncrementStep, SetValueF64, SetValueString};
 use kas::prelude::*;
 use kas::theme::{Background, FrameStyle, MarkStyle, Text, TextClass};
 use std::ops::RangeInclusive;
@@ -198,6 +198,8 @@ mod SpinBox {
     /// ### Messages
     ///
     /// [`SetValueF64`] may be used to set the input value.
+    ///
+    /// [`IncrementStep`] and [`DecrementStep`] change the value by one step.
     ///
     /// [`SetValueString`] may be used to set the input as a text value.
     #[widget]
@@ -445,6 +447,10 @@ mod SpinBox {
                         None
                     }
                 }
+            } else if let Some(IncrementStep) = cx.try_pop() {
+                Some(self.edit.guard.value.add_step(self.edit.guard.step))
+            } else if let Some(DecrementStep) = cx.try_pop() {
+                Some(self.edit.guard.value.sub_step(self.edit.guard.step))
             } else if let Some(SetValueString(string)) = cx.try_pop() {
                 self.edit.set_string(cx, string);
                 SpinGuard::edit(&mut self.edit, cx, data);


### PR DESCRIPTION
Replaces #512. In comparison:

- Widget code does not use AccessKit as an API; instead #519 added `fn Tile::role()`. This will doubtless need some additions, but lets widgets report necessary details without dependency on AccessKit (and with a nicer API in my opinion).
- Output to AccessKit should be largely the same as #512.
- Some more actions are supported vs #512.

This PR still needs a few tweaks (TEMP / TODO commits) but is testable.

@DataTriny I'd appreciate if you gave this a little test and some feedback. I have successfully tested with a screen reader. Any obvious issues? My notes:

- I didn't use `accesskit::Role::GenericContainer` at all here; just `Unknown` for layout containers. Is that acceptable?
- I notice some focus tracking issues in Kas when using access keys. Edit: cause is that the event handler tries to focus the `AccessLabel` which doesn't support focus. I'm not going to solve the issue in this PR.
- More known issues are noted in #509

I also am fairly convinced that AccessKit's model is not the best fit for Kas; see https://github.com/AccessKit/accesskit/issues/591. Perhaps a lower-level intermediate library or perhaps the best answer would just be to support platform-specific accessibility tools eventually.