### PR TITLE
Fix calculator

### DIFF
--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -118,7 +118,7 @@ where
             }
         }
 
-        self.messages.count = 0;
+        self.messages.clear();
     }
 
     pub(crate) fn resume(&mut self, surface: &G::Surface<'_>) -> Result<(), Error> {

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -13,8 +13,9 @@ use std::ops::{Index, IndexMut};
 /// Make a [`Grid`] widget
 ///
 /// Constructs a table with auto-determined number of rows and columns.
-/// Cells may overlap, in which case behaviour is identical to [`float!`]: the
-/// first declared item is on top.
+///
+/// Cells are allowed to overlap but are not guaranteed to draw correctly in
+/// this case. The first declared widget of the overlap is "on top".
 ///
 /// # Syntax
 ///
@@ -145,9 +146,8 @@ mod Grid {
     /// through widgets with the Tab key currently uses the list order (though it
     /// may be changed in the future to use display order).
     ///
-    /// There is no protection against multiple widgets occupying the same cell.
-    /// If this does happen, the last widget in that cell will appear on top, but
-    /// overlapping widget drawing may not be pretty.
+    /// Cells are allowed to overlap but are not guaranteed to draw correctly in
+    /// this case. The first declared widget of the overlap is "on top".
     ///
     /// ## Alternatives
     ///
@@ -204,7 +204,8 @@ mod Grid {
         }
 
         fn draw(&self, mut draw: DrawCx) {
-            for n in 0..self.widgets.len() {
+            // Draw in reverse to show first of overlap on top
+            for n in (0..self.widgets.len()).rev() {
                 if let Some(child) = self.widgets.get_tile(n) {
                     child.draw(draw.re());
                 }

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -16,7 +16,7 @@ type Key = kas::event::Key<kas::event::SmolStr>;
 
 fn key_button(label: &str) -> Button<AccessLabel> {
     let string = AccessString::from(label);
-    let key = string.key().unwrap().clone();
+    let key = string.key().unwrap().0.clone();
     Button::label_msg(string, key)
 }
 fn key_button_with(label: &str, key: Key) -> Button<AccessLabel> {


### PR DESCRIPTION
Fix: #565 broke the warn log messages for unhandled messages

Fix: calculator was pushing the wrong message type.

Fix: draw order for overlapping grid cells.