### PR TITLE
Revise window / shared-runner-state code; add fns add_dataless_window and set_modal_with_parent

### DIFF
--- a/crates/kas-core/src/accesskit.rs
+++ b/crates/kas-core/src/accesskit.rs
@@ -7,7 +7,7 @@
 
 use crate::cast::Cast;
 use crate::geom::Offset;
-use crate::window::{POPUP_INNER_INDEX, Window};
+use crate::window::{POPUP_INNER_INDEX, WindowErased};
 use crate::{Role, RoleCx, TextOrSource, Tile, TileExt};
 use accesskit::{Action, Node, NodeId};
 
@@ -113,7 +113,7 @@ fn push_all_children(
 }
 
 /// Returns a list of nodes and the root node's identifier
-pub(crate) fn window_nodes<Data: 'static>(root: &Window<Data>) -> (Vec<(NodeId, Node)>, NodeId) {
+pub(crate) fn window_nodes(root: &dyn WindowErased) -> (Vec<(NodeId, Node)>, NodeId) {
     let mut nodes = vec![];
     let mut children = push_all_children(root.as_tile(), &mut nodes, false);
 

--- a/crates/kas-core/src/event/cx/accessibility.rs
+++ b/crates/kas-core/src/event/cx/accessibility.rs
@@ -9,7 +9,7 @@ use super::{EventCx, EventState};
 use crate::cast::CastApprox;
 use crate::event::{Command, Event, FocusSource, Scroll, ScrollDelta};
 use crate::geom::{Rect, Size};
-use crate::window::Window;
+use crate::window::WindowErased;
 use crate::{Id, Node, TileExt};
 
 impl EventState {
@@ -19,7 +19,10 @@ impl EventState {
         self.accesskit_is_enabled
     }
 
-    pub(crate) fn accesskit_tree_update<A>(&mut self, root: &Window<A>) -> accesskit::TreeUpdate {
+    pub(crate) fn accesskit_tree_update(
+        &mut self,
+        root: &dyn WindowErased,
+    ) -> accesskit::TreeUpdate {
         self.accesskit_is_enabled = true;
 
         let (nodes, root_id) = crate::accesskit::window_nodes(root);

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -22,7 +22,7 @@ use crate::geom::{Offset, Rect, Vec2};
 use crate::messages::Erased;
 use crate::runner::{Platform, RunnerT, WindowDataErased};
 use crate::theme::{SizeCx, ThemeSize};
-use crate::window::{PopupDescriptor, Window, WindowId};
+use crate::window::{PopupDescriptor, WindowId};
 use crate::{Action, HasId, Id, Node};
 use key::PendingSelFocus;
 use nav::PendingNavFocus;
@@ -159,12 +159,7 @@ impl EventState {
     /// [`Id`] identifiers and call widgets' [`Events::configure`]
     /// method. Additionally, it updates the [`EventState`] to account for
     /// renamed and removed widgets.
-    pub(crate) fn full_configure<A>(
-        &mut self,
-        sizer: &dyn ThemeSize,
-        win: &mut Window<A>,
-        data: &A,
-    ) {
+    pub(crate) fn full_configure(&mut self, sizer: &dyn ThemeSize, node: Node) {
         let id = Id::ROOT.make_child(self.window_id.get().cast());
 
         log::debug!(target: "kas_core::event", "full_configure of Window{id}");
@@ -172,7 +167,7 @@ impl EventState {
         // These are recreated during configure:
         self.nav_fallback = None;
 
-        ConfigCx::new(sizer, self).configure(win.as_node(data), id);
+        ConfigCx::new(sizer, self).configure(node, id);
         self.action |= Action::REGION_MOVED;
     }
 

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -10,9 +10,9 @@ use crate::event::{
     Event, EventCx, EventState, FocusSource, NavAdvance, PressStart, ScrollDelta, TimerHandle,
 };
 use crate::geom::{Affine, Coord, DVec2, Vec2};
-use crate::window::Window;
 use crate::window::WindowErased;
-use crate::{Action, Id, Layout, Node, TileExt, Widget};
+use crate::window::WindowWidget;
+use crate::{Action, Id, Layout, Node, TileExt};
 use cast::{CastApprox, CastFloat};
 use std::time::{Duration, Instant};
 use winit::event::{ElementState, MouseButton, MouseScrollDelta};
@@ -327,7 +327,7 @@ impl<'a> EventCx<'a> {
     /// Handle mouse cursor motion.
     pub(in crate::event::cx) fn handle_cursor_moved<A>(
         &mut self,
-        win: &mut Window<A>,
+        win: &mut dyn WindowWidget<Data = A>,
         data: &A,
         position: DVec2,
     ) {

--- a/crates/kas-core/src/event/cx/window.rs
+++ b/crates/kas-core/src/event/cx/window.rs
@@ -8,7 +8,7 @@
 use super::{EventCx, EventState, PopupState};
 use crate::cast::Cast;
 use crate::event::{Event, FocusSource};
-use crate::runner::{Platform, RunnerT, WindowDataErased};
+use crate::runner::{AppData, Platform, RunnerT, WindowDataErased};
 #[cfg(all(wayland_platform, feature = "clipboard"))]
 use crate::util::warn_about_error;
 use crate::window::{PopupDescriptor, Window, WindowId, WindowWidget};
@@ -222,7 +222,7 @@ impl<'a> EventCx<'a> {
     /// Caveat: if an error occurs opening the new window it will not be
     /// reported (except via log messages).
     #[inline]
-    pub fn add_window<Data: 'static>(&mut self, window: Window<Data>) -> WindowId {
+    pub fn add_window<Data: AppData>(&mut self, window: Window<Data>) -> WindowId {
         let data_type_id = std::any::TypeId::of::<Data>();
         unsafe {
             let window: Window<()> = std::mem::transmute(window);

--- a/crates/kas-core/src/event/cx/window.rs
+++ b/crates/kas-core/src/event/cx/window.rs
@@ -11,8 +11,8 @@ use crate::event::{Event, FocusSource};
 use crate::runner::{Platform, RunnerT, WindowDataErased};
 #[cfg(all(wayland_platform, feature = "clipboard"))]
 use crate::util::warn_about_error;
-use crate::window::{PopupDescriptor, Window, WindowId};
-use crate::{Action, Id, Node, Tile, Widget};
+use crate::window::{PopupDescriptor, Window, WindowId, WindowWidget};
+use crate::{Action, Id, Node, Tile};
 use winit::window::ResizeDirection;
 
 impl EventState {
@@ -356,7 +356,7 @@ impl<'a> EventCx<'a> {
     /// `Resized(size)`, `RedrawRequested`, `HiDpiFactorChanged(factor)`.
     pub(crate) fn handle_winit<A>(
         &mut self,
-        win: &mut Window<A>,
+        win: &mut dyn WindowWidget<Data = A>,
         data: &A,
         event: winit::event::WindowEvent,
     ) {

--- a/crates/kas-core/src/event/cx/window.rs
+++ b/crates/kas-core/src/event/cx/window.rs
@@ -217,8 +217,16 @@ impl<'a> EventCx<'a> {
     ///
     /// Adding the window is infallible. Opening the new window is theoretically
     /// fallible (unlikely assuming a window has already been opened).
+    ///
+    /// If `modal`, then the new `window` is considered owned by this window
+    /// (the window the calling widget belongs to), preventing interaction with
+    /// this window until the new `window` has been closed. **Note:** this is
+    /// mostly unimplemented; see [`Window::set_modal_with_parent`].
     #[inline]
-    pub fn add_dataless_window(&mut self, window: Window<()>) -> WindowId {
+    pub fn add_dataless_window(&mut self, mut window: Window<()>, modal: bool) -> WindowId {
+        if modal {
+            window.set_modal_with_parent(self.window_id);
+        }
         self.runner.add_dataless_window(window)
     }
 

--- a/crates/kas-core/src/event/cx/window.rs
+++ b/crates/kas-core/src/event/cx/window.rs
@@ -209,18 +209,31 @@ impl<'a> EventCx<'a> {
         }
     }
 
-    /// Add a window
+    /// Add a data-less window
     ///
-    /// Typically an application adds at least one window before the event-loop
-    /// starts (see `kas_wgpu::Toolkit::add`), however that method is not
-    /// available to a running UI. This method may be used instead.
+    /// This method may be used to attach a new window to the UI at run-time.
+    /// This method supports windows which do not take data; see also
+    /// [`Self::add_window`].
+    ///
+    /// Adding the window is infallible. Opening the new window is theoretically
+    /// fallible (unlikely assuming a window has already been opened).
+    #[inline]
+    pub fn add_dataless_window(&mut self, window: Window<()>) -> WindowId {
+        self.runner.add_dataless_window(window)
+    }
+
+    /// Add a window able to access top-level app data
+    ///
+    /// This method may be used to attach a new window to the UI at run-time.
+    /// See also [`Self::add_dataless_window`] for a variant which does not
+    /// require a `Data` parameter.
     ///
     /// Requirement: the type `Data` must match the type of data passed to the
     /// [`Runner`](https://docs.rs/kas/latest/kas/runner/struct.Runner.html)
     /// and used by other windows. If not, a run-time error will result.
     ///
-    /// Caveat: if an error occurs opening the new window it will not be
-    /// reported (except via log messages).
+    /// Adding the window is infallible. Opening the new window is theoretically
+    /// fallible (unlikely assuming a window has already been opened).
     #[inline]
     pub fn add_window<Data: AppData>(&mut self, window: Window<Data>) -> WindowId {
         let data_type_id = std::any::TypeId::of::<Data>();

--- a/crates/kas-core/src/runner/common.rs
+++ b/crates/kas-core/src/runner/common.rs
@@ -5,8 +5,8 @@
 
 //! Public items common to all backends
 
-use crate::draw::DrawSharedImpl;
-use crate::draw::{DrawIface, WindowCommon, color::Rgba};
+use crate::draw::color::Rgba;
+use crate::draw::{DrawIface, DrawSharedImpl, WindowCommon};
 use crate::geom::Size;
 use raw_window_handle as rwh;
 use std::time::Instant;

--- a/crates/kas-core/src/runner/event_loop.rs
+++ b/crates/kas-core/src/runner/event_loop.rs
@@ -210,7 +210,14 @@ where
                             .add_popup(&self.data, id, popup);
                     }
                 }
-                Pending::AddWindow(id, mut window) => {
+                Pending::AddWindow(id, window) => {
+                    let mut window = Box::new(Window::new(
+                        self.shared.config.clone(),
+                        self.shared.platform,
+                        id,
+                        window,
+                    ));
+
                     log::debug!("Pending: adding window {}", window.widget.title());
                     if !self.suspended {
                         match window.resume(&mut self.shared, &self.data, el) {

--- a/crates/kas-core/src/runner/event_loop.rs
+++ b/crates/kas-core/src/runner/event_loop.rs
@@ -5,7 +5,7 @@
 
 //! Event loop and handling
 
-use super::{AppData, GraphicsInstance, Pending, State};
+use super::{AppData, GraphicsInstance, Pending, SharedState};
 use super::{ProxyAction, Window};
 use crate::theme::Theme;
 use crate::{Action, window::WindowId};
@@ -28,8 +28,10 @@ where
     popups: HashMap<WindowId, WindowId>,
     /// Translates our WindowId to winit's
     id_map: HashMap<ww::WindowId, WindowId>,
-    /// Application state passed from Toolkit
-    state: State<A, G, T>,
+    /// Shared application state
+    shared: SharedState<A, G, T>,
+    /// User-provided application data
+    data: A,
     /// Timer resumes: (time, window identifier)
     resumes: Vec<(Instant, WindowId)>,
 }
@@ -53,7 +55,7 @@ where
                     first_future = i;
 
                     if let Some(w) = self.windows.get_mut(&resume.1) {
-                        w.update_timer(&mut self.state, resume.0)
+                        w.update_timer(&mut self.shared, &self.data, resume.0)
                     }
                 }
 
@@ -78,7 +80,7 @@ where
             }
             ProxyAction::Message(msg) => {
                 // Message is pushed in self.about_to_wait()
-                self.state.shared.messages.push_erased(msg.into_erased());
+                self.shared.messages.push_erased(msg.into_erased());
             }
             ProxyAction::WakeAsync => {
                 // We don't need to do anything here since about_to_wait will poll all futures.
@@ -88,7 +90,7 @@ where
                 if let Some(id) = self.id_map.get(&window_id)
                     && let Some(window) = self.windows.get_mut(id)
                 {
-                    window.accesskit_event(&mut self.state, event);
+                    window.accesskit_event(&mut self.shared, &self.data, event);
                 }
             }
         }
@@ -97,7 +99,7 @@ where
     fn resumed(&mut self, el: &ActiveEventLoop) {
         if self.suspended {
             for window in self.windows.values_mut() {
-                match window.resume(&mut self.state, el) {
+                match window.resume(&mut self.shared, &self.data, el) {
                     Ok(winit_id) => {
                         self.id_map.insert(winit_id, window.window_id());
                     }
@@ -118,7 +120,7 @@ where
     ) {
         if let Some(id) = self.id_map.get(&window_id)
             && let Some(window) = self.windows.get_mut(id)
-            && window.handle_event(&mut self.state, event)
+            && window.handle_event(&mut self.shared, &self.data, event)
         {
             el.set_control_flow(ControlFlow::Poll);
         }
@@ -126,11 +128,11 @@ where
 
     fn about_to_wait(&mut self, el: &ActiveEventLoop) {
         self.flush_pending(el);
-        self.state.handle_messages();
+        self.shared.handle_messages(&mut self.data);
 
         // Distribute inter-window messages.
         // NOTE: sending of these messages will be delayed until the next call to flush_pending.
-        while let Some((id, msg)) = self.state.shared.send_queue.pop_front() {
+        while let Some((id, msg)) = self.shared.send_queue.pop_front() {
             let mut window_id = id.window_id();
             if let Some(win_id) = self.popups.get(&window_id) {
                 window_id = *win_id;
@@ -155,8 +157,9 @@ where
     fn suspended(&mut self, _: &ActiveEventLoop) {
         if !self.suspended {
             self.windows
-                .retain(|_, window| window.suspend(&mut self.state));
-            self.state.suspended();
+                .retain(|_, window| window.suspend(&mut self.shared, &self.data));
+            self.data.suspended();
+            self.shared.suspended();
             self.suspended = true;
         }
     }
@@ -170,20 +173,25 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Loop<A, G, T>
 where
     T::Window: kas::theme::Window,
 {
-    pub(super) fn new(mut windows: Vec<Box<Window<A, G, T>>>, state: State<A, G, T>) -> Self {
+    pub(super) fn new(
+        mut windows: Vec<Box<Window<A, G, T>>>,
+        shared: SharedState<A, G, T>,
+        data: A,
+    ) -> Self {
         Loop {
             suspended: true,
             windows: windows.drain(..).map(|w| (w.window_id(), w)).collect(),
             popups: Default::default(),
             id_map: Default::default(),
-            state,
+            shared,
+            data,
             resumes: vec![],
         }
     }
 
     fn flush_pending(&mut self, el: &ActiveEventLoop) {
         let mut close_all = false;
-        while let Some(pending) = self.state.shared.pending.pop_front() {
+        while let Some(pending) = self.shared.pending.pop_front() {
             match pending {
                 Pending::AddPopup(parent_id, id, popup) => {
                     log::debug!("Pending: adding overlay");
@@ -191,22 +199,21 @@ where
                     self.windows
                         .get_mut(&parent_id)
                         .unwrap()
-                        .add_popup(&mut self.state, id, popup);
+                        .add_popup(&self.data, id, popup);
                     self.popups.insert(id, parent_id);
                 }
                 Pending::RepositionPopup(id, popup) => {
                     if let Some(parent_id) = self.popups.get(&id) {
-                        self.windows.get_mut(parent_id).unwrap().add_popup(
-                            &mut self.state,
-                            id,
-                            popup,
-                        );
+                        self.windows
+                            .get_mut(parent_id)
+                            .unwrap()
+                            .add_popup(&self.data, id, popup);
                     }
                 }
                 Pending::AddWindow(id, mut window) => {
                     log::debug!("Pending: adding window {}", window.widget.title());
                     if !self.suspended {
-                        match window.resume(&mut self.state, el) {
+                        match window.resume(&mut self.shared, &self.data, el) {
                             Ok(winit_id) => {
                                 self.id_map.insert(winit_id, id);
                             }
@@ -233,7 +240,7 @@ where
                         el.set_control_flow(ControlFlow::Poll);
                     } else {
                         for (_, window) in self.windows.iter_mut() {
-                            window.handle_action(&mut self.state, action);
+                            window.handle_action(&mut self.shared, &self.data, action);
                         }
                     }
                 }
@@ -243,18 +250,18 @@ where
 
         self.resumes.clear();
         self.windows.retain(|window_id, window| {
-            let (action, resume) = window.flush_pending(&mut self.state);
+            let (action, resume) = window.flush_pending(&mut self.shared, &self.data);
             if let Some(instant) = resume {
                 self.resumes.push((instant, *window_id));
             }
 
             if close_all || action.contains(Action::CLOSE) {
-                window.suspend(&mut self.state);
+                window.suspend(&mut self.shared, &self.data);
 
                 // Call flush_pending again since suspend may queue messages.
                 // We don't care about the returned Action or resume times since
                 // the window is being destroyed.
-                let _ = window.flush_pending(&mut self.state);
+                let _ = window.flush_pending(&mut self.shared, &self.data);
 
                 self.id_map.retain(|_, v| v != window_id);
                 false

--- a/crates/kas-core/src/runner/event_loop.rs
+++ b/crates/kas-core/src/runner/event_loop.rs
@@ -99,7 +99,7 @@ where
     fn resumed(&mut self, el: &ActiveEventLoop) {
         if self.suspended {
             for window in self.windows.values_mut() {
-                match window.resume(&mut self.shared, &self.data, el) {
+                match window.resume(&mut self.shared, &self.data, el, None) {
                     Ok(winit_id) => {
                         self.id_map.insert(winit_id, window.window_id());
                     }
@@ -220,7 +220,13 @@ where
 
                     log::debug!("Pending: adding window {}", window.widget.title());
                     if !self.suspended {
-                        match window.resume(&mut self.shared, &self.data, el) {
+                        let mut modal_parent = None;
+                        if let Some(id) = window.widget.properties().modal_parent {
+                            if let Some(window) = self.windows.get(&id) {
+                                modal_parent = window.winit_window();
+                            }
+                        }
+                        match window.resume(&mut self.shared, &self.data, el, modal_parent) {
                             Ok(winit_id) => {
                                 self.id_map.insert(winit_id, id);
                             }

--- a/crates/kas-core/src/runner/event_loop.rs
+++ b/crates/kas-core/src/runner/event_loop.rs
@@ -5,7 +5,7 @@
 
 //! Event loop and handling
 
-use super::{AppData, GraphicsInstance, Pending, SharedState};
+use super::{AppData, GraphicsInstance, Pending, Shared};
 use super::{ProxyAction, Window};
 use crate::theme::Theme;
 use crate::{Action, window::WindowId};
@@ -29,7 +29,7 @@ where
     /// Translates our WindowId to winit's
     id_map: HashMap<ww::WindowId, WindowId>,
     /// Shared application state
-    shared: SharedState<A, G, T>,
+    shared: Shared<A, G, T>,
     /// User-provided application data
     data: A,
     /// Timer resumes: (time, window identifier)
@@ -175,7 +175,7 @@ where
 {
     pub(super) fn new(
         mut windows: Vec<Box<Window<A, G, T>>>,
-        shared: SharedState<A, G, T>,
+        shared: Shared<A, G, T>,
         data: A,
     ) -> Self {
         Loop {

--- a/crates/kas-core/src/runner/mod.rs
+++ b/crates/kas-core/src/runner/mod.rs
@@ -15,7 +15,7 @@ use crate::messages::Erased;
 use crate::window::{PopupDescriptor, WindowId};
 use event_loop::Loop;
 pub(crate) use shared::RunnerT;
-use shared::State;
+use shared::SharedState;
 use std::fmt::Debug;
 pub use window::Window;
 pub(crate) use window::WindowDataErased;

--- a/crates/kas-core/src/runner/mod.rs
+++ b/crates/kas-core/src/runner/mod.rs
@@ -15,7 +15,7 @@ use crate::messages::Erased;
 use crate::window::{PopupDescriptor, WindowId};
 use event_loop::Loop;
 pub(crate) use shared::RunnerT;
-use shared::SharedState;
+use shared::Shared;
 use std::fmt::Debug;
 pub use window::Window;
 pub(crate) use window::WindowDataErased;

--- a/crates/kas-core/src/runner/runner.rs
+++ b/crates/kas-core/src/runner/runner.rs
@@ -5,7 +5,7 @@
 
 //! [`Runner`] and supporting elements
 
-use super::{AppData, GraphicsInstance, Platform, ProxyAction, Result, SharedState};
+use super::{AppData, GraphicsInstance, Platform, ProxyAction, Result, Shared};
 use crate::config::{Config, ConfigFactory};
 #[allow(unused)] use crate::event::ConfigCx;
 use crate::theme::Theme;
@@ -77,7 +77,7 @@ impl PreLaunchState {
         theme: T,
         windows: Vec<Box<super::Window<Data, G, T>>>,
     ) -> Result<()> {
-        let shared = SharedState::new(
+        let shared = Shared::new(
             self.platform,
             graphical,
             theme,

--- a/crates/kas-core/src/runner/runner.rs
+++ b/crates/kas-core/src/runner/runner.rs
@@ -5,7 +5,7 @@
 
 //! [`Runner`] and supporting elements
 
-use super::{AppData, GraphicsInstance, Platform, ProxyAction, Result, State};
+use super::{AppData, GraphicsInstance, Platform, ProxyAction, Result, SharedState};
 use crate::config::{Config, ConfigFactory};
 #[allow(unused)] use crate::event::ConfigCx;
 use crate::theme::Theme;
@@ -77,9 +77,8 @@ impl PreLaunchState {
         theme: T,
         windows: Vec<Box<super::Window<Data, G, T>>>,
     ) -> Result<()> {
-        let state = State::new(
+        let shared = SharedState::new(
             self.platform,
-            data,
             graphical,
             theme,
             self.config,
@@ -90,7 +89,7 @@ impl PreLaunchState {
             self.window_id_factory,
         )?;
 
-        let mut l = super::Loop::new(windows, state);
+        let mut l = super::Loop::new(windows, shared, data);
         self.el.run_app(&mut l)?;
         Ok(())
     }

--- a/crates/kas-core/src/runner/runner.rs
+++ b/crates/kas-core/src/runner/runner.rs
@@ -77,7 +77,7 @@ impl PreLaunchState {
         theme: T,
         windows: Vec<Box<super::Window<Data, G, T>>>,
     ) -> Result<()> {
-        let shared = Shared::new(
+        let shared = Shared::<Data, _, _>::new(
             self.platform,
             graphical,
             theme,

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -266,7 +266,7 @@ impl<Data: AppData, G: GraphicsInstance, T: Theme<G::Shared>> RunnerT for Shared
             self.config.clone(),
             self.platform,
             id,
-            Box::new(window),
+            window.boxed(),
         ));
         self.pending.push_back(Pending::AddWindow(id, window));
         id

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -33,7 +33,7 @@ pub(super) struct Shared<Data: AppData, G: GraphicsInstance, T: Theme<G::Shared>
     pub(super) draw: Option<SharedState<G::Shared>>,
     pub(super) theme: T,
     pub(super) messages: MessageStack,
-    pub(super) pending: VecDeque<Pending<Data, G, T>>,
+    pub(super) pending: VecDeque<Pending<Data>>,
     pub(super) send_queue: VecDeque<(Id, Erased)>,
     send_targets: HashMap<TypeId, Id>,
     pub(super) waker: Waker,
@@ -262,13 +262,8 @@ impl<Data: AppData, G: GraphicsInstance, T: Theme<G::Shared>> RunnerT for Shared
         // handled to create the winit window here or use statics to generate
         // errors now, but user code can't do much with this error anyway.
         let id = self.window_id_factory.make_next();
-        let window = Box::new(super::Window::new(
-            self.config.clone(),
-            self.platform,
-            id,
-            window.boxed(),
-        ));
-        self.pending.push_back(Pending::AddWindow(id, window));
+        self.pending
+            .push_back(Pending::AddWindow(id, window.boxed()));
         id
     }
 

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -154,13 +154,10 @@ pub(crate) trait RunnerT {
     /// Resize and reposition an existing pop-up
     fn reposition_popup(&mut self, id: WindowId, popup: PopupDescriptor);
 
-    /// Add a window
-    ///
-    /// Toolkits typically allow windows to be added directly, before start of
-    /// the event loop (e.g. `kas_wgpu::Toolkit::add`).
-    ///
-    /// This method is an alternative allowing a window to be added from an
-    /// event handler, albeit without error handling.
+    /// Add a window to the UI at run-time.
+    fn add_dataless_window(&mut self, window: WindowWidget<()>) -> WindowId;
+
+    /// Add a window to the UI at run-time.
     ///
     /// Safety: this method *should* require generic parameter `Data` (data type
     /// passed to the `Runner`). Realising this would require adding this type
@@ -245,6 +242,13 @@ impl<Data: AppData, G: GraphicsInstance, T: Theme<G::Shared>> RunnerT for Shared
 
     fn reposition_popup(&mut self, id: WindowId, popup: PopupDescriptor) {
         self.pending.push_back(Pending::RepositionPopup(id, popup));
+    }
+
+    fn add_dataless_window(&mut self, window: WindowWidget<()>) -> WindowId {
+        let id = self.window_id_factory.make_next();
+        self.pending
+            .push_back(Pending::AddWindow(id, window.map_any().boxed()));
+        id
     }
 
     unsafe fn add_window(&mut self, window: WindowWidget<()>, data_type_id: TypeId) -> WindowId {

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -266,7 +266,7 @@ impl<Data: AppData, G: GraphicsInstance, T: Theme<G::Shared>> RunnerT for Shared
             self.config.clone(),
             self.platform,
             id,
-            window,
+            Box::new(window),
         ));
         self.pending.push_back(Pending::AddWindow(id, window));
         id

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -217,6 +217,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         // NOTE: usage of Arc is inelegant, but avoids lots of unsafe code
         let window = Arc::new(window);
         let mut surface = state
+            .shared
             .instance
             .new_surface(window.clone(), self.widget.transparent())?;
         state.resume(&surface)?;

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -17,7 +17,7 @@ use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::SolveCache;
 use crate::messages::Erased;
 use crate::theme::{DrawCx, SizeCx, Theme, ThemeDraw, ThemeSize, Window as _};
-use crate::window::{Decorations, PopupDescriptor, Window as WindowWidget, WindowErased, WindowId};
+use crate::window::{Decorations, PopupDescriptor, Window as WindowWidget, WindowWidget as _, WindowErased, WindowId};
 use crate::{Action, Id, Layout, Tile, Widget, autoimpl};
 use std::cell::RefCell;
 use std::mem::take;

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -17,7 +17,7 @@ use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::SolveCache;
 use crate::messages::Erased;
 use crate::theme::{DrawCx, SizeCx, Theme, ThemeDraw, ThemeSize, Window as _};
-use crate::window::{Decorations, PopupDescriptor, Window as WindowWidget, WindowWidget as _, WindowErased, WindowId};
+use crate::window::{Decorations, PopupDescriptor, WindowId, WindowWidget};
 use crate::{Action, Id, Layout, Tile, Widget, autoimpl};
 use std::cell::RefCell;
 use std::mem::take;
@@ -54,7 +54,7 @@ struct WindowData<G: GraphicsInstance, T: Theme<G::Shared>> {
 #[autoimpl(Debug ignore self._data, self.widget, self.ev_state, self.window)]
 pub struct Window<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> {
     _data: std::marker::PhantomData<A>,
-    pub(super) widget: WindowWidget<A>,
+    pub(super) widget: Box<dyn WindowWidget<Data = A>>,
     ev_state: EventState,
     window: Option<WindowData<G, T>>,
 }
@@ -66,7 +66,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         config: Rc<RefCell<Config>>,
         platform: Platform,
         window_id: WindowId,
-        widget: WindowWidget<A>,
+        widget: Box<dyn WindowWidget<Data = A>>,
     ) -> Self {
         let config = WindowConfig::new(config);
         Window {

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -111,10 +111,9 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         let config = self.ev_state.config();
         let mut theme_window = shared.theme.new_window(config);
 
-        self.ev_state
-            .full_configure(theme_window.size(), &mut self.widget, data);
+        let mut node = self.widget.as_node(data);
+        self.ev_state.full_configure(theme_window.size(), node.re());
 
-        let node = self.widget.as_node(data);
         let sizer = SizeCx::new(theme_window.size());
         let mut solve_cache = SolveCache::find_constraints(node, sizer);
 
@@ -164,10 +163,9 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
             shared.theme.update_window(&mut theme_window, config);
 
             // Update text size which is assigned during configure
-            self.ev_state
-                .full_configure(theme_window.size(), &mut self.widget, data);
+            let mut node = self.widget.as_node(data);
+            self.ev_state.full_configure(theme_window.size(), node.re());
 
-            let node = self.widget.as_node(data);
             let sizer = SizeCx::new(theme_window.size());
             solve_cache = SolveCache::find_constraints(node, sizer);
 
@@ -263,7 +261,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
 
             let action = self
                 .ev_state
-                .flush_pending(shared, window, &mut self.widget, data);
+                .flush_pending(shared, window, self.widget.as_node(data));
 
             self.window = None;
             !action.contains(Action::CLOSE)
@@ -342,7 +340,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
 
         let action = self
             .ev_state
-            .flush_pending(shared, window, &mut self.widget, data);
+            .flush_pending(shared, window, self.widget.as_node(data));
 
         if action.contains(Action::CLOSE) {
             return (action, None);
@@ -509,7 +507,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         };
 
         self.ev_state
-            .full_configure(window.theme_window.size(), &mut self.widget, data);
+            .full_configure(window.theme_window.size(), self.widget.as_node(data));
 
         log::trace!(target: "kas_perf::wgpu::window", "reconfigure: {}µs", time.elapsed().as_micros());
     }

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -17,7 +17,7 @@ use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::SolveCache;
 use crate::messages::Erased;
 use crate::theme::{DrawCx, SizeCx, Theme, ThemeDraw, ThemeSize, Window as _};
-use crate::window::{Decorations, PopupDescriptor, WindowId, WindowWidget};
+use crate::window::{BoxedWindow, Decorations, PopupDescriptor, WindowId, WindowWidget};
 use crate::{Action, Id, Layout, Tile, Widget, autoimpl};
 use std::cell::RefCell;
 use std::mem::take;
@@ -66,12 +66,12 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         config: Rc<RefCell<Config>>,
         platform: Platform,
         window_id: WindowId,
-        widget: Box<dyn WindowWidget<Data = A>>,
+        widget: BoxedWindow<A>,
     ) -> Self {
         let config = WindowConfig::new(config);
         Window {
             _data: std::marker::PhantomData,
-            widget,
+            widget: widget.0,
             ev_state: EventState::new(window_id, config, platform),
             window: None,
         }

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -6,7 +6,7 @@
 //! Window types
 
 use super::common::WindowSurface;
-use super::shared::SharedState;
+use super::shared::Shared;
 use super::{AppData, GraphicsInstance, Platform};
 use crate::cast::{Cast, CastApprox};
 use crate::config::{Config, WindowConfig};
@@ -85,7 +85,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
     /// Open (resume) a window
     pub(super) fn resume(
         &mut self,
-        shared: &mut SharedState<A, G, T>,
+        shared: &mut Shared<A, G, T>,
         data: &A,
         el: &ActiveEventLoop,
     ) -> super::Result<winit::window::WindowId> {
@@ -257,7 +257,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
     /// Close (suspend) the window, keeping state (widget)
     ///
     /// Returns `true` unless this `Window` should be destoyed.
-    pub(super) fn suspend(&mut self, shared: &mut SharedState<A, G, T>, data: &A) -> bool {
+    pub(super) fn suspend(&mut self, shared: &mut Shared<A, G, T>, data: &A) -> bool {
         if let Some(ref mut window) = self.window {
             self.ev_state.suspended(shared);
 
@@ -277,7 +277,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
     /// Returns `true` to force polling temporarily.
     pub(super) fn handle_event(
         &mut self,
-        shared: &mut SharedState<A, G, T>,
+        shared: &mut Shared<A, G, T>,
         data: &A,
         event: WindowEvent,
     ) -> bool {
@@ -333,7 +333,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
     /// Handle all pending items before event loop sleeps
     pub(super) fn flush_pending(
         &mut self,
-        shared: &mut SharedState<A, G, T>,
+        shared: &mut Shared<A, G, T>,
         data: &A,
     ) -> (Action, Option<Instant>) {
         let Some(ref window) = self.window else {
@@ -377,7 +377,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
     /// Handle an action (excludes handling of CLOSE and EXIT)
     pub(super) fn handle_action(
         &mut self,
-        shared: &mut SharedState<A, G, T>,
+        shared: &mut Shared<A, G, T>,
         data: &A,
         mut action: Action,
     ) {
@@ -422,7 +422,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
     #[cfg(feature = "accesskit")]
     pub(super) fn accesskit_event(
         &mut self,
-        shared: &mut SharedState<A, G, T>,
+        shared: &mut Shared<A, G, T>,
         data: &A,
         event: accesskit_winit::WindowEvent,
     ) {
@@ -448,7 +448,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
 
     pub(super) fn update_timer(
         &mut self,
-        shared: &mut SharedState<A, G, T>,
+        shared: &mut Shared<A, G, T>,
         data: &A,
         requested_resume: Instant,
     ) {
@@ -566,11 +566,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
     ///
     /// Returns an error when drawing is aborted and further event handling may
     /// be needed before a redraw.
-    pub(super) fn do_draw(
-        &mut self,
-        shared: &mut SharedState<A, G, T>,
-        data: &A,
-    ) -> Result<(), ()> {
+    pub(super) fn do_draw(&mut self, shared: &mut Shared<A, G, T>, data: &A) -> Result<(), ()> {
         let start = Instant::now();
         let Some(ref mut window) = self.window else {
             return Ok(());

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -83,6 +83,7 @@ pub(crate) struct Properties {
     escapable: bool,
     alt_bypass: bool,
     disable_nav_focus: bool,
+    pub(crate) modal_parent: Option<WindowId>,
 }
 
 impl Default for Properties {
@@ -96,6 +97,7 @@ impl Default for Properties {
             escapable: false,
             alt_bypass: false,
             disable_nav_focus: false,
+            modal_parent: None,
         }
     }
 }
@@ -598,6 +600,22 @@ impl<Data: AppData> Window<Data> {
     pub fn without_nav_focus(mut self) -> Self {
         self.props.disable_nav_focus = true;
         self
+    }
+
+    /// Set the window as being modal with the given `parent`
+    ///
+    /// If set, this window is considered modal: it is owned by `parent`, is not
+    /// listed on the taskbar, and prevents interaction with `parent` until it
+    /// has been closed.
+    ///
+    /// **Implementation status:** partially implement on Windows only.
+    /// This feature uses [`WindowAttributesExtWindows`]'s `with_owner_window`
+    /// and `with_skip_taskbar` methods where available.
+    /// Winit currently provides no equivalents for other platforms.
+    ///
+    /// [`WindowAttributesExtWindows`]: https://docs.rs/winit/latest/winit/platform/windows/trait.WindowAttributesExtWindows.html
+    pub fn set_modal_with_parent(&mut self, parent: WindowId) {
+        self.props.modal_parent = Some(parent);
     }
 }
 

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -11,6 +11,7 @@ use crate::dir::{Direction, Directional};
 use crate::event::{Command, ConfigCx, Event, EventCx, IsUsed, Scroll, Unused, Used};
 use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::{self, Align, AlignHints, AxisInfo, SizeRules};
+use crate::runner::AppData;
 use crate::theme::{DrawCx, FrameStyle, SizeCx};
 use crate::widgets::{Border, Label, TitleBar};
 use crate::{Action, Events, Id, Layout, Role, RoleCx, Tile, TileExt, Widget};
@@ -133,7 +134,7 @@ mod Window {
     ///
     /// [`kas::messages::SetWindowIcon`] may be used to set the icon.
     #[widget]
-    pub struct Window<Data: 'static> {
+    pub struct Window<Data: AppData> {
         core: widget_core!(),
         props: Properties,
         #[widget]
@@ -411,7 +412,7 @@ mod Window {
     }
 }
 
-impl<Data: 'static> Window<Data> {
+impl<Data: AppData> Window<Data> {
     /// Construct a window with a `W: Widget` and a title
     pub fn new(ui: impl Widget<Data = Data> + 'static, title: impl ToString) -> Self {
         Self::new_boxed(Box::new(ui), title)
@@ -562,7 +563,7 @@ impl<Data: 'static> Window<Data> {
     }
 }
 
-impl<Data: 'static> WindowWidget for Window<Data> {
+impl<Data: AppData> WindowWidget for Window<Data> {
     fn add_popup(&mut self, cx: &mut ConfigCx, data: &Data, id: WindowId, popup: PopupDescriptor) {
         let index = 'index: {
             for i in 0..self.popups.len() {
@@ -600,7 +601,7 @@ impl<Data: 'static> WindowWidget for Window<Data> {
     }
 }
 
-impl<Data: 'static> Window<Data> {
+impl<Data: AppData> Window<Data> {
     fn resize_popup(&mut self, cx: &mut ConfigCx, data: &Data, index: usize) {
         // Notation: p=point/coord, s=size, m=margin
         // r=window/root rect, c=anchor rect

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -13,6 +13,7 @@ use crate::geom::{Coord, Offset, Rect, Size};
 use crate::layout::{self, Align, AlignHints, AxisInfo, SizeRules};
 use crate::runner::AppData;
 use crate::theme::{DrawCx, FrameStyle, SizeCx};
+use crate::widgets::adapt::MapAny;
 use crate::widgets::{Border, Label, TitleBar};
 use crate::{Action, Events, Id, Layout, Role, RoleCx, Tile, TileExt, Widget};
 use kas_macros::{autoimpl, impl_self, widget_set_rect};
@@ -411,6 +412,34 @@ mod Window {
                 .field("core", &self.core)
                 .field("title", &self.title_bar.title())
                 .finish()
+        }
+    }
+}
+
+impl Window<()> {
+    /// Map data type.
+    ///
+    /// Expectation: the window will be configured and sized after this.
+    pub(crate) fn map_any<Data: AppData>(self) -> Window<Data> {
+        Window {
+            core: Default::default(),
+            props: self.props,
+            // TODO(opt): maybe we shoudn't box here?
+            inner: Box::new(MapAny::new(self.inner)),
+            tooltip: self.tooltip,
+            title_bar: self.title_bar,
+            b_w: self.b_w,
+            b_e: self.b_e,
+            b_n: self.b_n,
+            b_s: self.b_s,
+            b_nw: self.b_nw,
+            b_ne: self.b_ne,
+            b_sw: self.b_sw,
+            b_se: self.b_se,
+            bar_h: 0,
+            dec_offset: Default::default(),
+            dec_size: Default::default(),
+            popups: self.popups,
         }
     }
 }

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -23,6 +23,10 @@ pub(crate) trait WindowErased: Tile {
     fn close_tooltip(&mut self, cx: &mut EventCx);
 }
 
+pub(crate) trait WindowWidget: WindowErased + Widget {}
+
+impl<W: WindowErased + Widget> WindowWidget for W {}
+
 /// Window properties
 pub(crate) struct Properties {
     icon: Option<Icon>, // initial icon, if any
@@ -610,7 +614,7 @@ impl<Data: 'static> Window<Data> {
         };
         self.popups[index].2 = t;
         let r = r + t; // work in translated coordinate space
-        let result = self.as_node(data).find_node(&popup.id, |mut node| {
+        let result = Widget::as_node(self, data).find_node(&popup.id, |mut node| {
             let mut cache = layout::SolveCache::find_constraints(node.re(), cx.size_cx());
             let ideal = cache.ideal(false);
             let m = cache.margins();

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -121,6 +121,9 @@ impl Properties {
     }
 }
 
+/// A boxed [`Window`]
+pub struct BoxedWindow<Data: 'static>(pub(crate) Box<dyn WindowWidget<Data = Data>>);
+
 #[impl_self]
 mod Window {
     /// The window widget
@@ -439,6 +442,12 @@ impl<Data: AppData> Window<Data> {
             dec_size: Default::default(),
             popups: Default::default(),
         }
+    }
+
+    /// Convert into a [`BoxedWindow`]
+    #[inline]
+    pub fn boxed(self) -> BoxedWindow<Data> {
+        BoxedWindow(Box::new(self))
     }
 
     /// Get the window's title

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -50,6 +50,11 @@ mod MessageBox {
         pub fn into_window<A: AppData>(self, title: impl ToString) -> Window<A> {
             Window::new(self.map_any(), title).with_restrictions(true, true)
         }
+
+        /// Display as a modal window with the given `title`
+        pub fn display(self, cx: &mut EventCx, title: impl ToString) {
+            cx.add_dataless_window(self.into_window(title));
+        }
     }
 
     // TODO: call register_nav_fallback and close on Command::Escape, Enter

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -16,6 +16,7 @@
 use crate::{Button, EditBox, Filler, Label, adapt::AdaptWidgetAny};
 use kas::event::NamedKey;
 use kas::prelude::*;
+use kas::runner::AppData;
 use kas::text::format::FormattableText;
 
 #[derive(Copy, Clone, Debug)]
@@ -46,7 +47,7 @@ mod MessageBox {
         }
 
         /// Build a [`Window`]
-        pub fn into_window<A: 'static>(self, title: impl ToString) -> Window<A> {
+        pub fn into_window<A: AppData>(self, title: impl ToString) -> Window<A> {
             Window::new(self.map_any(), title).with_restrictions(true, true)
         }
     }
@@ -122,7 +123,7 @@ mod TextEdit {
         }
 
         /// Build a [`Window`]
-        pub fn into_window<A: 'static>(self, title: impl ToString) -> Window<A> {
+        pub fn into_window<A: AppData>(self, title: impl ToString) -> Window<A> {
             Window::new(self.map_any(), title)
         }
 

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -53,7 +53,7 @@ mod MessageBox {
 
         /// Display as a modal window with the given `title`
         pub fn display(self, cx: &mut EventCx, title: impl ToString) {
-            cx.add_dataless_window(self.into_window(title));
+            cx.add_dataless_window(self.into_window(title), true);
         }
     }
 

--- a/examples/text-editor/text-editor.rs
+++ b/examples/text-editor/text-editor.rs
@@ -6,6 +6,7 @@
 //! A simple text editor
 
 use kas::prelude::*;
+use kas::widgets::dialog::MessageBox;
 use kas::widgets::{Button, EditBox, EditField, EditGuard, Filler, column, row};
 use std::error::Error;
 
@@ -61,6 +62,14 @@ mod Editor {
 
         fn handle_messages(&mut self, cx: &mut EventCx<'_>, _: &()) {
             if let Some(msg) = cx.try_pop() {
+                if self.editor.guard().edited
+                    && matches!(msg, EditorAction::New | EditorAction::Open)
+                {
+                    MessageBox::new("Refusing operation due to edited contents")
+                        .display(cx, "Open document");
+                    return;
+                }
+
                 match msg {
                     EditorAction::New => {
                         self.editor.set_string(cx, String::new());

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -237,7 +237,7 @@ where
             self.state.config().clone(),
             self.state.platform(),
             id,
-            Box::new(window),
+            window.boxed(),
         ));
         self.windows.push(win);
         id

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -237,7 +237,7 @@ where
             self.state.config().clone(),
             self.state.platform(),
             id,
-            window,
+            Box::new(window),
         ));
         self.windows.push(win);
         id


### PR DESCRIPTION
Various non-API-breaking revisions to runner (window and shared state) code. `enum Pending` drops two generic parameters. `runner::Window` could theoretically be instantiated for multiple input data types now, though I opted not to do so.

Add fn `EventCx::add_dataless_window`: this is like `add_window` except does not require the user to provide the input data type (and does not allow the new window to access said data). Note that this is a workaround since adding the runner input data type to `EventCx` as a generic parameter would be enormously disruptive.

Add fn `Window::set_modal_with_parent`. This uses [`with_owner_window`](https://docs.rs/winit/latest/winit/platform/windows/trait.WindowAttributesExtWindows.html#tymethod.with_owner_window) and `with_skip_taskbar` on Windows but is otherwise unimplemented. Testing (through wine) shows that the taskbar is skipped but input to the parent window is not prevented. Ugh. I like the API at least.

`kas::widgets::dialog::MessageBox` gains fn `display` using this and `examples/text-editor` uses that to prevent new/open ops over edited content. Both are quick hacks needing further work.