### PR TITLE
Fix #522; move Events::NAVIGABLE to Tile::navigable

### DIFF
--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -122,7 +122,7 @@ pub fn _nav_next<W: Events>(
     focus: Option<&Id>,
     advance: NavAdvance,
 ) -> Option<Id> {
-    if !W::NAVIGABLE {
+    if !widget.navigable() {
         nav_next_non_nav(widget.as_node(data), cx, focus, advance)
     } else {
         nav_next_nav(widget.as_node(data), cx, focus, advance)

--- a/crates/kas-core/src/core/node.rs
+++ b/crates/kas-core/src/core/node.rs
@@ -10,11 +10,13 @@ use crate::event::{ConfigCx, Event, EventCx, IsUsed};
 use crate::geom::Rect;
 use crate::layout::{AlignHints, AxisInfo, SizeRules};
 use crate::theme::SizeCx;
+use crate::util::IdentifyWidget;
 use crate::{Id, NavAdvance, Tile};
 
 #[cfg(not(feature = "unsafe_node"))]
 trait NodeT {
     fn id_ref(&self) -> &Id;
+    fn identify(&self) -> IdentifyWidget<'_>;
     fn rect(&self) -> Rect;
 
     fn clone_node(&mut self) -> Node<'_>;
@@ -44,6 +46,9 @@ trait NodeT {
 impl<'a, T> NodeT for (&'a mut dyn Widget<Data = T>, &'a T) {
     fn id_ref(&self) -> &Id {
         self.0.id_ref()
+    }
+    fn identify(&self) -> IdentifyWidget<'_> {
+        self.0.identify()
     }
     fn rect(&self) -> Rect {
         self.0.rect()
@@ -165,6 +170,14 @@ impl<'a> Node<'a> {
     #[inline]
     pub fn id(&self) -> Id {
         self.id_ref().clone()
+    }
+
+    /// Return a [`Display`]-able widget identifier
+    ///
+    /// [`Display`]: std::fmt::Display
+    #[inline]
+    pub fn identify(&self) -> IdentifyWidget<'_> {
+        self.0.identify()
     }
 
     /// Test widget identifier for equality

--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -286,7 +286,9 @@ impl<'a> Role<'a> {
 
         let mut node = accesskit::Node::new(self.as_accesskit_role());
         node.set_bounds(tile.rect().cast());
-        // TODO: if NAVIGABLE, node.add_action(Action::Focus);
+        if tile.navigable() {
+            node.add_action(Action::Focus);
+        }
 
         match *self {
             Role::Unknown | Role::Border => (),

--- a/crates/kas-core/src/core/tile.rs
+++ b/crates/kas-core/src/core/tile.rs
@@ -83,6 +83,13 @@ pub trait Tile: Layout {
         unimplemented!() // make rustdoc show that this is a provided method
     }
 
+    /// Whether this widget supports navigation focus
+    ///
+    /// By default this is false.
+    fn navigable(&self) -> bool {
+        false
+    }
+
     /// Describe the widget's role
     ///
     /// This descriptor supports accessibility tooling and UI introspection.

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -61,14 +61,6 @@ pub trait Events: Widget + Sized {
     /// animations.)
     const REDRAW_ON_HOVER: bool = false;
 
-    /// Is this widget navigable via <kbd>Tab</kbd> key?
-    ///
-    /// Note that when this is `false` then the widget will not receive
-    /// navigation focus via the <kbd>Tab</kbd> key, but it may still receive
-    /// navigation focus through some other means, for example a keyboard
-    /// shortcut or a mouse click.
-    const NAVIGABLE: bool = false;
-
     /// The mouse cursor icon to use on hover
     ///
     /// Defaults to `None`.

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -526,7 +526,7 @@ impl EventState {
     /// globally then nothing happens, otherwise widget `id` should receive
     /// [`Event::NavFocus`].
     ///
-    /// Normally, [`Events::NAVIGABLE`] will be true for widget `id` but this
+    /// Normally, [`Tile::navigable`] will return true for widget `id` but this
     /// is not checked or required. For example, a `ScrollLabel` can receive
     /// focus on text selection with the mouse.
     pub fn set_nav_focus(&mut self, id: Id, source: FocusSource) {
@@ -539,7 +539,7 @@ impl EventState {
     /// Advance the navigation focus
     ///
     /// If `target == Some(id)`, this looks for the next widget from `id`
-    /// (inclusive) which is navigable ([`Events::NAVIGABLE`]). Otherwise where
+    /// (inclusive) which is [navigable](Tile::navigable). Otherwise where
     /// some widget `id` has [`nav_focus`](Self::nav_focus) this looks for the
     /// next navigable widget *excluding* `id`. If no reference is available,
     /// this instead looks for the first navigable widget.

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -337,13 +337,24 @@ impl EventState {
         }
     }
 
-    /// Adds an access key for a widget
+    /// Register `id` as handler of an access `key`
     ///
     /// An *access key* (also known as mnemonic) is a shortcut key able to
-    /// directly open menus,
-    /// activate buttons, etc. A user triggers the key by pressing `Alt+Key`,
-    /// or (if `alt_bypass` is enabled) by simply pressing the key.
-    /// The widget with this `id` then receives [`Command::Activate`].
+    /// directly open menus, activate buttons, etc. By default, when the user
+    /// presses (and holds) key <kbd>Alt</kbd>, access keys in labels will be
+    /// underlined and when the user presses the corresponding key then the
+    /// widget registered as handler for that access key will receive navigation
+    /// focus and [`Command::Activate`].
+    ///
+    /// If `id` itself cannot support navigation focus or handle
+    /// [`Command::Activate`], then ancestors of `id` will have the opportunity
+    /// to receive navigation focus and handle this [`Event::Command`].
+    ///
+    /// If multiple widgets attempt to register themselves as handlers of the
+    /// same `key`, then only the first succeeds.
+    ///
+    /// [`Self::enable_alt_bypass`] allows usage of access keys without
+    /// <kbd>Alt</kbd>.
     ///
     /// Note that access keys may be automatically derived from labels:
     /// see [`crate::text::AccessString`].

--- a/crates/kas-core/src/text/string.rs
+++ b/crates/kas-core/src/text/string.rs
@@ -95,8 +95,8 @@ impl AccessString {
     }
 
     /// Get the key binding, if any
-    pub fn key(&self) -> Option<&Key> {
-        self.key.as_ref()
+    pub fn key(&self) -> Option<Key> {
+        self.key.clone()
     }
 
     /// Get the text

--- a/crates/kas-widgets/src/adapt/with_label.rs
+++ b/crates/kas-widgets/src/adapt/with_label.rs
@@ -122,5 +122,21 @@ mod WithLabel {
 
     impl Events for Self {
         type Data = W::Data;
+
+        fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+            let id = self.make_child_id(widget_index!(self.inner));
+            if id.is_valid() {
+                cx.configure(self.inner.as_node(data), id);
+
+                if let Some(key) = self.label.access_key() {
+                    cx.add_access_key(self.inner.id_ref(), key.clone());
+                }
+            }
+
+            let id = self.make_child_id(widget_index!(self.label));
+            if id.is_valid() {
+                cx.configure(self.label.as_node(&()), id);
+            }
+        }
     }
 }

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -98,6 +98,10 @@ mod Button {
     }
 
     impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+
         fn role(&self, cx: &mut dyn RoleCx) -> Role<'_> {
             cx.set_label(self.inner.id());
             Role::Button
@@ -110,7 +114,6 @@ mod Button {
 
     impl Events for Self {
         const REDRAW_ON_HOVER: bool = true;
-        const NAVIGABLE: bool = true;
 
         type Data = W::Data;
 

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -233,6 +233,22 @@ mod CheckButton {
     impl Events for Self {
         type Data = A;
 
+        fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+            let id = self.make_child_id(widget_index!(self.inner));
+            if id.is_valid() {
+                cx.configure(self.inner.as_node(data), id);
+
+                if let Some(key) = self.label.access_key() {
+                    cx.add_access_key(self.inner.id_ref(), key.clone());
+                }
+            }
+
+            let id = self.make_child_id(widget_index!(self.label));
+            if id.is_valid() {
+                cx.configure(self.label.as_node(&()), id);
+            }
+        }
+
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Self::Data) {
             if let Some(kas::messages::Activate(code)) = cx.try_pop() {
                 self.inner.toggle(cx, data);

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -33,7 +33,6 @@ mod CheckBox {
 
     impl Events for Self {
         const REDRAW_ON_HOVER: bool = true;
-        const NAVIGABLE: bool = true;
 
         type Data = A;
 
@@ -77,6 +76,10 @@ mod CheckBox {
     }
 
     impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             Role::CheckBox(self.state)
         }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -53,6 +53,10 @@ mod ComboBox {
     }
 
     impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             Role::ComboBox {
                 active: self.active,
@@ -73,7 +77,6 @@ mod ComboBox {
 
     impl Events for Self {
         const REDRAW_ON_HOVER: bool = true;
-        const NAVIGABLE: bool = true;
 
         type Data = A;
 

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -882,6 +882,10 @@ mod EditField {
     }
 
     impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             // TODO: this is also a ScrollRegion!
             Role::TextInput {
@@ -899,7 +903,6 @@ mod EditField {
 
     impl Events for Self {
         const REDRAW_ON_HOVER: bool = true;
-        const NAVIGABLE: bool = true;
 
         type Data = G::Data;
 

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -41,6 +41,10 @@ mod MenuEntry {
     }
 
     impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+
         fn role(&self, cx: &mut dyn RoleCx) -> Role<'_> {
             cx.set_label(self.label.id());
             Role::Button
@@ -77,8 +81,6 @@ mod MenuEntry {
     }
 
     impl Events for Self {
-        const NAVIGABLE: bool = true;
-
         type Data = ();
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -160,6 +160,22 @@ mod MenuToggle {
     impl Events for Self {
         type Data = A;
 
+        fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+            let id = self.make_child_id(widget_index!(self.checkbox));
+            if id.is_valid() {
+                cx.configure(self.checkbox.as_node(data), id);
+
+                if let Some(key) = self.label.access_key() {
+                    cx.add_access_key(self.checkbox.id_ref(), key.clone());
+                }
+            }
+
+            let id = self.make_child_id(widget_index!(self.label));
+            if id.is_valid() {
+                cx.configure(self.label.as_node(&()), id);
+            }
+        }
+
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Self::Data) {
             if let Some(kas::messages::Activate(code)) = cx.try_pop() {
                 self.checkbox.toggle(cx, data);

--- a/crates/kas-widgets/src/menu/mod.rs
+++ b/crates/kas-widgets/src/menu/mod.rs
@@ -49,8 +49,8 @@ pub struct SubItems<'a> {
 ///
 /// Implementations will automatically receive nav focus on mouse-hover, thus
 /// should ensure that [`Tile::probe`] returns the identifier of the widget
-/// which should be focussed, and that this widget has
-/// [`Events::NAVIGABLE`] return true.
+/// which should be focussed, and that this widget has [`Tile::navigable`]
+/// return true.
 #[autoimpl(for<T: trait + ?Sized> Box<T>)]
 pub trait Menu: Widget {
     /// Access row items for aligned layout

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -117,6 +117,10 @@ mod SubMenu {
     }
 
     impl Tile for Self {
+        fn navigable(&self) -> bool {
+            !TOP_LEVEL
+        }
+
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             Role::Menu {
                 expanded: self.popup.is_open(),
@@ -134,8 +138,6 @@ mod SubMenu {
     }
 
     impl Events for Self {
-        const NAVIGABLE: bool = !TOP_LEVEL;
-
         type Data = Data;
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &Data, event: Event) -> IsUsed {

--- a/crates/kas-widgets/src/nav_frame.rs
+++ b/crates/kas-widgets/src/nav_frame.rs
@@ -40,9 +40,13 @@ mod NavFrame {
         }
     }
 
-    impl Events for Self {
-        const NAVIGABLE: bool = true;
+    impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+    }
 
+    impl Events for Self {
         type Data = W::Data;
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -192,6 +192,22 @@ mod RadioButton {
     impl Events for Self {
         type Data = A;
 
+        fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
+            let id = self.make_child_id(widget_index!(self.inner));
+            if id.is_valid() {
+                cx.configure(self.inner.as_node(data), id);
+
+                if let Some(key) = self.label.access_key() {
+                    cx.add_access_key(self.inner.id_ref(), key.clone());
+                }
+            }
+
+            let id = self.make_child_id(widget_index!(self.label));
+            if id.is_valid() {
+                cx.configure(self.label.as_node(&()), id);
+            }
+        }
+
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Self::Data) {
             if let Some(kas::messages::Activate(code)) = cx.try_pop() {
                 self.inner.select(cx, data);

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -32,7 +32,6 @@ mod RadioBox {
 
     impl Events for Self {
         const REDRAW_ON_HOVER: bool = true;
-        const NAVIGABLE: bool = true;
 
         type Data = A;
 
@@ -77,6 +76,10 @@ mod RadioBox {
     }
 
     impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             Role::RadioButton(self.state)
         }

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -303,6 +303,10 @@ mod Slider {
     }
 
     impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             Role::Slider {
                 min: self.range.0.cast(),
@@ -324,7 +328,6 @@ mod Slider {
 
     impl Events for Self {
         const REDRAW_ON_HOVER: bool = true;
-        const NAVIGABLE: bool = true;
 
         type Data = A;
 

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -45,6 +45,10 @@ mod Tab {
     }
 
     impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+
         fn role(&self, cx: &mut dyn RoleCx) -> Role<'_> {
             cx.set_label(self.label.id());
             Role::Tab
@@ -57,7 +61,6 @@ mod Tab {
 
     impl Events for Self {
         const REDRAW_ON_HOVER: bool = true;
-        const NAVIGABLE: bool = true;
 
         type Data = ();
 

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -356,9 +356,13 @@ mod Mandlebrot {
         }
     }
 
-    impl Events for Mandlebrot {
-        const NAVIGABLE: bool = true;
+    impl Tile for Self {
+        fn navigable(&self) -> bool {
+            true
+        }
+    }
 
+    impl Events for Mandlebrot {
         type Data = i32;
 
         fn configure(&mut self, cx: &mut ConfigCx) {


### PR DESCRIPTION
Fix #522 by allowing the parent to register itself or another child as handler of an `AccessLabel`'s `access_key`.

Let navigable widgets advertise support for `accesskit::Action::Focus` by replacing `const Events::NAVIGABLE` with `fn Tile::navigable`. This is a further change to a recent change (`Events::NAVIGABLE`), and justifiable since (a) "is navigable" is a property, not event handling; and (b) `const` members are not accessible from dyn-safe traits.