### PR TITLE
trait DataGenerator

### DIFF
--- a/crates/kas-view/src/data_clerk.rs
+++ b/crates/kas-view/src/data_clerk.rs
@@ -211,7 +211,7 @@ pub trait DataClerk<Index> {
     /// <code>[Token](crate::Token)&lt;[Self::Key], [Self::Item]&gt;</code>.
     type Token: Borrow<Self::Key>;
 
-    /// Update the query
+    /// Update the clerk
     ///
     /// This is called by [`kas::Events::update`]. It should update `self` as
     /// required reflecting possible data-changes and indicate through the

--- a/crates/kas-view/src/generator.rs
+++ b/crates/kas-view/src/generator.rs
@@ -1,0 +1,150 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Data generation (high-level) traits
+
+use crate::{DataChanges, DataClerk, DataKey, DataLen, Token, TokenChanges};
+use kas::Id;
+use kas::event::ConfigCx;
+#[allow(unused)] use kas::{Action, Events, Widget};
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+/// Indicates whether an update to a [`DataGenerator`] has changed
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[must_use]
+pub enum GeneratorChanges {
+    /// `None` indicates that no changes to the data has occurred.
+    None,
+    /// Indicates that [`DataGenerator::len`] may have changed but generated
+    /// values have not changed.
+    LenOnly,
+    /// `Any` indicates that changes to the data set may have occurred.
+    Any,
+}
+
+/// A generator for use with [`GeneratorClerk`]
+///
+/// This provides a substantially simpler interface than [`DataClerk`].
+pub trait DataGenerator<Index> {
+    /// Input data type (of parent widget)
+    ///
+    /// Data of this type is passed through the parent widget; see
+    /// [`Widget::Data`] and the [`Events`] trait. This input data might be used
+    /// to access a data set stored in another widget or to pass a query or
+    /// filter into the `DataClerk`.
+    ///
+    /// Note that it is not currently possible to pass in references to multiple
+    /// data items (such as an external data set and a filter) via `Data`. This
+    /// would require use of Generic Associated Types (GATs), not only here but
+    /// also in the [`Widget`](kas::Widget) trait; alas, GATs are not (yet)
+    /// compatible with dyn traits and Kas requires use of `dyn Widget`. Instead
+    /// one can share the data set (e.g. `Rc<RefCell<DataSet>>`) or store within
+    /// the `DataClerk` using the `clerk` / `clerk_mut` methods to access; in
+    /// both cases it may be necessary to update the view controller explicitly
+    /// (e.g. `cx.update(list.as_node(&input))`) after the data set changes.
+    type Data;
+
+    /// Item type
+    ///
+    /// This is the generated type.
+    type Item: Clone + Default;
+
+    /// Update the generator
+    ///
+    /// This is called by [`kas::Events::update`]. It should update `self` as
+    /// required reflecting possible data-changes and indicate through the
+    /// returned [`GeneratorChanges`] value the updates required to tokens and
+    /// views.
+    ///
+    /// Note: this method is called automatically when input data changes. When
+    /// data owned or referenced by the `DataClerk` implementation is changed it
+    /// may be necessary to explicitly update the view controller, e.g. using
+    /// [`ConfigCx::update`] or [`Action::UPDATE`].
+    ///
+    /// This method may be called frequently and without changes to `data`.
+    fn update(&mut self, data: &Self::Data) -> GeneratorChanges;
+
+    /// Get the number of indexable items
+    ///
+    /// Scroll bars and the `index` values passed to [`Self::generate`] are
+    /// limited by the result of this method.
+    ///
+    /// Where the data set size is a known fixed `len` (or unfixed but with
+    /// maximum `len <= lbound`), this method should return
+    /// <code>[DataLen::Known][](len)</code>.
+    ///
+    /// Where the data set size is unknown (or unfixed and greater than
+    /// `lbound`), this method should return
+    /// <code>[DataLen::LBound][](lbound)</code>.
+    ///
+    /// `lbound` is set to allow scrolling a little beyond the current view
+    /// position (i.e. a little larger than the last prepared `range.end`).
+    fn len(&self, data: &Self::Data, lbound: Index) -> DataLen<Index>;
+
+    /// Generate an item
+    ///
+    /// The `index` will be less than the result of the last call to
+    /// [`Self::len`].
+    fn generate(&self, data: &Self::Data, index: Index) -> Self::Item;
+}
+
+/// An implementation of [`DataClerk`] for data generators
+pub struct GeneratorClerk<Index, G: DataGenerator<Index>> {
+    g: G,
+    _index: PhantomData<Index>,
+}
+
+impl<Index: Default, G: DataGenerator<Index>> GeneratorClerk<Index, G> {
+    /// Construct a `GeneratorClerk`
+    pub fn new(generator: G) -> Self {
+        GeneratorClerk {
+            g: generator,
+            _index: PhantomData,
+        }
+    }
+}
+
+impl<Index: DataKey, G: DataGenerator<Index>> DataClerk<Index> for GeneratorClerk<Index, G> {
+    type Data = G::Data;
+    type Key = Index;
+    type Item = G::Item;
+    type Token = Token<Self::Key, Self::Item>;
+
+    fn update(&mut self, _: &mut ConfigCx, _: Id, data: &Self::Data) -> DataChanges {
+        match self.g.update(data) {
+            GeneratorChanges::None => DataChanges::None,
+            GeneratorChanges::LenOnly => DataChanges::NoPreparedItems,
+            GeneratorChanges::Any => DataChanges::Any,
+        }
+    }
+
+    fn len(&self, data: &Self::Data, lbound: Index) -> DataLen<Index> {
+        self.g.len(data, lbound)
+    }
+
+    fn update_token(
+        &self,
+        data: &Self::Data,
+        index: Index,
+        token: &mut Option<Self::Token>,
+    ) -> TokenChanges {
+        if let Some(token) = token.as_ref()
+            && token.key == index
+        {
+            return TokenChanges::None;
+        }
+
+        *token = Some(Token {
+            key: index.clone(),
+            item: self.g.generate(data, index),
+        });
+        TokenChanges::Any
+    }
+
+    fn item<'r>(&'r self, _: &'r Self::Data, token: &'r Self::Token) -> &'r Self::Item {
+        &token.item
+    }
+}

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -457,7 +457,9 @@ mod GridView {
                     let i = solver.data_to_child(cell);
                     let w = &mut self.widgets[i];
 
-                    let changes = self.clerk.update_token(data, cell, &mut w.token);
+                    let changes =
+                        self.clerk
+                            .update_token(data, cell, self.value_update, &mut w.token);
                     let Some(token) = w.token.as_ref() else {
                         continue;
                     };

--- a/crates/kas-view/src/lib.rs
+++ b/crates/kas-view/src/lib.rs
@@ -19,6 +19,11 @@
 //! A [`DataClerk`] manages all interactions between the view and the data as
 //! well as providing a local cache of (at least) the currently visible data.
 //!
+//! ### Data generators
+//!
+//! A higher-level interface is provided for data generators: [`DataGenerator`]
+//! using clerk [`GeneratorClerk`].
+//!
 //! ## View controller
 //!
 //! This crate provides the following **view controllers**:
@@ -36,8 +41,10 @@
 
 mod data_clerk;
 use std::borrow::Borrow;
+mod generator;
 
 pub use data_clerk::*;
+pub use generator::*;
 
 pub mod filter;
 

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -504,7 +504,9 @@ mod ListView {
             for i in solver.data_range() {
                 let w = &mut self.widgets[i % solver.cur_len];
 
-                let changes = self.clerk.update_token(data, i, &mut w.token);
+                let changes = self
+                    .clerk
+                    .update_token(data, i, self.value_update, &mut w.token);
                 let Some(token) = w.token.as_ref() else {
                     continue;
                 };

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -11,10 +11,9 @@
 //! to calculate the maximum scroll offset).
 
 use kas::prelude::*;
-use kas::view::{DataClerk, Driver, ListView};
+use kas::view::{Driver, ListView};
 use kas::widgets::{column, *};
-use kas_view::{DataChanges, DataLen, TokenChanges};
-use std::borrow::Borrow;
+use kas_view::{DataGenerator, DataLen, GeneratorChanges, GeneratorClerk};
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -32,21 +31,7 @@ enum Control {
 }
 
 #[derive(Debug)]
-struct Token<K, I> {
-    key: K,
-    ver: u64,
-    item: I,
-}
-
-impl<K, I> Borrow<K> for Token<K, I> {
-    fn borrow(&self) -> &K {
-        &self.key
-    }
-}
-
-#[derive(Debug)]
 struct Data {
-    ver: u64,
     row_limit: bool,
     len: usize,
     last_string: usize,
@@ -58,7 +43,6 @@ struct Data {
 impl Data {
     fn new(row_limit: bool, len: usize) -> Self {
         Data {
-            ver: 0,
             row_limit,
             len,
             last_string: len,
@@ -75,7 +59,6 @@ impl Data {
             .unwrap_or_else(|| format!("Entry #{}", index + 1))
     }
     fn handle(&mut self, control: Control) {
-        self.ver = self.ver.wrapping_add(1);
         let len = match control {
             Control::SetRowLimit(row_limit) => {
                 self.row_limit = row_limit;
@@ -166,15 +149,14 @@ mod ListEntry {
 }
 
 #[derive(Default)]
-struct Clerk;
-impl DataClerk<usize> for Clerk {
+struct Generator;
+impl DataGenerator<usize> for Generator {
     type Data = Data;
     type Key = usize;
-    type Token = Token<usize, Item>;
     type Item = Item;
 
-    fn update(&mut self, _: &mut ConfigCx, _: Id, _: &Self::Data) -> DataChanges {
-        DataChanges::Any
+    fn update(&mut self, _: &Self::Data) -> GeneratorChanges {
+        GeneratorChanges::Any
     }
 
     fn len(&self, data: &Self::Data, lbound: usize) -> DataLen<usize> {
@@ -185,33 +167,12 @@ impl DataClerk<usize> for Clerk {
         }
     }
 
-    fn update_token(
-        &self,
-        data: &Self::Data,
-        index: usize,
-        update_item: bool,
-        token: &mut Option<Self::Token>,
-    ) -> TokenChanges {
-        let mut changes = TokenChanges::Any;
-        if let Some(token) = token.as_ref()
-            && token.key == index
-        {
-            if token.ver == data.ver {
-                return TokenChanges::None;
-            }
-            changes = TokenChanges::SameKey;
-        }
-
-        *token = Some(Token {
-            key: index,
-            ver: data.ver,
-            item: (data.active, data.get_string(index)),
-        });
-        changes
+    fn key(&self, _: &Self::Data, index: usize) -> Option<Self::Key> {
+        Some(index)
     }
 
-    fn item<'r>(&'r self, _: &'r Self::Data, token: &'r Self::Token) -> &'r Item {
-        &token.item
+    fn generate(&self, data: &Self::Data, key: &usize) -> Self::Item {
+        (data.active, data.get_string(*key))
     }
 }
 
@@ -256,7 +217,8 @@ fn main() -> kas::runner::Result<()> {
 
     let data = Data::new(false, 5);
 
-    let list = ListView::new(Clerk::default(), MyDriver).on_update(|cx, list, data: &Data| {
+    let clerk = GeneratorClerk::new(Generator::default());
+    let list = ListView::new(clerk, MyDriver).on_update(|cx, list, data: &Data| {
         list.set_direction(cx, data.dir);
     });
     let tree = column![

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -189,6 +189,7 @@ impl DataClerk<usize> for Clerk {
         &self,
         data: &Self::Data,
         index: usize,
+        update_item: bool,
         token: &mut Option<Self::Token>,
     ) -> TokenChanges {
         let mut changes = TokenChanges::Any;

--- a/examples/times-tables.rs
+++ b/examples/times-tables.rs
@@ -21,6 +21,8 @@ impl DataGenerator<GridIndex> for TableCache {
     /// Our table is square; it's size is input.
     type Data = u32;
 
+    type Key = GridIndex;
+
     /// Data items are `u64` since e.g. 65536² is not representable by `u32`.
     type Item = u64;
 
@@ -37,8 +39,12 @@ impl DataGenerator<GridIndex> for TableCache {
         DataLen::Known(GridIndex::splat(self.dim))
     }
 
-    fn generate(&self, _: &Self::Data, index: GridIndex) -> u64 {
-        product(index)
+    fn key(&self, _: &Self::Data, index: GridIndex) -> Option<GridIndex> {
+        Some(index)
+    }
+
+    fn generate(&self, _: &Self::Data, index: &GridIndex) -> u64 {
+        product(*index)
     }
 }
 


### PR DESCRIPTION
Following #546, we add a simpler interface for data generators.

Also adds parameter `update_item` to `fn DataClerk::update_token`.