### PR TITLE
List/GridView improvements: scrolling, sizing, performance

### DIFF
--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -202,9 +202,12 @@ impl ScrollComponent {
     /// change in offset. In practice the caller will likely be performing all
     /// required updates regardless and the return value can be safely ignored.
     pub fn set_sizes(&mut self, window_size: Size, content_size: Size) -> Action {
-        self.max_offset =
-            (Offset::conv(content_size) - Offset::conv(window_size)).max(Offset::ZERO);
-        self.set_offset(self.offset)
+        let max_offset = (Offset::conv(content_size) - Offset::conv(window_size)).max(Offset::ZERO);
+        if max_offset == self.max_offset {
+            return Action::empty();
+        }
+        self.max_offset = max_offset;
+        Action::SCROLLED | self.set_offset(self.offset)
     }
 
     /// Set the scroll offset

--- a/crates/kas-core/src/event/response.rs
+++ b/crates/kas-core/src/event/response.rs
@@ -5,7 +5,7 @@
 
 //! Event handling: IsUsed and Scroll types
 
-use crate::geom::{Rect, Vec2};
+use crate::geom::{Offset, Rect, Vec2};
 
 pub use IsUsed::{Unused, Used};
 
@@ -101,4 +101,16 @@ pub enum Scroll {
     /// any parent with non-zero translation will intercept this value and
     /// either consume or translate it.
     Rect(Rect),
+}
+
+impl std::ops::Sub<Offset> for Scroll {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Offset) -> Self {
+        match self {
+            Scroll::Rect(rect) => Scroll::Rect(rect - rhs),
+            other => other,
+        }
+    }
 }

--- a/crates/kas-core/src/geom.rs
+++ b/crates/kas-core/src/geom.rs
@@ -488,6 +488,15 @@ impl Offset {
     }
 }
 
+impl std::ops::Neg for Offset {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        Offset(-self.0, -self.1)
+    }
+}
+
 impl std::ops::Add for Offset {
     type Output = Self;
 

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -453,7 +453,12 @@ mod GridView {
             }
 
             let dur = (Instant::now() - time).as_micros();
-            log::debug!(target: "kas_perf::view::grid_view", "map_view_widgets: {dur}μs");
+            log::debug!(
+                target: "kas_perf::view::grid_view",
+                "map_view_widgets {}×{} widgets in {dur}μs",
+                cur_len.col,
+                cur_len.row,
+            );
         }
 
         fn update_content_size(&mut self, cx: &mut ConfigCx) {

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -912,7 +912,8 @@ mod GridView {
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx, data: &C::Data, scroll: Scroll) {
-            self.scroll.scroll(cx, self.id(), self.rect(), scroll);
+            self.scroll
+                .scroll(cx, self.id(), self.rect(), scroll - self.virtual_offset);
             self.map_view_widgets(&mut cx.config_cx(), data, false);
         }
     }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -952,7 +952,8 @@ mod ListView {
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx, data: &C::Data, scroll: Scroll) {
-            self.scroll.scroll(cx, self.id(), self.rect(), scroll);
+            self.scroll
+                .scroll(cx, self.id(), self.rect(), scroll - self.virtual_offset());
             self.post_scroll(&mut cx.config_cx(), data);
         }
     }

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -579,23 +579,15 @@ mod ListView {
             });
             axis = AxisInfo::new(axis.is_vertical(), other);
 
-            self.child_size_min = i32::MAX;
             let mut rules = SizeRules::EMPTY;
             for w in self.widgets.iter_mut() {
                 if w.key.is_some() {
                     let child_rules = w.item.size_rules(sizer.re(), axis);
-                    if axis.is_vertical() == self.direction.is_vertical() {
-                        self.child_size_min = self.child_size_min.min(child_rules.min_size());
-                    }
                     rules = rules.max(child_rules);
                 }
             }
-            if self.child_size_min == i32::MAX {
-                self.child_size_min = 1;
-            }
-            self.child_size_min = self.child_size_min.max(1);
-
             if axis.is_vertical() == self.direction.is_vertical() {
+                self.child_size_min = rules.min_size().max(1);
                 self.child_size_ideal = rules.ideal_size().max(sizer.min_element_size());
                 let m = rules.margins();
                 self.child_inter_margin =

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -503,7 +503,10 @@ mod ListView {
             }
 
             let dur = (Instant::now() - time).as_micros();
-            log::debug!(target: "kas_perf::view::list_view", "map_view_widgets: {dur}μs");
+            log::debug!(
+                target: "kas_perf::view::list_view",
+                "map_view_widgets {cur_len} view widgets in {dur}μs",
+            );
         }
 
         fn update_content_size(&mut self, cx: &mut ConfigCx) {

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -397,7 +397,11 @@ impl<CW: CustomWindow> DrawImpl for DrawWindow<CW> {
     ) -> PassId {
         let parent = match class {
             PassType::Clip => &self.clip_regions[parent_pass.pass()],
-            PassType::Overlay => &self.clip_regions[0],
+            PassType::Overlay => {
+                // NOTE: parent_pass.pass() is always zero in this case since
+                // this is only invoked from the Window (root).
+                &self.clip_regions[0]
+            }
         };
         let rect = rect - parent.1;
         let offset = offset + parent.1;

--- a/examples/reformat-id.rs
+++ b/examples/reformat-id.rs
@@ -10,11 +10,47 @@ use kas_core::Id;
 fn main() {
     let mut args = std::env::args();
     if args.len() != 2 {
-        eprintln!("Usage: {} DECIMAL", args.next().unwrap());
+        eprintln!("Usage: {} CODE", args.next().unwrap());
+        eprintln!("where CODE is #HEX_PATH or DECIMAL");
         return;
     }
 
     let s = args.skip(1).next().unwrap();
+
+    if s.starts_with("#") {
+        print!("[");
+        let mut first = true;
+        let mut i = 1;
+        let mut n = 0;
+        while i < s.len() {
+            let b = match u8::from_str_radix(&s[i..i + 1], 16) {
+                Ok(b) => b,
+                Err(err) => {
+                    println!();
+                    eprintln!("Parse error: {err}");
+                    return;
+                }
+            };
+            i += 1;
+
+            n |= b & 7;
+            if b & 8 != 0 {
+                n <<= 3;
+                continue;
+            }
+
+            if !first {
+                print!(", ");
+            }
+            first = false;
+
+            print!("{n}");
+            n = 0;
+        }
+        println!("]");
+        return;
+    }
+
     let n: u64 = match s.parse() {
         Ok(n) => n,
         Err(e) => {


### PR DESCRIPTION
Some changes to `ListView` and `GridView`:

- Rename `update_widgets` to `map_view_widgets` and avoid calling (or exit early) if not necessary; this improves performance when scrolling with many child widgets (e.g. `times-tables` with ~2800 visible entries now has usable performance in debug builds and very good performance in release builds).
- Resize view widgets automatically when required. This fixes the overlapping text when longer `times-tables` entries are scrolled into view.
- Use a virtual scroll offset to avoid positioning view widgets far from the origin. This increases the scrollable range, e.g. in `data-list-view` from ~500'000 to ~26'000'000. The main motivation for this was just to prove that this is possible.

Also, `examples/reformat-id.rs` now supports `#` encoded widget ids.