### PR TITLE
Split run-time errors out of kas::runner::Error

### DIFF
--- a/crates/kas-core/src/runner/mod.rs
+++ b/crates/kas-core/src/runner/mod.rs
@@ -26,7 +26,7 @@ pub use runner::{ClosedError, PreLaunchState, Proxy};
 
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(docsrs, doc(cfg(internal_doc)))]
-pub use common::{GraphicsInstance, WindowSurface};
+pub use common::{GraphicsInstance, RunError, WindowSurface};
 
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(docsrs, doc(cfg(internal_doc)))]

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -5,7 +5,7 @@
 
 //! Shared state
 
-use super::{AppData, Error, GraphicsInstance, MessageStack, Pending, Platform};
+use super::{AppData, Error, GraphicsInstance, MessageStack, Pending, Platform, RunError};
 use crate::config::Config;
 use crate::draw::{DrawShared, DrawSharedImpl, SharedState};
 use crate::messages::Erased;
@@ -121,7 +121,7 @@ where
         self.messages.clear();
     }
 
-    pub(crate) fn resume(&mut self, surface: &G::Surface<'_>) -> Result<(), Error> {
+    pub(crate) fn resume(&mut self, surface: &G::Surface<'_>) -> Result<(), RunError> {
         if self.draw.is_none() {
             let mut draw_shared = self.instance.new_shared(Some(surface))?;
             draw_shared.set_raster_config(self.config.borrow().font.raster());

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -5,7 +5,7 @@
 
 //! Window types
 
-use super::common::WindowSurface;
+use super::common::{RunError, WindowSurface};
 use super::shared::Shared;
 use super::{AppData, GraphicsInstance, Platform};
 use crate::cast::{Cast, CastApprox};
@@ -95,7 +95,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         data: &A,
         el: &ActiveEventLoop,
         #[allow(unused)] modal_parent: Option<&winit::window::Window>,
-    ) -> super::Result<winit::window::WindowId> {
+    ) -> Result<winit::window::WindowId, RunError> {
         let time = Instant::now();
 
         // We use the logical size and scale factor of the largest monitor as

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -17,7 +17,7 @@ use kas::config::RasterConfig;
 use kas::draw::color::Rgba;
 use kas::draw::*;
 use kas::geom::{Quad, Size, Vec2};
-use kas::runner::Error;
+use kas::runner::RunError;
 use kas::text::{Effect, TextDisplay};
 
 impl<C: CustomPipe> DrawPipe<C> {
@@ -27,13 +27,13 @@ impl<C: CustomPipe> DrawPipe<C> {
         custom: &mut CB,
         options: &Options,
         surface: Option<&wgpu::Surface>,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, RunError> {
         let mut adapter_options = options.adapter_options();
         adapter_options.compatible_surface = surface;
         let req = instance.request_adapter(&adapter_options);
         let adapter = match block_on(req) {
             Ok(a) => a,
-            Err(e) => return Err(Error::Graphics(Box::new(e))),
+            Err(e) => return Err(RunError::Graphics(Box::new(e))),
         };
         log::info!("Using graphics adapter: {}", adapter.get_info().name);
 
@@ -42,7 +42,7 @@ impl<C: CustomPipe> DrawPipe<C> {
         desc.required_limits = desc.required_limits.using_resolution(adapter.limits());
 
         let req = adapter.request_device(&desc);
-        let (device, queue) = block_on(req).map_err(|e| Error::Graphics(Box::new(e)))?;
+        let (device, queue) = block_on(req).map_err(|e| RunError::Graphics(Box::new(e)))?;
 
         let shaders = ShaderManager::new(&device);
 

--- a/crates/kas-wgpu/src/lib.rs
+++ b/crates/kas-wgpu/src/lib.rs
@@ -25,7 +25,7 @@ mod shaded_theme;
 mod surface;
 
 use crate::draw::{CustomPipeBuilder, DrawPipe};
-use kas::runner::{self, Result};
+use kas::runner::{self, RunError};
 use wgpu::rwh;
 
 pub use draw_shaded::{DrawShaded, DrawShadedImpl};
@@ -64,7 +64,10 @@ impl<CB: CustomPipeBuilder> runner::GraphicsInstance for Instance<CB> {
 
     type Surface<'a> = surface::Surface<'a, CB::Pipe>;
 
-    fn new_shared(&mut self, surface: Option<&Self::Surface<'_>>) -> Result<Self::Shared> {
+    fn new_shared(
+        &mut self,
+        surface: Option<&Self::Surface<'_>>,
+    ) -> Result<Self::Shared, RunError> {
         DrawPipe::new(
             &self.instance,
             &mut self.custom,
@@ -77,7 +80,7 @@ impl<CB: CustomPipeBuilder> runner::GraphicsInstance for Instance<CB> {
         &mut self,
         window: W,
         transparent: bool,
-    ) -> Result<Self::Surface<'window>>
+    ) -> Result<Self::Surface<'window>, RunError>
     where
         W: rwh::HasWindowHandle + rwh::HasDisplayHandle + Send + Sync + 'window,
         Self: Sized,

--- a/crates/kas-wgpu/src/surface.rs
+++ b/crates/kas-wgpu/src/surface.rs
@@ -10,7 +10,7 @@ use kas::cast::Cast;
 use kas::draw::color::Rgba;
 use kas::draw::{DrawIface, DrawSharedImpl, WindowCommon};
 use kas::geom::Size;
-use kas::runner::{Error, WindowSurface, raw_window_handle as rwh};
+use kas::runner::{RunError, WindowSurface, raw_window_handle as rwh};
 use std::time::Instant;
 use wgpu::PresentMode;
 
@@ -23,14 +23,14 @@ pub struct Surface<'a, C: CustomPipe> {
 }
 
 impl<'a, C: CustomPipe> Surface<'a, C> {
-    pub fn new<W>(instance: &wgpu::Instance, window: W, transparent: bool) -> Result<Self, Error>
+    pub fn new<W>(instance: &wgpu::Instance, window: W, transparent: bool) -> Result<Self, RunError>
     where
         W: rwh::HasWindowHandle + rwh::HasDisplayHandle + Send + Sync + 'a,
         Self: Sized,
     {
         let surface = instance
             .create_surface(window)
-            .map_err(|e| Error::Graphics(Box::new(e)))?;
+            .map_err(|e| RunError::Graphics(Box::new(e)))?;
 
         Ok(Surface {
             surface,


### PR DESCRIPTION
Adds a new hidden `RunError` enum.