### PR TITLE
Access keys: register on draw

### DIFF
--- a/crates/kas-core/src/config/config.rs
+++ b/crates/kas-core/src/config/config.rs
@@ -92,6 +92,7 @@ pub struct WindowConfig {
     pub(super) kinetic_decay_sub: f32,
     pub(super) scroll_dist: f32,
     pub(super) pan_dist_thresh: f32,
+    pub(crate) alt_bypass: bool,
     /// Whether navigation focus is enabled for this application window
     pub(crate) nav_focus: bool,
 }
@@ -107,6 +108,7 @@ impl WindowConfig {
             kinetic_decay_sub: f32::NAN,
             scroll_dist: f32::NAN,
             pan_dist_thresh: f32::NAN,
+            alt_bypass: false,
             nav_focus: true,
         }
     }

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -5,8 +5,8 @@
 
 //! Widget method implementations
 
-use crate::event::{ConfigCx, Event, EventCx, FocusSource, IsUsed, Scroll, Unused};
-use crate::{Events, Id, NavAdvance, Node, Tile, Widget};
+use crate::event::{ConfigCx, Event, EventCx, FocusSource, IsUsed, NavAdvance, Scroll, Unused};
+use crate::{Events, Id, Node, Tile, Widget};
 
 /// Generic implementation of [`Widget::_send`]
 #[inline(always)]

--- a/crates/kas-core/src/core/node.rs
+++ b/crates/kas-core/src/core/node.rs
@@ -6,12 +6,12 @@
 //! Node API for widgets
 
 use super::Widget;
-use crate::event::{ConfigCx, Event, EventCx, IsUsed};
+use crate::event::{ConfigCx, Event, EventCx, IsUsed, NavAdvance};
 use crate::geom::Rect;
 use crate::layout::{AlignHints, AxisInfo, SizeRules};
 use crate::theme::SizeCx;
 use crate::util::IdentifyWidget;
-use crate::{Id, NavAdvance, Tile};
+use crate::{Id, Tile};
 
 #[cfg(not(feature = "unsafe_node"))]
 trait NodeT {

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -9,26 +9,9 @@
 use super::{Node, Tile};
 use crate::Id;
 #[allow(unused)] use crate::event::EventState;
-use crate::event::{ConfigCx, Event, EventCx, IsUsed};
+use crate::event::{ConfigCx, Event, EventCx, IsUsed, NavAdvance};
 #[allow(unused)] use kas_macros as macros;
 use kas_macros::autoimpl;
-
-/// Action of Widget::_nav_next
-#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
-#[cfg_attr(docsrs, doc(cfg(internal_doc)))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum NavAdvance {
-    /// Match only `focus` if navigable
-    None,
-    /// Walk children forwards, self first
-    ///
-    /// Parameter: whether this can match self (in addition to other widgets).
-    Forward(bool),
-    /// Walk children backwards, self last
-    ///
-    /// Parameter: whether this can match self (in addition to other widgets).
-    Reverse(bool),
-}
 
 /// The Widget trait
 ///

--- a/crates/kas-core/src/event/cx/key.rs
+++ b/crates/kas-core/src/event/cx/key.rs
@@ -5,12 +5,12 @@
 
 //! Event context: key handling and selection focus
 
-use super::{EventCx, EventState};
+use super::{EventCx, EventState, NavAdvance};
 #[allow(unused)] use crate::Events;
 use crate::event::{Command, Event, FocusSource};
 use crate::util::WidgetHierarchy;
 use crate::{Action, HasId};
-use crate::{Id, NavAdvance, Node, geom::Rect, runner::WindowDataErased};
+use crate::{Id, Node, geom::Rect, runner::WindowDataErased};
 use std::collections::HashMap;
 use winit::event::{ElementState, Ime, KeyEvent};
 use winit::keyboard::{Key, ModifiersState, PhysicalKey};

--- a/crates/kas-core/src/event/cx/key.rs
+++ b/crates/kas-core/src/event/cx/key.rs
@@ -422,9 +422,12 @@ impl<'a> EventCx<'a> {
         }
 
         if let Some(id) = target {
+            self.close_non_ancestors_of(Some(&id));
+
             if let Some(id) = self.nav_next(widget.re(), Some(&id), NavAdvance::None) {
                 self.set_nav_focus(id, FocusSource::Key);
             }
+
             let event = Event::Command(Command::Activate, Some(code));
             self.send_event(widget, id, event);
         } else if self.config.nav_focus && opt_cmd == Some(Command::Tab) {

--- a/crates/kas-core/src/event/cx/key.rs
+++ b/crates/kas-core/src/event/cx/key.rs
@@ -29,7 +29,7 @@ impl EventState {
     }
 
     pub(crate) fn add_access_key_binding(&mut self, id: &Id, key: &Key) -> bool {
-        if !self.modifiers.alt_key() {
+        if !self.modifiers.alt_key() && !self.config.alt_bypass {
             return false;
         }
 
@@ -37,7 +37,7 @@ impl EventState {
             false
         } else {
             self.access_keys.insert(key.clone(), id.clone());
-            true
+            self.modifiers.alt_key()
         }
     }
 
@@ -195,29 +195,6 @@ impl EventState {
         if let Some(code) = code.into() {
             inner(self, id.has_id(), code);
         }
-    }
-
-    /// Add a new access key layer
-    ///
-    /// This method constructs a new "layer" for access keys: any keys
-    /// added via [`EventState::add_access_key`] to a widget which is a descentant
-    /// of (or equal to) `id` will only be active when that layer is active.
-    ///
-    /// This method should only be called by parents of a pop-up: layers over
-    /// the base layer are *only* activated by an open pop-up.
-    ///
-    /// If `alt_bypass` is true, then this layer's access keys will be
-    /// active even without Alt pressed (but only highlighted with Alt pressed).
-    pub fn new_access_layer(&mut self, id: Id, alt_bypass: bool) {}
-
-    /// Enable `alt_bypass` for layer
-    ///
-    /// This may be called by a child widget during configure to enable or
-    /// disable alt-bypass for the access-key layer containing its access keys.
-    /// This allows access keys to be used as shortcuts without the Alt
-    /// key held. See also [`EventState::new_access_layer`].
-    pub fn enable_alt_bypass(&mut self, id: &Id, alt_bypass: bool) {
-        // TODO
     }
 
     /// End Input Method Editor focus on `target`, if present

--- a/crates/kas-core/src/event/cx/key.rs
+++ b/crates/kas-core/src/event/cx/key.rs
@@ -425,14 +425,14 @@ impl<'a> EventCx<'a> {
             self.close_non_ancestors_of(Some(&id));
 
             if let Some(id) = self.nav_next(widget.re(), Some(&id), NavAdvance::None) {
-                self.set_nav_focus(id, FocusSource::Key);
+                self.request_nav_focus(id, FocusSource::Key);
             }
 
             let event = Event::Command(Command::Activate, Some(code));
             self.send_event(widget, id, event);
         } else if self.config.nav_focus && opt_cmd == Some(Command::Tab) {
             let shift = self.modifiers.shift_key();
-            self.next_nav_focus_impl(widget.re(), None, shift, FocusSource::Key);
+            self.next_nav_focus(None, shift, FocusSource::Key);
         } else if opt_cmd == Some(Command::Escape)
             && let Some(id) = self.popups.last().map(|desc| desc.id)
         {

--- a/crates/kas-core/src/event/cx/key.rs
+++ b/crates/kas-core/src/event/cx/key.rs
@@ -27,14 +27,21 @@ pub(super) struct PendingSelFocus {
 pub(super) type AccessLayer = (bool, HashMap<Key, Id>);
 
 impl EventState {
-    /// True when access key labels should be shown
-    ///
-    /// (True when Alt is held and no widget has character focus.)
-    ///
-    /// This is a fast check.
-    #[inline]
-    pub fn show_access_labels(&self) -> bool {
-        self.modifiers.alt_key()
+    pub(crate) fn clear_access_key_bindings(&mut self) {
+        self.access_keys.clear();
+    }
+
+    pub(crate) fn add_access_key_binding(&mut self, id: &Id, key: &Key) -> bool {
+        if !self.modifiers.alt_key() {
+            return false;
+        }
+
+        if self.access_keys.contains_key(key) {
+            false
+        } else {
+            self.access_keys.insert(key.clone(), id.clone());
+            true
+        }
     }
 
     /// Get the current modifier state

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -7,7 +7,7 @@
 
 use linear_map::{LinearMap, set::LinearSet};
 use smallvec::SmallVec;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
@@ -23,7 +23,7 @@ use crate::runner::{MessageStack, Platform, RunnerT, WindowDataErased};
 use crate::theme::{SizeCx, ThemeSize};
 use crate::window::{PopupDescriptor, Window, WindowId};
 use crate::{Action, HasId, Id, Node};
-use key::{AccessLayer, PendingSelFocus};
+use key::PendingSelFocus;
 use nav::PendingNavFocus;
 
 #[cfg(feature = "accesskit")] mod accessibility;
@@ -85,7 +85,6 @@ pub struct EventState {
     key_depress: LinearMap<PhysicalKey, Id>,
     mouse: Mouse,
     touch: Touch,
-    access_layers: BTreeMap<Id, AccessLayer>,
     access_keys: HashMap<Key, Id>,
     popups: SmallVec<[PopupState; 16]>,
     popup_removed: SmallVec<[(Id, WindowId); 16]>,
@@ -128,7 +127,6 @@ impl EventState {
             key_depress: Default::default(),
             mouse: Default::default(),
             touch: Default::default(),
-            access_layers: Default::default(),
             access_keys: Default::default(),
             popups: Default::default(),
             popup_removed: Default::default(),
@@ -169,10 +167,7 @@ impl EventState {
         log::debug!(target: "kas_core::event", "full_configure of Window{id}");
 
         // These are recreated during configure:
-        self.access_layers.clear();
         self.nav_fallback = None;
-
-        self.new_access_layer(id.clone(), false);
 
         ConfigCx::new(sizer, self).configure(win.as_node(data), id);
         self.action |= Action::REGION_MOVED;

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -7,7 +7,7 @@
 
 use linear_map::{LinearMap, set::LinearSet};
 use smallvec::SmallVec;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::future::Future;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
@@ -86,6 +86,7 @@ pub struct EventState {
     mouse: Mouse,
     touch: Touch,
     access_layers: BTreeMap<Id, AccessLayer>,
+    access_keys: HashMap<Key, Id>,
     popups: SmallVec<[PopupState; 16]>,
     popup_removed: SmallVec<[(Id, WindowId); 16]>,
     time_updates: Vec<(Instant, Id, TimerHandle)>,
@@ -128,6 +129,7 @@ impl EventState {
             mouse: Default::default(),
             touch: Default::default(),
             access_layers: Default::default(),
+            access_keys: Default::default(),
             popups: Default::default(),
             popup_removed: Default::default(),
             time_updates: vec![],

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -6,7 +6,6 @@
 //! Event context state
 
 use linear_map::{LinearMap, set::LinearSet};
-pub(crate) use press::{Mouse, Touch};
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, VecDeque};
 use std::future::Future;
@@ -35,7 +34,9 @@ mod send;
 mod timer;
 mod window;
 
+pub use nav::NavAdvance;
 pub use press::{GrabBuilder, GrabMode, Press, PressSource, PressStart};
+pub(crate) use press::{Mouse, Touch};
 pub use timer::TimerHandle;
 
 struct PopupState {

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -65,7 +65,7 @@ struct PopupState {
 // `SmallVec` is used to keep contents in local memory.
 pub struct EventState {
     pub(crate) window_id: WindowId,
-    config: WindowConfig,
+    pub(crate) config: WindowConfig,
     platform: Platform,
     disabled: Vec<Id>,
     window_has_focus: bool,

--- a/crates/kas-core/src/event/cx/nav.rs
+++ b/crates/kas-core/src/event/cx/nav.rs
@@ -49,23 +49,6 @@ impl PendingNavFocus {
 }
 
 impl EventState {
-    /// Disable or enable navigation focus
-    ///
-    /// When nav focus is disabled, [`EventState::nav_focus`] always returns
-    /// `None`. Any existing focus is immediately cleared. Both
-    /// [`EventState::request_nav_focus`] and [`EventState::next_nav_focus`]
-    /// will fail to do anything. Input such as the <kbd>Tab</kbd> key and mouse
-    /// click will not set navigation focus.
-    pub fn disable_nav_focus(&mut self, disabled: bool) {
-        self.config.nav_focus = !disabled;
-        if disabled {
-            self.pending_nav_focus = PendingNavFocus::Set {
-                target: None,
-                source: FocusSource::Synthetic,
-            };
-        }
-    }
-
     /// Get whether this widget has navigation focus
     #[inline]
     pub fn has_nav_focus(&self, w_id: &Id) -> bool {

--- a/crates/kas-core/src/event/cx/nav.rs
+++ b/crates/kas-core/src/event/cx/nav.rs
@@ -7,8 +7,25 @@
 
 use super::{EventCx, EventState};
 use crate::event::{Event, FocusSource};
-use crate::{Action, Id, NavAdvance, Node};
+use crate::{Action, Id, Node};
 #[allow(unused)] use crate::{Tile, event::Command};
+
+/// Action of Widget::_nav_next
+#[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+#[cfg_attr(docsrs, doc(cfg(internal_doc)))]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum NavAdvance {
+    /// Match only `focus` if navigable
+    None,
+    /// Walk children forwards, self first
+    ///
+    /// Parameter: whether this can match self (in addition to other widgets).
+    Forward(bool),
+    /// Walk children backwards, self last
+    ///
+    /// Parameter: whether this can match self (in addition to other widgets).
+    Reverse(bool),
+}
 
 #[crate::impl_default(PendingNavFocus::None)]
 pub(super) enum PendingNavFocus {

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -6,11 +6,13 @@
 //! Event handling: mouse events
 
 use super::{GrabMode, Press, PressSource, velocity};
-use crate::event::{Event, EventCx, EventState, FocusSource, PressStart, ScrollDelta, TimerHandle};
+use crate::event::{
+    Event, EventCx, EventState, FocusSource, NavAdvance, PressStart, ScrollDelta, TimerHandle,
+};
 use crate::geom::{Affine, Coord, DVec2, Vec2};
 use crate::window::Window;
 use crate::window::WindowErased;
-use crate::{Action, Id, Layout, NavAdvance, Node, TileExt, Widget};
+use crate::{Action, Id, Layout, Node, TileExt, Widget};
 use cast::{CastApprox, CastFloat};
 use std::time::{Duration, Instant};
 use winit::event::{ElementState, MouseButton, MouseScrollDelta};

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -7,10 +7,10 @@
 
 use super::{GrabMode, Press, PressSource, velocity};
 use crate::config::EventWindowConfig;
-use crate::event::{Event, EventCx, EventState, FocusSource, PressStart};
+use crate::event::{Event, EventCx, EventState, FocusSource, NavAdvance, PressStart};
 use crate::geom::{Affine, DVec2, Vec2};
 use crate::window::Window;
-use crate::{Action, Id, Layout, NavAdvance, Node, Widget};
+use crate::{Action, Id, Layout, Node, Widget};
 use cast::{Cast, CastApprox, CastFloat, Conv};
 use smallvec::SmallVec;
 use winit::event::TouchPhase;

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -13,7 +13,7 @@
 #[doc(no_inline)]
 pub use crate::dir::{Direction, Directional};
 #[doc(no_inline)]
-pub use crate::event::{ConfigCx, Event, EventCx, EventState, IsUsed, Unused, Used};
+pub use crate::event::{Command, ConfigCx, Event, EventCx, EventState, IsUsed, Unused, Used};
 #[doc(no_inline)]
 pub use crate::geom::{Coord, Offset, Rect, Size};
 #[doc(no_inline)]

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -591,6 +591,8 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
                 .update_if_active(|| self.ev_state.accesskit_tree_update(&self.widget))
         }
 
+        self.ev_state.clear_access_key_bindings();
+
         {
             let rect = Rect::new(Coord::ZERO, window.surface.size());
             let draw = window

--- a/crates/kas-core/src/text/string.rs
+++ b/crates/kas-core/src/text/string.rs
@@ -95,8 +95,8 @@ impl AccessString {
     }
 
     /// Get the key binding, if any
-    pub fn key(&self) -> Option<Key> {
-        self.key.clone()
+    pub fn key(&self) -> Option<&Key> {
+        self.key.as_ref()
     }
 
     /// Get the text

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -75,6 +75,7 @@ impl std::str::FromStr for Background {
 ///
 /// -   `draw.check_box(&*self, self.state);` — note `&*self` to convert from to
 ///     `&W` from `&mut W`, since the latter would cause borrow conflicts
+#[autoimpl(Debug ignore self.h)]
 pub struct DrawCx<'a> {
     h: &'a mut dyn ThemeDraw,
     id: Id,
@@ -209,24 +210,21 @@ impl<'a> DrawCx<'a> {
         self.h.get_clip_rect()
     }
 
-    /// Register `id` as handler of an access `key`
+    /// Register widget `id` as handler of an access `key`
     ///
     /// An *access key* (also known as mnemonic) is a shortcut key able to
-    /// directly open menus, activate buttons, etc. By default, when the user
-    /// presses (and holds) key <kbd>Alt</kbd>, access keys in labels will be
-    /// underlined and when the user presses the corresponding key then the
-    /// widget registered as handler for that access key will receive navigation
-    /// focus and [`Command::Activate`].
+    /// directly open menus, activate buttons, etc. Usually this requires that
+    /// the <kbd>Alt</kbd> is held, though
+    /// [alt-bypass mode](crate::window::Window::with_alt_bypass) is available.
     ///
-    /// If `id` itself cannot support navigation focus or handle
-    /// [`Command::Activate`], then ancestors of `id` will have the opportunity
-    /// to receive navigation focus and handle this [`Event::Command`].
+    /// The widget `id` is bound to the given `key`, if available. When the
+    /// access key is pressed (assuming that this binding succeeds), widget `id`
+    /// will receive navigation focus (if supported; otherwise an ancestor may
+    /// receive focus) and is sent [`Command::Activate`] (likewise, an ancestor
+    /// may handle this if widget `id` does not).
     ///
     /// If multiple widgets attempt to register themselves as handlers of the
     /// same `key`, then only the first succeeds.
-    ///
-    /// Note that access keys may be automatically derived from labels:
-    /// see [`crate::text::AccessString`].
     ///
     /// Returns `true` when the key should be underlined.
     pub fn access_key(&mut self, id: &Id, key: &Key) -> bool {

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -7,8 +7,7 @@
 
 use winit::keyboard::Key;
 
-use super::{FrameStyle, MarkStyle, SelectionStyle, SizeCx, Text, TextClass, ThemeSize};
-#[allow(unused)] use crate::Layout;
+use super::{FrameStyle, MarkStyle, SelectionStyle, SizeCx, Text, ThemeSize};
 use crate::dir::Direction;
 use crate::draw::color::{ParseError, Rgb};
 use crate::draw::{Draw, DrawIface, DrawShared, DrawSharedImpl, ImageId, PassType};
@@ -17,6 +16,7 @@ use crate::event::{ConfigCx, EventState};
 use crate::geom::{Offset, Rect};
 use crate::text::{Effect, TextDisplay, format::FormattableText};
 use crate::{Id, Tile, autoimpl};
+#[allow(unused)] use crate::{Layout, theme::TextClass};
 use std::ops::Range;
 use std::time::Instant;
 
@@ -277,13 +277,12 @@ impl<'a> DrawCx<'a> {
         text: &Text<T>,
         effects: &[Effect<()>],
     ) {
-        let class = text.class();
         if let Ok(display) = text.display() {
             if effects.is_empty() {
                 // Use the faster and simpler implementation when we don't have effects
-                self.h.text(&self.id, rect, display, class);
+                self.h.text(&self.id, rect, display);
             } else {
-                self.h.text_effects(&self.id, rect, display, effects, class);
+                self.h.text_effects(&self.id, rect, display, effects);
             }
         }
     }
@@ -307,8 +306,7 @@ impl<'a> DrawCx<'a> {
             return;
         };
 
-        self.h
-            .text_selected_range(&self.id, rect, display, range, text.class());
+        self.h.text_selected_range(&self.id, rect, display, range);
     }
 
     /// Draw an edit marker at the given `byte` index on this `text`
@@ -319,9 +317,8 @@ impl<'a> DrawCx<'a> {
     /// [`ConfigCx::text_configure`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
     pub fn text_cursor<T: FormattableText>(&mut self, rect: Rect, text: &Text<T>, byte: usize) {
-        let class = text.class();
         if let Ok(text) = text.display() {
-            self.h.text_cursor(&self.id, rect, text, class, byte);
+            self.h.text_cursor(&self.id, rect, text, byte);
         }
     }
 
@@ -464,7 +461,7 @@ pub trait ThemeDraw {
     ///
     /// [`ConfigCx::text_configure`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
-    fn text(&mut self, id: &Id, rect: Rect, text: &TextDisplay, class: TextClass);
+    fn text(&mut self, id: &Id, rect: Rect, text: &TextDisplay);
 
     /// Draw text with effects
     ///
@@ -477,37 +474,16 @@ pub trait ThemeDraw {
     ///
     /// [`ConfigCx::text_configure`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
-    fn text_effects(
-        &mut self,
-        id: &Id,
-        rect: Rect,
-        text: &TextDisplay,
-        effects: &[Effect<()>],
-        class: TextClass,
-    );
+    fn text_effects(&mut self, id: &Id, rect: Rect, text: &TextDisplay, effects: &[Effect<()>]);
 
     /// Method used to implement [`DrawCx::text_selected`]
-    fn text_selected_range(
-        &mut self,
-        id: &Id,
-        rect: Rect,
-        text: &TextDisplay,
-        range: Range<usize>,
-        class: TextClass,
-    );
+    fn text_selected_range(&mut self, id: &Id, rect: Rect, text: &TextDisplay, range: Range<usize>);
 
     /// Draw an edit marker at the given `byte` index on this `text`
     ///
     /// [`ConfigCx::text_configure`] should be called prior to this method to
     /// select a font, font size and wrap options (based on the [`TextClass`]).
-    fn text_cursor(
-        &mut self,
-        id: &Id,
-        rect: Rect,
-        text: &TextDisplay,
-        class: TextClass,
-        byte: usize,
-    );
+    fn text_cursor(&mut self, id: &Id, rect: Rect, text: &TextDisplay, byte: usize);
 
     /// Draw UI element: check box
     ///

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -230,7 +230,7 @@ impl<'a> DrawCx<'a> {
     ///
     /// Returns `true` when the key should be underlined.
     pub fn access_key(&mut self, id: &Id, key: &Key) -> bool {
-        self.ev_state().show_access_labels()
+        self.ev_state().add_access_key_binding(id, key)
     }
 
     /// Draw a frame inside the given `rect`

--- a/crates/kas-core/src/theme/flat_theme.rs
+++ b/crates/kas-core/src/theme/flat_theme.rs
@@ -20,7 +20,7 @@ use crate::event::EventState;
 use crate::geom::*;
 use crate::text::TextDisplay;
 use crate::theme::dimensions as dim;
-use crate::theme::{Background, FrameStyle, MarkStyle, TextClass};
+use crate::theme::{Background, FrameStyle, MarkStyle};
 use crate::theme::{ColorsLinear, InputState, Theme};
 use crate::theme::{ThemeDraw, ThemeSize};
 

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -334,18 +334,14 @@ where
         rect: Rect,
         text: &TextDisplay,
         effects: &[Effect<()>],
-        class: TextClass,
+        _: TextClass,
     ) {
         let col = if self.ev.is_disabled(id) {
             self.cols.text_disabled
         } else {
             self.cols.text
         };
-        if class.is_access_key() && !self.ev.show_access_labels() {
-            self.draw.text(rect, text, col);
-        } else {
-            self.draw.text_effects(rect, text, col, effects);
-        }
+        self.draw.text_effects(rect, text, col, effects);
     }
 
     fn text_selected_range(

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -19,7 +19,7 @@ use crate::event::EventState;
 use crate::geom::*;
 use crate::text::{Effect, TextDisplay};
 use crate::theme::dimensions as dim;
-use crate::theme::{Background, FrameStyle, MarkStyle, TextClass};
+use crate::theme::{Background, FrameStyle, MarkStyle};
 use crate::theme::{ColorsLinear, InputState, Theme};
 use crate::theme::{SelectionStyle, ThemeDraw, ThemeSize};
 
@@ -319,7 +319,7 @@ where
         }
     }
 
-    fn text(&mut self, id: &Id, rect: Rect, text: &TextDisplay, _: TextClass) {
+    fn text(&mut self, id: &Id, rect: Rect, text: &TextDisplay) {
         let col = if self.ev.is_disabled(id) {
             self.cols.text_disabled
         } else {
@@ -328,14 +328,7 @@ where
         self.draw.text(rect, text, col);
     }
 
-    fn text_effects(
-        &mut self,
-        id: &Id,
-        rect: Rect,
-        text: &TextDisplay,
-        effects: &[Effect<()>],
-        _: TextClass,
-    ) {
+    fn text_effects(&mut self, id: &Id, rect: Rect, text: &TextDisplay, effects: &[Effect<()>]) {
         let col = if self.ev.is_disabled(id) {
             self.cols.text_disabled
         } else {
@@ -350,7 +343,6 @@ where
         rect: Rect,
         text: &TextDisplay,
         range: Range<usize>,
-        _: TextClass,
     ) {
         let col = if self.ev.is_disabled(id) {
             self.cols.text_disabled
@@ -389,7 +381,7 @@ where
         self.draw.text_effects_rgba(rect, text, &effects);
     }
 
-    fn text_cursor(&mut self, id: &Id, rect: Rect, text: &TextDisplay, _: TextClass, byte: usize) {
+    fn text_cursor(&mut self, id: &Id, rect: Rect, text: &TextDisplay, byte: usize) {
         if self.ev.window_has_focus() && !self.w.anim.text_cursor(self.draw.draw, id, byte) {
             return;
         }

--- a/crates/kas-core/src/widgets/mark.rs
+++ b/crates/kas-core/src/widgets/mark.rs
@@ -130,10 +130,7 @@ mod MarkButton {
         type Data = ();
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
-            event.on_activate(cx, self.id(), |cx| {
-                cx.push(self.msg.clone());
-                Used
-            })
+            event.on_click(cx, self.id(), |cx| cx.push(self.msg.clone()))
         }
 
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {

--- a/crates/kas-core/src/window/popup.rs
+++ b/crates/kas-core/src/window/popup.rs
@@ -80,10 +80,6 @@ mod Popup {
     impl Events for Self {
         type Data = W::Data;
 
-        fn configure(&mut self, cx: &mut ConfigCx) {
-            cx.new_access_layer(self.id(), true);
-        }
-
         fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
             if self.win_id.is_some() {
                 let id = self.make_child_id(widget_index!(self.inner));

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -43,6 +43,8 @@ mod Window {
         restrictions: (bool, bool),
         drag_anywhere: bool,
         transparent: bool,
+        alt_bypass: bool,
+        disable_nav_focus: bool,
         #[widget]
         inner: Box<dyn Widget<Data = Data>>,
         #[widget(&())]
@@ -223,6 +225,14 @@ mod Window {
                 // usually preferred where supported (e.g. KDE).
                 self.decorations = Decorations::Toolkit;
             }
+
+            if self.alt_bypass {
+                cx.config.alt_bypass = true;
+            }
+
+            if self.disable_nav_focus {
+                cx.config.nav_focus = false;
+            }
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
@@ -304,6 +314,8 @@ impl<Data: 'static> Window<Data> {
             restrictions: (true, false),
             drag_anywhere: true,
             transparent: false,
+            alt_bypass: false,
+            disable_nav_focus: false,
             inner: ui,
             tooltip: Popup::new(Label::default(), Direction::Down).align(Align::Center),
             title_bar: TitleBar::new(title),
@@ -421,6 +433,24 @@ impl<Data: 'static> Window<Data> {
     /// Default: `false`.
     pub fn with_transparent(mut self, transparent: bool) -> Self {
         self.transparent = transparent;
+        self
+    }
+
+    /// Enable <kbd>Alt</kbd> bypass
+    ///
+    /// Access keys usually require that <kbd>Alt</kbd> be held. This method
+    /// allows access keys to be activated without holding <kbd>Alt</kbd>.
+    pub fn with_alt_bypass(mut self) -> Self {
+        self.alt_bypass = true;
+        self
+    }
+
+    /// Disable navigation focus
+    ///
+    /// Usually, widgets may be focussed and this focus may be navigated using
+    /// the <kbd>Tab</kbd> key. This method prevents widgets from gaining focus.
+    pub fn without_nav_focus(mut self) -> Self {
+        self.disable_nav_focus = true;
         self
     }
 

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -161,13 +161,7 @@ mod Window {
         }
 
         fn draw(&self, mut draw: DrawCx) {
-            if self.dec_size != Size::ZERO {
-                draw.frame(self.rect(), FrameStyle::Window, Default::default());
-                if self.bar_h > 0 {
-                    self.title_bar.draw(draw.re());
-                }
-            }
-            self.inner.draw(draw.re());
+            // Draw access keys first to prioritise their access key bindings
             for (_, popup, translation) in &self.popups {
                 if let Some(child) = self.find_tile(&popup.id) {
                     let clip_rect = child.rect() - *translation;
@@ -176,6 +170,14 @@ mod Window {
                     });
                 }
             }
+
+            if self.dec_size != Size::ZERO {
+                draw.frame(self.rect(), FrameStyle::Window, Default::default());
+                if self.bar_h > 0 {
+                    self.title_bar.draw(draw.re());
+                }
+            }
+            self.inner.draw(draw.re());
         }
     }
 

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -303,7 +303,7 @@ impl<Data: 'static> Window<Data> {
             drag_anywhere: true,
             transparent: false,
             inner: ui,
-            tooltip: Popup::new(Label::default(), Direction::Down, Align::Center),
+            tooltip: Popup::new(Label::default(), Direction::Down).align(Align::Center),
             title_bar: TitleBar::new(title),
             b_w: Border::new(ResizeDirection::West),
             b_e: Border::new(ResizeDirection::East),

--- a/crates/kas-macros/src/extends.rs
+++ b/crates/kas-macros/src/extends.rs
@@ -80,12 +80,12 @@ impl Extends {
                 (#base).selection(rect, style);
             }
 
-            fn text(&mut self, id: &Id, rect: Rect, text: &TextDisplay, class: TextClass) {
-                (#base).text(id, rect, text, class);
+            fn text(&mut self, id: &Id, rect: Rect, text: &TextDisplay) {
+                (#base).text(id, rect, text);
             }
 
-            fn text_effects(&mut self, id: &Id, rect: Rect, text: &TextDisplay, effects: &[::kas::text::Effect<()>], class: TextClass) {
-                (#base).text_effects(id, rect, text, effects, class);
+            fn text_effects(&mut self, id: &Id, rect: Rect, text: &TextDisplay, effects: &[::kas::text::Effect<()>]) {
+                (#base).text_effects(id, rect, text, effects);
             }
 
             fn text_selected_range(
@@ -94,9 +94,8 @@ impl Extends {
                 rect: Rect,
                 text: &TextDisplay,
                 range: Range<usize>,
-                class: TextClass,
             ) {
-                (#base).text_selected_range(id, rect, text, range, class);
+                (#base).text_selected_range(id, rect, text, range);
             }
 
             fn text_cursor(
@@ -104,10 +103,9 @@ impl Extends {
                 id: &Id,
                 rect: Rect,
                 text: &TextDisplay,
-                class: TextClass,
                 byte: usize,
             ) {
-                (#base).text_cursor(id, rect, text, class, byte);
+                (#base).text_cursor(id, rect, text, byte);
             }
 
             fn check_box(&mut self, id: &Id, rect: Rect, checked: bool, last_change: Option<Instant>) {

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -1011,7 +1011,7 @@ fn widget_nav_next() -> Toks {
             cx: &mut ::kas::event::ConfigCx,
             data: &Self::Data,
             focus: Option<&::kas::Id>,
-            advance: ::kas::NavAdvance,
+            advance: ::kas::event::NavAdvance,
         ) -> Option<::kas::Id> {
             ::kas::impls::_nav_next(self, cx, data, focus, advance)
         }

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -629,9 +629,9 @@ pub fn widget(attr_span: Span, scope: &mut Scope) -> Result<()> {
         fn_set_rect = quote! {
             fn set_rect(
                 &mut self,
-                cx: &mut ::kas::event::ConfigCx,
+                _: &mut ::kas::event::ConfigCx,
                 rect: ::kas::geom::Rect,
-                hints: ::kas::layout::AlignHints,
+                _: ::kas::layout::AlignHints,
             ) {
                 #[cfg(debug_assertions)]
                 #core_path.status.set_rect(&#core_path._id);

--- a/crates/kas-macros/src/widget_derive.rs
+++ b/crates/kas-macros/src/widget_derive.rs
@@ -366,7 +366,7 @@ fn derive_widget(attr_span: Span, args: DeriveArgs, scope: &mut Scope) -> Result
             cx: &mut ::kas::event::ConfigCx,
             data: &Self::Data,
             focus: Option<&::kas::Id>,
-            advance: ::kas::NavAdvance,
+            advance: ::kas::event::NavAdvance,
         ) -> Option<::kas::Id> {
             #map_data
             self.#inner._nav_next(cx, data, focus, advance)

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 use kas::event::components::ScrollComponent;
-use kas::event::{Command, CursorIcon, FocusSource, NavAdvance, Scroll, TimerHandle};
+use kas::event::{CursorIcon, FocusSource, NavAdvance, Scroll, TimerHandle};
 use kas::layout::{GridCellInfo, solve_size_rules};
 use kas::prelude::*;
 use kas::theme::SelectionStyle;

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -6,9 +6,8 @@
 //! Grid view controller
 
 use super::*;
-use kas::NavAdvance;
 use kas::event::components::ScrollComponent;
-use kas::event::{Command, CursorIcon, FocusSource, Scroll, TimerHandle};
+use kas::event::{Command, CursorIcon, FocusSource, NavAdvance, Scroll, TimerHandle};
 use kas::layout::{GridCellInfo, solve_size_rules};
 use kas::prelude::*;
 use kas::theme::SelectionStyle;

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -7,7 +7,7 @@
 
 use crate::{DataClerk, DataKey, Driver, SelectionMode, SelectionMsg};
 use kas::event::components::ScrollComponent;
-use kas::event::{Command, CursorIcon, FocusSource, NavAdvance, Scroll, TimerHandle};
+use kas::event::{CursorIcon, FocusSource, NavAdvance, Scroll, TimerHandle};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
 use kas::theme::SelectionStyle;

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -6,9 +6,8 @@
 //! List view controller
 
 use crate::{DataClerk, DataKey, Driver, SelectionMode, SelectionMsg};
-use kas::NavAdvance;
 use kas::event::components::ScrollComponent;
-use kas::event::{Command, CursorIcon, FocusSource, Scroll, TimerHandle};
+use kas::event::{Command, CursorIcon, FocusSource, NavAdvance, Scroll, TimerHandle};
 use kas::layout::solve_size_rules;
 use kas::prelude::*;
 use kas::theme::SelectionStyle;

--- a/crates/kas-wgpu/src/draw/mod.rs
+++ b/crates/kas-wgpu/src/draw/mod.rs
@@ -34,6 +34,23 @@ pub(crate) const RENDER_TEX_FORMAT: TextureFormat = TextureFormat::Bgra8UnormSrg
 
 type Scale = [f32; 4];
 
+#[derive(Debug)]
+struct ClipRegion {
+    rect: Rect,
+    offset: Offset,
+    order: u64,
+}
+
+impl Default for ClipRegion {
+    fn default() -> Self {
+        ClipRegion {
+            rect: Rect::ZERO,
+            offset: Offset::ZERO,
+            order: 1,
+        }
+    }
+}
+
 /// Shared pipeline data
 pub struct DrawPipe<C> {
     pub(crate) adapter: wgpu::Adapter,
@@ -57,7 +74,7 @@ kas::impl_scope! {
     pub struct DrawWindow<CW: CustomWindow> {
         pub(crate) common: WindowCommon,
         scale: Scale,
-        clip_regions: Vec<(Rect, Offset)> = vec![Default::default()],
+        clip_regions: Vec<ClipRegion> = vec![Default::default()],
         images: images::Window,
         shaded_square: shaded_square::Window,
         shaded_round: shaded_round::Window,

--- a/crates/kas-wgpu/src/shaded_theme.rs
+++ b/crates/kas-wgpu/src/shaded_theme.rs
@@ -22,7 +22,7 @@ use kas::text::TextDisplay;
 use kas::theme::dimensions as dim;
 use kas::theme::{Background, ThemeDraw, ThemeSize};
 use kas::theme::{ColorsLinear, FlatTheme, InputState, SimpleTheme, Theme};
-use kas::theme::{FrameStyle, MarkStyle, TextClass};
+use kas::theme::{FrameStyle, MarkStyle};
 
 /// A theme using simple shading to give apparent depth to elements
 #[derive(Clone, Debug)]

--- a/crates/kas-widgets/src/access_label.rs
+++ b/crates/kas-widgets/src/access_label.rs
@@ -159,10 +159,6 @@ mod AccessLabel {
 
         fn configure(&mut self, cx: &mut ConfigCx) {
             cx.text_configure(&mut self.text);
-
-            if let Some(key) = self.text.text().key() {
-                cx.add_access_key(self.id_ref(), key.clone());
-            }
         }
     }
 }

--- a/crates/kas-widgets/src/adapt/adapt_cx.rs
+++ b/crates/kas-widgets/src/adapt/adapt_cx.rs
@@ -103,17 +103,6 @@ impl<'a: 'b, 'b> AdaptConfigCx<'a, 'b> {
         self.cx.set_disabled(self.id.clone(), state);
     }
 
-    /// Enable `alt_bypass` for layer
-    ///
-    /// This may be called by a child widget during configure to enable or
-    /// disable alt-bypass for the access-key layer containing its access keys.
-    /// This allows access keys to be used as shortcuts without the Alt
-    /// key held. See also [`EventState::new_access_layer`].
-    #[inline]
-    pub fn enable_alt_bypass(&mut self, alt_bypass: bool) {
-        self.cx.enable_alt_bypass(&self.id, alt_bypass);
-    }
-
     /// Schedule a timed update
     ///
     /// Widget updates may be used for delayed action. For animation, prefer to

--- a/crates/kas-widgets/src/adapt/with_label.rs
+++ b/crates/kas-widgets/src/adapt/with_label.rs
@@ -12,8 +12,8 @@ use kas::prelude::*;
 mod WithLabel {
     /// A wrapper widget with a label
     ///
-    /// The label supports access keys, which activate `self.inner` on
-    /// usage.
+    /// The label supports access keys; on usage the inner widget will receive
+    /// event `Event::Command(Command::Activate)`.
     ///
     /// Mouse/touch input on the label sends events to the inner widget.
     #[derive(Clone, Default)]
@@ -132,6 +132,7 @@ mod WithLabel {
             let id = self.make_child_id(widget_index!(self.label));
             if id.is_valid() {
                 cx.configure(self.label.as_node(&()), id);
+                self.label.set_target(self.inner.id());
             }
         }
     }

--- a/crates/kas-widgets/src/adapt/with_label.rs
+++ b/crates/kas-widgets/src/adapt/with_label.rs
@@ -127,10 +127,6 @@ mod WithLabel {
             let id = self.make_child_id(widget_index!(self.inner));
             if id.is_valid() {
                 cx.configure(self.inner.as_node(data), id);
-
-                if let Some(key) = self.label.access_key() {
-                    cx.add_access_key(self.inner.id_ref(), key.clone());
-                }
             }
 
             let id = self.make_child_id(widget_index!(self.label));

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -123,11 +123,10 @@ mod Button {
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &W::Data, event: Event) -> IsUsed {
-            event.on_activate(cx, self.id(), |cx| {
+            event.on_click(cx, self.id(), |cx| {
                 if let Some(f) = self.on_press.as_ref() {
                     f(cx, data);
                 }
-                Used
             })
         }
 

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -125,12 +125,6 @@ mod Button {
 
         type Data = W::Data;
 
-        fn configure(&mut self, cx: &mut ConfigCx) {
-            if let Some(key) = self.key.clone() {
-                cx.add_access_key(self.id_ref(), key);
-            }
-        }
-
         fn handle_event(&mut self, cx: &mut EventCx, data: &W::Data, event: Event) -> IsUsed {
             event.on_click(cx, self.id(), |cx| {
                 if let Some(f) = self.on_press.as_ref() {

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -97,6 +97,15 @@ mod Button {
         }
     }
 
+    impl Layout for Self {
+        fn draw(&self, mut draw: DrawCx) {
+            if let Some(key) = self.key.as_ref() {
+                let _ = draw.access_key(self.id_ref(), key);
+            }
+            kas::MacroDefinedLayout::draw(self, draw);
+        }
+    }
+
     impl Tile for Self {
         fn navigable(&self) -> bool {
             true

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -242,6 +242,7 @@ mod CheckButton {
             let id = self.make_child_id(widget_index!(self.label));
             if id.is_valid() {
                 cx.configure(self.label.as_node(&()), id);
+                self.label.set_target(self.inner.id());
             }
         }
 

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -46,10 +46,7 @@ mod CheckBox {
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &A, event: Event) -> IsUsed {
-            event.on_activate(cx, self.id(), |cx| {
-                self.toggle(cx, data);
-                Used
-            })
+            event.on_click(cx, self.id(), |cx| self.toggle(cx, data))
         }
 
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Self::Data) {

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -237,10 +237,6 @@ mod CheckButton {
             let id = self.make_child_id(widget_index!(self.inner));
             if id.is_valid() {
                 cx.configure(self.inner.as_node(data), id);
-
-                if let Some(key) = self.label.access_key() {
-                    cx.add_access_key(self.inner.id_ref(), key.clone());
-                }
             }
 
             let id = self.make_child_id(widget_index!(self.label));

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -171,7 +171,7 @@ mod ComboBox {
                     let target = if cond { press.id } else { None };
                     cx.set_grab_depress(press.source, target.clone());
                     if let Some(id) = target {
-                        cx.set_nav_focus(id, FocusSource::Pointer);
+                        cx.request_nav_focus(id, FocusSource::Pointer);
                     }
                     Used
                 }

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -7,7 +7,7 @@
 
 use crate::adapt::AdaptEvents;
 use crate::{Column, Label, Mark, menu::MenuEntry};
-use kas::event::{Command, FocusSource};
+use kas::event::FocusSource;
 use kas::messages::{Collapse, Expand, SetIndex};
 use kas::prelude::*;
 use kas::theme::FrameStyle;

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -274,7 +274,6 @@ impl<A, V: Clone + Debug + Eq + 'static> ComboBox<A, V> {
                     }
                 }),
                 Direction::Down,
-                Align::TL,
             ),
             active: 0,
             opening: false,

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -14,7 +14,7 @@
 //! and their design is likely to change.
 
 use crate::{Button, EditBox, Filler, Label, adapt::AdaptWidgetAny};
-use kas::event::{Command, NamedKey};
+use kas::event::NamedKey;
 use kas::prelude::*;
 use kas::text::format::FormattableText;
 

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -51,6 +51,7 @@ mod MessageBox {
         }
     }
 
+    // TODO: call register_nav_fallback and close on Command::Escape, Enter
     impl Events for Self {
         type Data = ();
 
@@ -58,10 +59,6 @@ mod MessageBox {
             if let Some(MessageBoxOk) = cx.try_pop() {
                 cx.action(self, Action::CLOSE);
             }
-        }
-
-        fn configure(&mut self, cx: &mut ConfigCx) {
-            cx.enable_alt_bypass(self.id_ref(), true);
         }
     }
 }

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -7,7 +7,7 @@
 
 use crate::{ScrollBar, ScrollMsg};
 use kas::event::components::{ScrollComponent, TextInput, TextInputAction};
-use kas::event::{Command, CursorIcon, ElementState, FocusSource, ImePurpose, PhysicalKey, Scroll};
+use kas::event::{CursorIcon, ElementState, FocusSource, ImePurpose, PhysicalKey, Scroll};
 use kas::geom::Vec2;
 use kas::messages::{ReplaceSelectedText, SetValueText};
 use kas::prelude::*;

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -166,10 +166,6 @@ mod MenuToggle {
             let id = self.make_child_id(widget_index!(self.checkbox));
             if id.is_valid() {
                 cx.configure(self.checkbox.as_node(data), id);
-
-                if let Some(key) = self.label.access_key() {
-                    cx.add_access_key(self.checkbox.id_ref(), key.clone());
-                }
             }
 
             let id = self.make_child_id(widget_index!(self.label));

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -171,6 +171,7 @@ mod MenuToggle {
             let id = self.make_child_id(widget_index!(self.label));
             if id.is_valid() {
                 cx.configure(self.label.as_node(&()), id);
+                self.label.set_target(self.checkbox.id());
             }
         }
 

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -6,7 +6,7 @@
 //! Menubar
 
 use super::{Menu, SubMenu, SubMenuBuilder};
-use kas::event::{Command, FocusSource, TimerHandle};
+use kas::event::{FocusSource, TimerHandle};
 use kas::layout::{self, RowPositionSolver, RowSetter, RowSolver, RulesSetter, RulesSolver};
 use kas::prelude::*;
 use kas::theme::FrameStyle;

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -191,7 +191,7 @@ mod MenuBar {
                             self.delayed_open = None;
                             self.set_menu_path(cx, data, Some(&id), false);
                         } else if id != self.delayed_open {
-                            cx.set_nav_focus(id.clone(), FocusSource::Pointer);
+                            cx.request_nav_focus(id.clone(), FocusSource::Pointer);
                             let delay = cx.config().event().menu_delay();
                             cx.request_timer(self.id(), TIMER_SHOW, delay);
                             self.delayed_open = Some(id);

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -59,7 +59,7 @@ mod SubMenu {
                 core: Default::default(),
                 label: AccessLabel::new(label).with_class(TextClass::MenuLabel),
                 mark: Mark::new(MarkStyle::Chevron(direction), "Open"),
-                popup: Popup::new(MenuView::new(list), direction, Align::TL),
+                popup: Popup::new(MenuView::new(list), direction),
             }
         }
 

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -7,7 +7,7 @@
 
 use super::{BoxedMenu, Menu, SubItems};
 use crate::{AccessLabel, Mark};
-use kas::event::{Command, FocusSource};
+use kas::event::FocusSource;
 use kas::layout::{self, RulesSetter, RulesSolver};
 use kas::messages::{Activate, Collapse, Expand};
 use kas::prelude::*;

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -196,10 +196,6 @@ mod RadioButton {
             let id = self.make_child_id(widget_index!(self.inner));
             if id.is_valid() {
                 cx.configure(self.inner.as_node(data), id);
-
-                if let Some(key) = self.label.access_key() {
-                    cx.add_access_key(self.inner.id_ref(), key.clone());
-                }
             }
 
             let id = self.make_child_id(widget_index!(self.label));

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -201,6 +201,7 @@ mod RadioButton {
             let id = self.make_child_id(widget_index!(self.label));
             if id.is_valid() {
                 cx.configure(self.label.as_node(&()), id);
+                self.label.set_target(self.inner.id());
             }
         }
 

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -45,10 +45,7 @@ mod RadioBox {
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &Self::Data, event: Event) -> IsUsed {
-            event.on_activate(cx, self.id(), |cx| {
-                self.select(cx, data);
-                Used
-            })
+            event.on_click(cx, self.id(), |cx| self.select(cx, data))
         }
 
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Self::Data) {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -7,7 +7,7 @@
 
 use super::{ScrollBar, ScrollMsg};
 use kas::event::components::{ScrollComponent, TextInput, TextInputAction};
-use kas::event::{Command, CursorIcon, FocusSource, Scroll};
+use kas::event::{CursorIcon, FocusSource, Scroll};
 use kas::prelude::*;
 use kas::text::SelectionHelper;
 use kas::text::format::FormattableText;

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -6,7 +6,7 @@
 //! `Slider` control
 
 use super::{GripMsg, GripPart};
-use kas::event::{Command, FocusSource};
+use kas::event::FocusSource;
 use kas::messages::{DecrementStep, IncrementStep, SetValueF64};
 use kas::prelude::*;
 use kas::theme::Feature;

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -393,7 +393,9 @@ mod Slider {
             }
 
             match cx.try_pop() {
-                Some(GripMsg::PressStart) => cx.set_nav_focus(self.id(), FocusSource::Synthetic),
+                Some(GripMsg::PressStart) => {
+                    cx.request_nav_focus(self.id(), FocusSource::Synthetic)
+                }
                 Some(GripMsg::PressMove(pos)) => {
                     self.apply_grip_offset(cx, data, pos);
                 }

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -6,7 +6,6 @@
 //! SpinBox widget
 
 use crate::{EditField, EditGuard, MarkButton};
-use kas::event::Command;
 use kas::messages::{DecrementStep, IncrementStep, ReplaceSelectedText, SetValueF64, SetValueText};
 use kas::prelude::*;
 use kas::theme::{Background, FrameStyle, MarkStyle, Text, TextClass};

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -65,10 +65,7 @@ mod Tab {
         type Data = ();
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &(), event: Event) -> IsUsed {
-            event.on_activate(cx, self.id(), |cx| {
-                cx.push(Select);
-                Used
-            })
+            event.on_click(cx, self.id(), |cx| cx.push(Select))
         }
 
         fn handle_messages(&mut self, cx: &mut EventCx, _: &()) {

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -58,15 +58,11 @@ fn calc_ui() -> Window<()> {
     .map_any();
 
     let ui = Adapt::new(column![display, buttons], Calculator::new())
-        .on_message(|_, calc, key| calc.handle(key))
-        .on_configure(|cx, _| {
-            cx.disable_nav_focus(true);
-
-            // Enable key bindings without Alt held:
-            cx.enable_alt_bypass(true);
-        });
+        .on_message(|_, calc, key| calc.handle(key));
 
     Window::new(ui, "Calculator")
+        .with_alt_bypass()
+        .without_nav_focus()
 }
 
 fn main() -> kas::runner::Result<()> {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -113,7 +113,7 @@ fn widgets() -> Page<AppData> {
         struct {
             core: widget_core!(),
             #[widget] text: Text<Data, String> = format_data!(data: &Data, "{}", &data.text),
-            #[widget(&())] popup: Popup<TextEdit> = Popup::new(TextEdit::new("", true), Direction::Down, Align::TL),
+            #[widget(&())] popup: Popup<TextEdit> = Popup::new(TextEdit::new("", true), Direction::Down),
         }
         impl Events for Self {
             type Data = Data;

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -8,7 +8,7 @@
 //! Demonstrates use of a custom draw pipe.
 
 use kas::draw::{Draw, DrawIface, PassId};
-use kas::event::{self, Command};
+use kas::event::{CursorIcon, GrabMode};
 use kas::geom::{Affine, DVec2, Linear, Vec2, Vec3};
 use kas::prelude::*;
 use kas::widgets::adapt::Reserve;
@@ -420,8 +420,8 @@ mod Mandlebrot {
                 }
                 Event::PressStart(press) => {
                     return press
-                        .grab(self.id(), event::GrabMode::PAN_FULL)
-                        .with_icon(event::CursorIcon::Grabbing)
+                        .grab(self.id(), GrabMode::PAN_FULL)
+                        .with_icon(CursorIcon::Grabbing)
                         .complete(cx);
                 }
                 _ => return Unused,

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -24,7 +24,7 @@ struct Timer {
 
 const TIMER: TimerHandle = TimerHandle::new(0, true);
 
-fn make_window() -> impl Widget<Data = ()> {
+fn make_ui() -> impl Widget<Data = ()> {
     let ui = row![
         format_data!(timer: &Timer, "{}.{:03}", timer.elapsed.as_secs(), timer.elapsed.subsec_millis()),
         Button::label_msg("&reset", MsgReset).map_any(),
@@ -32,7 +32,6 @@ fn make_window() -> impl Widget<Data = ()> {
     ];
 
     ui.with_state(Timer::default())
-        .on_configure(|cx, _| cx.enable_alt_bypass(true))
         .on_message(|_, timer, MsgReset| *timer = Timer::default())
         .on_message(|cx, timer, MsgStart| {
             let now = Instant::now();
@@ -56,7 +55,8 @@ fn make_window() -> impl Widget<Data = ()> {
 fn main() -> kas::runner::Result<()> {
     env_logger::init();
 
-    let window = Window::new(make_window(), "Stopwatch")
+    let window = Window::new(make_ui(), "Stopwatch")
+        .with_alt_bypass()
         .with_decorations(kas::window::Decorations::Border)
         .with_transparent(true)
         .with_restrictions(true, true);


### PR DESCRIPTION
Previously access keys were registered as widgets were configured, then bound to layers per pop-up. Giving stack pages their own layer helped but did not solve issues.

Determining visible widgets through `Tile::child_indices` and registering access keys from that was also considered, but found insufficient.

It turns out that building a hash-set of access-key registrations on each draw is not particularly expensive. In fact, my attempt to benchmark this showed *improved* draw times (slightly suspicious):
```
1. cargo run --example gallery --features nightly-diagnostics,stable --release
2. Tap Alt key repeatedly
3. Copy last 100 lines into 'out'
4. cat out | cut -b 62-64 | paste -sd+ | bc
Before: 59095, 58448
After: 57224, 57743
```
Results are the sum of 100 draws in μs, as reported by `do_draw` under `kas_perf`.

Closes #536.