### PR TITLE
Remove usage of doc_auto_cfg feature (and cfg docsrs where unused)

### DIFF
--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -11,7 +11,6 @@
 //! -   [`impl_self`], [`impl_scope!`], [`impl_anon!`], [`autoimpl`] and [`impl_default`] are
 //!     re-implementations of [`impl-tools`](https://crates.io/crates/impl-tools) macros
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "spec", feature(specialization))]
 

--- a/crates/kas-image/Cargo.toml
+++ b/crates/kas-image/Cargo.toml
@@ -15,7 +15,6 @@ exclude = ["/screenshots"]
 
 [package.metadata.docs.rs]
 features = ["docs_rs", "svg"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Non-local features required for doc builds.

--- a/crates/kas-image/src/lib.rs
+++ b/crates/kas-image/src/lib.rs
@@ -11,8 +11,6 @@
 //! [tiny-skia]: https://crates.io/crates/tiny-skia
 //! [resvg]: https://crates.io/crates/resvg
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 pub extern crate tiny_skia;
 
 #[cfg(feature = "canvas")] mod canvas;

--- a/crates/kas-view/Cargo.toml
+++ b/crates/kas-view/Cargo.toml
@@ -15,7 +15,6 @@ exclude = ["/screenshots"]
 
 [package.metadata.docs.rs]
 features = ["kas/wayland"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 kas-widgets = { version = "0.16.0", path = "../kas-widgets" }

--- a/crates/kas-view/src/lib.rs
+++ b/crates/kas-view/src/lib.rs
@@ -28,8 +28,6 @@
 //! Simple types (strings and numbers) may use a pre-defined [`driver`],
 //! otherwise a custom implementation of [`Driver`] is required.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 pub mod clerk;
 pub mod filter;
 

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -14,7 +14,6 @@ documentation = "https://docs.rs/kas-wgpu/"
 
 [package.metadata.docs.rs]
 features = ["kas/wayland"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []

--- a/crates/kas-wgpu/src/lib.rs
+++ b/crates/kas-wgpu/src/lib.rs
@@ -18,8 +18,6 @@
 //!
 //! [WGPU]: https://github.com/gfx-rs/wgpu
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 pub mod draw;
 mod draw_shaded;
 pub mod options;

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -15,7 +15,6 @@ exclude = ["/screenshots"]
 
 [package.metadata.docs.rs]
 features = ["kas/wayland"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 log = "0.4"

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -57,8 +57,6 @@
 //! -   [`AccessLabel`]: a label which parses access keys
 //! -   [`GripPart`]: a handle (e.g. for a slider, splitter or scroll_bar)
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 pub mod adapt;
 #[doc(no_inline)]
 pub use adapt::{Adapt, AdaptWidget, AdaptWidgetAny};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,6 @@
 //! -   [Examples](https://github.com/kas-gui/kas/tree/master/examples)
 //! -   [Discuss](https://github.com/kas-gui/kas/discussions)
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 /// KAS prelude
 ///
 /// This module allows convenient importation of common unabiguous items:


### PR DESCRIPTION
Feature `doc_auto_cfg` was stabilised.

Feature `doc_cfg` is still unstable and used by `kas-core` (somewhat ineffectively since the annotation is not always visible in `kas-core` docs and never visible in re-exports under `kas`).