### PR TITLE
Impl PartialOrd for geom types; PressStart type; PressSource size opt; fixes

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -144,6 +144,7 @@ unit_arg = "allow"
 match_like_matches_macro = "allow"
 needless_range_loop = "allow"
 too_many_arguments = "allow"
+neg_cmp_op_on_partial_ord = "allow"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(internal_doc)'] }

--- a/crates/kas-core/src/config/event.rs
+++ b/crates/kas-core/src/config/event.rs
@@ -6,10 +6,10 @@
 //! Event handling configuration
 
 use crate::Action;
-use crate::cast::{Cast, CastFloat};
+use crate::cast::Cast;
 #[allow(unused)] use crate::event::Event;
 use crate::event::ModifiersState;
-use crate::geom::Offset;
+use crate::geom::Vec2;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::cell::Ref;
@@ -214,10 +214,10 @@ impl<'a> EventWindowConfig<'a> {
     /// Get distance in pixels to scroll due to mouse wheel
     ///
     /// Calculates scroll distance from `(horiz, vert)` lines.
-    pub fn scroll_distance(&self, lines: (f32, f32)) -> Offset {
-        let x = (self.0.scroll_dist * lines.0).cast_nearest();
-        let y = (self.0.scroll_dist * lines.1).cast_nearest();
-        Offset(x, y)
+    pub fn scroll_distance(&self, lines: (f32, f32)) -> Vec2 {
+        let x = self.0.scroll_dist * lines.0;
+        let y = self.0.scroll_dist * lines.1;
+        Vec2(x, y)
     }
 
     /// Drag distance threshold before panning (scrolling) starts

--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -120,12 +120,12 @@ pub enum Role<'a> {
         /// accomodate more complex texts and potentially other details.
         text: &'a str,
         /// The cursor index within `contents`
-        edit_pos: usize,
+        cursor: usize,
         /// The selection index. Equals `cursor` if the selection is empty.
         /// May be less than or greater than `cursor`. (Aside: some toolkits
         /// call this the selection anchor but Kas does not; see
         /// [`kas::text::SelectionHelper`].)
-        sel_pos: usize,
+        sel_index: usize,
     },
     /// Editable text
     ///
@@ -133,7 +133,7 @@ pub enum Role<'a> {
     ///
     /// [`kas::messages::SetValueText`] may be used to replace the entire
     /// text. [`kas::messages::ReplaceSelectedText`] may be used to insert text
-    /// at `edit_pos`, replacing all text between `edit_pos` and `sel_pos`.
+    /// at `cursor`, replacing all text between `cursor` and `sel_index`.
     TextInput {
         /// Text contents
         ///
@@ -143,12 +143,12 @@ pub enum Role<'a> {
         /// Whether the text input supports multi-line text
         multi_line: bool,
         /// The cursor index within `contents`
-        edit_pos: usize,
+        cursor: usize,
         /// The selection index. Equals `cursor` if the selection is empty.
         /// May be less than or greater than `cursor`. (Aside: some toolkits
         /// call this the selection anchor but Kas does not; see
         /// [`kas::text::SelectionHelper`].)
-        sel_pos: usize,
+        sel_index: usize,
     },
     /// A gripable handle
     ///

--- a/crates/kas-core/src/core/tile.rs
+++ b/crates/kas-core/src/core/tile.rs
@@ -205,8 +205,8 @@ pub trait Tile: Layout {
     ///
     /// Usually this is zero; only widgets with scrollable or offset content
     /// *and* child widgets need to implement this.
-    /// Such widgets must also implement [`Events::handle_scroll`] and
-    /// [`Tile::probe`].
+    /// Such widgets must also implement [`Tile::probe`] and (if they scroll)
+    /// [`Events::handle_scroll`].
     ///
     /// Affects event handling via [`Tile::probe`] and affects the positioning
     /// of pop-up menus. [`Layout::draw`] must be implemented directly using

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -364,7 +364,7 @@ impl ScrollComponent {
                 self.kinetic.stop();
                 self.scroll_by_delta(cx, id, delta.as_offset(cx));
             }
-            Event::PressStart { press, .. }
+            Event::PressStart(press)
                 if self.max_offset != Offset::ZERO && cx.config_enable_pan(*press) =>
             {
                 let _ = press
@@ -466,7 +466,7 @@ impl TextInput {
     pub fn handle(&mut self, cx: &mut EventCx, w_id: Id, event: Event) -> TextInputAction {
         use TextInputAction as Action;
         match event {
-            Event::PressStart { press } if press.is_primary() => {
+            Event::PressStart(press) if press.is_primary() => {
                 let mut action = Action::Used;
                 let icon = if press.is_touch() {
                     self.phase = Phase::Start(*press, press.coord);

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -106,10 +106,8 @@ impl Kinetic {
 
         if let Some(source) = self.press {
             let decay_sub = evc.kinetic_grab_sub();
-            let grab_vel = cx.press_velocity(source).unwrap_or_default() + self.vel;
-
-            let v = self.vel - grab_vel;
-            self.vel -= v.abs().min(Vec2::splat(decay_sub * dur)) * v.sign();
+            let v = cx.press_velocity(source).unwrap_or_default();
+            self.vel -= v.abs().min(Vec2::splat(decay_sub * dur)) * -v.sign();
         }
 
         let (decay_mul, decay_sub) = evc.kinetic_decay();

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -469,7 +469,7 @@ impl TextInput {
             Event::PressStart(press) if press.is_primary() => {
                 let mut action = Action::Used;
                 let icon = if press.is_touch() {
-                    self.phase = Phase::Start(*press, press.coord);
+                    self.phase = Phase::Start(*press, press.coord());
                     let delay = cx.config().event().touch_select_delay();
                     cx.request_timer(w_id.clone(), TIMER_SELECT, delay);
                     None
@@ -480,7 +480,7 @@ impl TextInput {
                     } else {
                         self.phase = Phase::Cursor(*press);
                         action = Action::Focus {
-                            coord: press.coord,
+                            coord: press.coord(),
                             action: SelectionAction {
                                 anchor: true,
                                 clear: !cx.modifiers().shift_key(),

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -440,7 +440,7 @@ pub enum TextInputAction {
     ///
     /// To handle:
     ///
-    /// 1.  Translate `coord` to a text index and call [`SelectionHelper::set_edit_pos`].
+    /// 1.  Translate `coord` to a text index and call [`SelectionHelper::set_edit_index`].
     /// 2.  Call [`SelectionHelper::action`].
     /// 3.  If supporting the primary buffer (Unix), set its contents now if the
     ///     widget has selection focus or otherwise when handling

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -35,7 +35,7 @@ mod send;
 mod timer;
 mod window;
 
-pub use press::{GrabBuilder, GrabMode, Press, PressSource};
+pub use press::{GrabBuilder, GrabMode, Press, PressSource, PressStart};
 pub use timer::TimerHandle;
 
 struct PopupState {

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -15,7 +15,7 @@ use std::mem::transmute;
 use super::{EventCx, IsUsed};
 #[allow(unused)] use crate::Events; // for doc-links
 use crate::event::{CursorIcon, MouseButton, Unused, Used};
-use crate::geom::{Coord, Vec2};
+use crate::geom::{Coord, Offset, Vec2};
 use crate::{Action, Id};
 pub(crate) use mouse::Mouse;
 pub(crate) use touch::Touch;
@@ -184,10 +184,23 @@ pub struct PressStart {
     /// Identifier of the widget currently under the press
     pub id: Option<Id>,
     /// Current coordinate
-    pub coord: Coord,
+    coord: Coord,
+}
+
+impl std::ops::AddAssign<Offset> for PressStart {
+    #[inline]
+    fn add_assign(&mut self, offset: Offset) {
+        self.coord += offset;
+    }
 }
 
 impl PressStart {
+    /// Get the current press coordinate
+    #[inline]
+    pub fn coord(&self) -> Coord {
+        self.coord
+    }
+
     /// Grab pan/move/press-end events for widget `id`
     ///
     /// There are three types of grab ([`GrabMode`]):

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -20,7 +20,7 @@ use crate::{Action, Id};
 pub(crate) use mouse::Mouse;
 pub(crate) use touch::Touch;
 
-/// Controls the types of events delivered by [`Press::grab`]
+/// Controls the types of events delivered by [`PressStart::grab`]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum GrabMode {
     /// Deliver [`Event::PressEnd`] only for each grabbed press
@@ -173,19 +173,21 @@ impl PressSource {
     }
 }
 
-/// Details of press events
+/// Details of press start events
+///
+/// This type dereferences to [`PressSource`].
 #[crate::autoimpl(Deref using self.source)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Press {
-    /// Source
+pub struct PressStart {
+    /// Source of the press
     pub source: PressSource,
-    /// Identifier of current widget
+    /// Identifier of the widget currently under the press
     pub id: Option<Id>,
     /// Current coordinate
     pub coord: Coord,
 }
 
-impl Press {
+impl PressStart {
     /// Grab pan/move/press-end events for widget `id`
     ///
     /// There are three types of grab ([`GrabMode`]):
@@ -219,7 +221,21 @@ impl Press {
     }
 }
 
-/// Bulider pattern (see [`Press::grab`])
+/// Details of press events
+///
+/// This type dereferences to [`PressSource`].
+#[crate::autoimpl(Deref using self.source)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Press {
+    /// Source of the press
+    pub source: PressSource,
+    /// Identifier of the widget currently under the press
+    pub id: Option<Id>,
+    /// Current coordinate
+    pub coord: Coord,
+}
+
+/// Bulider pattern (see [`PressStart::grab`])
 ///
 /// Conclude by calling [`Self::complete`].
 #[must_use]
@@ -337,7 +353,7 @@ impl EventState {
     /// automatically "unset" when the widget is no longer under the mouse.
     ///
     /// See also [`EventCx::set_grab_cursor`]: if a mouse grab
-    /// ([`Press::grab`]) is active, its icon takes precedence.
+    /// ([`PressStart::grab`]) is active, its icon takes precedence.
     pub fn set_mouse_over_icon(&mut self, icon: CursorIcon) {
         // Note: this is acted on by EventState::update
         self.mouse.icon = icon;
@@ -346,7 +362,7 @@ impl EventState {
     /// Set a grab's depress target
     ///
     /// When a grab on mouse or touch input is in effect
-    /// ([`Press::grab`]), the widget owning the grab may set itself
+    /// ([`PressStart::grab`]), the widget owning the grab may set itself
     /// or any other widget as *depressed* ("pushed down"). Each grab depresses
     /// at most one widget, thus setting a new depress target clears any
     /// existing target. Initially a grab depresses its owner.
@@ -427,7 +443,7 @@ impl<'a> EventCx<'a> {
     /// Update the mouse cursor used during a grab
     ///
     /// This only succeeds if widget `id` has an active mouse-grab (see
-    /// [`Press::grab`]). The cursor will be reset when the mouse-grab
+    /// [`PressStart::grab`]). The cursor will be reset when the mouse-grab
     /// ends.
     pub fn set_grab_cursor(&mut self, id: &Id, icon: CursorIcon) {
         if let Some(ref grab) = self.mouse.grab

--- a/crates/kas-core/src/event/cx/press.rs
+++ b/crates/kas-core/src/event/cx/press.rs
@@ -219,6 +219,18 @@ impl PressStart {
             cursor: None,
         }
     }
+
+    /// Convenience wrapper for [`Self::grab`] using [`GrabMode::Click`]
+    #[inline]
+    pub fn grab_click(&self, id: Id) -> GrabBuilder {
+        self.grab(id, GrabMode::Click)
+    }
+
+    /// Convenience wrapper for [`Self::grab`] using [`GrabMode::Grab`]
+    #[inline]
+    pub fn grab_move(&self, id: Id) -> GrabBuilder {
+        self.grab(id, GrabMode::Grab)
+    }
 }
 
 /// Details of press events

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -11,7 +11,7 @@ use crate::geom::{Affine, Coord, DVec2};
 use crate::window::Window;
 use crate::window::WindowErased;
 use crate::{Action, Id, NavAdvance, Node, TileExt, Widget};
-use cast::{Cast, CastApprox, ConvApprox};
+use cast::CastApprox;
 use std::time::{Duration, Instant};
 use winit::event::{ElementState, MouseButton, MouseScrollDelta};
 use winit::window::CursorIcon;
@@ -352,7 +352,7 @@ impl<'a> EventCx<'a> {
                         id,
                         coord,
                     };
-                    let delta = coord - self.mouse.last_coord;
+                    let delta = position - self.mouse.last_position;
                     let event = Event::PressMove { press, delta };
                     self.send_event(window.re(), target, event);
                 }
@@ -408,12 +408,7 @@ impl<'a> EventCx<'a> {
 
         let event = Event::Scroll(match delta {
             MouseScrollDelta::LineDelta(x, y) => ScrollDelta::Lines(x, y),
-            MouseScrollDelta::PixelDelta(pos) => {
-                // The delta is given as a PhysicalPosition, so we need
-                // to convert to our vector type (Offset) here.
-                let coord = Coord::conv_approx(pos);
-                ScrollDelta::Pixels(coord.cast())
-            }
+            MouseScrollDelta::PixelDelta(pos) => ScrollDelta::PixelDelta(pos.into()),
         });
         if let Some(id) = self.mouse.over.clone() {
             self.send_event(window, id, event);

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -6,7 +6,7 @@
 //! Event handling: mouse events
 
 use super::{GrabMode, Press, PressSource, velocity};
-use crate::event::{Event, EventCx, EventState, FocusSource, ScrollDelta, TimerHandle};
+use crate::event::{Event, EventCx, EventState, FocusSource, PressStart, ScrollDelta, TimerHandle};
 use crate::geom::{Affine, Coord, DVec2};
 use crate::window::Window;
 use crate::window::WindowErased;
@@ -468,12 +468,12 @@ impl<'a> EventCx<'a> {
                 }
 
                 let source = PressSource::mouse(button, self.mouse.last_click_repetitions);
-                let press = Press {
+                let press = PressStart {
                     source,
                     id: Some(id.clone()),
                     coord: self.mouse.last_coord,
                 };
-                let event = Event::PressStart { press };
+                let event = Event::PressStart(press);
                 self.send_event(window, id, event);
             }
         }

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -11,7 +11,7 @@ use crate::geom::{Affine, Coord, DVec2};
 use crate::window::Window;
 use crate::window::WindowErased;
 use crate::{Action, Id, NavAdvance, Node, TileExt, Widget};
-use cast::{Cast, CastApprox, ConvApprox};
+use cast::{Cast, CastApprox, Conv, ConvApprox};
 use std::time::{Duration, Instant};
 use winit::event::{ElementState, MouseButton, MouseScrollDelta};
 use winit::window::CursorIcon;
@@ -179,8 +179,9 @@ impl Mouse {
             GrabMode::Click => GrabDetails::Click,
             GrabMode::Grab => GrabDetails::Grab,
             GrabMode::Pan { scale, rotate } => {
-                let position = self.last_position;
-                debug_assert_eq!(coord, position.cast_approx());
+                // coord may have been offset by a scroll region; we must keep
+                // that but should try to preserve fractional precision.
+                let position = DVec2::conv(coord) + self.last_position.fract();
 
                 // Do we have a pin?
                 if matches!(&self.last_pin, Some((id2, _)) if id == *id2) {

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -11,7 +11,7 @@ use crate::geom::{Affine, Coord, DVec2};
 use crate::window::Window;
 use crate::window::WindowErased;
 use crate::{Action, Id, NavAdvance, Node, TileExt, Widget};
-use cast::{Cast, CastApprox, Conv, ConvApprox};
+use cast::{Cast, CastApprox, ConvApprox};
 use std::time::{Duration, Instant};
 use winit::event::{ElementState, MouseButton, MouseScrollDelta};
 use winit::window::CursorIcon;
@@ -172,17 +172,13 @@ impl Mouse {
         button: MouseButton,
         repetitions: u32,
         id: Id,
-        coord: Coord,
+        position: DVec2,
         mode: GrabMode,
     ) -> bool {
         let details = match mode {
             GrabMode::Click => GrabDetails::Click,
             GrabMode::Grab => GrabDetails::Grab,
             GrabMode::Pan { scale, rotate } => {
-                // coord may have been offset by a scroll region; we must keep
-                // that but should try to preserve fractional precision.
-                let position = DVec2::conv(coord) + self.last_position.fract();
-
                 // Do we have a pin?
                 if matches!(&self.last_pin, Some((id2, _)) if id == *id2) {
                     GrabDetails::pan(position, (scale, rotate))
@@ -471,7 +467,7 @@ impl<'a> EventCx<'a> {
                 let press = PressStart {
                     source,
                     id: Some(id.clone()),
-                    coord: self.mouse.last_coord,
+                    position: self.mouse.last_position,
                 };
                 let event = Event::PressStart(press);
                 self.send_event(window, id, event);

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -282,7 +282,7 @@ impl<'a> EventCx<'a> {
             } else {
                 last_pin = None;
                 let press = Press {
-                    source: PressSource::Mouse(grab.button, grab.repetitions),
+                    source: PressSource::mouse(grab.button, grab.repetitions),
                     id: self.mouse.over.clone(),
                     coord: self.mouse.last_coord,
                 };
@@ -352,7 +352,7 @@ impl<'a> EventCx<'a> {
                 GrabDetails::Grab => {
                     let target = grab.start_id.clone();
                     let press = Press {
-                        source: PressSource::Mouse(grab.button, grab.repetitions),
+                        source: PressSource::mouse(grab.button, grab.repetitions),
                         id,
                         coord,
                     };
@@ -373,7 +373,7 @@ impl<'a> EventCx<'a> {
             .map(|state| state.desc.id.clone())
         {
             let press = Press {
-                source: PressSource::Mouse(FAKE_MOUSE_BUTTON, 0),
+                source: PressSource::mouse(FAKE_MOUSE_BUTTON, 0),
                 id,
                 coord,
             };
@@ -467,7 +467,7 @@ impl<'a> EventCx<'a> {
                     self.set_nav_focus(id, FocusSource::Pointer);
                 }
 
-                let source = PressSource::Mouse(button, self.mouse.last_click_repetitions);
+                let source = PressSource::mouse(button, self.mouse.last_click_repetitions);
                 let press = Press {
                     source,
                     id: Some(id.clone()),

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -7,7 +7,7 @@
 
 use super::{GrabMode, Press, PressSource, velocity};
 use crate::event::{Event, EventCx, EventState, FocusSource, PressStart, ScrollDelta, TimerHandle};
-use crate::geom::{Affine, Coord, DVec2};
+use crate::geom::{Affine, Coord, DVec2, Vec2};
 use crate::window::Window;
 use crate::window::WindowErased;
 use crate::{Action, Id, NavAdvance, Node, TileExt, Widget};
@@ -335,9 +335,9 @@ impl<'a> EventCx<'a> {
         coord: Coord,
         position: DVec2,
     ) {
-        let delta = position - self.mouse.last_position;
+        let delta: Vec2 = (position - self.mouse.last_position).cast_approx();
         if delta.is_finite() {
-            self.mouse.samples.push_delta(delta.cast_approx());
+            self.mouse.samples.push_delta(delta);
         }
         self.mouse.last_position = position;
         self.mouse.last_click_button = FAKE_MOUSE_BUTTON;
@@ -405,7 +405,9 @@ impl<'a> EventCx<'a> {
 
         let event = Event::Scroll(match delta {
             MouseScrollDelta::LineDelta(x, y) => ScrollDelta::Lines(x, y),
-            MouseScrollDelta::PixelDelta(pos) => ScrollDelta::PixelDelta(pos.into()),
+            MouseScrollDelta::PixelDelta(pos) => {
+                ScrollDelta::PixelDelta(DVec2::from(pos).cast_approx())
+            }
         });
         if let Some(id) = self.mouse.over.clone() {
             self.send_event(window, id, event);

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -7,7 +7,7 @@
 
 use super::{GrabMode, Press, PressSource, velocity};
 use crate::config::EventWindowConfig;
-use crate::event::{Event, EventCx, EventState, FocusSource};
+use crate::event::{Event, EventCx, EventState, FocusSource, PressStart};
 use crate::geom::{Affine, Coord, DVec2, Vec2};
 use crate::window::Window;
 use crate::{Action, Id, NavAdvance, Node, Widget};
@@ -327,12 +327,12 @@ impl<'a> EventCx<'a> {
                         self.set_nav_focus(id, FocusSource::Pointer);
                     }
 
-                    let press = Press {
+                    let press = PressStart {
                         source,
                         id: Some(id.clone()),
                         coord,
                     };
-                    let event = Event::PressStart { press };
+                    let event = Event::PressStart(press);
                     self.send_event(win.as_node(data), id, event);
                 }
             }

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -185,7 +185,7 @@ impl Touch {
         }
 
         if let Some(grab) = self.get_touch(touch_id) {
-            if grab.mode.is_pan() != mode.is_pan() || grab.cancel {
+            if grab.start_id != id || grab.mode != mode || grab.cancel {
                 return false;
             }
 
@@ -193,7 +193,7 @@ impl Touch {
             grab.cur_id = Some(id.clone());
             grab.last_move = coord;
             grab.coord = coord;
-            grab.mode = grab.mode.max(mode);
+            grab.last_position = coord.cast();
             grab.velocity = velocity;
             true
         } else if self.touch_grab.len() < MAX_TOUCHES {

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -345,19 +345,19 @@ impl<'a> EventCx<'a> {
                     .enumerate()
                     .find_map(|(i, grab)| (grab.id == touch.id).then_some(i));
                 if let Some(index) = grab_index {
+                    let last_pos = std::mem::replace(
+                        &mut self.touch.touch_grab[index].last_position,
+                        position,
+                    );
+                    let delta: Vec2 = (position - last_pos).cast_approx();
+
                     let vi = self.touch.touch_grab[index].vel_index as usize;
                     if vi < VELOCITY_LEN {
-                        let last_pos = std::mem::replace(
-                            &mut self.touch.touch_grab[index].last_position,
-                            position,
-                        );
-                        let delta = position - last_pos;
-                        self.touch.velocity[vi].push_delta(delta.cast_approx());
+                        self.touch.velocity[vi].push_delta(delta);
                     }
 
                     let grab = &mut self.touch.touch_grab[index];
                     grab.over = over;
-                    let delta = position - grab.last_position;
 
                     match grab.mode {
                         GrabMode::Click => {}

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -259,7 +259,7 @@ impl<'a> EventCx<'a> {
                 let grab = self.remove_touch(i);
 
                 let press = Press {
-                    source: PressSource::Touch(grab.id),
+                    source: PressSource::touch(grab.id),
                     id: grab.over,
                     coord: grab.last_coord,
                 };
@@ -312,7 +312,7 @@ impl<'a> EventCx<'a> {
         data: &A,
         touch: winit::event::Touch,
     ) {
-        let source = PressSource::Touch(touch.id);
+        let source = PressSource::touch(touch.id);
         let coord = touch.location.cast_approx();
         match touch.phase {
             TouchPhase::Started => {
@@ -367,7 +367,7 @@ impl<'a> EventCx<'a> {
                         GrabMode::Grab => {
                             let target = grab.start_id.clone();
                             let press = Press {
-                                source: PressSource::Touch(grab.id),
+                                source: PressSource::touch(grab.id),
                                 id: grab.over.clone(),
                                 coord,
                             };

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -360,7 +360,7 @@ impl<'a> EventCx<'a> {
 
                     let grab = &mut self.touch.touch_grab[index];
                     grab.over = over;
-                    let delta = coord - grab.last_coord;
+                    let delta = position - grab.last_position;
                     grab.last_coord = coord;
 
                     match grab.mode {

--- a/crates/kas-core/src/event/cx/window.rs
+++ b/crates/kas-core/src/event/cx/window.rs
@@ -8,6 +8,7 @@
 use super::{EventCx, EventState, PopupState};
 use crate::event::{Event, FocusSource};
 use crate::runner::{MessageStack, Platform, RunnerT, WindowDataErased};
+#[cfg(all(wayland_platform, feature = "clipboard"))]
 use crate::util::warn_about_error;
 use crate::window::{PopupDescriptor, Window, WindowId};
 use crate::{Action, Id, Tile, Widget};

--- a/crates/kas-core/src/event/event.rs
+++ b/crates/kas-core/src/event/event.rs
@@ -216,7 +216,7 @@ impl<'a> std::ops::AddAssign<Offset> for Event<'a> {
                 press.coord += offset;
             }
             Event::PressStart(press) => {
-                press.coord += offset;
+                *press += offset;
             }
             Event::PressMove { press, .. } => {
                 press.coord += offset;

--- a/crates/kas-core/src/event/event.rs
+++ b/crates/kas-core/src/event/event.rs
@@ -250,9 +250,7 @@ impl<'a> Event<'a> {
                 cx.depress_with_key(id, code);
                 f(cx)
             }
-            Event::PressStart(press) if press.is_primary() => {
-                press.grab(id, GrabMode::Click).complete(cx)
-            }
+            Event::PressStart(press) if press.is_primary() => press.grab_click(id).complete(cx),
             Event::PressEnd { press, success, .. } => {
                 if success && id == press.id {
                     f(cx)

--- a/crates/kas-core/src/event/event.rs
+++ b/crates/kas-core/src/event/event.rs
@@ -723,4 +723,5 @@ fn sizes() {
     assert_eq!(size_of::<TimerHandle>(), 8);
     assert_eq!(size_of::<WindowId>(), 4);
     assert_eq!(size_of::<FocusSource>(), 1);
+    assert_eq!(size_of::<Event>(), 48);
 }

--- a/crates/kas-core/src/event/event.rs
+++ b/crates/kas-core/src/event/event.rs
@@ -5,14 +5,14 @@
 
 //! Event handling: `Event` type and dependencies
 
-use cast::CastApprox;
+use cast::{Cast, CastApprox};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use super::{EventCx, IsUsed, TimerHandle, Unused, Used};
 #[allow(unused)] use super::{EventState, GrabMode};
 use super::{Key, KeyEvent, NamedKey, PhysicalKey, Press, PressStart};
-use crate::geom::{Affine, Offset};
+use crate::geom::{Affine, DVec2, Offset};
 #[allow(unused)] use crate::{Events, window::Popup};
 use crate::{Id, dir::Direction, window::WindowId};
 
@@ -119,7 +119,7 @@ pub enum Event<'a> {
     /// the handler be fast. It may be useful to schedule a pre-draw update
     /// with [`EventState::request_frame_timer`] to handle any post-move
     /// updates.
-    PressMove { press: Press, delta: Offset },
+    PressMove { press: Press, delta: DVec2 },
     /// End of a click/touch press
     ///
     /// If `success`, this is a button-release or touch finish; otherwise this
@@ -624,7 +624,7 @@ pub enum ScrollDelta {
     /// For a ‘natural scrolling’ touch pad (that acts like a touch screen) this
     /// means moving your fingers right and down should give positive values,
     /// and move the content right and down (to reveal more things left and up).
-    Pixels(Offset),
+    PixelDelta(DVec2),
 }
 
 impl ScrollDelta {
@@ -632,7 +632,7 @@ impl ScrollDelta {
     pub fn is_vertical(self) -> bool {
         match self {
             ScrollDelta::Lines(0.0, _) => true,
-            ScrollDelta::Pixels(Offset(0, _)) => true,
+            ScrollDelta::PixelDelta(DVec2(0.0, _)) => true,
             _ => false,
         }
     }
@@ -641,7 +641,7 @@ impl ScrollDelta {
     pub fn is_horizontal(self) -> bool {
         match self {
             ScrollDelta::Lines(_, 0.0) => true,
-            ScrollDelta::Pixels(Offset(_, 0)) => true,
+            ScrollDelta::PixelDelta(DVec2(_, 0.0)) => true,
             _ => false,
         }
     }
@@ -649,10 +649,10 @@ impl ScrollDelta {
     /// Convert to a pan offset
     ///
     /// Line deltas are converted to a distance based on `scroll_distance` configuration.
-    pub fn as_offset(self, cx: &EventState) -> Offset {
+    pub fn as_offset(self, cx: &EventState) -> DVec2 {
         match self {
-            ScrollDelta::Lines(x, y) => cx.config().event().scroll_distance((x, y)),
-            ScrollDelta::Pixels(d) => d,
+            ScrollDelta::Lines(x, y) => cx.config().event().scroll_distance((x, y)).cast(),
+            ScrollDelta::PixelDelta(d) => d,
         }
     }
 
@@ -661,7 +661,7 @@ impl ScrollDelta {
         // TODO: this should be configurable?
         match self {
             ScrollDelta::Lines(_, y) => -0.5 * y as f64,
-            ScrollDelta::Pixels(Offset(_, y)) => -0.01 * y as f64,
+            ScrollDelta::PixelDelta(DVec2(_, y)) => -0.01 * y,
         }
     }
 
@@ -670,7 +670,7 @@ impl ScrollDelta {
     /// This is used for surfaces where panning/scrolling is preferred over
     /// zooming, though both are supported (for example, a web page).
     /// The <kbd>Ctrl</kbd> key is used to select between the two modes.
-    pub fn as_offset_or_factor(self, cx: &EventState) -> Result<Offset, f64> {
+    pub fn as_offset_or_factor(self, cx: &EventState) -> Result<DVec2, f64> {
         if cx.modifiers().control_key() {
             Err(self.as_factor(cx))
         } else {
@@ -684,7 +684,7 @@ impl ScrollDelta {
     /// though both are supported (for example, a map view where click-and-drag
     /// may also be used to pan). Mouse wheel actions always zoom while the
     /// touchpad scrolling may cause either effect.
-    pub fn as_factor_or_offset(self, cx: &EventState) -> Result<f64, Offset> {
+    pub fn as_factor_or_offset(self, cx: &EventState) -> Result<f64, DVec2> {
         if matches!(self, ScrollDelta::Lines(_, _)) || cx.modifiers().control_key() {
             Ok(self.as_factor(cx))
         } else {

--- a/crates/kas-core/src/event/event.rs
+++ b/crates/kas-core/src/event/event.rs
@@ -719,9 +719,9 @@ fn sizes() {
     assert_eq!(size_of::<KeyEvent>(), 128);
     assert_eq!(size_of::<ScrollDelta>(), 12);
     assert_eq!(size_of::<Affine>(), 32);
-    assert_eq!(size_of::<Press>(), 32);
+    assert_eq!(size_of::<Press>(), 24);
     assert_eq!(size_of::<TimerHandle>(), 8);
     assert_eq!(size_of::<WindowId>(), 4);
     assert_eq!(size_of::<FocusSource>(), 1);
-    assert_eq!(size_of::<Event>(), 48);
+    assert_eq!(size_of::<Event>(), 40);
 }

--- a/crates/kas-core/src/event/response.rs
+++ b/crates/kas-core/src/event/response.rs
@@ -5,7 +5,7 @@
 
 //! Event handling: IsUsed and Scroll types
 
-use crate::geom::{Offset, Rect};
+use crate::geom::{Rect, Vec2};
 
 pub use IsUsed::{Unused, Used};
 
@@ -92,7 +92,7 @@ pub enum Scroll {
     ///
     /// With the usual scroll offset conventions, this delta must be subtracted
     /// from the scroll offset.
-    Offset(Offset),
+    Offset(Vec2),
     /// Start kinetic scrolling
     Kinetic(KineticStart),
     /// Focus the given rect

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -594,13 +594,10 @@ impl Rect {
         self.pos + self.size
     }
 
-    /// Check whether the given coordinate is contained within this rect
+    /// Check whether `p` is contained within this rect
     #[inline]
-    pub fn contains(&self, c: Coord) -> bool {
-        c.0 >= self.pos.0
-            && c.0 < self.pos.0 + (self.size.0)
-            && c.1 >= self.pos.1
-            && c.1 < self.pos.1 + (self.size.1)
+    pub fn contains<P: PartialOrd<Coord>>(&self, p: P) -> bool {
+        p >= self.pos && p < self.pos2()
     }
 
     /// Calculate the intersection of two rects

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -525,6 +525,38 @@ macro_rules! impl_vec2 {
             }
         }
 
+        impl PartialEq<Coord> for $T {
+            fn eq(&self, rhs: &Coord) -> bool {
+                DVec2::from(*self) == DVec2::conv(*rhs)
+            }
+        }
+
+        impl PartialOrd<Coord> for $T {
+            fn partial_cmp(&self, rhs: &Coord) -> Option<Ordering> {
+                DVec2::from(*self).partial_cmp(&DVec2::conv(*rhs))
+            }
+
+            #[inline]
+            fn lt(&self, rhs: &Coord) -> bool {
+                DVec2::from(*self) < DVec2::conv(*rhs)
+            }
+
+            #[inline]
+            fn le(&self, rhs: &Coord) -> bool {
+                DVec2::from(*self) <= DVec2::conv(*rhs)
+            }
+
+            #[inline]
+            fn ge(&self, rhs: &Coord) -> bool {
+                DVec2::from(*self) >= DVec2::conv(*rhs)
+            }
+
+            #[inline]
+            fn gt(&self, rhs: &Coord) -> bool {
+                DVec2::from(*self) > DVec2::conv(*rhs)
+            }
+        }
+
         impl From<($f, $f)> for $T {
             #[inline]
             fn from(arg: ($f, $f)) -> Self {
@@ -609,6 +641,18 @@ impl Conv<Vec2> for kas_text::Vec2 {
     }
 }
 
+impl From<Vec2> for DVec2 {
+    #[inline]
+    fn from(v: Vec2) -> DVec2 {
+        DVec2(v.0.into(), v.1.into())
+    }
+}
+impl Conv<Vec2> for DVec2 {
+    #[inline]
+    fn try_conv(v: Vec2) -> Result<DVec2> {
+        Ok(DVec2(v.0.into(), v.1.into()))
+    }
+}
 impl ConvApprox<DVec2> for Vec2 {
     fn try_conv_approx(size: DVec2) -> Result<Vec2> {
         Ok(Vec2(size.0.try_cast_approx()?, size.1.try_cast_approx()?))

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -238,6 +238,30 @@ macro_rules! impl_vec2 {
                 $T(self.0.max(other.0), self.1.max(other.1))
             }
 
+            /// Restrict a value to a certain interval unless it is NaN
+            ///
+            /// Returns `max` if `self` is greater than `max`, and `min` if
+            /// `self` is less than `min`. Otherwise this returns `self`.
+            ///
+            /// Note that this function returns NaN if the initial value was NaN
+            /// as well.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `min > max`, `min` is NaN, or `max` is NaN.
+            #[inline]
+            #[must_use = "method does not modify self but returns a new value"]
+            pub fn clamp(mut self, min: Self, max: Self) -> Self {
+                assert!(min <= max);
+                if self < min {
+                    self = min;
+                }
+                if self > max {
+                    self = max;
+                }
+                self
+            }
+
             /// Take the absolute value of each component
             #[inline]
             #[must_use = "method does not modify self but returns a new value"]

--- a/crates/kas-core/src/layout/size_types.rs
+++ b/crates/kas-core/src/layout/size_types.rs
@@ -230,7 +230,7 @@ impl_scope! {
         ///
         /// Default: `1.0`
         pub ideal_factor: f32 = 1.0,
-        /// If true, aspect ratio is fixed relative to [`Self.size`]
+        /// If true, aspect ratio is fixed relative to [`Self::size`]
         ///
         /// Default: `true`
         pub fix_aspect: bool = true,

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -437,7 +437,7 @@ pub trait ThemeDraw {
     /// If `effects` is empty or all [`Effect::flags`] are default then it is
     /// equivalent (and faster) to call [`Self::text`] instead.
     ///
-    /// Special effect: if `class` is [`TextClass::AccessLabel(_)`] then
+    /// Special effect: if `class` is [`TextClass::AccessLabel`] then
     /// underline and strikethrough are only drawn if
     /// [`EventState::show_access_labels`].
     ///

--- a/crates/kas-core/src/theme/flat_theme.rs
+++ b/crates/kas-core/src/theme/flat_theme.rs
@@ -162,7 +162,7 @@ where
     ) -> Quad {
         #[cfg(debug_assertions)]
         {
-            if !inner.a.lt(inner.b) {
+            if !(inner.a < inner.b) {
                 log::warn!("button_frame: frame too small: {outer:?}");
             }
         }

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -122,7 +122,7 @@ where
         let inner = outer.shrink(self.w.dims.button_frame as f32);
         #[cfg(debug_assertions)]
         {
-            if !inner.a.lt(inner.b) {
+            if !(inner.a < inner.b) {
                 log::warn!("button_frame: frame too small: {outer:?}");
             }
         }

--- a/crates/kas-core/src/widgets/decorations.rs
+++ b/crates/kas-core/src/widgets/decorations.rs
@@ -68,7 +68,7 @@ mod Border {
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
-                Event::PressStart { .. } => {
+                Event::PressStart(_) => {
                     cx.drag_resize_window(self.direction);
                     Used
                 }
@@ -182,7 +182,7 @@ mod TitleBar {
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
-                Event::PressStart { .. } => {
+                Event::PressStart(_) => {
                     cx.drag_window();
                     Used
                 }

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -234,7 +234,7 @@ mod Window {
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
-                Event::PressStart { .. } if self.drag_anywhere => {
+                Event::PressStart(_) if self.drag_anywhere => {
                     cx.drag_window();
                     Used
                 }

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -792,7 +792,7 @@ mod GridView {
                         Unused
                     };
                 }
-                Event::PressStart { ref press }
+                Event::PressStart(ref press)
                     if press.is_primary() && cx.config().event().mouse_nav_focus() =>
                 {
                     if let Some(index) = cx.last_child() {

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -807,9 +807,7 @@ mod GridView {
 
                     // Press may also be grabbed by scroll component (replacing
                     // this). Either way we can select on PressEnd.
-                    press
-                        .grab(self.id(), kas::event::GrabMode::Click)
-                        .complete(cx)
+                    press.grab_click(self.id()).complete(cx)
                 }
                 Event::PressEnd { ref press, success } if press.is_primary() => {
                     if let Some((index, ref key)) = self.press_target {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -821,7 +821,7 @@ mod ListView {
                         Unused
                     };
                 }
-                Event::PressStart { ref press }
+                Event::PressStart(ref press)
                     if press.is_primary() && cx.config().event().mouse_nav_focus() =>
                 {
                     if let Some(index) = cx.last_child() {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -836,9 +836,7 @@ mod ListView {
 
                     // Press may also be grabbed by scroll component (replacing
                     // this). Either way we can select on PressEnd.
-                    press
-                        .grab(self.id(), kas::event::GrabMode::Click)
-                        .complete(cx)
+                    press.grab_click(self.id()).complete(cx)
                 }
                 Event::PressEnd { ref press, success } if press.is_primary() => {
                     if let Some((index, ref key)) = self.press_target {

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -69,3 +69,4 @@ glob = "0.3"
 [lints.clippy]
 needless_lifetimes = "allow"
 unit_arg = "allow"
+neg_cmp_op_on_partial_ord = "allow"

--- a/crates/kas-wgpu/src/draw/atlases.rs
+++ b/crates/kas-wgpu/src/draw/atlases.rs
@@ -237,7 +237,7 @@ impl<I: bytemuck::Pod> Pipeline<I> {
         let tex_size = Vec2::conv(Size::from(tex_size));
         let a = to_vec2(alloc.rectangle.min) / tex_size;
         let b = to_vec2(alloc.rectangle.max) / tex_size;
-        debug_assert!(Vec2::ZERO.le(a) && a.le(b) && b.le(Vec2::splat(1.0)));
+        debug_assert!(Vec2::ZERO <= a && a <= b && b <= Vec2::splat(1.0));
         let tex_quad = Quad { a, b };
 
         Ok((atlas, alloc.id, origin, tex_quad))

--- a/crates/kas-wgpu/src/draw/flat_round.rs
+++ b/crates/kas-wgpu/src/draw/flat_round.rs
@@ -182,7 +182,7 @@ impl Window {
         let aa = rect.a;
         let bb = rect.b;
 
-        if !aa.lt(bb) || col.a == 0.0 {
+        if !(aa < bb) || col.a == 0.0 {
             // zero / negative size or transparent: nothing to draw
             return;
         }
@@ -232,17 +232,17 @@ impl Window {
         let mut cc = inner.a;
         let mut dd = inner.b;
 
-        if !aa.lt(bb) || col.a == 0.0 {
+        if !(aa < bb) || col.a == 0.0 {
             // zero / negative size or transparent: nothing to draw
             return;
         }
-        if !aa.le(cc) || !cc.le(bb) {
+        if !(aa <= cc) || !(cc <= bb) {
             cc = aa;
         }
-        if !aa.le(dd) || !dd.le(bb) {
+        if !(aa <= dd) || !(dd <= bb) {
             dd = bb;
         }
-        if !cc.le(dd) {
+        if !(cc <= dd) {
             dd = cc;
         }
 

--- a/crates/kas-wgpu/src/draw/images.rs
+++ b/crates/kas-wgpu/src/draw/images.rs
@@ -328,7 +328,7 @@ impl Window {
 
     /// Add a rectangle to the buffer
     pub fn rect(&mut self, pass: PassId, atlas: u32, tex: Quad, rect: Quad) {
-        if !rect.a.lt(rect.b) {
+        if !(rect.a < rect.b) {
             // zero / negative size: nothing to draw
             return;
         }

--- a/crates/kas-wgpu/src/draw/round_2col.rs
+++ b/crates/kas-wgpu/src/draw/round_2col.rs
@@ -114,7 +114,7 @@ impl Window {
         let aa = rect.a;
         let bb = rect.b;
 
-        if !aa.lt(bb) || (col1.a == 0.0 && col2.a == 0.0) {
+        if !(aa < bb) || (col1.a == 0.0 && col2.a == 0.0) {
             // zero / negative size or transparent: nothing to draw
             return;
         }
@@ -151,17 +151,17 @@ impl Window {
         let mut cc = inner.a;
         let mut dd = inner.b;
 
-        if !aa.lt(bb) || (col1.a == 0.0 && col2.a == 0.0) {
+        if !(aa < bb) || (col1.a == 0.0 && col2.a == 0.0) {
             // zero / negative size or transparent: nothing to draw
             return;
         }
-        if !aa.le(cc) || !cc.le(bb) {
+        if !(aa <= cc) || !(cc <= bb) {
             cc = aa;
         }
-        if !aa.le(dd) || !dd.le(bb) {
+        if !(aa <= dd) || !(dd <= bb) {
             dd = bb;
         }
-        if !cc.le(dd) {
+        if !(cc <= dd) {
             dd = cc;
         }
 

--- a/crates/kas-wgpu/src/draw/shaded_round.rs
+++ b/crates/kas-wgpu/src/draw/shaded_round.rs
@@ -121,11 +121,11 @@ impl Window {
         let aa = rect.a;
         let bb = rect.b;
 
-        if !aa.lt(bb) {
+        if !(aa < bb) {
             // zero / negative size: nothing to draw
             return;
         }
-        if !Vec2::splat(-1.0).le(norm) || !norm.le(Vec2::splat(1.0)) {
+        if !(Vec2::splat(-1.0) <= norm) || !(norm <= Vec2::splat(1.0)) {
             norm = Vec2::splat(0.0);
         }
 
@@ -173,20 +173,20 @@ impl Window {
         let mut cc = inner.a;
         let mut dd = inner.b;
 
-        if !aa.lt(bb) {
+        if !(aa < bb) {
             // zero / negative size: nothing to draw
             return;
         }
-        if !aa.le(cc) || !cc.le(bb) {
+        if !(aa <= cc) || !(cc <= bb) {
             cc = aa;
         }
-        if !aa.le(dd) || !dd.le(bb) {
+        if !(aa <= dd) || !(dd <= bb) {
             dd = bb;
         }
-        if !cc.le(dd) {
+        if !(cc <= dd) {
             dd = cc;
         }
-        if !Vec2::splat(-1.0).le(norm) || !norm.le(Vec2::splat(1.0)) {
+        if !(Vec2::splat(-1.0) <= norm) || !(norm <= Vec2::splat(1.0)) {
             norm = Vec2::splat(0.0);
         }
 

--- a/crates/kas-wgpu/src/draw/shaded_square.rs
+++ b/crates/kas-wgpu/src/draw/shaded_square.rs
@@ -107,7 +107,7 @@ impl Window {
         let aa = rect.a;
         let bb = rect.b;
 
-        if !aa.lt(bb) {
+        if !(aa < bb) {
             // zero / negative size: nothing to draw
             return;
         }
@@ -131,11 +131,11 @@ impl Window {
         let aa = rect.a;
         let bb = rect.b;
 
-        if !aa.lt(bb) {
+        if !(aa < bb) {
             // zero / negative size: nothing to draw
             return;
         }
-        if !Vec2::splat(-1.0).le(norm) || !norm.le(Vec2::splat(1.0)) {
+        if !(Vec2::splat(-1.0) <= norm) || !(norm <= Vec2::splat(1.0)) {
             norm = Vec2::splat(0.0);
         }
 
@@ -181,20 +181,20 @@ impl Window {
         let mut cc = inner.a;
         let mut dd = inner.b;
 
-        if !aa.lt(bb) {
+        if !(aa < bb) {
             // zero / negative size: nothing to draw
             return;
         }
-        if !aa.le(cc) || !cc.le(bb) {
+        if !(aa <= cc) || !(cc <= bb) {
             cc = aa;
         }
-        if !aa.le(dd) || !dd.le(bb) {
+        if !(aa <= dd) || !(dd <= bb) {
             dd = bb;
         }
-        if !cc.le(dd) {
+        if !(cc <= dd) {
             dd = cc;
         }
-        if !Vec2::splat(-1.0).le(norm) || !norm.le(Vec2::splat(1.0)) {
+        if !(Vec2::splat(-1.0) <= norm) || !(norm <= Vec2::splat(1.0)) {
             norm = Vec2::splat(0.0);
         }
 

--- a/crates/kas-wgpu/src/draw/text_pipe.rs
+++ b/crates/kas-wgpu/src/draw/text_pipe.rs
@@ -430,7 +430,7 @@ impl Window {
         }
 
         let (mut ta, mut tb) = (sprite.tex_quad.a, sprite.tex_quad.b);
-        if !a.ge(rect.a) || !b.le(rect.b) {
+        if !(a >= rect.a) || !(b <= rect.b) {
             let size_inv = Vec2::splat(1.0) / (b - a);
             let fa0 = 0f32.max((rect.a.0 - a.0) * size_inv.0);
             let fa1 = 0f32.max((rect.a.1 - a.1) * size_inv.1);

--- a/crates/kas-wgpu/src/shaded_theme.rs
+++ b/crates/kas-wgpu/src/shaded_theme.rs
@@ -143,7 +143,7 @@ where
         let inner = outer.shrink(self.w.dims.frame as f32);
         #[cfg(debug_assertions)]
         {
-            if !inner.a.lt(inner.b) {
+            if !(inner.a < inner.b) {
                 log::warn!("draw_edit_box: frame too small: {outer:?}");
             }
         }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -148,7 +148,7 @@ mod ComboBox {
                         Unused
                     }
                 }
-                Event::PressStart { press } => {
+                Event::PressStart(press) => {
                     if press
                         .id
                         .as_ref()

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -156,9 +156,7 @@ mod ComboBox {
                         .unwrap_or(false)
                     {
                         if press.is_primary() {
-                            press
-                                .grab(self.id(), kas::event::GrabMode::Grab)
-                                .complete(cx);
+                            press.grab_move(self.id()).complete(cx);
                             cx.set_grab_depress(*press, press.id);
                             self.opening = !self.popup.is_open();
                         }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -1060,7 +1060,7 @@ mod EditField {
                     self.prepare_text(cx);
                     Used
                 }
-                Event::PressStart { press } if press.is_tertiary() => press
+                Event::PressStart(press) if press.is_tertiary() => press
                     .grab(self.id(), kas::event::GrabMode::Click)
                     .complete(cx),
                 Event::PressEnd { press, .. } if press.is_tertiary() => {

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -1060,9 +1060,9 @@ mod EditField {
                     self.prepare_text(cx);
                     Used
                 }
-                Event::PressStart(press) if press.is_tertiary() => press
-                    .grab(self.id(), kas::event::GrabMode::Click)
-                    .complete(cx),
+                Event::PressStart(press) if press.is_tertiary() => {
+                    press.grab_click(self.id()).complete(cx)
+                }
                 Event::PressEnd { press, .. } if press.is_tertiary() => {
                     if let Some(content) = cx.get_primary() {
                         self.set_cursor_from_coord(cx, press.coord);

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Debug;
 
-use kas::event::{CursorIcon, Press};
+use kas::event::{CursorIcon, PressStart};
 use kas::prelude::*;
 
 /// A message from a [`GripPart`]
@@ -111,7 +111,7 @@ mod GripPart {
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
-                Event::PressStart { press, .. } => {
+                Event::PressStart(press) => {
                     cx.push(GripMsg::PressStart);
                     press
                         .grab(self.id(), kas::event::GrabMode::Grab)
@@ -227,7 +227,7 @@ mod GripPart {
         /// The grip position is not adjusted; the caller should also call
         /// [`Self::set_offset`] to do so. This is separate to allow adjustment of
         /// the posision; e.g. `Slider` pins the position to the nearest detent.
-        pub fn handle_press_on_track(&mut self, cx: &mut EventCx, press: &Press) -> Offset {
+        pub fn handle_press_on_track(&mut self, cx: &mut EventCx, press: &PressStart) -> Offset {
             press
                 .grab(self.id(), kas::event::GrabMode::Grab)
                 .with_icon(CursorIcon::Grabbing)

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -119,7 +119,7 @@ mod GripPart {
                         .complete(cx);
 
                     // Event delivery implies coord is over the grip.
-                    self.press_coord = press.coord - self.offset();
+                    self.press_coord = press.coord() - self.offset();
                     Used
                 }
                 Event::PressMove { press, .. } => {
@@ -233,9 +233,10 @@ mod GripPart {
                 .with_icon(CursorIcon::Grabbing)
                 .complete(cx);
 
-            let offset = press.coord - self.track.pos - Offset::conv(self.rect.size / 2);
+            let coord = press.coord();
+            let offset = coord - self.track.pos - Offset::conv(self.rect.size / 2);
             let offset = offset.clamp(Offset::ZERO, self.max_offset());
-            self.press_coord = press.coord - offset;
+            self.press_coord = coord - offset;
             offset
         }
     }

--- a/crates/kas-widgets/src/grip.rs
+++ b/crates/kas-widgets/src/grip.rs
@@ -114,7 +114,7 @@ mod GripPart {
                 Event::PressStart(press) => {
                     cx.push(GripMsg::PressStart);
                     press
-                        .grab(self.id(), kas::event::GrabMode::Grab)
+                        .grab_move(self.id())
                         .with_icon(CursorIcon::Grabbing)
                         .complete(cx);
 
@@ -229,7 +229,7 @@ mod GripPart {
         /// the posision; e.g. `Slider` pins the position to the nearest detent.
         pub fn handle_press_on_track(&mut self, cx: &mut EventCx, press: &PressStart) -> Offset {
             press
-                .grab(self.id(), kas::event::GrabMode::Grab)
+                .grab_move(self.id())
                 .with_icon(CursorIcon::Grabbing)
                 .complete(cx);
 

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -471,7 +471,7 @@ mod List {
 
         /// Access layout storage
         ///
-        /// The number of columns/rows is [`Self.len`].
+        /// The number of columns/rows is [`Self::len`].
         #[inline]
         pub fn layout_storage(&mut self) -> &mut (impl RowStorage + use<C, D>) {
             &mut self.layout

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -139,7 +139,7 @@ mod MenuBar {
                     }
                     Used
                 }
-                Event::PressStart { press } => {
+                Event::PressStart(press) => {
                     if press
                         .id
                         .as_ref()

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -151,9 +151,7 @@ mod MenuBar {
                             let press_in_the_bar = self.rect().contains(press.coord);
 
                             if !press_in_the_bar || !any_menu_open {
-                                press
-                                    .grab(self.id(), kas::event::GrabMode::Grab)
-                                    .complete(cx);
+                                press.grab_move(self.id()).complete(cx);
                             }
                             cx.set_grab_depress(*press, press.id.clone());
                             if press_in_the_bar {

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -148,7 +148,7 @@ mod MenuBar {
                     {
                         if press.is_primary() {
                             let any_menu_open = self.widgets.iter().any(|w| w.menu_is_open());
-                            let press_in_the_bar = self.rect().contains(press.coord);
+                            let press_in_the_bar = self.rect().contains(press.coord());
 
                             if !press_in_the_bar || !any_menu_open {
                                 press.grab_move(self.id()).complete(cx);

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -360,7 +360,7 @@ mod ScrollBar {
                     }
                     Used
                 }
-                Event::PressStart { press } => {
+                Event::PressStart(press) => {
                     let offset = self.grip.handle_press_on_track(cx, &press);
                     self.apply_grip_offset(cx, offset);
                     Used

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -378,7 +378,7 @@ mod Slider {
                         }
                     }
                 }
-                Event::PressStart { press } => {
+                Event::PressStart(press) => {
                     let offset = self.grip.handle_press_on_track(cx, &press);
                     self.apply_grip_offset(cx, data, offset);
                 }

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -396,8 +396,9 @@ mod Mandlebrot {
                     }
                 },
                 Event::Scroll(delta) => match delta.as_factor_or_offset(cx) {
-                    Ok(factor) => self.transform *= Linear::scale(2f64.powf(factor)),
+                    Ok(factor) => self.transform *= Linear::scale(2f64.powf(factor.cast())),
                     Err(offset) => {
+                        let offset: DVec2 = offset.cast();
                         self.transform -= self.transform.alpha() * self.view_alpha * offset;
                     }
                 },

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -398,8 +398,7 @@ mod Mandlebrot {
                 Event::Scroll(delta) => match delta.as_factor_or_offset(cx) {
                     Ok(factor) => self.transform *= Linear::scale(2f64.powf(factor)),
                     Err(offset) => {
-                        self.transform -=
-                            self.transform.alpha() * self.view_alpha * DVec2::conv(offset);
+                        self.transform -= self.transform.alpha() * self.view_alpha * offset;
                     }
                 },
                 Event::Pan(t) => {

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -418,7 +418,7 @@ mod Mandlebrot {
                         + (self.transform.alpha() - new_alpha) * self.view_delta;
                     self.transform = Affine::new(new_alpha, new_delta);
                 }
-                Event::PressStart { press } => {
+                Event::PressStart(press) => {
                     return press
                         .grab(self.id(), event::GrabMode::PAN_FULL)
                         .with_icon(event::CursorIcon::Grabbing)


### PR DESCRIPTION
This change set started off with the question "what if we replace `fn Tile::translation(&self) -> Offset` with `fn Tile::transform(&self) -> Affine`", collected a bunch of tweaks and little fixes on the way, then ultimately rejected the afore-mentioned suggestion.

It turns out that using an affine floating-point transform together with passing the pointer coordinates with `f64` is easy enough to implement, but not useful:

- We want pixel-perfect, axis-aligned sizing, which makes the perplexing question of how to apply the transform to `fn Layout::size_rules` moot: any sizing or rotation here is wrong. (Even a 90° rotation is problematic since we promise x-axis sizing before y-axis to allow measurement of text height post-wrapping. This could be worked around in specific cases, but it's clear that Kas's layout model is not a good fit for anything beyond axis-aligned boxes.)
- We want pixel-perfect rendering. We handle scroll-offsets with draw transforms, and while these could *obviously* be used to handle scaling and rotation too, we would lose pixel-perfect rendering. (Even 90° or 180° rotation might be problematic due to sub-pixel rendering, though we don't currently use that.)

This PR therefore keeps all sizes, most offsets and positions in integer formats, though it does make a few exceptions (notably because pointer precision is available in `f64` form (sorta — on Wayland it may only be non-integral because of the scale factor) and velocity sampling does benefit).

### Tweaks

Geometry types now implement `PartialOrd`. This is convenient, and the impls meet all semantic requirements of `PartialOrd`, using the "obvious" implementation that `a >= b` if `a.x >= b.x && a.y >= b.y`. (They do not and cannot implement `Ord` however.)

`Vec2` and `DVec2` now support `fn clamp`.

`Coord` can now be compared to `Vec2` and `DVec2` using `PartialOrd`, `PartialEq`. `fn Rect::contains` now works with any of these types.

`Event::PressStart` now has its own `PressStart` type. This passes the pointer position using `DVec2` which simplifies logic around press velocity.

`Event::PressMove` passes its `delta` as `Vec2`.

Avoid using `pos` as a text index since usually this name is used for a 2D position.

New size-optimized implementation of `PressSource` (8 bytes instead of 16).

### Fixes

- Fix mouse pan grab inside a scrolled region
- Avoid spurious high press velocity when mouse coordinates are not reported while the cursor is off-screen