### PR TITLE
Move fn probe to trait Events

### DIFF
--- a/crates/kas-core/src/core/events.rs
+++ b/crates/kas-core/src/core/events.rs
@@ -7,9 +7,9 @@
 
 #[allow(unused)] use super::Layout;
 use super::{Tile, Widget};
-use crate::Id;
 #[allow(unused)] use crate::event::EventState;
 use crate::event::{ConfigCx, CursorIcon, Event, EventCx, IsUsed, Scroll, Unused};
+use crate::{Id, geom::Coord};
 #[allow(unused)] use kas_macros as macros;
 
 /// Widget event-handling
@@ -86,6 +86,42 @@ pub trait Events: Widget + Sized {
     #[inline]
     fn make_child_id(&mut self, index: usize) -> Id {
         self.id_ref().make_child(index)
+    }
+
+    /// Probe a coordinate for a widget's [`Id`]
+    ///
+    /// Returns the [`Id`] of the widget expected to handle clicks and touch
+    /// events at the given `coord`. Typically this is the lowest descendant in
+    /// the widget tree at the given `coord`, but it is not required to be; e.g.
+    /// a `Button` may use an inner widget as a label but return its own [`Id`]
+    /// to indicate that the button (not the inner label) handles clicks.
+    ///
+    /// # Calling
+    ///
+    /// Call [`Layout::try_probe`] instead.
+    ///
+    /// # Implementation
+    ///
+    /// The callee may usually assume that it occupies `coord` and may thus
+    /// return its own [`Id`] when no child occupies the input `coord`.
+    /// If there are cases where a click within [`Layout::rect`] should be
+    /// considered a miss (non-rectangular hit-testing) then
+    /// [`Layout::try_probe`] must be implemented instead.
+    ///
+    /// If the [`Tile::translation`] is non-zero for any child, then the
+    /// coordinate passed to that child must be translated:
+    /// `coord + translation`.
+    ///
+    /// ## Default implementation
+    ///
+    /// The default implementation returns `self.id()` and may be used for
+    /// childless widgets. If the [`layout`](macro@crate::layout) attribute
+    /// macro is used or an explicit implementation of [`Layout::try_probe`] is
+    /// provided, these are used instead of the default implementation of this
+    /// method.
+    fn probe(&self, coord: Coord) -> Id {
+        let _ = coord;
+        self.id()
     }
 
     /// Configure self

--- a/crates/kas-core/src/core/layout.rs
+++ b/crates/kas-core/src/core/layout.rs
@@ -30,13 +30,6 @@ use kas_macros::autoimpl;
 /// `#[impl_self]`) or provide default implementations of its methods (if an
 /// explicit impl of `Layout` is found but some methods are missing).
 ///
-/// ## Foreign items
-///
-/// The [`#widget`] macro permits implementation of the following items within
-/// `impl Layout`:
-///
-/// -   `fn` [`LayoutFnProbe::probe`]
-///
 /// [`#widget`]: macros::widget
 #[autoimpl(for<T: trait + ?Sized> &'_ mut T, Box<T>)]
 pub trait Layout {
@@ -143,7 +136,7 @@ pub trait Layout {
     /// # Implementation
     ///
     /// In most cases widgets should implement
-    /// [`fn probe`](LayoutFnProbe::probe) instead; the `#[widget]` macro can
+    /// [`Events::probe`] instead; the `#[widget]` macro can
     /// use it to implement `try_probe` as follows:
     /// ```ignore
     /// self.rect().contains(coord).then(|| self.probe(coord))
@@ -155,7 +148,7 @@ pub trait Layout {
     /// implementation which simply returns `None`.
     ///
     /// Widgets without any children (including layout children) may use the
-    /// default implementation of [`fn probe`](LayoutFnProbe::probe).
+    /// default implementation of [`Events::probe`].
     fn try_probe(&self, coord: Coord) -> Option<Id> {
         let _ = coord;
         None
@@ -190,43 +183,6 @@ pub trait Layout {
     /// limitation that widgets cannot easily detect a parent's state while
     /// being drawn).
     fn draw(&self, draw: DrawCx);
-}
-
-/// `fn probe` for [`Layout`]
-///
-/// This trait should not be implemented directly. Instead, the
-/// [`widget`](crate::widget) macro allows implementation of
-/// [`probe`](Self::probe) within an implementation of [`Layout`].
-pub trait LayoutFnProbe: Sized {
-    /// Probe a coordinate for a widget's [`Id`]
-    ///
-    /// Returns the [`Id`] of the widget expected to handle clicks and touch
-    /// events at the given `coord`. Typically this is the lowest descendant in
-    /// the widget tree at the given `coord`, but it is not required to be; e.g.
-    /// a `Button` may use an inner widget as a label but return its own [`Id`]
-    /// to indicate that the button (not the inner label) handles clicks.
-    ///
-    /// # Calling
-    ///
-    /// Call [`Layout::try_probe`] instead.
-    ///
-    /// # Implementation
-    ///
-    /// The callee may usually assume that it occupies `coord` and may thus
-    /// return its own [`Id`] when no child occupies the input `coord`.
-    /// If there are cases where a click within [`Layout::rect`] should be
-    /// considered a miss (non-rectangular hit-testing) then
-    /// [`Layout::try_probe`] must be implemented instead.
-    ///
-    /// If the [`Tile::translation`] is non-zero for any child, then the
-    /// coordinate passed to that child must be translated:
-    /// `coord + translation`.
-    ///
-    /// ## Default implementation
-    ///
-    /// The `#[widget]` macro provides a default implementation returning the
-    /// result of [`Tile::id`] for childless widgets.
-    fn probe(&self, coord: Coord) -> Id;
 }
 
 /// Macro-defined layout

--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -283,6 +283,16 @@ mod Window {
             }
             self.inner.draw(draw.re());
         }
+    }
+
+    impl Tile for Self {
+        fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
+            Role::Window
+        }
+    }
+
+    impl Events for Self {
+        type Data = Data;
 
         fn probe(&self, coord: Coord) -> Id {
             for (_, popup, translation) in self.popups.iter().rev() {
@@ -309,16 +319,6 @@ mod Window {
                 .or_else(|| self.b_se.try_probe(coord))
                 .unwrap_or_else(|| self.id())
         }
-    }
-
-    impl Tile for Self {
-        fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
-            Role::Window
-        }
-    }
-
-    impl Events for Self {
-        type Data = Data;
 
         fn configure(&mut self, cx: &mut ConfigCx) {
             if cx.platform().is_wayland() && self.props.decorations == Decorations::Server {

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -767,23 +767,6 @@ mod GridView {
                 }
             });
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            if self.scroll.is_kinetic_scrolling() {
-                return self.id();
-            }
-
-            let num = self.cur_end();
-            let coord = coord + self.translation(0);
-            for child in &self.widgets[..num] {
-                if child.token.is_some()
-                    && let Some(id) = child.item.try_probe(coord)
-                {
-                    return id;
-                }
-            }
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -835,6 +818,23 @@ mod GridView {
         fn make_child_id(&mut self, _: usize) -> Id {
             // We configure children in map_view_widgets and do not want this method to be called
             unimplemented!()
+        }
+
+        fn probe(&self, coord: Coord) -> Id {
+            if self.scroll.is_kinetic_scrolling() {
+                return self.id();
+            }
+
+            let num = self.cur_end();
+            let coord = coord + self.translation(0);
+            for child in &self.widgets[..num] {
+                if child.token.is_some()
+                    && let Some(id) = child.item.try_probe(coord)
+                {
+                    return id;
+                }
+            }
+            self.id()
         }
 
         fn configure(&mut self, cx: &mut ConfigCx) {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -773,22 +773,6 @@ mod ListView {
                 }
             });
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            if self.scroll.is_kinetic_scrolling() {
-                return self.id();
-            }
-
-            let coord = coord + self.translation(0);
-            for child in &self.widgets[..self.cur_len.cast()] {
-                if child.token.is_some()
-                    && let Some(id) = child.item.try_probe(coord)
-                {
-                    return id;
-                }
-            }
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -840,6 +824,22 @@ mod ListView {
         fn make_child_id(&mut self, _: usize) -> Id {
             // We configure children in map_view_widgets and do not want this method to be called
             unimplemented!()
+        }
+
+        fn probe(&self, coord: Coord) -> Id {
+            if self.scroll.is_kinetic_scrolling() {
+                return self.id();
+            }
+
+            let coord = coord + self.translation(0);
+            for child in &self.widgets[..self.cur_len.cast()] {
+                if child.token.is_some()
+                    && let Some(id) = child.item.try_probe(coord)
+                {
+                    return id;
+                }
+            }
+            self.id()
         }
 
         fn configure(&mut self, cx: &mut ConfigCx) {

--- a/crates/kas-widgets/src/adapt/with_label.rs
+++ b/crates/kas-widgets/src/adapt/with_label.rs
@@ -104,12 +104,6 @@ mod WithLabel {
         }
     }
 
-    impl Layout for Self {
-        fn probe(&self, _: Coord) -> Id {
-            self.inner.id()
-        }
-    }
-
     impl Tile for Self {
         fn role_child_properties(&self, cx: &mut dyn RoleCx, index: usize) {
             if index == widget_index!(self.inner) {
@@ -124,6 +118,10 @@ mod WithLabel {
 
     impl Events for Self {
         type Data = W::Data;
+
+        fn probe(&self, _: Coord) -> Id {
+            self.inner.id()
+        }
 
         fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
             let id = self.make_child_id(widget_index!(self.inner));

--- a/crates/kas-widgets/src/button.rs
+++ b/crates/kas-widgets/src/button.rs
@@ -104,10 +104,6 @@ mod Button {
             }
             kas::MacroDefinedLayout::draw(self, draw);
         }
-
-        fn probe(&self, _: Coord) -> Id {
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -124,6 +120,10 @@ mod Button {
         const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = W::Data;
+
+        fn probe(&self, _: Coord) -> Id {
+            self.id()
+        }
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &W::Data, event: Event) -> IsUsed {
             event.on_click(cx, self.id(), |cx| {

--- a/crates/kas-widgets/src/check_box.rs
+++ b/crates/kas-widgets/src/check_box.rs
@@ -212,10 +212,6 @@ mod CheckButton {
             let dir = self.direction();
             shrink_to_text(&mut self.rect(), dir, &self.label);
         }
-
-        fn probe(&self, _: Coord) -> Id {
-            self.inner.id()
-        }
     }
 
     impl Tile for Self {
@@ -232,6 +228,10 @@ mod CheckButton {
 
     impl Events for Self {
         type Data = A;
+
+        fn probe(&self, _: Coord) -> Id {
+            self.inner.id()
+        }
 
         fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
             let id = self.make_child_id(widget_index!(self.inner));

--- a/crates/kas-widgets/src/combobox.rs
+++ b/crates/kas-widgets/src/combobox.rs
@@ -52,12 +52,6 @@ mod ComboBox {
         on_select: Option<Box<dyn Fn(&mut EventCx, V)>>,
     }
 
-    impl Layout for Self {
-        fn probe(&self, _: Coord) -> Id {
-            self.id()
-        }
-    }
-
     impl Tile for Self {
         fn navigable(&self) -> bool {
             true
@@ -81,6 +75,10 @@ mod ComboBox {
         const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = A;
+
+        fn probe(&self, _: Coord) -> Id {
+            self.id()
+        }
 
         fn update(&mut self, cx: &mut ConfigCx, data: &A) {
             let msg = (self.state_fn)(cx, data);

--- a/crates/kas-widgets/src/edit.rs
+++ b/crates/kas-widgets/src/edit.rs
@@ -426,18 +426,6 @@ mod EditBox {
                 self.vert_bar.draw(draw.re());
             }
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            if self.scroll.max_offset().1 > 0 {
-                if let Some(id) = self.vert_bar.try_probe(coord) {
-                    return id;
-                }
-            }
-
-            // If coord is over self but not over self.vert_bar, we assign
-            // the event to self.inner without further question.
-            self.inner.id()
-        }
     }
 
     impl Tile for Self {
@@ -459,6 +447,18 @@ mod EditBox {
 
     impl Events for Self {
         type Data = G::Data;
+
+        fn probe(&self, coord: Coord) -> Id {
+            if self.scroll.max_offset().1 > 0 {
+                if let Some(id) = self.vert_bar.try_probe(coord) {
+                    return id;
+                }
+            }
+
+            // If coord is over self but not over self.vert_bar, we assign
+            // the event to self.inner without further question.
+            self.inner.id()
+        }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             let rect = Rect {
@@ -936,10 +936,6 @@ mod EditField {
         fn draw(&self, draw: DrawCx) {
             self.draw_with_offset(draw, self.rect(), Offset::ZERO);
         }
-
-        fn probe(&self, _: Coord) -> Id {
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -961,6 +957,10 @@ mod EditField {
         const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = G::Data;
+
+        fn probe(&self, _: Coord) -> Id {
+            self.id()
+        }
 
         #[inline]
         fn mouse_over_icon(&self) -> Option<CursorIcon> {

--- a/crates/kas-widgets/src/float.rs
+++ b/crates/kas-widgets/src/float.rs
@@ -148,6 +148,16 @@ mod Float {
                 }
             }
         }
+    }
+
+    impl Tile for Self {
+        fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
+            Role::None
+        }
+    }
+
+    impl Events for Self {
+        type Data = C::Data;
 
         fn probe(&self, coord: Coord) -> Id {
             for i in 0..self.widgets.len() {
@@ -158,12 +168,6 @@ mod Float {
                 }
             }
             self.id()
-        }
-    }
-
-    impl Tile for Self {
-        fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
-            Role::None
         }
     }
 }

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -210,6 +210,16 @@ mod Grid {
                 }
             }
         }
+    }
+
+    impl Tile for Self {
+        fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
+            Role::None
+        }
+    }
+
+    impl Events for Self {
+        type Data = C::Data;
 
         fn probe(&self, coord: Coord) -> Id {
             for n in 0..self.widgets.len() {
@@ -220,12 +230,6 @@ mod Grid {
                 }
             }
             self.id()
-        }
-    }
-
-    impl Tile for Self {
-        fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
-            Role::None
         }
     }
 }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -293,14 +293,6 @@ mod List {
             let solver = RowPositionSolver::new(self.direction);
             solver.for_children(&self.widgets, draw.get_clip_rect(), |w| w.draw(draw.re()));
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            let solver = RowPositionSolver::new(self.direction);
-            solver
-                .find_child(&self.widgets, coord)
-                .and_then(|child| child.try_probe(coord))
-                .unwrap_or_else(|| self.id())
-        }
     }
 
     impl Tile for Self {
@@ -339,6 +331,14 @@ mod List {
                     return self.id_ref().make_child(key);
                 }
             }
+        }
+
+        fn probe(&self, coord: Coord) -> Id {
+            let solver = RowPositionSolver::new(self.direction);
+            solver
+                .find_child(&self.widgets, coord)
+                .and_then(|child| child.try_probe(coord))
+                .unwrap_or_else(|| self.id())
         }
 
         fn configure(&mut self, _: &mut ConfigCx) {

--- a/crates/kas-widgets/src/menu/menu_entry.rs
+++ b/crates/kas-widgets/src/menu/menu_entry.rs
@@ -38,10 +38,6 @@ mod MenuEntry {
             draw.frame(self.rect(), FrameStyle::MenuEntry, Default::default());
             self.label.draw(draw.re());
         }
-
-        fn probe(&self, _: Coord) -> Id {
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -82,6 +78,10 @@ mod MenuEntry {
 
     impl Events for Self {
         type Data = ();
+
+        fn probe(&self, _: Coord) -> Id {
+            self.id()
+        }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
@@ -145,10 +145,6 @@ mod MenuToggle {
             draw.frame(self.rect(), FrameStyle::MenuEntry, Default::default());
             kas::MacroDefinedLayout::draw(self, draw);
         }
-
-        fn probe(&self, _: Coord) -> Id {
-            self.checkbox.id()
-        }
     }
 
     impl Tile for Self {
@@ -161,6 +157,10 @@ mod MenuToggle {
 
     impl Events for Self {
         type Data = A;
+
+        fn probe(&self, _: Coord) -> Id {
+            self.checkbox.id()
+        }
 
         fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
             let id = self.make_child_id(widget_index!(self.checkbox));

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -106,14 +106,6 @@ mod MenuBar {
             let rect = self.rect();
             solver.for_children(&self.widgets, rect, |w| w.draw(draw.re()));
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            let solver = RowPositionSolver::new(self.direction);
-            solver
-                .find_child(&self.widgets, coord)
-                .and_then(|child| child.try_probe(coord))
-                .unwrap_or_else(|| self.id())
-        }
     }
 
     impl Tile for Self {
@@ -131,6 +123,14 @@ mod MenuBar {
     }
 
     impl Events for Self {
+        fn probe(&self, coord: Coord) -> Id {
+            let solver = RowPositionSolver::new(self.direction);
+            solver
+                .find_child(&self.widgets, coord)
+                .and_then(|child| child.try_probe(coord))
+                .unwrap_or_else(|| self.id())
+        }
+
         fn handle_event(&mut self, cx: &mut EventCx, data: &Data, event: Event) -> IsUsed {
             match event {
                 Event::Timer(TIMER_SHOW) => {

--- a/crates/kas-widgets/src/menu/submenu.rs
+++ b/crates/kas-widgets/src/menu/submenu.rs
@@ -114,10 +114,6 @@ mod SubMenu {
                 self.mark.draw(draw.re());
             }
         }
-
-        fn probe(&self, _: Coord) -> Id {
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -139,6 +135,10 @@ mod SubMenu {
 
     impl Events for Self {
         type Data = Data;
+
+        fn probe(&self, _: Coord) -> Id {
+            self.id()
+        }
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &Data, event: Event) -> IsUsed {
             match event {
@@ -354,15 +354,6 @@ mod MenuView {
                 child.draw(draw.re());
             }
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            for child in self.list.iter() {
-                if let Some(id) = child.try_probe(coord) {
-                    return id;
-                }
-            }
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -376,6 +367,17 @@ mod MenuView {
         }
         fn get_child(&self, index: usize) -> Option<&dyn Tile> {
             self.list.get(index).map(|w| w.as_tile())
+        }
+    }
+
+    impl Events for Self {
+        fn probe(&self, coord: Coord) -> Id {
+            for child in self.list.iter() {
+                if let Some(id) = child.try_probe(coord) {
+                    return id;
+                }
+            }
+            self.id()
         }
     }
 

--- a/crates/kas-widgets/src/radio_box.rs
+++ b/crates/kas-widgets/src/radio_box.rs
@@ -171,10 +171,6 @@ mod RadioButton {
             let dir = self.direction();
             crate::check_box::shrink_to_text(&mut self.rect(), dir, &self.label);
         }
-
-        fn probe(&self, _: Coord) -> Id {
-            self.inner.id()
-        }
     }
 
     impl Tile for Self {
@@ -191,6 +187,10 @@ mod RadioButton {
 
     impl Events for Self {
         type Data = A;
+
+        fn probe(&self, _: Coord) -> Id {
+            self.inner.id()
+        }
 
         fn configure_recurse(&mut self, cx: &mut ConfigCx, data: &Self::Data) {
             let id = self.make_child_id(widget_index!(self.inner));

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -123,16 +123,6 @@ mod ScrollRegion {
                 self.inner.draw(draw.re());
             });
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            if self.scroll.is_kinetic_scrolling() {
-                return self.id();
-            }
-
-            self.inner
-                .try_probe(coord + self.scroll_offset())
-                .unwrap_or_else(|| self.id())
-        }
     }
 
     impl Tile for Self {
@@ -151,6 +141,16 @@ mod ScrollRegion {
 
     impl Events for Self {
         type Data = W::Data;
+
+        fn probe(&self, coord: Coord) -> Id {
+            if self.scroll.is_kinetic_scrolling() {
+                return self.id();
+            }
+
+            self.inner
+                .try_probe(coord + self.scroll_offset())
+                .unwrap_or_else(|| self.id())
+        }
 
         fn mouse_over_icon(&self) -> Option<CursorIcon> {
             self.scroll

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -338,13 +338,6 @@ mod ScrollBar {
                 draw.scroll_bar(self.rect(), &self.grip, dir);
             }
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            if self.invisible && self.max_value == 0 {
-                return self.id();
-            }
-            self.grip.try_probe(coord).unwrap_or_else(|| self.id())
-        }
     }
 
     impl Tile for Self {
@@ -361,6 +354,13 @@ mod ScrollBar {
         const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = ();
+
+        fn probe(&self, coord: Coord) -> Id {
+            if self.invisible && self.max_value == 0 {
+                return self.id();
+            }
+            self.grip.try_probe(coord).unwrap_or_else(|| self.id())
+        }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             match event {
@@ -623,6 +623,10 @@ mod ScrollBars {
                 }
             }
         }
+    }
+
+    impl Events for Self {
+        type Data = W::Data;
 
         fn probe(&self, coord: Coord) -> Id {
             self.vert_bar
@@ -631,10 +635,6 @@ mod ScrollBars {
                 .or_else(|| self.inner.try_probe(coord))
                 .unwrap_or_else(|| self.id())
         }
-    }
-
-    impl Events for Self {
-        type Data = W::Data;
 
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
             let index = cx.last_child();

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -349,12 +349,6 @@ mod ScrollText {
                 draw.with_pass(|draw| self.vert_bar.draw(draw));
             }
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            self.vert_bar
-                .try_probe(coord)
-                .unwrap_or_else(|| self.label.id())
-        }
     }
 
     impl Tile for Self {
@@ -445,6 +439,12 @@ mod ScrollText {
 
     impl Events for Self {
         type Data = A;
+
+        fn probe(&self, coord: Coord) -> Id {
+            self.vert_bar
+                .try_probe(coord)
+                .unwrap_or_else(|| self.label.id())
+        }
 
         #[inline]
         fn mouse_over_icon(&self) -> Option<CursorIcon> {

--- a/crates/kas-widgets/src/slider.rs
+++ b/crates/kas-widgets/src/slider.rs
@@ -300,15 +300,6 @@ mod Slider {
             let dir = self.direction.as_direction();
             draw.slider(self.rect(), &self.grip, dir);
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            if self.on_move.is_some() {
-                if let Some(id) = self.grip.try_probe(coord) {
-                    return id;
-                }
-            }
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -331,6 +322,15 @@ mod Slider {
         const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = A;
+
+        fn probe(&self, coord: Coord) -> Id {
+            if self.on_move.is_some() {
+                if let Some(id) = self.grip.try_probe(coord) {
+                    return id;
+                }
+            }
+            self.id()
+        }
 
         fn update(&mut self, cx: &mut ConfigCx, data: &A) {
             let v = (self.state_fn)(cx, data);

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -365,13 +365,6 @@ mod SpinBox {
             self.b_up.draw(draw.re());
             self.b_down.draw(draw.re());
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            self.b_up
-                .try_probe(coord)
-                .or_else(|| self.b_down.try_probe(coord))
-                .unwrap_or_else(|| self.edit.id())
-        }
     }
 
     impl Tile for Self {
@@ -387,6 +380,13 @@ mod SpinBox {
 
     impl Events for Self {
         type Data = A;
+
+        fn probe(&self, coord: Coord) -> Id {
+            self.b_up
+                .try_probe(coord)
+                .or_else(|| self.b_down.try_probe(coord))
+                .unwrap_or_else(|| self.edit.id())
+        }
 
         fn configure(&mut self, cx: &mut ConfigCx) {
             cx.text_configure(&mut self.unit);

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -237,29 +237,6 @@ mod Splitter {
                 draw.separator(w.rect())
             });
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            if !self.size_solved {
-                debug_assert!(false);
-                return self.id();
-            }
-
-            // find_child should gracefully handle the case that a coord is between
-            // widgets, so there's no harm (and only a small performance loss) in
-            // calling it twice.
-
-            let solver = layout::RowPositionSolver::new(self.direction);
-            if let Some(child) = solver.find_child(&self.widgets, coord) {
-                return child.try_probe(coord).unwrap_or_else(|| self.id());
-            }
-
-            let solver = layout::RowPositionSolver::new(self.direction);
-            if let Some(child) = solver.find_child(&self.grips, coord) {
-                return child.try_probe(coord).unwrap_or_else(|| self.id());
-            }
-
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -289,6 +266,29 @@ mod Splitter {
         fn make_child_id(&mut self, child_index: usize) -> Id {
             let is_grip = (child_index & 1) != 0;
             self.make_next_id(is_grip, child_index / 2)
+        }
+
+        fn probe(&self, coord: Coord) -> Id {
+            if !self.size_solved {
+                debug_assert!(false);
+                return self.id();
+            }
+
+            // find_child should gracefully handle the case that a coord is between
+            // widgets, so there's no harm (and only a small performance loss) in
+            // calling it twice.
+
+            let solver = layout::RowPositionSolver::new(self.direction);
+            if let Some(child) = solver.find_child(&self.widgets, coord) {
+                return child.try_probe(coord).unwrap_or_else(|| self.id());
+            }
+
+            let solver = layout::RowPositionSolver::new(self.direction);
+            if let Some(child) = solver.find_child(&self.grips, coord) {
+                return child.try_probe(coord).unwrap_or_else(|| self.id());
+            }
+
+            self.id()
         }
 
         fn configure(&mut self, _: &mut ConfigCx) {

--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -136,16 +136,6 @@ mod Stack {
                 entry.0.draw(draw.re());
             }
         }
-
-        fn probe(&self, coord: Coord) -> Id {
-            if let Some(entry) = self.widgets.get(self.active) {
-                debug_assert_eq!(entry.1, State::Sized);
-                if let Some(id) = entry.0.try_probe(coord) {
-                    return id;
-                }
-            }
-            self.id()
-        }
     }
 
     impl Tile for Self {
@@ -216,6 +206,16 @@ mod Stack {
                     return self.id_ref().make_child(key);
                 }
             }
+        }
+
+        fn probe(&self, coord: Coord) -> Id {
+            if let Some(entry) = self.widgets.get(self.active) {
+                debug_assert_eq!(entry.1, State::Sized);
+                if let Some(id) = entry.0.try_probe(coord) {
+                    return id;
+                }
+            }
+            self.id()
         }
 
         fn configure(&mut self, _: &mut ConfigCx) {

--- a/crates/kas-widgets/src/tab_stack.rs
+++ b/crates/kas-widgets/src/tab_stack.rs
@@ -44,12 +44,6 @@ mod Tab {
         }
     }
 
-    impl Layout for Self {
-        fn probe(&self, _: Coord) -> Id {
-            self.id()
-        }
-    }
-
     impl Tile for Self {
         fn navigable(&self) -> bool {
             true
@@ -65,6 +59,10 @@ mod Tab {
         const REDRAW_ON_MOUSE_OVER: bool = true;
 
         type Data = ();
+
+        fn probe(&self, _: Coord) -> Id {
+            self.id()
+        }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &(), event: Event) -> IsUsed {
             event.on_click(cx, self.id(), |cx| cx.push(Select))

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -20,15 +20,13 @@ mod CursorWidget {
         cursor: CursorIcon,
     }
 
-    impl Layout for Self {
+    impl Events for Self {
+        type Data = ();
+
         fn probe(&self, _: Coord) -> Id {
             // This widget takes mouse focus, not self.label
             self.id()
         }
-    }
-
-    impl Events for Self {
-        type Data = ();
 
         fn mouse_over_icon(&self) -> Option<CursorIcon> {
             Some(self.cursor)


### PR DESCRIPTION
This revises #563: `fn probe` is moved to trait `Events`.

# Motivation

After #563, rust-analyzer complains: `fn probe` is not a member of trait `Layout`.

It doesn't do this concerning `type Data` within trait `Events` (this might be a bug).

Further, I'd prefer not having the method in trait `Tile` (it should not be called, therefore should not be accessible from `dyn Widget`) or a new trait (purely to reduce the number of items in crate `kas`). `Events` works fine however.