### PR TITLE
hello example, timed animation

### DIFF
--- a/crates/kas-core/src/draw/mod.rs
+++ b/crates/kas-core/src/draw/mod.rs
@@ -92,6 +92,26 @@ impl WindowCommon {
     pub fn report_dur_text(&mut self, dur: Duration) {
         self.dur_text += dur;
     }
+
+    /// Check whether immediate redraw is required, and if so clear it
+    pub fn immediate_redraw(&mut self) -> bool {
+        match self.anim {
+            AnimationState::None => return false,
+            // AnimationState::Timed(_) => return false,
+            AnimationState::Timed(when) if when > Instant::now() => return false,
+            _ => (),
+        }
+        self.anim = AnimationState::None;
+        true
+    }
+
+    /// Get the next resume time due to animation
+    pub fn next_resume(&self) -> Option<Instant> {
+        match self.anim {
+            AnimationState::Timed(when) => Some(when),
+            _ => None,
+        }
+    }
 }
 
 /// Draw pass identifier

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -642,14 +642,13 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
 
         const SECOND: Duration = Duration::from_secs(1);
         window.frame_count.1 += 1;
-        let now = Instant::now();
-        if window.frame_count.0 + SECOND <= now {
+        if window.frame_count.0 + SECOND <= end {
             log::debug!(
                 "Window {:?}: {} frames in last second",
                 window.window_id,
                 window.frame_count.1
             );
-            window.frame_count.0 = now;
+            window.frame_count.0 = end;
             window.frame_count.1 = 0;
         }
 

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -11,7 +11,7 @@ use super::{AppData, GraphicsInstance, MessageStack, Platform};
 use crate::cast::{Cast, CastApprox};
 use crate::config::{Config, WindowConfig};
 use crate::draw::PassType;
-use crate::draw::{AnimationState, color::Rgba};
+use crate::draw::color::Rgba;
 use crate::event::{ConfigCx, CursorIcon, EventState};
 use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::SolveCache;
@@ -354,8 +354,16 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         }
         self.handle_action(state, action);
 
-        let resume = self.ev_state.next_resume();
         let window = self.window.as_mut().unwrap();
+        let resume = match (
+            self.ev_state.next_resume(),
+            window.surface.common_mut().next_resume(),
+        ) {
+            (None, None) => None,
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (Some(a), Some(b)) => Some(a.min(b)),
+        };
 
         // NOTE: need_frame_update() does not imply a need to redraw, but other
         // approaches do not yield good frame timing for e.g. kinetic scrolling.
@@ -442,6 +450,11 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         let Some(ref mut window) = self.window else {
             return;
         };
+
+        if window.surface.common_mut().immediate_redraw() {
+            window.need_redraw = true;
+            window.request_redraw();
+        }
 
         let mut messages = MessageStack::new();
         let widget = self.widget.as_node(&state.data);
@@ -600,8 +613,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         }
         let time2 = Instant::now();
 
-        let anim = take(&mut window.surface.common_mut().anim);
-        window.need_redraw = anim != AnimationState::None;
+        window.need_redraw = window.surface.common_mut().immediate_redraw();
         self.ev_state.action -= Action::REDRAW;
         // NOTE: we used to return Err(()) if !action.is_empty() here, e.g. if a
         // widget requested a resize during draw. Likely it's better not to do

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -249,7 +249,9 @@ fn main() -> kas::runner::Result<()> {
         "Demonstration of dynamic widget creation / deletion",
         CheckButton::new("Explicit row limit:", |_, data: &Data| data.row_limit)
             .with_msg(Control::SetRowLimit),
-        controls.map(|data: &Data| &data.len),
+        controls
+            .map(|data: &Data| &data.len)
+            .on_update(|cx, _, data: &Data| cx.set_disabled(!data.row_limit)),
         "Contents of selected entry:",
         Text::new(|_, data: &Data| data.active_string.clone()),
         Separator::new(),

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,10 +5,15 @@
 
 //! Hello world example
 
-use kas::widgets::dialog::MessageBox;
+use kas::window::Window;
+use kas_widgets::{Button, column};
 
 fn main() -> kas::runner::Result<()> {
-    let window = MessageBox::new("Message").into_window("Hello world");
+    let ui = column![
+        "Hello, world!",
+        Button::label("&Close").with(|cx, _| cx.exit())
+    ];
+    let window = Window::new(ui, "Hello");
 
     kas::runner::Runner::new(())?.with(window).run()
 }


### PR DESCRIPTION
Avoid continuous redraws with timed animation (e.g. a flashing text cursor). Previously timed animation requests where handled the same way as continuous animation requests.

Update `hello` example to use a declarative UI description instead of just a message box.