### PR TITLE
Tooltips, rename hover → mouse over, popup behaviour tweaks

### DIFF
--- a/crates/kas-core/src/config/event.rs
+++ b/crates/kas-core/src/config/event.rs
@@ -157,7 +157,7 @@ impl<'a> EventWindowConfig<'a> {
         Ref::map(self.0.config.borrow(), |c| &c.event)
     }
 
-    /// Delay before sending [`Event::MouseHover`]
+    /// Delay before mouse hover action (show tooltip)
     #[inline]
     pub fn hover_delay(&self) -> Duration {
         Duration::from_millis(self.base().hover_delay_ms.cast())

--- a/crates/kas-core/src/config/event.rs
+++ b/crates/kas-core/src/config/event.rs
@@ -150,7 +150,7 @@ impl<'a> EventWindowConfig<'a> {
         Ref::map(self.0.config.borrow(), |c| &c.event)
     }
 
-    /// Delay before opening/closing menus on mouse hover
+    /// Delay before opening/closing menus on mouse over
     #[inline]
     pub fn menu_delay(&self) -> Duration {
         Duration::from_millis(self.base().menu_delay_ms.cast())

--- a/crates/kas-core/src/config/event.rs
+++ b/crates/kas-core/src/config/event.rs
@@ -7,6 +7,7 @@
 
 use crate::Action;
 use crate::cast::{Cast, CastFloat};
+#[allow(unused)] use crate::event::Event;
 use crate::event::ModifiersState;
 use crate::geom::Offset;
 #[cfg(feature = "serde")]
@@ -18,6 +19,7 @@ use std::time::Duration;
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum EventConfigMsg {
+    HoverDelay(u32),
     MenuDelay(u32),
     TouchSelectDelay(u32),
     KineticTimeout(u32),
@@ -55,6 +57,9 @@ pub enum EventConfigMsg {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EventConfig {
+    #[cfg_attr(feature = "serde", serde(default = "defaults::hover_delay_ms"))]
+    pub hover_delay_ms: u32,
+
     #[cfg_attr(feature = "serde", serde(default = "defaults::menu_delay_ms"))]
     pub menu_delay_ms: u32,
 
@@ -96,6 +101,7 @@ pub struct EventConfig {
 impl Default for EventConfig {
     fn default() -> Self {
         EventConfig {
+            hover_delay_ms: defaults::hover_delay_ms(),
             menu_delay_ms: defaults::menu_delay_ms(),
             touch_select_delay_ms: defaults::touch_select_delay_ms(),
             kinetic_timeout_ms: defaults::kinetic_timeout_ms(),
@@ -116,6 +122,7 @@ impl Default for EventConfig {
 impl EventConfig {
     pub(super) fn change_config(&mut self, msg: EventConfigMsg) -> Action {
         match msg {
+            EventConfigMsg::HoverDelay(v) => self.hover_delay_ms = v,
             EventConfigMsg::MenuDelay(v) => self.menu_delay_ms = v,
             EventConfigMsg::TouchSelectDelay(v) => self.touch_select_delay_ms = v,
             EventConfigMsg::KineticTimeout(v) => self.kinetic_timeout_ms = v,
@@ -148,6 +155,12 @@ impl<'a> EventWindowConfig<'a> {
     #[inline]
     pub fn base(&self) -> Ref<'_, EventConfig> {
         Ref::map(self.0.config.borrow(), |c| &c.event)
+    }
+
+    /// Delay before sending [`Event::MouseHover`]
+    #[inline]
+    pub fn hover_delay(&self) -> Duration {
+        Duration::from_millis(self.base().hover_delay_ms.cast())
     }
 
     /// Delay before opening/closing menus on mouse over
@@ -288,6 +301,9 @@ impl MousePan {
 mod defaults {
     use super::MousePan;
 
+    pub fn hover_delay_ms() -> u32 {
+        1000
+    }
     pub fn menu_delay_ms() -> u32 {
         250
     }

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -28,8 +28,8 @@ pub fn _send<W: Events>(
         // Side-effects of receiving events at the target widget.
         // These actions do not affect is_used or event propagation.
         match &event {
-            Event::MouseHover(state) => {
-                widget.handle_hover(cx, *state);
+            Event::MouseOver(state) => {
+                widget.handle_mouse_over(cx, *state);
             }
             Event::NavFocus(FocusSource::Key) => {
                 cx.set_scroll(Scroll::Rect(widget.rect()));

--- a/crates/kas-core/src/core/tile.rs
+++ b/crates/kas-core/src/core/tile.rs
@@ -90,6 +90,16 @@ pub trait Tile: Layout {
         false
     }
 
+    /// Tooltip
+    ///
+    /// This is shown on mouse hover and may or may not use the same text as the
+    /// label defined by the role.
+    ///
+    /// By default this is `None`.
+    fn tooltip(&self) -> Option<&str> {
+        None
+    }
+
     /// Describe the widget's role
     ///
     /// This descriptor supports accessibility tooling and UI introspection.

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -54,18 +54,18 @@ use kas_macros::autoimpl;
 ///
 /// [`#widget`]: macros::widget
 pub trait Events: Widget + Sized {
-    /// Does this widget have a different appearance when hovered?
+    /// Does this widget have a different appearance on mouse over?
     ///
-    /// If `true`, then mouse hover and loss of mouse hover will cause a redraw.
-    /// (Note that [`Layout::draw`] can infer the hover state and start
-    /// animations.)
-    const REDRAW_ON_HOVER: bool = false;
+    /// If `true`, then the mouse moving over and leaving the widget will cause
+    /// a redraw. (Note that [`Layout::draw`] can infer the mouse-over state and
+    /// start animations.)
+    const REDRAW_ON_MOUSE_OVER: bool = false;
 
-    /// The mouse cursor icon to use on hover
+    /// The mouse cursor icon to use on mouse over
     ///
     /// Defaults to `None`.
     #[inline]
-    fn hover_icon(&self) -> Option<CursorIcon> {
+    fn mouse_over_icon(&self) -> Option<CursorIcon> {
         None
     }
 
@@ -166,15 +166,18 @@ pub trait Events: Widget + Sized {
 
     /// Mouse focus handler
     ///
-    /// Called when mouse hover state changes. (This is a low-level alternative
-    /// to [`Self::REDRAW_ON_HOVER`] and [`Self::hover_icon`].)
+    /// Called when mouse moves over or leaves this widget.
+    /// (This is a low-level alternative
+    /// to [`Self::REDRAW_ON_MOUSE_OVER`] and [`Self::mouse_over_icon`].)
+    ///
+    /// `state` is true when the mouse is over this widget.
     #[inline]
-    fn handle_hover(&mut self, cx: &mut EventCx, is_hovered: bool) {
-        if Self::REDRAW_ON_HOVER {
+    fn handle_mouse_over(&mut self, cx: &mut EventCx, state: bool) {
+        if Self::REDRAW_ON_MOUSE_OVER {
             cx.redraw(&self);
         }
-        if is_hovered && let Some(icon) = self.hover_icon() {
-            cx.set_hover_cursor(icon);
+        if state && let Some(icon) = self.mouse_over_icon() {
+            cx.set_mouse_over_icon(icon);
         }
     }
 

--- a/crates/kas-core/src/decorations.rs
+++ b/crates/kas-core/src/decorations.rs
@@ -201,6 +201,10 @@ mod MarkButton {
     }
 
     impl Tile for Self {
+        fn tooltip(&self) -> Option<&str> {
+            Some(&self.label)
+        }
+
         fn role(&self, cx: &mut dyn RoleCx) -> Role<'_> {
             cx.set_label(&self.label);
             Role::Button

--- a/crates/kas-core/src/decorations.rs
+++ b/crates/kas-core/src/decorations.rs
@@ -83,7 +83,7 @@ mod Border {
     impl Events for Self {
         type Data = ();
 
-        fn hover_icon(&self) -> Option<CursorIcon> {
+        fn mouse_over_icon(&self) -> Option<CursorIcon> {
             if self.resizable {
                 Some(self.direction.into())
             } else {
@@ -208,7 +208,7 @@ mod MarkButton {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = ();
 

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -775,8 +775,13 @@ impl<'a> EventCx<'a> {
 
         let parent_id = self.window.window_id();
         let id = self.runner.add_popup(parent_id, popup.clone());
-        let nav_focus = self.nav_focus.clone();
-        self.popups.push((id, popup, nav_focus));
+        let old_nav_focus = self.nav_focus.clone();
+        self.popups.push(PopupState {
+            id,
+            desc: popup,
+            old_nav_focus,
+            is_sized: false,
+        });
         self.clear_nav_focus();
         id
     }
@@ -816,7 +821,7 @@ impl<'a> EventCx<'a> {
     /// the popup was open.
     pub fn close_window(&mut self, mut id: WindowId) {
         for (index, p) in self.popups.iter().enumerate() {
-            if p.0 == id {
+            if p.id == id {
                 id = self.close_popup(index);
                 break;
             }

--- a/crates/kas-core/src/event/cx/cx_pub.rs
+++ b/crates/kas-core/src/event/cx/cx_pub.rs
@@ -18,7 +18,7 @@ use crate::theme::SizeCx;
 #[cfg(all(wayland_platform, feature = "clipboard"))]
 use crate::util::warn_about_error;
 #[allow(unused)] use crate::{Events, Layout, Tile}; // for doc-links
-use crate::{HasId, Window};
+use crate::{HasId, PopupDescriptor, Window};
 
 impl EventState {
     /// Get the platform
@@ -752,7 +752,7 @@ impl<'a> EventCx<'a> {
         self.scroll = scroll;
     }
 
-    /// Add an overlay (pop-up)
+    /// Add a pop-up
     ///
     /// A pop-up is a box used for things like tool-tips and menus which is
     /// drawn on top of other content and has focus for input.
@@ -770,7 +770,7 @@ impl<'a> EventCx<'a> {
     ///
     /// A pop-up may be closed by calling [`EventCx::close_window`] with
     /// the [`WindowId`] returned by this method.
-    pub(crate) fn add_popup(&mut self, popup: crate::PopupDescriptor) -> WindowId {
+    pub(crate) fn add_popup(&mut self, popup: PopupDescriptor) -> WindowId {
         log::trace!(target: "kas_core::event", "add_popup: {popup:?}");
 
         let parent_id = self.window.window_id();
@@ -779,6 +779,14 @@ impl<'a> EventCx<'a> {
         self.popups.push((id, popup, nav_focus));
         self.clear_nav_focus();
         id
+    }
+
+    /// Resize and reposition an existing pop-up
+    ///
+    /// This method takes a new [`PopupDescriptor`]. Its first field, `id`, is
+    /// expected to remain unchanged but other fields may differ.
+    pub(crate) fn reposition_popup(&mut self, id: WindowId, popup: PopupDescriptor) {
+        self.runner.reposition_popup(id, popup);
     }
 
     /// Add a window

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -6,7 +6,7 @@
 //! Event context state
 
 use linear_map::{LinearMap, set::LinearSet};
-use press::{Mouse, Touch};
+pub(crate) use press::{Mouse, Touch};
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::future::Future;

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -278,9 +278,9 @@ impl<'a> EventCx<'a> {
             }
 
             if matches!(cmd, Command::Debug) {
-                let hover = self.mouse.hover();
-                let hier = WidgetHierarchy::new(widget.as_tile(), hover.clone());
-                log::debug!("Widget heirarchy (filter={hover:?}): {hier}");
+                let over_id = self.mouse.over_id();
+                let hier = WidgetHierarchy::new(widget.as_tile(), over_id.clone());
+                log::debug!("Widget heirarchy (filter={over_id:?}): {hier}");
                 return;
             }
         }

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -153,6 +153,7 @@ impl EventState {
         if state.is_sized {
             self.popup_removed.push((state.desc.id, state.id));
         }
+        self.mouse.tooltip_popup_close(&state.desc.parent);
 
         if let Some(id) = state.old_nav_focus {
             self.set_nav_focus(id, FocusSource::Synthetic);

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -55,6 +55,13 @@ enum PendingNavFocus {
 
 type AccessLayer = (bool, HashMap<Key, Id>);
 
+struct PopupState {
+    id: WindowId,
+    desc: crate::PopupDescriptor,
+    old_nav_focus: Option<Id>,
+    is_sized: bool,
+}
+
 /// Event context state
 ///
 /// This struct encapsulates window-specific event-handling state and handling.
@@ -95,8 +102,7 @@ pub struct EventState {
     mouse: Mouse,
     touch: Touch,
     access_layers: BTreeMap<Id, AccessLayer>,
-    // For each: (WindowId of popup, popup descriptor, old nav focus)
-    popups: SmallVec<[(WindowId, crate::PopupDescriptor, Option<Id>); 16]>,
+    popups: SmallVec<[PopupState; 16]>,
     popup_removed: SmallVec<[(Id, WindowId); 16]>,
     time_updates: Vec<(Instant, Id, TimerHandle)>,
     frame_updates: LinearSet<(Id, TimerHandle)>,
@@ -143,14 +149,16 @@ impl EventState {
     // The caller must call `runner.close_window(window_id)`.
     #[must_use]
     fn close_popup(&mut self, index: usize) -> WindowId {
-        let (window_id, popup, onf) = self.popups.remove(index);
-        self.popup_removed.push((popup.id, window_id));
+        let state = self.popups.remove(index);
+        if state.is_sized {
+            self.popup_removed.push((state.desc.id, state.id));
+        }
 
-        if let Some(id) = onf {
+        if let Some(id) = state.old_nav_focus {
             self.set_nav_focus(id, FocusSource::Synthetic);
         }
 
-        window_id
+        state.id
     }
 
     /// Clear all focus and grabs on `target`
@@ -193,6 +201,14 @@ impl EventState {
 
         self.mouse.cancel_event_focus(target);
         self.touch.cancel_event_focus(target);
+    }
+
+    pub(crate) fn confirm_popup_is_sized(&mut self, id: WindowId) {
+        for popup in &mut self.popups {
+            if popup.id == id {
+                popup.is_sized = true;
+            }
+        }
     }
 }
 
@@ -265,7 +281,11 @@ impl<'a> EventCx<'a> {
                 return;
             }
 
-            if let Some(id) = self.popups.last().map(|popup| popup.1.id.clone())
+            if let Some(id) = self
+                .popups
+                .last()
+                .filter(|popup| popup.is_sized)
+                .map(|popup| popup.desc.id.clone())
                 && send(self, id, cmd)
             {
                 return;
@@ -288,7 +308,8 @@ impl<'a> EventCx<'a> {
         // Next priority goes to access keys when Alt is held or alt_bypass is true
         let mut target = None;
         for id in (self.popups.iter().rev())
-            .map(|(_, popup, _)| popup.id.clone())
+            .filter(|popup| popup.is_sized)
+            .map(|state| state.desc.id.clone())
             .chain(std::iter::once(widget.id()))
         {
             if let Some(layer) = self.access_layers.get(&id) {
@@ -313,7 +334,7 @@ impl<'a> EventCx<'a> {
             let shift = self.modifiers.shift_key();
             self.next_nav_focus_impl(widget.re(), None, shift, FocusSource::Key);
         } else if opt_cmd == Some(Command::Escape)
-            && let Some(id) = self.popups.last().map(|(id, _, _)| *id)
+            && let Some(id) = self.popups.last().map(|desc| desc.id)
         {
             self.close_window(id);
         }
@@ -399,7 +420,12 @@ impl<'a> EventCx<'a> {
     }
 
     fn send_popup_first(&mut self, mut widget: Node<'_>, id: Option<Id>, event: Event) {
-        while let Some(pid) = self.popups.last().map(|(_, p, _)| p.id.clone()) {
+        while let Some(pid) = self
+            .popups
+            .last()
+            .filter(|popup| popup.is_sized)
+            .map(|state| state.desc.id.clone())
+        {
             let mut target = pid;
             if let Some(id) = id.clone()
                 && target.is_ancestor_of(&id)
@@ -530,7 +556,12 @@ impl<'a> EventCx<'a> {
             return;
         }
 
-        if let Some(id) = self.popups.last().map(|(_, p, _)| p.id.clone()) {
+        if let Some(id) = self
+            .popups
+            .last()
+            .filter(|popup| popup.is_sized)
+            .map(|state| state.desc.id.clone())
+        {
             if id.is_ancestor_of(widget.id_ref()) {
                 // do nothing
             } else if let Some(r) = widget.find_node(&id, |node| {

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -394,7 +394,7 @@ impl<'a> EventCx<'a> {
                     self.action(win.id(), Action::REDRAW);
                 } else {
                     // Window focus lost: close all popups
-                    while let Some(id) = self.popups.last().map(|(id, _, _)| *id) {
+                    while let Some(id) = self.popups.last().map(|state| state.id) {
                         self.close_window(id);
                     }
                 }

--- a/crates/kas-core/src/event/cx/platform.rs
+++ b/crates/kas-core/src/event/cx/platform.rs
@@ -194,7 +194,7 @@ impl EventState {
             }
         });
 
-        if let Some(icon) = self.mouse.update_hover_icon() {
+        if let Some(icon) = self.mouse.update_cursor_icon() {
             window.set_cursor_icon(icon);
         }
 

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -11,6 +11,7 @@ pub(crate) mod velocity;
 
 #[allow(unused)] use super::{Event, EventState}; // for doc-links
 use super::{EventCx, IsUsed};
+#[allow(unused)] use crate::Events; // for doc-links
 use crate::event::{CursorIcon, MouseButton, Unused, Used};
 use crate::geom::{Coord, Vec2};
 use crate::{Action, Id};
@@ -280,7 +281,7 @@ impl EventState {
 
     /// Set the cursor icon
     ///
-    /// This is normally called when handling [`Event::MouseOver`]. In other
+    /// This is normally called from [`Events::handle_mouse_over`]. In other
     /// cases, calling this method may be ineffective. The cursor is
     /// automatically "unset" when the widget is no longer under the mouse.
     ///

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -15,8 +15,8 @@ use super::{EventCx, IsUsed};
 use crate::event::{CursorIcon, MouseButton, Unused, Used};
 use crate::geom::{Coord, Vec2};
 use crate::{Action, Id};
-pub(super) use mouse::Mouse;
-pub(super) use touch::Touch;
+pub(crate) use mouse::Mouse;
+pub(crate) use touch::Touch;
 
 /// Controls the types of events delivered by [`Press::grab`]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -266,7 +266,7 @@ impl EventState {
             }
         }
         for popup in &self.popups {
-            if *w_id == popup.1.parent {
+            if *w_id == popup.desc.parent {
                 return true;
             }
         }

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -274,21 +274,21 @@ impl EventState {
 
     /// Get whether the widget is under the mouse cursor
     #[inline]
-    pub fn is_hovered(&self, w_id: &Id) -> bool {
-        self.mouse.grab.is_none() && *w_id == self.mouse.hover
+    pub fn is_under_mouse(&self, w_id: &Id) -> bool {
+        self.mouse.grab.is_none() && *w_id == self.mouse.over
     }
 
     /// Set the cursor icon
     ///
-    /// This is normally called when handling [`Event::MouseHover`]. In other
+    /// This is normally called when handling [`Event::MouseOver`]. In other
     /// cases, calling this method may be ineffective. The cursor is
-    /// automatically "unset" when the widget is no longer hovered.
+    /// automatically "unset" when the widget is no longer under the mouse.
     ///
     /// See also [`EventCx::set_grab_cursor`]: if a mouse grab
     /// ([`Press::grab`]) is active, its icon takes precedence.
-    pub fn set_hover_cursor(&mut self, icon: CursorIcon) {
+    pub fn set_mouse_over_icon(&mut self, icon: CursorIcon) {
         // Note: this is acted on by EventState::update
-        self.mouse.hover_icon = icon;
+        self.mouse.icon = icon;
     }
 
     /// Set a grab's depress target

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -238,7 +238,7 @@ impl<'a> EventCx<'a> {
     fn set_over(&mut self, mut window: Node<'_>, mut w_id: Option<Id>) {
         if let Some(ref id) = w_id
             && let Some(popup) = self.popups.last()
-            && !popup.1.id.is_ancestor_of(id)
+            && !popup.desc.id.is_ancestor_of(id)
         {
             w_id = None;
         }
@@ -365,7 +365,12 @@ impl<'a> EventCx<'a> {
                     self.need_frame_update = true;
                 }
             }
-        } else if let Some(popup_id) = self.popups.last().map(|(_, p, _)| p.id.clone()) {
+        } else if let Some(popup_id) = self
+            .popups
+            .last()
+            .filter(|popup| popup.is_sized)
+            .map(|state| state.desc.id.clone())
+        {
             let press = Press {
                 source: PressSource::Mouse(FAKE_MOUSE_BUTTON, 0),
                 id,

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -241,14 +241,7 @@ impl EventState {
 impl<'a> EventCx<'a> {
     // Clear old `over` id, set new `over`, send events.
     // If there is a popup, only permit descendants of that.
-    fn set_over(&mut self, mut window: Node<'_>, mut w_id: Option<Id>) {
-        if let Some(ref id) = w_id
-            && let Some(popup) = self.popups.last()
-            && !popup.desc.id.is_ancestor_of(id)
-        {
-            w_id = None;
-        }
-
+    fn set_over(&mut self, mut window: Node<'_>, w_id: Option<Id>) {
         if self.mouse.over != w_id {
             log::trace!("set_over: w_id={w_id:?}");
             self.mouse.icon = Default::default();

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -214,6 +214,12 @@ impl Mouse {
         }
         true
     }
+
+    pub(in crate::event::cx) fn tooltip_popup_close(&mut self, id: &Id) {
+        if self.tooltip_source.as_ref() == Some(id) {
+            self.tooltip_source = None;
+        }
+    }
 }
 
 impl EventState {
@@ -507,9 +513,6 @@ impl<'a> EventCx<'a> {
                 {
                     win.show_tooltip(self, id.clone(), text.to_string());
                     self.mouse.tooltip_source = Some(id.clone());
-                } else {
-                    let delay = self.config().event().hover_delay();
-                    self.request_timer(win.as_tile().id(), Mouse::TIMER_HOVER, delay);
                 }
             }
             _ => (),

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -320,21 +320,23 @@ impl<'a> EventCx<'a> {
         match touch.phase {
             TouchPhase::Started => {
                 let start_id = win.try_probe(coord);
-                if let Some(id) = start_id.as_ref() {
+                self.close_non_ancestors_of(start_id.as_ref());
+
+                if let Some(id) = start_id {
                     if self.config.event().touch_nav_focus()
                         && let Some(id) =
-                            self.nav_next(win.as_node(data), Some(id), NavAdvance::None)
+                            self.nav_next(win.as_node(data), Some(&id), NavAdvance::None)
                     {
                         self.set_nav_focus(id, FocusSource::Pointer);
                     }
 
                     let press = Press {
                         source,
-                        id: start_id.clone(),
+                        id: Some(id.clone()),
                         coord,
                     };
                     let event = Event::PressStart { press };
-                    self.send_popup_first(win.as_node(data), start_id, event);
+                    self.send_event(win.as_node(data), id, event);
                 }
             }
             TouchPhase::Moved => {

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -61,7 +61,7 @@ struct PanGrab {
 }
 
 #[derive(Default)]
-pub(in crate::event::cx) struct Touch {
+pub(crate) struct Touch {
     pub(super) touch_grab: SmallVec<[TouchGrab; MAX_TOUCHES]>,
     pan_grab: SmallVec<[PanGrab; MAX_PANS]>,
     velocity: [velocity::Samples; MAX_VELOCITY],

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -202,10 +202,10 @@ pub enum Event<'a> {
     ImeFocus,
     /// Notification that a widget has lost IME focus
     LostImeFocus,
-    /// Notification that a widget gains or loses mouse hover
+    /// Notification that the mouse moves over or leaves a widget
     ///
-    /// The payload is `true` when focus is gained, `false` when lost.
-    MouseHover(bool),
+    /// The state is `true` on mouse over, `false` when the mouse leaves.
+    MouseOver(bool),
 }
 
 impl<'a> std::ops::Add<Offset> for Event<'a> {
@@ -291,8 +291,8 @@ impl<'a> Event<'a> {
             CursorMove { .. } | PressStart { .. } => false,
             Pan { .. } | PressMove { .. } | PressEnd { .. } => true,
             Timer(_) | PopupClosed(_) => true,
-            NavFocus { .. } | SelFocus(_) | KeyFocus | ImeFocus | MouseHover(true) => false,
-            LostNavFocus | LostKeyFocus | LostSelFocus | LostImeFocus | MouseHover(false) => true,
+            NavFocus { .. } | SelFocus(_) | KeyFocus | ImeFocus | MouseOver(true) => false,
+            LostNavFocus | LostKeyFocus | LostSelFocus | LostImeFocus | MouseOver(false) => true,
         }
     }
 
@@ -332,7 +332,7 @@ impl<'a> Event<'a> {
             SelFocus(_) | LostSelFocus => false,
             KeyFocus | LostKeyFocus => false,
             ImeFocus | LostImeFocus => false,
-            MouseHover(_) => true,
+            MouseOver(_) => true,
         }
     }
 }

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -332,7 +332,7 @@ impl<'a> Event<'a> {
             SelFocus(_) | LostSelFocus => false,
             KeyFocus | LostKeyFocus => false,
             ImeFocus | LostImeFocus => false,
-            MouseOver(_) => true,
+            MouseOver(_) => false,
         }
     }
 }

--- a/crates/kas-core/src/event/events.rs
+++ b/crates/kas-core/src/event/events.rs
@@ -104,17 +104,8 @@ pub enum Event<'a> {
     /// Call [`Press::grab`] in order to "grab" corresponding motion
     /// and release events.
     ///
-    /// This event is sent in exactly two cases, in this order:
-    ///
-    /// 1.  When a [`Popup`] is open. A [`Popup`] will close itself if
-    ///     `press.id` is not a descendant of itself, but will still return
-    ///     [`Unused`]. The parent (or an ancestor) of the
-    ///     [`Popup`] should handle this event.
-    /// 2.  If a widget is found under the mouse when pressed or where a touch
-    ///     event starts, this event is sent to the widget.
-    ///
-    /// If `start_id` is `None`, then no widget was found at the coordinate and
-    /// the event will only be delivered to pop-up layer owners.
+    /// This event is sent to the widget under the mouse or touch position. If
+    /// no such widget is found, this event is not sent.
     PressStart { press: Press },
     /// Movement of mouse or a touch press
     ///

--- a/crates/kas-core/src/popup.rs
+++ b/crates/kas-core/src/popup.rs
@@ -160,7 +160,13 @@ mod Popup {
         ///
         /// Returns `true` when the popup is newly opened. In this case, the
         /// caller may wish to call [`EventState::next_nav_focus`] next.
-        pub fn open(&mut self, cx: &mut EventCx, data: &W::Data, parent: Id) -> bool {
+        pub fn open(
+            &mut self,
+            cx: &mut EventCx,
+            data: &W::Data,
+            parent: Id,
+            set_focus: bool,
+        ) -> bool {
             let desc = kas::PopupDescriptor {
                 id: self.id(),
                 parent,
@@ -178,7 +184,7 @@ mod Popup {
             let id = self.make_child_id(index);
             cx.configure(self.inner.as_node(data), id);
 
-            self.win_id = Some(cx.add_popup(desc));
+            self.win_id = Some(cx.add_popup(desc, set_focus));
 
             true
         }

--- a/crates/kas-core/src/popup.rs
+++ b/crates/kas-core/src/popup.rs
@@ -142,7 +142,7 @@ mod Popup {
             self.win_id.is_some()
         }
 
-        /// Open the popup
+        /// Open or reposition the popup
         ///
         /// The popup is positioned next to the `parent`'s rect in the specified
         /// direction (if this is not possible, the direction may be reversed).
@@ -153,7 +153,12 @@ mod Popup {
         /// Returns `true` when the popup is newly opened. In this case, the
         /// caller may wish to call [`EventState::next_nav_focus`] next.
         pub fn open(&mut self, cx: &mut EventCx, data: &W::Data, parent: Id) -> bool {
-            if self.win_id.is_some() {
+            if let Some(id) = self.win_id {
+                cx.reposition_popup(id, kas::PopupDescriptor {
+                    id: self.id(),
+                    parent,
+                    direction: self.direction,
+                });
                 return false;
             }
 

--- a/crates/kas-core/src/popup.rs
+++ b/crates/kas-core/src/popup.rs
@@ -8,7 +8,7 @@
 use crate::dir::Direction;
 use crate::event::{ConfigCx, Event, EventCx, IsUsed, Scroll, Unused, Used};
 use crate::layout::Align;
-use crate::{ChildIndices, Events, Id, Tile, TileExt, Widget, WindowId};
+use crate::{ChildIndices, Events, Id, Tile, Widget, WindowId};
 use kas_macros::{impl_self, widget_index};
 
 #[allow(unused)] use crate::event::EventState;
@@ -97,21 +97,8 @@ mod Popup {
             }
         }
 
-        fn handle_event(&mut self, cx: &mut EventCx, _: &W::Data, event: Event) -> IsUsed {
+        fn handle_event(&mut self, _: &mut EventCx, _: &W::Data, event: Event) -> IsUsed {
             match event {
-                Event::PressStart { press } => {
-                    if press
-                        .id
-                        .as_ref()
-                        .map(|id| self.is_ancestor_of(id))
-                        .unwrap_or(false)
-                    {
-                        Unused
-                    } else {
-                        self.close(cx);
-                        Unused
-                    }
-                }
                 Event::PopupClosed(_) => {
                     self.win_id = None;
                     Used

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -266,6 +266,10 @@ mod Window {
                     cx.drag_window();
                     Used
                 }
+                Event::Timer(handle) if handle == crate::event::Mouse::TIMER_HOVER => {
+                    // TODO
+                    Used
+                }
                 _ => Unused,
             }
         }

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -275,7 +275,7 @@ mod Window {
                     Used
                 }
                 Event::Timer(handle) if handle == crate::event::Mouse::TIMER_HOVER => {
-                    // TODO
+                    cx.hover_timer_expiry(self);
                     Used
                 }
                 _ => Unused,

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -319,7 +319,7 @@ mod Window {
 
         fn show_tooltip(&mut self, cx: &mut EventCx, id: Id, text: String) {
             self.tooltip.inner.set_string(cx, text);
-            self.tooltip.open(cx, &(), id);
+            self.tooltip.open(cx, &(), id, false);
         }
 
         fn close_tooltip(&mut self, cx: &mut EventCx) {

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -482,8 +482,20 @@ impl<Data: 'static> Window<Data> {
         id: WindowId,
         popup: kas::PopupDescriptor,
     ) {
-        let index = self.popups.len();
-        self.popups.push((id, popup, Offset::ZERO));
+        let index = 'index: {
+            for i in 0..self.popups.len() {
+                if self.popups[i].0 == id {
+                    debug_assert_eq!(self.popups[i].1.id, popup.id);
+                    self.popups[i].1 = popup;
+                    break 'index i;
+                }
+            }
+
+            let len = self.popups.len();
+            self.popups.push((id, popup, Offset::ZERO));
+            len
+        };
+
         self.resize_popup(cx, data, index);
         cx.action(self.id(), Action::REGION_MOVED);
     }

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -240,7 +240,7 @@ mod Window {
             }
             self.inner.draw(draw.re());
             for (_, popup, translation) in &self.popups {
-                if let Some(child) = self.inner.find_tile(&popup.id) {
+                if let Some(child) = self.find_tile(&popup.id) {
                     let clip_rect = child.rect() - *translation;
                     draw.with_overlay(clip_rect, *translation, |draw| {
                         child.draw(draw);
@@ -523,7 +523,7 @@ impl<Data: 'static> Window<Data> {
         // Notation: p=point/coord, s=size, m=margin
         // r=window/root rect, c=anchor rect
         let r = self.rect();
-        let (_, ref mut popup, ref mut translation) = self.popups[index];
+        let popup = self.popups[index].1.clone();
 
         let is_reversed = popup.direction.is_reversed();
         let place_in = |rp, rs: i32, cp: i32, cs: i32, ideal, m: (u16, u16)| -> (i32, i32) {
@@ -551,12 +551,12 @@ impl<Data: 'static> Window<Data> {
             (pos, size)
         };
 
-        let Some((c, t)) = self.inner.as_tile().find_tile_rect(&popup.parent) else {
+        let Some((c, t)) = self.as_tile().find_tile_rect(&popup.parent) else {
             return;
         };
-        *translation = t;
+        self.popups[index].2 = t;
         let r = r + t; // work in translated coordinate space
-        let result = self.inner.as_node(data).find_node(&popup.id, |mut node| {
+        let result = self.as_node(data).find_node(&popup.id, |mut node| {
             let mut cache = layout::SolveCache::find_constraints(node.re(), cx.size_cx());
             let ideal = cache.ideal(false);
             let m = cache.margins();

--- a/crates/kas-core/src/root.rs
+++ b/crates/kas-core/src/root.rs
@@ -497,6 +497,7 @@ impl<Data: 'static> Window<Data> {
         };
 
         self.resize_popup(cx, data, index);
+        cx.confirm_popup_is_sized(id);
         cx.action(self.id(), Action::REGION_MOVED);
     }
 

--- a/crates/kas-core/src/runner/event_loop.rs
+++ b/crates/kas-core/src/runner/event_loop.rs
@@ -181,6 +181,15 @@ where
                         .add_popup(&mut self.state, id, popup);
                     self.popups.insert(id, parent_id);
                 }
+                Pending::RepositionPopup(id, popup) => {
+                    if let Some(parent_id) = self.popups.get(&id) {
+                        self.windows.get_mut(parent_id).unwrap().add_popup(
+                            &mut self.state,
+                            id,
+                            popup,
+                        );
+                    }
+                }
                 Pending::AddWindow(id, mut window) => {
                     log::debug!("Pending: adding window {}", window.widget.title());
                     if !self.suspended {

--- a/crates/kas-core/src/runner/mod.rs
+++ b/crates/kas-core/src/runner/mod.rs
@@ -172,6 +172,7 @@ impl AppData for () {
 #[crate::autoimpl(Debug)]
 enum Pending<A: AppData, G: GraphicsInstance, T: kas::theme::Theme<G::Shared>> {
     AddPopup(WindowId, WindowId, kas::PopupDescriptor),
+    RepositionPopup(WindowId, kas::PopupDescriptor),
     // NOTE: we don't need G, T here if we construct the Window later.
     // But this way we can pass a single boxed value.
     AddWindow(WindowId, Box<Window<A, G, T>>),
@@ -424,7 +425,7 @@ mod test {
     fn size_of_pending() {
         assert_eq!(
             std::mem::size_of::<Pending<(), AGB, crate::theme::SimpleTheme>>(),
-            32
+            40
         );
     }
 }

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -139,6 +139,9 @@ pub(crate) trait RunnerT {
     /// that `Some` result does not guarantee the operation succeeded).
     fn add_popup(&mut self, parent_id: WindowId, popup: crate::PopupDescriptor) -> WindowId;
 
+    /// Resize and reposition an existing pop-up
+    fn reposition_popup(&mut self, id: WindowId, popup: kas::PopupDescriptor);
+
     /// Add a window
     ///
     /// Toolkits typically allow windows to be added directly, before start of
@@ -211,6 +214,10 @@ impl<Data: AppData, G: GraphicsInstance, T: Theme<G::Shared>> RunnerT for Shared
         self.pending
             .push_back(Pending::AddPopup(parent_id, id, popup));
         id
+    }
+
+    fn reposition_popup(&mut self, id: WindowId, popup: kas::PopupDescriptor) {
+        self.pending.push_back(Pending::RepositionPopup(id, popup));
     }
 
     unsafe fn add_window(&mut self, window: kas::Window<()>, data_type_id: TypeId) -> WindowId {

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -428,6 +428,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         state.handle_messages(&mut messages);
     }
 
+    /// Add or reposition a pop-up
     pub(super) fn add_popup(
         &mut self,
         state: &mut State<A, G, T>,

--- a/crates/kas-core/src/theme/colors.rs
+++ b/crates/kas-core/src/theme/colors.rs
@@ -25,12 +25,12 @@ bitflags::bitflags! {
         ///
         /// All other states should be ignored when disabled.
         const DISABLED = 1 << 0;
-        /// "Hover" is true if the mouse is over this element
-        const HOVER = 1 << 2;
+        /// True if the mouse is over this element
+        const UNDER_MOUSE = 1 << 2;
         /// Elements such as buttons, handles and menu entries may be depressed
         /// (visually pushed) by a click or touch event or an access key.
         /// This is often visualised by a darker colour and/or by offsetting
-        /// graphics. The `hover` state should be ignored when depressed.
+        /// graphics. Depressed items typically ignore the `UNDER_MOUSE` state.
         const DEPRESS = 1 << 3;
         /// Keyboard navigation of UIs moves a "focus" from widget to widget.
         const NAV_FOCUS = 1 << 4;
@@ -60,8 +60,8 @@ impl InputState {
         if ev.is_disabled(id) {
             state |= InputState::DISABLED;
         }
-        if ev.is_hovered(id) {
-            state |= InputState::HOVER;
+        if ev.is_under_mouse(id) {
+            state |= InputState::UNDER_MOUSE;
         }
         if ev.has_nav_focus(id) {
             state |= InputState::NAV_FOCUS;
@@ -75,11 +75,12 @@ impl InputState {
         state
     }
 
-    /// Construct, setting all components, also setting hover from `id2`
+    /// Construct as [`Self::new_all`], but also set [`InputState::UNDER_MOUSE`]
+    /// if `id2` is under the mouse pointer.
     pub fn new2(ev: &EventState, id: &Id, id2: &Id) -> Self {
         let mut state = Self::new_all(ev, id);
-        if ev.is_hovered(id2) {
-            state |= InputState::HOVER;
+        if ev.is_under_mouse(id2) {
+            state |= InputState::UNDER_MOUSE;
         }
         state
     }
@@ -90,10 +91,10 @@ impl InputState {
         self.contains(InputState::DISABLED)
     }
 
-    /// Extract `HOVER` bit
+    /// Extract `UNDER_MOUSE` bit
     #[inline]
-    pub fn hover(self) -> bool {
-        self.contains(InputState::HOVER)
+    pub fn under_mouse(self) -> bool {
+        self.contains(InputState::UNDER_MOUSE)
     }
 
     /// Extract `DEPRESS` bit
@@ -282,7 +283,7 @@ impl ColorsLinear {
             col.average()
         } else if state.depress() {
             col.multiply(MULT_DEPRESS)
-        } else if state.hover() || state.key_focus() {
+        } else if state.under_mouse() || state.key_focus() {
             col.multiply(MULT_HIGHLIGHT).max(MIN_HIGHLIGHT)
         } else {
             col

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -104,7 +104,7 @@ impl<'a> DrawCx<'a> {
     /// Set the identity of the current widget
     ///
     /// This struct tracks the [`Id`] of the calling widget to allow evaluation
-    /// of widget state (e.g. is disabled, is hovered, has key focus).
+    /// of widget state (e.g. is disabled, is under the mouse, has key focus).
     /// Usually you don't need to worry about this since the `#[widget]` macro
     /// injects a call to this method at the start of [`Layout::draw`].
     pub fn set_id(&mut self, id: Id) {

--- a/crates/kas-core/src/theme/flat_theme.rs
+++ b/crates/kas-core/src/theme/flat_theme.rs
@@ -28,8 +28,8 @@ use crate::theme::{ThemeDraw, ThemeSize};
 // Also the maximum inner radius of circular borders to overlap with this rect.
 const BG_SHRINK_FACTOR: f32 = 1.0 - std::f32::consts::FRAC_1_SQRT_2;
 
-// Shadow enlargement on hover
-const SHADOW_HOVER: f32 = 1.1;
+// Shadow enlargement on mouse over
+const SHADOW_MOUSE_OVER: f32 = 1.1;
 // Shadow enlargement for pop-ups
 const SHADOW_POPUP: f32 = 1.2;
 
@@ -37,7 +37,7 @@ const SHADOW_POPUP: f32 = 1.2;
 enum ShadowStyle {
     None,
     Normal,
-    Hover,
+    MouseOver,
 }
 
 /// A theme with flat (unshaded) rendering
@@ -169,9 +169,9 @@ where
 
         if shadow != ShadowStyle::None {
             let (mut a, mut b) = (self.w.dims.shadow_a, self.w.dims.shadow_b);
-            if shadow == ShadowStyle::Hover {
-                a *= SHADOW_HOVER;
-                b *= SHADOW_HOVER;
+            if shadow == ShadowStyle::MouseOver {
+                a *= SHADOW_MOUSE_OVER;
+                b *= SHADOW_MOUSE_OVER;
             }
             let shadow_outer = Quad::from_coords(a + inner.a, b + inner.b);
             let col1 = if self.cols.is_dark { col_frame } else { Rgba::BLACK };
@@ -201,7 +201,7 @@ where
         self.draw
             .rounded_frame(outer, inner, BG_SHRINK_FACTOR, self.cols.frame);
 
-        if !state.disabled() && !self.cols.is_dark && (state.nav_focus() || state.hover()) {
+        if !state.disabled() && !self.cols.is_dark && (state.nav_focus() || state.under_mouse()) {
             let r = 0.5 * self.w.dims.button_frame as f32;
             let y = outer.b.1 - r;
             let a = Vec2(outer.a.0 + r, y);
@@ -356,7 +356,7 @@ where
                     () if (self.cols.is_dark || state.disabled() || state.depress()) => {
                         ShadowStyle::None
                     }
-                    () if state.hover() => ShadowStyle::Hover,
+                    () if state.under_mouse() => ShadowStyle::MouseOver,
                     _ => ShadowStyle::Normal,
                 };
 
@@ -387,7 +387,7 @@ where
 
         let shadow = match () {
             () if (self.cols.is_dark || state.disabled() || state.depress()) => ShadowStyle::None,
-            () if state.hover() => ShadowStyle::Hover,
+            () if state.under_mouse() => ShadowStyle::MouseOver,
             _ => ShadowStyle::Normal,
         };
 
@@ -406,8 +406,8 @@ where
         if !(self.cols.is_dark || state.disabled() || state.depress()) {
             let (mut a, mut b) = (self.w.dims.shadow_a, self.w.dims.shadow_b);
             let mut mult = 0.65;
-            if state.hover() {
-                mult *= SHADOW_HOVER;
+            if state.under_mouse() {
+                mult *= SHADOW_MOUSE_OVER;
             }
             a *= mult;
             b *= mult;
@@ -494,8 +494,8 @@ where
         if !self.cols.is_dark && !state.contains(InputState::DISABLED | InputState::DEPRESS) {
             let (mut a, mut b) = (self.w.dims.shadow_a, self.w.dims.shadow_b);
             let mut mult = 0.6;
-            if state.hover() {
-                mult *= SHADOW_HOVER;
+            if state.under_mouse() {
+                mult *= SHADOW_MOUSE_OVER;
             }
             a *= mult;
             b *= mult;

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -145,7 +145,7 @@ where
         let inner = outer.shrink(self.w.dims.button_frame as f32);
         self.draw.frame(outer, inner, self.cols.frame);
 
-        if !state.disabled() && !self.cols.is_dark && (state.nav_focus() || state.hover()) {
+        if !state.disabled() && !self.cols.is_dark && (state.nav_focus() || state.under_mouse()) {
             let mut line = outer;
             line.a.1 = line.b.1 - self.w.dims.button_frame as f32;
             let col = if state.nav_focus() {
@@ -452,7 +452,7 @@ where
             self.cols.text_disabled
         } else {
             let is_depressed = self.ev.is_depressed(id);
-            if self.ev.is_hovered(id) || is_depressed {
+            if self.ev.is_under_mouse(id) || is_depressed {
                 self.draw.rect(rect.cast(), self.cols.accent_soft);
             }
             if is_depressed { self.cols.accent } else { self.cols.text }

--- a/crates/kas-view/src/filter/filter_list.rs
+++ b/crates/kas-view/src/filter/filter_list.rs
@@ -94,7 +94,7 @@ mod FilterBoxListView {
         /// Set fixed, invisible bars (inline)
         ///
         /// In this mode scroll bars are either enabled but invisible until
-        /// hovered by the mouse or disabled completely.
+        /// under the mouse or disabled completely.
         #[inline]
         pub fn with_invisible_bars(mut self, horiz: bool, vert: bool) -> Self
         where

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -674,7 +674,7 @@ mod GridView {
     }
 
     impl Events for Self {
-        fn hover_icon(&self) -> Option<CursorIcon> {
+        fn mouse_over_icon(&self) -> Option<CursorIcon> {
             self.scroll
                 .is_kinetic_scrolling()
                 .then_some(CursorIcon::AllScroll)

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -714,7 +714,7 @@ mod ListView {
     }
 
     impl Events for Self {
-        fn hover_icon(&self) -> Option<CursorIcon> {
+        fn mouse_over_icon(&self) -> Option<CursorIcon> {
             self.scroll
                 .is_kinetic_scrolling()
                 .then_some(CursorIcon::AllScroll)

--- a/crates/kas-widgets/src/adapt/with_label.rs
+++ b/crates/kas-widgets/src/adapt/with_label.rs
@@ -178,6 +178,10 @@ mod WithHiddenLabel {
     }
 
     impl Tile for Self {
+        fn tooltip(&self) -> Option<&str> {
+            Some(&self.label)
+        }
+
         fn role(&self, cx: &mut dyn RoleCx) -> Role<'_> {
             cx.set_label(&self.label);
             self.inner.role(cx)

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -112,7 +112,7 @@ mod Button {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = W::Data;
 

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -32,7 +32,7 @@ mod CheckBox {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = A;
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -276,6 +276,7 @@ impl<A, V: Clone + Debug + Eq + 'static> ComboBox<A, V> {
                     }
                 }),
                 Direction::Down,
+                Align::TL,
             ),
             active: 0,
             opening: false,

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -76,7 +76,7 @@ mod ComboBox {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = A;
 

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -215,7 +215,7 @@ mod ComboBox {
 
     impl Self {
         fn open_popup(&mut self, cx: &mut EventCx, source: FocusSource) {
-            if self.popup.open(cx, &(), self.id()) {
+            if self.popup.open(cx, &(), self.id(), true) {
                 if let Some(w) = self.popup.inner.inner.get_child(self.active) {
                     cx.next_nav_focus(w.id(), false, source);
                 }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -931,12 +931,12 @@ mod EditField {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = G::Data;
 
         #[inline]
-        fn hover_icon(&self) -> Option<CursorIcon> {
+        fn mouse_over_icon(&self) -> Option<CursorIcon> {
             Some(CursorIcon::Text)
         }
 

--- a/crates/kas-widgets/src/event_config.rs
+++ b/crates/kas-widgets/src/event_config.rs
@@ -20,48 +20,53 @@ mod EventConfig {
     /// TODO: support undo and/or revert to saved values.
     #[widget]
     #[layout(grid! {
-        (0, 0) => "Menu delay:",
+        (0, 0) => "Hover delay:",
         (1, 0) => self.menu_delay,
 
-        (0, 1) => "Touch-selection delay:",
-        (1, 1) => self.touch_select_delay,
+        (0, 1) => "Menu delay:",
+        (1, 1) => self.menu_delay,
 
-        (0, 2) => "Kinetic scrolling timeout:",
-        (1, 2) => self.kinetic_timeout,
+        (0, 2) => "Touch-selection delay:",
+        (1, 2) => self.touch_select_delay,
 
-        (0, 3) => "Kinetic decay (relative):",
-        (1, 3) => self.kinetic_decay_mul,
+        (0, 3) => "Kinetic scrolling timeout:",
+        (1, 3) => self.kinetic_timeout,
 
-        (0, 4) => "Kinetic decay (absolute):",
-        (1, 4) => self.kinetic_decay_sub,
+        (0, 4) => "Kinetic decay (relative):",
+        (1, 4) => self.kinetic_decay_mul,
 
-        (0, 5) => "Kinetic decay when grabbed:",
-        (1, 5) => self.kinetic_grab_sub,
+        (0, 5) => "Kinetic decay (absolute):",
+        (1, 5) => self.kinetic_decay_sub,
 
-        (0, 6) => "Scroll wheel distance:",
-        (1, 6) => self.scroll_dist_em,
+        (0, 6) => "Kinetic decay when grabbed:",
+        (1, 6) => self.kinetic_grab_sub,
 
-        (0, 7) => "Pan distance threshold:",
-        (1, 7) => self.pan_dist_thresh,
+        (0, 7) => "Scroll wheel distance:",
+        (1, 7) => self.scroll_dist_em,
 
-        (0, 8) => "Mouse pan:",
-        (1, 8) => self.mouse_pan,
+        (0, 8) => "Pan distance threshold:",
+        (1, 8) => self.pan_dist_thresh,
 
-        (0, 9) => "Mouse text pan:",
-        (1, 9) => self.mouse_text_pan,
+        (0, 9) => "Mouse pan:",
+        (1, 9) => self.mouse_pan,
 
-        (1, 10) => self.mouse_wheel_actions,
+        (0, 10) => "Mouse text pan:",
+        (1, 10) => self.mouse_text_pan,
 
-        (1, 11) => self.mouse_nav_focus,
+        (1, 11) => self.mouse_wheel_actions,
 
-        (1, 12) => self.touch_nav_focus,
+        (1, 12) => self.mouse_nav_focus,
 
-        (0, 13) => "Restore default values:",
-        (1, 13) => Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
+        (1, 13) => self.touch_nav_focus,
+
+        (0, 14) => "Restore default values:",
+        (1, 14) => Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
     })]
     #[impl_default(EventConfig::new())]
     pub struct EventConfig {
         core: widget_core!(),
+        #[widget]
+        hover_delay: SpinBox<(), u32>,
         #[widget]
         menu_delay: SpinBox<(), u32>,
         #[widget]
@@ -112,6 +117,12 @@ mod EventConfig {
 
             EventConfig {
                 core: Default::default(),
+                hover_delay: SpinBox::new(0..=10_000, |cx, _| {
+                    cx.config().base().event.menu_delay_ms
+                })
+                .with_step(100)
+                .with_msg(EventConfigMsg::HoverDelay)
+                .with_unit("ms"),
                 menu_delay: SpinBox::new(0..=5_000, |cx, _| cx.config().base().event.menu_delay_ms)
                     .with_step(50)
                     .with_msg(EventConfigMsg::MenuDelay)

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -100,12 +100,12 @@ mod GripPart {
     }
 
     impl Events for GripPart {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = ();
 
         #[inline]
-        fn hover_icon(&self) -> Option<CursorIcon> {
+        fn mouse_over_icon(&self) -> Option<CursorIcon> {
             Some(CursorIcon::Grab)
         }
 

--- a/crates/kas-widgets/src/mark.rs
+++ b/crates/kas-widgets/src/mark.rs
@@ -117,7 +117,7 @@ mod MarkButton {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = ();
 

--- a/crates/kas-widgets/src/mark.rs
+++ b/crates/kas-widgets/src/mark.rs
@@ -57,6 +57,10 @@ mod Mark {
     }
 
     impl Tile for Self {
+        fn tooltip(&self) -> Option<&str> {
+            Some(&self.label)
+        }
+
         fn role(&self, cx: &mut dyn RoleCx) -> Role<'_> {
             cx.set_label(&self.label);
             Role::Indicator
@@ -110,6 +114,10 @@ mod MarkButton {
     }
 
     impl Tile for Self {
+        fn tooltip(&self) -> Option<&str> {
+            Some(&self.label)
+        }
+
         fn role(&self, cx: &mut dyn RoleCx) -> Role<'_> {
             cx.set_label(&self.label);
             Role::Button

--- a/crates/kas-widgets/src/menu/mod.rs
+++ b/crates/kas-widgets/src/menu/mod.rs
@@ -47,7 +47,7 @@ pub struct SubItems<'a> {
 
 /// Trait governing menus, sub-menus and menu-entries
 ///
-/// Implementations will automatically receive nav focus on mouse-hover, thus
+/// Implementations will automatically receive nav focus on mouse-over, thus
 /// should ensure that [`Tile::probe`] returns the identifier of the widget
 /// which should be focussed, and that this widget has [`Tile::navigable`]
 /// return true.

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -59,7 +59,7 @@ mod SubMenu {
                 core: Default::default(),
                 label: AccessLabel::new(label).with_class(TextClass::MenuLabel),
                 mark: Mark::new(MarkStyle::Chevron(direction), "Open"),
-                popup: Popup::new(MenuView::new(list), direction),
+                popup: Popup::new(MenuView::new(list), direction, Align::TL),
             }
         }
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -64,7 +64,7 @@ mod SubMenu {
         }
 
         fn open_menu(&mut self, cx: &mut EventCx, data: &Data, set_focus: bool) {
-            if self.popup.open(cx, data, self.id()) {
+            if self.popup.open(cx, data, self.id(), true) {
                 if set_focus {
                     cx.next_nav_focus(self.id(), false, FocusSource::Key);
                 }
@@ -154,10 +154,10 @@ mod SubMenu {
 
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Data) {
             if let Some(Activate(code)) = cx.try_pop() {
-                self.popup.open(cx, data, self.id());
+                self.popup.open(cx, data, self.id(), true);
                 cx.depress_with_key(self.id(), code);
             } else if let Some(Expand) = cx.try_pop() {
-                self.popup.open(cx, data, self.id());
+                self.popup.open(cx, data, self.id(), true);
             } else if let Some(Collapse) = cx.try_pop() {
                 self.popup.close(cx);
             } else {

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -31,7 +31,7 @@ mod RadioBox {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = A;
 

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -153,7 +153,7 @@ mod ScrollRegion {
     impl Events for Self {
         type Data = W::Data;
 
-        fn hover_icon(&self) -> Option<CursorIcon> {
+        fn mouse_over_icon(&self) -> Option<CursorIcon> {
             self.scroll
                 .is_kinetic_scrolling()
                 .then_some(CursorIcon::AllScroll)

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -26,8 +26,8 @@ pub enum ScrollBarMode {
     ///
     /// Parameters: `(horiz_is_visible, vert_is_visible)`.
     Fixed(bool, bool),
-    /// Enabled scroll bars float over content and are only drawn when hovered
-    /// over by the mouse. Disabled scroll bars are fully hidden.
+    /// Enabled scroll bars float over content and are only drawn on mouse over.
+    /// Disabled scroll bars are fully hidden.
     ///
     /// Parameters: `(horiz_is_enabled, vert_is_enabled)`.
     Invisible(bool, bool),
@@ -66,7 +66,7 @@ mod ScrollBar {
         max_value: i32,
         value: i32,
         invisible: bool,
-        is_hovered: bool,
+        is_under_mouse: bool,
         force_visible: bool,
         #[widget]
         grip: GripPart,
@@ -116,7 +116,7 @@ mod ScrollBar {
                 max_value: 0,
                 value: 0,
                 invisible: false,
-                is_hovered: false,
+                is_under_mouse: false,
                 force_visible: false,
                 grip: GripPart::new(),
             }
@@ -130,7 +130,7 @@ mod ScrollBar {
 
         /// Set invisible property
         ///
-        /// An "invisible" scroll bar is only drawn on mouse-hover
+        /// An "invisible" scroll bar is only drawn on mouse-over
         #[inline]
         pub fn set_invisible(&mut self, invisible: bool) {
             self.invisible = invisible;
@@ -138,7 +138,7 @@ mod ScrollBar {
 
         /// Set invisible property (inline)
         ///
-        /// An "invisible" scroll bar is only drawn on mouse-hover
+        /// An "invisible" scroll bar is only drawn on mouse-over
         #[inline]
         pub fn with_invisible(mut self, invisible: bool) -> Self {
             self.invisible = invisible;
@@ -224,7 +224,7 @@ mod ScrollBar {
                 self.value = value;
                 self.grip.set_offset(cx, self.offset());
             }
-            if !self.is_hovered {
+            if !self.is_under_mouse {
                 self.force_visible = true;
                 let delay = cx.config().event().touch_select_delay();
                 cx.request_timer(self.id(), TIMER_HIDE, delay);
@@ -347,14 +347,14 @@ mod ScrollBar {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = ();
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
                 Event::Timer(TIMER_HIDE) => {
-                    if !self.is_hovered {
+                    if !self.is_under_mouse {
                         self.force_visible = false;
                         cx.redraw(self);
                     }
@@ -365,14 +365,14 @@ mod ScrollBar {
                     self.apply_grip_offset(cx, offset);
                     Used
                 }
-                Event::MouseHover(true) => {
-                    self.is_hovered = true;
+                Event::MouseOver(true) => {
+                    self.is_under_mouse = true;
                     self.force_visible = true;
                     cx.redraw(self);
                     Used
                 }
-                Event::MouseHover(false) => {
-                    self.is_hovered = false;
+                Event::MouseOver(false) => {
+                    self.is_under_mouse = false;
                     let delay = cx.config().event().touch_select_delay();
                     cx.request_timer(self.id(), TIMER_HIDE, delay);
                     Used
@@ -446,7 +446,7 @@ mod ScrollBars {
         /// Set fixed, invisible bars (inline)
         ///
         /// In this mode scroll bars are either enabled but invisible until
-        /// hovered by the mouse or disabled completely.
+        /// mouse over or disabled completely.
         #[inline]
         pub fn with_invisible_bars(mut self, horiz: bool, vert: bool) -> Self
         where
@@ -662,7 +662,7 @@ mod ScrollBarRegion {
         /// Set fixed, invisible bars (inline)
         ///
         /// In this mode scroll bars are either enabled but invisible until
-        /// hovered by the mouse or disabled completely.
+        /// mouse over or disabled completely.
         #[inline]
         pub fn with_invisible_bars(self, horiz: bool, vert: bool) -> Self
         where

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -171,7 +171,7 @@ mod SelectableText {
         type Data = A;
 
         #[inline]
-        fn hover_icon(&self) -> Option<CursorIcon> {
+        fn mouse_over_icon(&self) -> Option<CursorIcon> {
             Some(CursorIcon::Text)
         }
 
@@ -408,7 +408,7 @@ mod ScrollText {
         type Data = A;
 
         #[inline]
-        fn hover_icon(&self) -> Option<CursorIcon> {
+        fn mouse_over_icon(&self) -> Option<CursorIcon> {
             Some(CursorIcon::Text)
         }
 

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -328,7 +328,7 @@ mod Slider {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = A;
 

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -60,7 +60,7 @@ mod Tab {
     }
 
     impl Events for Self {
-        const REDRAW_ON_HOVER: bool = true;
+        const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = ();
 

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -22,7 +22,7 @@ mod CursorWidget {
 
     impl Tile for Self {
         fn probe(&self, _: Coord) -> Id {
-            // Steal mouse focus: hover points to self, not self.label
+            // This widget takes mouse focus, not self.label
             self.id()
         }
     }
@@ -30,7 +30,7 @@ mod CursorWidget {
     impl Events for Self {
         type Data = ();
 
-        fn hover_icon(&self) -> Option<CursorIcon> {
+        fn mouse_over_icon(&self) -> Option<CursorIcon> {
             Some(self.cursor)
         }
     }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -113,7 +113,7 @@ fn widgets() -> Box<dyn Widget<Data = AppData>> {
         struct {
             core: widget_core!(),
             #[widget] text: Text<Data, String> = format_data!(data: &Data, "{}", &data.text),
-            #[widget(&())] popup: Popup<TextEdit> = Popup::new(TextEdit::new("", true), Direction::Down),
+            #[widget(&())] popup: Popup<TextEdit> = Popup::new(TextEdit::new("", true), Direction::Down, Align::TL),
         }
         impl Events for Self {
             type Data = Data;

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -126,7 +126,7 @@ fn widgets() -> Box<dyn Widget<Data = AppData>> {
                     // let ed = TextEdit::new(text, true);
                     // cx.add_window::<()>(ed.into_window("Edit text"));
                     // TODO: cx.add_modal(..)
-                    self.popup.open(cx, &(), self.id());
+                    self.popup.open(cx, &(), self.id(), true);
                 } else if let Some(result) = cx.try_pop() {
                     match result {
                         TextEditResult::Cancel => (),

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -357,6 +357,10 @@ mod Mandlebrot {
     }
 
     impl Tile for Self {
+        fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
+            Role::Unknown
+        }
+
         fn navigable(&self) -> bool {
             true
         }


### PR DESCRIPTION
Add `Tile` method:
```rust
    /// Tooltip
    ///
    /// This is shown on mouse hover and may or may not use the same text as the
    /// label defined by the role.
    ///
    /// By default this is `None`.
    fn tooltip(&self) -> Option<&str> {
        None
    }
```

`Event::MouseHover` was renamed to `MouseOver` since this is sent immediately when the widget under the mouse changes. I considered adding `MouseHover` sent after a delay, but decided not to (largely because its only usage should be to show a tooltip, and this is better handled outside of widget code).

`Event::PressStart` is no longer sent to popups first. Instead, popups which are not an ancestor of the widget under the mouse are closed first.

Mouse focus is now allowed to track widgets which are not descended from the top-most popup. This is an opinionated change (e.g. it is now possible to click on controls while a menu is open). It might be changed again later, but would need an exception for the tooltip popup as well as considering touch input and some visual effect to defocus under-menu content.

Popups now support alignment other than top-left. Tooltips are centred below their target if possible.