### PR TITLE
Widget lifecycle: configure_recurse before events; mock view item for sizing

### DIFF
--- a/crates/kas-core/src/core/events.rs
+++ b/crates/kas-core/src/core/events.rs
@@ -38,16 +38,15 @@ use crate::{Id, geom::Coord};
 /// and involves calling the following methods in order:
 ///
 /// 1.  [`Events::configure`]
-/// 2.  [`Events::update`]
-/// 3.  [`Events::configure_recurse`]
+/// 2.  [`Events::configure_recurse`]
 ///
-/// Configuration and update may be repeated at any time.
+/// Configuration may be repeated at any time but must be followed by an update.
 ///
 /// ### Update
 ///
 /// Widgets must be updated during configure (see above), since
-/// [`Events::update`] must be called before sizing (except as noted in
-/// [`Layout::size_rules`]) and before other widget methods.
+/// [`Events::update`] must be called before sizing and before other widget
+/// methods.
 ///
 /// Widgets must also be updated after their input data (see [`Widget::Data`])
 /// changes (unless not visible, in which case the update may be postponed until

--- a/crates/kas-core/src/core/tile.rs
+++ b/crates/kas-core/src/core/tile.rs
@@ -27,6 +27,11 @@ use kas_macros::autoimpl;
 /// `Tile` may not be implemented directly; it will be implemented by the
 /// [`#widget`] macro.
 ///
+/// # Call order
+///
+/// Widgets must be configured (see [`Events#configuration`]) before any `Tile`
+/// method is called.
+///
 /// # Tree reflection
 ///
 /// `Tile` offers a reflection API over the widget tree via

--- a/crates/kas-core/src/core/widget.rs
+++ b/crates/kas-core/src/core/widget.rs
@@ -25,15 +25,15 @@ use kas_macros::autoimpl;
 ///
 /// # Widget lifecycle
 ///
-/// 1.  The widget is configured ([`Events::configure`]) and immediately updated
-///     ([`Events::update`]).
-/// 2.  The widget has its size-requirements checked by calling
-///     [`Layout::size_rules`] for each axis.
-/// 3.  [`Layout::set_rect`] is called to position elements. This may use data
-///     cached by `size_rules`.
-/// 4.  The widget is updated again after any data change (see [`ConfigCx::update`]).
-/// 5.  The widget is ready for event-handling and drawing
-///     ([`Events::handle_event`], [`Tile::try_probe`], [`Layout::draw`]).
+/// Widget methods have a specified call order:
+///
+/// 1.  The widget is configured (see [`Events#configuration`])
+/// 2.  The widget is updated ([`Events#update`])
+/// 3.  The widget is sized (see [`Layout#sizing`])
+/// 4.  The widget is ready for other methods to be called
+///
+/// Configuration, update and sizing may be repeated at any time (see above
+/// linked documentation).
 ///
 /// Widgets are responsible for ensuring that their children may observe this
 /// lifecycle. Usually this simply involves inclusion of the child in layout

--- a/crates/kas-core/src/event/config_cx.rs
+++ b/crates/kas-core/src/event/config_cx.rs
@@ -16,7 +16,7 @@ use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
 #[allow(unused)] use crate::event::{Event, EventCx};
-#[allow(unused)] use crate::{Action, Events, Layout};
+#[allow(unused)] use crate::{Action, Events};
 
 /// Widget configuration and update context
 ///
@@ -51,10 +51,9 @@ impl<'a> ConfigCx<'a> {
 
     /// Configure a widget
     ///
-    /// All widgets must be configured after construction (see
-    /// [widget lifecycle](Layout#widget-lifecycle)).
-    /// This method performs complete configuration of the widget by calling
-    /// [`Events::configure`], [`Events::update`], [`Events::configure_recurse`].
+    /// All widgets must be configured after construction; see
+    /// [widget lifecycle](crate::Widget#widget-lifecycle) and
+    /// [configuration](Events#configuration).
     ///
     /// Pass the `id` to assign to the widget. This is usually constructed with
     /// [`Events::make_child_id`].
@@ -67,9 +66,8 @@ impl<'a> ConfigCx<'a> {
 
     /// Update a widget
     ///
-    /// All widgets must be updated after input data changes.
-    /// This method recursively updates the widget by calling
-    /// [`Events::update`] and [`Events::update_recurse`].
+    /// All widgets must be updated after input data changes; see
+    /// [update](Events#update).
     #[inline]
     pub fn update(&mut self, mut widget: Node<'_>) {
         widget._update(self);

--- a/crates/kas-core/src/event/config_cx.rs
+++ b/crates/kas-core/src/event/config_cx.rs
@@ -55,13 +55,11 @@ impl<'a> ConfigCx<'a> {
     /// [widget lifecycle](crate::Widget#widget-lifecycle) and
     /// [configuration](Events#configuration).
     ///
-    /// Pass the `id` to assign to the widget. This is usually constructed with
-    /// [`Events::make_child_id`].
+    /// Assigns `id` to the widget. This must be valid and is usually
+    /// constructed with [`Events::make_child_id`].
     #[inline]
     pub fn configure(&mut self, mut widget: Node<'_>, id: Id) {
-        if id.is_valid() {
-            widget._configure(self, id);
-        }
+        widget._configure(self, id);
     }
 
     /// Update a widget

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -390,6 +390,10 @@ impl<'a> DerefMut for EventCx<'a> {
 impl<'a> EventCx<'a> {
     /// Configure a widget
     ///
+    /// All widgets must be configured after construction; see
+    /// [widget lifecycle](crate::Widget#widget-lifecycle) and
+    /// [configuration](Events#configuration).
+    ///
     /// This is a shortcut to [`ConfigCx::configure`].
     #[inline]
     pub fn configure(&mut self, mut widget: Node<'_>, id: Id) {
@@ -398,9 +402,8 @@ impl<'a> EventCx<'a> {
 
     /// Update a widget
     ///
-    /// [`Events::update`] will be called recursively on each child and finally
-    /// `self`. If a widget stores state which it passes to children as input
-    /// data, it should call this (or [`ConfigCx::update`]) after mutating the state.
+    /// All widgets must be updated after input data changes; see
+    /// [update](Events#update).
     #[inline]
     pub fn update(&mut self, mut widget: Node<'_>) {
         widget._update(&mut self.config_cx());

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -942,8 +942,8 @@ fn widget_recursive_methods(core_path: &Toks) -> Toks {
             #core_path.status.configure(&#core_path._id);
 
             ::kas::Events::configure(self, cx);
-            ::kas::Events::update(self, cx, data);
             ::kas::Events::configure_recurse(self, cx, data);
+            ::kas::Events::update(self, cx, data);
         }
 
         fn _update(

--- a/crates/kas-view/src/data_clerk.rs
+++ b/crates/kas-view/src/data_clerk.rs
@@ -339,4 +339,16 @@ pub trait DataClerk<Index> {
     ///
     /// This method should be fast since it may be called repeatedly.
     fn item<'r>(&'r self, data: &'r Self::Data, token: &'r Self::Token) -> &'r Self::Item;
+
+    /// Get a mock data item for sizing purposes
+    ///
+    /// This method is called if no data items are available when initially
+    /// sizing the view. If an item is returned, then a mock view widget is
+    /// created using this data in order to determine size requirements.
+    ///
+    /// The default implementation returns `None`.
+    fn mock_item(&self, data: &Self::Data) -> Option<Self::Item> {
+        let _ = data;
+        None
+    }
 }

--- a/crates/kas-view/src/generator.rs
+++ b/crates/kas-view/src/generator.rs
@@ -114,6 +114,18 @@ pub trait DataGenerator<Index> {
     /// The `key` will be the result of [`Self::key`] for an `index` less than
     /// [`Self::len`].
     fn generate(&self, data: &Self::Data, key: &Self::Key) -> Self::Item;
+
+    /// Get a mock data item for sizing purposes
+    ///
+    /// This method is called if no data items are available when initially
+    /// sizing the view. If an item is returned, then a mock view widget is
+    /// created using this data in order to determine size requirements.
+    ///
+    /// The default implementation returns `None`.
+    fn mock_item(&self, data: &Self::Data) -> Option<Self::Item> {
+        let _ = data;
+        None
+    }
 }
 
 /// An implementation of [`DataClerk`] for data generators
@@ -124,6 +136,7 @@ pub struct GeneratorClerk<Index, G: DataGenerator<Index>> {
 
 impl<Index: Default, G: DataGenerator<Index>> GeneratorClerk<Index, G> {
     /// Construct a `GeneratorClerk`
+    #[inline]
     pub fn new(generator: G) -> Self {
         GeneratorClerk {
             g: generator,
@@ -132,6 +145,7 @@ impl<Index: Default, G: DataGenerator<Index>> GeneratorClerk<Index, G> {
     }
 
     /// Access the inner generator
+    #[inline]
     pub fn generator(&self) -> &G {
         &self.g
     }
@@ -158,6 +172,7 @@ impl<Index: DataKey, G: DataGenerator<Index>> DataClerk<Index> for GeneratorCler
         }
     }
 
+    #[inline]
     fn len(&self, data: &Self::Data, lbound: Index) -> DataLen<Index> {
         self.g.len(data, lbound)
     }
@@ -198,7 +213,13 @@ impl<Index: DataKey, G: DataGenerator<Index>> DataClerk<Index> for GeneratorCler
         changes
     }
 
+    #[inline]
     fn item<'r>(&'r self, _: &'r Self::Data, token: &'r Self::Token) -> &'r Self::Item {
         &token.item
+    }
+
+    #[inline]
+    fn mock_item(&self, data: &Self::Data) -> Option<Self::Item> {
+        self.g.mock_item(data)
     }
 }

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -197,6 +197,15 @@ mod GridView {
         press_target: Option<(usize, C::Key)>,
     }
 
+    impl Default for Self
+    where
+        C: Default,
+        V: Default,
+    {
+        fn default() -> Self {
+            Self::new(C::default(), V::default())
+        }
+    }
     impl Self {
         /// Construct a new instance
         pub fn new(clerk: C, driver: V) -> Self {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -164,6 +164,16 @@ mod ListView {
         press_target: Option<(usize, C::Key)>,
     }
 
+    impl Default for Self
+    where
+        C: Default,
+        V: Default,
+        D: Default,
+    {
+        fn default() -> Self {
+            Self::new(C::default(), V::default())
+        }
+    }
     impl Self
     where
         D: Default,


### PR DESCRIPTION
- Update documentation on widget lifecycle
- Configuring a widget with invalid `Id` is an error, not something to silently ignore
- Call `Events::update` after `configure_recurse`
- Add `DataClerk::mock_item` for explicit control over sizing before data is available
- Tweak `ListView` and `GridView` configuration & sizing