### PR TITLE
Small fixes

### DIFF
--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -148,7 +148,13 @@ impl<'a> DrawCx<'a> {
         self.h.components().1
     }
 
-    /// Access the draw device as a [`DrawRounded`] implementation
+    /// Access the draw device as a [`DrawRounded`] implementation, if possible
+    ///
+    /// Warning: this does not reflect whether the underlying draw device
+    /// supports [`DrawRounded`] (which would require specialization) but
+    /// whether the theme in question requires [`DrawRounded`]. As such, this
+    /// method is only useful with a theme requiring this extension such as
+    /// [`FlatTheme`](super::FlatTheme).
     pub fn draw_rounded(&mut self) -> Option<&mut dyn DrawRounded> {
         self.h.draw_rounded()
     }

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -209,6 +209,7 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
     }
 
     fn draw_rounded(&mut self) -> Option<&mut dyn DrawRounded> {
+        // FIXME: this should return Some(&mut self.draw) where DS::Draw: DrawRoundedImpl
         None
     }
 

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -172,7 +172,7 @@ fn main() -> kas::runner::Result<()> {
         .with_decorations(kas::window::Decorations::None)
         .with_transparent(true);
 
-    kas::runner::Runner::with_theme(kas::theme::SimpleTheme::default())
+    kas::runner::Runner::with_theme(kas::theme::FlatTheme::default())
         .build(())?
         .with(window)
         .run()

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -719,10 +719,10 @@ Event configuration editor
 
 Updated items should have immediate effect.
 
-To persist, set the following environment variables:
+To persist configuration set `KAS_CONFIG`:
 ```
-KAS_CONFIG=config.yaml
-KAS_CONFIG_MODE=readwrite
+export KAS_CONFIG=config.toml
+cargo run --example gallery --features toml
 ```
 ",
     )


### PR DESCRIPTION
Fix clock by using the `FlatTheme`, noting that `DrawCx::draw_rounded` returns `None` with `SimpleTheme`.

Fix `SizeRules::solve_widths_impl` with regards to `dist_over_b_lower_stretch`.