### PR TITLE
Move `fn try_probe` and allow selection of message in dialog boxes

### DIFF
--- a/crates/kas-core/src/core/events.rs
+++ b/crates/kas-core/src/core/events.rs
@@ -49,7 +49,7 @@ use crate::{Id, geom::Coord};
 ///
 ///     This method may be called again at any time.
 /// 5.  The widget is ready for event-handling and drawing
-///     ([`Events::handle_event`], [`Layout::try_probe`], [`Layout::draw`]).
+///     ([`Events::handle_event`], [`Tile::try_probe`], [`Layout::draw`]).
 ///
 /// Widgets are responsible for ensuring that their children may observe this
 /// lifecycle. Usually this simply involves inclusion of the child in layout
@@ -98,7 +98,7 @@ pub trait Events: Widget + Sized {
     ///
     /// # Calling
     ///
-    /// Call [`Layout::try_probe`] instead.
+    /// Call [`Tile::try_probe`] instead.
     ///
     /// # Implementation
     ///
@@ -106,7 +106,7 @@ pub trait Events: Widget + Sized {
     /// return its own [`Id`] when no child occupies the input `coord`.
     /// If there are cases where a click within [`Layout::rect`] should be
     /// considered a miss (non-rectangular hit-testing) then
-    /// [`Layout::try_probe`] must be implemented instead.
+    /// [`Tile::try_probe`] must be implemented instead.
     ///
     /// If the [`Tile::translation`] is non-zero for any child, then the
     /// coordinate passed to that child must be translated:
@@ -116,7 +116,7 @@ pub trait Events: Widget + Sized {
     ///
     /// The default implementation returns `self.id()` and may be used for
     /// childless widgets. If the [`layout`](macro@crate::layout) attribute
-    /// macro is used or an explicit implementation of [`Layout::try_probe`] is
+    /// macro is used or an explicit implementation of [`Tile::try_probe`] is
     /// provided, these are used instead of the default implementation of this
     /// method.
     fn probe(&self, coord: Coord) -> Id {

--- a/crates/kas-core/src/core/layout.rs
+++ b/crates/kas-core/src/core/layout.rs
@@ -204,9 +204,6 @@ pub trait MacroDefinedLayout {
     /// Set size and position
     fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints);
 
-    /// Probe a coordinate for a widget's [`Id`]
-    fn try_probe(&self, coord: Coord) -> Option<Id>;
-
     /// Draw a widget and its children
     fn draw(&self, draw: DrawCx);
 }

--- a/crates/kas-core/src/core/layout.rs
+++ b/crates/kas-core/src/core/layout.rs
@@ -5,9 +5,8 @@
 
 //! Layout, Tile and TileExt traits
 
-use crate::Id;
 use crate::event::ConfigCx;
-use crate::geom::{Coord, Rect};
+use crate::geom::Rect;
 use crate::layout::{AlignHints, AxisInfo, SizeRules};
 use crate::theme::{DrawCx, SizeCx};
 use kas_macros::autoimpl;
@@ -94,7 +93,7 @@ pub trait Layout {
     /// Required: [`Self::size_rules`] is called for both axes before this
     /// method is called, and that this method has been called *after* the last
     /// call to [`Self::size_rules`] *before* any of the following methods:
-    /// [`Layout::try_probe`], [`Layout::draw`], [`Events::handle_event`].
+    /// [`Tile::try_probe`], [`Layout::draw`], [`Events::handle_event`].
     ///
     /// # Implementation
     ///
@@ -116,43 +115,6 @@ pub trait Layout {
     ///
     /// [`Stretch`]: crate::layout::Stretch
     fn set_rect(&mut self, cx: &mut ConfigCx, rect: Rect, hints: AlignHints);
-
-    /// Probe a coordinate for a widget's [`Id`]
-    ///
-    /// Returns the [`Id`] of the widget expected to handle clicks and touch
-    /// events at the given `coord`, or `None` if `self` does not occupy this
-    /// `coord`. Typically the result is the lowest descendant in
-    /// the widget tree at the given `coord`, but it is not required to be; e.g.
-    /// a `Button` may use an inner widget as a label but return its own [`Id`]
-    /// to indicate that the button (not the inner label) handles clicks.
-    ///
-    /// # Calling
-    ///
-    /// ## Call order
-    ///
-    /// It is expected that [`Layout::set_rect`] is called before this method,
-    /// but failure to do so should not cause a fatal error.
-    ///
-    /// # Implementation
-    ///
-    /// In most cases widgets should implement
-    /// [`Events::probe`] instead; the `#[widget]` macro can
-    /// use it to implement `try_probe` as follows:
-    /// ```ignore
-    /// self.rect().contains(coord).then(|| self.probe(coord))
-    /// ```
-    ///
-    /// ## Default implementation
-    ///
-    /// Non-widgets do not have an [`Id`], and therefore should use the default
-    /// implementation which simply returns `None`.
-    ///
-    /// Widgets without any children (including layout children) may use the
-    /// default implementation of [`Events::probe`].
-    fn try_probe(&self, coord: Coord) -> Option<Id> {
-        let _ = coord;
-        None
-    }
 
     /// Draw a widget and its children
     ///

--- a/crates/kas-core/src/core/tile.rs
+++ b/crates/kas-core/src/core/tile.rs
@@ -5,7 +5,7 @@
 
 //! Layout, Tile and TileExt traits
 
-use crate::geom::{Offset, Rect};
+use crate::geom::{Coord, Offset, Rect};
 use crate::util::IdentifyWidget;
 use crate::{ChildIndices, HasId, Id, Layout, Role, RoleCx};
 use kas_macros::autoimpl;
@@ -175,6 +175,35 @@ pub trait Tile: Layout {
         id.next_key_after(self.id_ref())
     }
 
+    /// Probe a coordinate for a widget's [`Id`]
+    ///
+    /// Returns the [`Id`] of the widget expected to handle clicks and touch
+    /// events at the given `coord`, or `None` if `self` does not occupy this
+    /// `coord`. Typically the result is the lowest descendant in
+    /// the widget tree at the given `coord`, but it is not required to be; e.g.
+    /// a `Button` may use an inner widget as a label but return its own [`Id`]
+    /// to indicate that the button (not the inner label) handles clicks.
+    ///
+    /// # Calling
+    ///
+    /// ## Call order
+    ///
+    /// It is expected that [`Layout::set_rect`] is called before this method,
+    /// but failure to do so should not cause a fatal error.
+    ///
+    /// # Implementation
+    ///
+    /// In most cases widgets should implement
+    /// [`Events::probe`] instead; the `#[widget]` macro can
+    /// use it to implement `try_probe` as follows:
+    /// ```ignore
+    /// self.rect().contains(coord).then(|| self.probe(coord))
+    /// ```
+    fn try_probe(&self, coord: Coord) -> Option<Id> {
+        let _ = coord;
+        unimplemented!() // make rustdoc show that this is a provided method
+    }
+
     /// Navigation in spatial order
     ///
     /// Controls <kbd>Tab</kbd> navigation order of children.
@@ -205,10 +234,10 @@ pub trait Tile: Layout {
     ///
     /// Usually this is zero; only widgets with scrollable or offset content
     /// *and* child widgets need to implement this.
-    /// Such widgets must also implement [`Layout::try_probe`] and (if they
+    /// Such widgets must also implement [`Tile::try_probe`] and (if they
     /// scroll) [`Events::handle_scroll`].
     ///
-    /// Affects event handling via [`Layout::try_probe`] and affects the
+    /// Affects event handling via [`Tile::try_probe`] and affects the
     /// positioning of pop-up menus. [`Layout::draw`] must be implemented
     /// directly using [`DrawCx::with_clip_region`] to offset contents.
     ///

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -33,7 +33,7 @@ use kas_macros::autoimpl;
 ///     cached by `size_rules`.
 /// 4.  The widget is updated again after any data change (see [`ConfigCx::update`]).
 /// 5.  The widget is ready for event-handling and drawing
-///     ([`Events::handle_event`], [`Layout::try_probe`], [`Layout::draw`]).
+///     ([`Events::handle_event`], [`Tile::try_probe`], [`Layout::draw`]).
 ///
 /// Widgets are responsible for ensuring that their children may observe this
 /// lifecycle. Usually this simply involves inclusion of the child in layout

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -12,7 +12,7 @@ use crate::event::{
 use crate::geom::{Affine, Coord, DVec2, Vec2};
 use crate::window::WindowErased;
 use crate::window::WindowWidget;
-use crate::{Action, Id, Layout, Node, TileExt};
+use crate::{Action, Id, Node, TileExt};
 use cast::{CastApprox, CastFloat};
 use std::time::{Duration, Instant};
 use winit::event::{ElementState, MouseButton, MouseScrollDelta};

--- a/crates/kas-core/src/event/cx/send.rs
+++ b/crates/kas-core/src/event/cx/send.rs
@@ -9,8 +9,7 @@ use super::{EventCx, EventState};
 use crate::event::{Command, Event, Scroll, ScrollDelta, Used};
 use crate::messages::Erased;
 use crate::runner::ReadMessage;
-#[allow(unused)]
-use crate::{Events, Layout, event::ConfigCx};
+#[allow(unused)] use crate::{Events, Tile, event::ConfigCx};
 use crate::{Id, Node};
 use std::fmt::Debug;
 use std::task::Poll;
@@ -20,7 +19,7 @@ impl EventState {
     ///
     /// When calling this method, be aware that some widgets use an inner
     /// component to handle events, thus calling with the outer widget's `id`
-    /// may not have the desired effect. [`Layout::try_probe`] and
+    /// may not have the desired effect. [`Tile::try_probe`] and
     /// [`EventState::next_nav_focus`] are usually able to find the appropriate
     /// event-handling target.
     ///

--- a/crates/kas-core/src/event/event.rs
+++ b/crates/kas-core/src/event/event.rs
@@ -113,7 +113,7 @@ pub enum Event<'a> {
     /// Motion events for the grabbed mouse pointer or touched finger are sent.
     ///
     /// If `cur_id` is `None`, no widget was found at the coordinate (either
-    /// outside the window or [`crate::Layout::try_probe`] failed).
+    /// outside the window or [`crate::Tile::try_probe`] failed).
     ///
     /// This event may be sent 10+ times per frame, thus it is important that
     /// the handler be fast. It may be useful to schedule a pre-draw update
@@ -134,7 +134,7 @@ pub enum Event<'a> {
     /// sent.
     ///
     /// If `cur_id` is `None`, no widget was found at the coordinate (either
-    /// outside the window or [`crate::Layout::try_probe`] failed).
+    /// outside the window or [`crate::Tile::try_probe`] failed).
     PressEnd { press: Press, success: bool },
     /// Update from a timer
     ///

--- a/crates/kas-core/src/event/mod.rs
+++ b/crates/kas-core/src/event/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! 1.  Determine the target's [`Id`]. For example, this may be
 //!     the [`nav_focus`](EventState::nav_focus) or may be determined from
-//!     from mouse/touch coordinates by calling [`try_probe`](crate::Layout::try_probe).
+//!     from mouse/touch coordinates by calling [`try_probe`](crate::Tile::try_probe).
 //! 2.  If the target is [disabled](EventState::is_disabled), then find the
 //!     top-most ancestor which is disabled and make that the target, but
 //!     inhibit calling of [`Events::handle_event`] on this widget (but still

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -844,7 +844,7 @@ impl Layout {
                 }
 
                 toks.append_all(quote! {
-                    if let Some(id) = ::kas::Layout::try_probe(&#expr, coord) {
+                    if let Some(id) = ::kas::Tile::try_probe(&#expr, coord) {
                         Some(id)
                     } else
                 });
@@ -855,7 +855,7 @@ impl Layout {
                 }
 
                 toks.append_all(quote! {
-                    if let Some(id) = ::kas::Layout::try_probe(&#core_path.#stor, coord) {
+                    if let Some(id) = ::kas::Tile::try_probe(&#core_path.#stor, coord) {
                         Some(id)
                     } else
                 });

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -453,7 +453,6 @@ pub fn widget(attr_span: Span, scope: &mut Scope) -> Result<()> {
         });
         let tree_size_rules = tree.size_rules(&core_path);
         let tree_set_rect = tree.set_rect(&core_path);
-        let tree_try_probe = tree.try_probe(&core_path);
         let tree_draw = tree.draw(&core_path);
         fn_nav_next = tree.nav_next(children.iter());
 
@@ -482,11 +481,6 @@ pub fn widget(attr_span: Span, scope: &mut Scope) -> Result<()> {
                 ) {
                     #set_rect
                     #tree_set_rect
-                }
-
-                #[inline]
-                fn try_probe(&self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
-                    #tree_try_probe
                 }
 
                 #[inline]
@@ -531,13 +525,15 @@ pub fn widget(attr_span: Span, scope: &mut Scope) -> Result<()> {
             }
         };
 
-        if fn_probe_span.is_none() {
+        if fn_probe_span.is_none()
+            && let Some(toks) = tree.try_probe(&core_path, &children)
+        {
             fn_try_probe = Some(quote! {
                 fn try_probe(&self, coord: ::kas::geom::Coord) -> Option<::kas::Id> {
                     #[cfg(debug_assertions)]
                     self.#core.status.require_rect(&self.#core._id);
 
-                    ::kas::MacroDefinedLayout::try_probe(self, coord)
+                    #toks
                 }
             });
         }

--- a/crates/kas-macros/src/widget_derive.rs
+++ b/crates/kas-macros/src/widget_derive.rs
@@ -278,10 +278,6 @@ fn derive_widget(attr_span: Span, args: DeriveArgs, scope: &mut Scope) -> Result
             layout_impl.items.push(Verbatim(fn_set_rect));
         }
 
-        if !has_item("try_probe") {
-            layout_impl.items.push(Verbatim(fn_try_probe));
-        }
-
         if !has_item("draw") {
             layout_impl.items.push(Verbatim(fn_draw));
         }
@@ -291,7 +287,6 @@ fn derive_widget(attr_span: Span, args: DeriveArgs, scope: &mut Scope) -> Result
                 #fn_rect
                 #fn_size_rules
                 #fn_set_rect
-                #fn_try_probe
                 #fn_draw
             }
         });
@@ -325,12 +320,17 @@ fn derive_widget(attr_span: Span, args: DeriveArgs, scope: &mut Scope) -> Result
         if !has_item("role") {
             tile_impl.items.push(Verbatim(fn_role));
         }
+
+        if !has_item("try_probe") {
+            tile_impl.items.push(Verbatim(fn_try_probe));
+        }
     } else {
         scope.generated.push(quote! {
             impl #impl_generics ::kas::Tile for #impl_target {
                 #required_tile_methods
                 #tile_methods
                 #fn_role
+                #fn_try_probe
             }
         });
     }

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -13,7 +13,9 @@
 //! At the current time, only a minimal selection of dialog boxes are provided
 //! and their design is likely to change.
 
-use crate::{AccessLabel, Button, EditBox, Filler, Label, ScrollLabel, adapt::AdaptWidgetAny};
+use crate::{
+    AccessLabel, Button, EditBox, Filler, ScrollLabel, SelectableLabel, adapt::AdaptWidgetAny,
+};
 use kas::prelude::*;
 use kas::runner::AppData;
 use kas::text::format::FormattableText;
@@ -31,7 +33,7 @@ mod MessageBox {
     pub struct MessageBox<T: FormattableText + 'static> {
         core: widget_core!(),
         #[widget]
-        label: Label<T>,
+        label: SelectableLabel<T>,
         #[widget]
         button: Button<AccessLabel>,
     }
@@ -41,7 +43,7 @@ mod MessageBox {
         pub fn new(message: T) -> Self {
             MessageBox {
                 core: Default::default(),
-                label: Label::new(message),
+                label: SelectableLabel::new(message),
                 button: Button::label_msg("&Ok", MessageBoxOk),
             }
         }
@@ -99,7 +101,7 @@ mod AlertError {
         parent: Id,
         title: String,
         #[widget]
-        label: Label<T>,
+        label: SelectableLabel<T>,
         #[widget]
         details: ScrollLabel<String>,
         #[widget]
@@ -120,7 +122,7 @@ mod AlertError {
                 core: Default::default(),
                 parent: Id::default(),
                 title: "Error".to_string(),
-                label: Label::new(message),
+                label: SelectableLabel::new(message),
                 details: ScrollLabel::new(details),
                 ok: Button::label_msg("&Ok", ErrorResult),
             }
@@ -192,7 +194,7 @@ mod AlertUnsaved {
         parent: Id,
         title: String,
         #[widget]
-        label: Label<T>,
+        label: SelectableLabel<T>,
         #[widget]
         save: Button<AccessLabel>,
         #[widget]
@@ -208,7 +210,7 @@ mod AlertUnsaved {
                 core: Default::default(),
                 parent: Id::default(),
                 title: "Unsaved changes".to_string(),
-                label: Label::new(message),
+                label: SelectableLabel::new(message),
                 save: Button::label_msg("&Save", UnsavedResult::Save),
                 discard: Button::label_msg("&Discard", UnsavedResult::Discard),
                 cancel: Button::label_msg("&Cancel", UnsavedResult::Cancel),

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -140,7 +140,7 @@ mod AlertError {
         pub fn display_for(mut self, cx: &mut EventCx, parent: Id) {
             self.parent = parent;
             let title = std::mem::take(&mut self.title);
-            let window = Window::new(self.map_any(), title).with_restrictions(true, true);
+            let window = Window::new(self, title).with_restrictions(true, true);
             cx.add_dataless_window(window, true);
         }
     }
@@ -229,7 +229,7 @@ mod AlertUnsaved {
         pub fn display_for(mut self, cx: &mut EventCx, parent: Id) {
             self.parent = parent;
             let title = std::mem::take(&mut self.title);
-            let window = Window::new(self.map_any(), title).with_restrictions(true, true);
+            let window = Window::new(self, title).with_restrictions(true, true);
             cx.add_dataless_window(window, true);
         }
     }

--- a/crates/kas-widgets/src/menu/mod.rs
+++ b/crates/kas-widgets/src/menu/mod.rs
@@ -48,7 +48,7 @@ pub struct SubItems<'a> {
 /// Trait governing menus, sub-menus and menu-entries
 ///
 /// Implementations will automatically receive nav focus on mouse-over, thus
-/// should ensure that [`Layout::try_probe`] returns the identifier of the
+/// should ensure that [`Tile::try_probe`] returns the identifier of the
 /// widget which should be focussed, and that this widget has
 /// [`Tile::navigable`] return true.
 #[autoimpl(for<T: trait + ?Sized> Box<T>)]


### PR DESCRIPTION
Allow selection of the message in dialog boxes.

Move `fn try_probe` from trait `Layout` to `Tile` since non-widget implementations cannot implement `try_probe`. This fixes a bug where the generated `try_probe` would return `None` in widgets like `Label` and `SelectableText` where layout is generated over a non-widget.