### PR TITLE
Call `update` before `configure_recurse`; tweak view controllers

### DIFF
--- a/crates/kas-core/src/core/events.rs
+++ b/crates/kas-core/src/core/events.rs
@@ -38,9 +38,14 @@ use crate::{Id, geom::Coord};
 /// and involves calling the following methods in order:
 ///
 /// 1.  [`Events::configure`]
-/// 2.  [`Events::configure_recurse`]
+/// 2.  [`Events::update`]
+/// 3.  [`Events::configure_recurse`]
 ///
-/// Configuration may be repeated at any time but must be followed by an update.
+/// Note that both `configure` and `update` may be called before child widgets
+/// have been configured. This is important to ensure that parent widgets are
+/// always updated before their children.
+///
+/// Configuration may be repeated at any time.
 ///
 /// ### Update
 ///

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -942,8 +942,8 @@ fn widget_recursive_methods(core_path: &Toks) -> Toks {
             #core_path.status.configure(&#core_path._id);
 
             ::kas::Events::configure(self, cx);
-            ::kas::Events::configure_recurse(self, cx, data);
             ::kas::Events::update(self, cx, data);
+            ::kas::Events::configure_recurse(self, cx, data);
         }
 
         fn _update(

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -856,9 +856,7 @@ mod GridView {
 
         fn configure(&mut self, cx: &mut ConfigCx) {
             cx.register_nav_fallback(self.id());
-        }
 
-        fn configure_recurse(&mut self, _: &mut ConfigCx, _: &Self::Data) {
             if self.widgets.is_empty() {
                 // Ensure alloc_len > 0 for initial sizing
                 self.child_size = Size::splat(1); // hack: avoid div by 0

--- a/crates/kas-view/src/grid_view.rs
+++ b/crates/kas-view/src/grid_view.rs
@@ -587,13 +587,6 @@ mod GridView {
                 self.data_len = data_len;
                 self.token_update = Update::Token;
 
-                if self.update_content_size(cx) {
-                    // We may be able to request additional screen space.
-                    // We may need to map new view widgets.
-                    cx.resize(&self);
-                    return;
-                }
-
                 if self.cur_len.col != data_len.col.min(self.alloc_len.col)
                     || self.cur_len.row != data_len.row.min(self.alloc_len.row)
                 {

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -481,16 +481,20 @@ mod ListView {
             let first_data = usize::conv(u64::conv(offset) / u64::conv(self.skip));
 
             let alloc_len = self.widgets.len();
-            let lbound = first_data + 2 * alloc_len;
-            let data_len = self.clerk.len(data, lbound);
-            self.len_is_known = data_len.is_known();
-            let data_len = data_len.len();
-            if data_len != usize::conv(self.data_len) {
-                self.data_len = data_len.cast();
-                self.update_content_size(cx);
+            let data_len;
+            if !self.len_is_known {
+                let lbound = first_data + 2 * alloc_len;
+                let result = self.clerk.len(data, lbound);
+                self.len_is_known = result.is_known();
+                data_len = result.len();
+                if data_len != usize::conv(self.data_len) {
+                    self.data_len = data_len.cast();
+                    self.update_content_size(cx);
+                }
+            } else {
+                data_len = self.data_len.cast();
             }
-            let cur_len: usize = data_len.min(alloc_len);
-
+            let cur_len = data_len.min(alloc_len);
             let first_data = first_data.min(data_len - cur_len);
 
             let old_start = self.first_data.cast();
@@ -588,23 +592,29 @@ mod ListView {
         ) {
             let start: usize = self.first_data.cast();
             let end = start + usize::conv(self.cur_len);
+
+            let lbound = usize::conv(start) + 2 * self.widgets.len();
+            let data_len = self.clerk.len(data, lbound);
+            self.len_is_known = data_len.is_known();
+            let data_len = data_len.len().cast();
+
+            if data_len != self.data_len {
+                let old_len = self.data_len;
+                self.data_len = data_len;
+
+                let cur_len = data_len.min(self.widgets.len().cast());
+                if self.cur_len != cur_len || end >= usize::conv(data_len.min(old_len)) {
+                    self.cur_len = cur_len;
+                    self.token_update = self.token_update.max(Update::Token);
+                    return self.post_scroll(cx, data);
+                }
+            }
+
             let range = match changes {
                 Changes::None | Changes::NoPreparedItems => 0..0,
                 Changes::Range(range) => start.max(range.start)..end.min(range.end),
                 Changes::Any => start..end,
             };
-
-            let lbound = usize::conv(self.first_data) + 2 * self.widgets.len();
-            let data_len = self.clerk.len(data, lbound);
-            self.len_is_known = data_len.is_known();
-            let data_len = data_len.len().cast();
-            if data_len != self.data_len {
-                self.data_len = data_len;
-
-                if self.cur_len != data_len.min(self.widgets.len().cast()) {
-                    return self.post_scroll(cx, data);
-                }
-            }
 
             if !range.is_empty() {
                 self.token_update = self.token_update.max(Update::Token);

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -861,9 +861,7 @@ mod ListView {
 
         fn configure(&mut self, cx: &mut ConfigCx) {
             cx.register_nav_fallback(self.id());
-        }
 
-        fn configure_recurse(&mut self, _: &mut ConfigCx, _: &Self::Data) {
             if self.widgets.is_empty() {
                 // Ensure alloc_len > 0 for initial sizing
                 self.skip = 1; // hack: avoid div by 0

--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -601,13 +601,6 @@ mod ListView {
             if data_len != self.data_len {
                 self.data_len = data_len;
 
-                if self.update_content_size(cx) {
-                    // We may be able to request additional screen space.
-                    // We may need to map new view widgets.
-                    cx.resize(&self);
-                    return;
-                }
-
                 if self.cur_len != data_len.min(self.widgets.len().cast()) {
                     return self.post_scroll(cx, data);
                 }

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -578,6 +578,28 @@ mod List {
             w
         }
 
+        /// Removes all children at positions ≥ `len`
+        ///
+        /// Does nothing if `self.len() < len`.
+        ///
+        /// Triggers [`Action::RESIZE`].
+        pub fn truncate(&mut self, cx: &mut EventState, len: usize) {
+            if len < self.len() {
+                cx.resize(&self);
+                loop {
+                    let w = self.widgets.pop().unwrap();
+                    if w.id_ref().is_valid() {
+                        if let Some(key) = w.id_ref().next_key_after(self.id_ref()) {
+                            self.id_map.remove(&key);
+                        }
+                    }
+                    if len == self.widgets.len() {
+                        return;
+                    }
+                }
+            }
+        }
+
         /// Replace the child at `index`
         ///
         /// Panics if `index` is out of bounds.


### PR DESCRIPTION
This reverts the configure/update order change of #573 since it could allow children to be updated before their parent. The goal of that change was to ensure that children are configured before the parent is updated which *could* be supported with two separate tree traversals (configure, update), but in practice parent-update-before-child-configure seems to work fine.

More tweaks to ListView/GridView configuration included. Changing data length can no longer cause a resize since (a) the view is scrollable and (b) in most cases, making this useful would require resizing the window, but allowing widgets to resize the window could result in undesirable (and slow) behaviour.

Add `fn truncate` to the `List` widget.