### PR TITLE
Revise minimal feature to use kas-soft; test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,10 +111,14 @@ jobs:
         run: cargo test --manifest-path crates/kas-view/Cargo.toml --all-features --features kas/wayland
       - name: Test kas-wgpu
         run: cargo test --manifest-path crates/kas-wgpu/Cargo.toml --features kas/x11
+      - name: Test kas-soft
+        run: cargo test --manifest-path crates/kas-soft/Cargo.toml --features wayland
       - name: Test kas-dylib
         run: cargo test --manifest-path crates/kas-dylib/Cargo.toml --features kas-soft/x11
       - name: Test kas
-        run: cargo test --features stable
+        run: |
+          cargo test --no-default-features --features minimal
+          cargo test --features stable
       - name: Test examples/mandlebrot
         run: cargo test --manifest-path examples/mandlebrot/Cargo.toml
       - name: Test examples/text-editor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 #########  meta / build features  #########
 
-# Basic support for common platforms
-minimal = ["wayland", "vulkan", "dx12", "metal"]
-# Minimal + strongly recommended features
-default = ["minimal", "clipboard", "shaping"]
+# Basic support for common platforms (uses kas-soft)
+minimal = ["wayland", "soft"]
+# Recommended minimal feature set (uses kas-wgpu)
+default = ["wayland", "vulkan", "dx12", "metal", "clipboard", "shaping"]
 # All standard test target features
 stable = ["default", "view", "image-default-formats", "canvas", "svg", "markdown", "spawn", "x11", "toml", "yaml", "json", "ron", "macros_log"]
 # Enables all "recommended" features for nightly rustc
@@ -154,7 +154,7 @@ optional = true
 default-features = false
 
 [dev-dependencies]
-kas = { path = ".", features = ["view", "markdown", "svg", "canvas"] }
+kas = { path = ".", default-features = false, features = ["view", "markdown", "svg", "canvas"] }
 chrono = "0.4"
 env_logger = "0.11"
 log = "0.4"

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -165,6 +165,7 @@ mod Clock {
     }
 }
 
+#[cfg(feature = "wgpu")]
 fn main() -> kas::runner::Result<()> {
     env_logger::init();
 
@@ -176,4 +177,9 @@ fn main() -> kas::runner::Result<()> {
         .build(())?
         .with(window)
         .run()
+}
+
+#[cfg(not(feature = "wgpu"))]
+fn main() {
+    eprintln!("This example requires feature wgpu!");
 }


### PR DESCRIPTION
Kas's feature `minimal` (without default features) now uses kas-soft for rendering. Default features still uses kas-wgpu. If both features are enabled, kas-wgpu takes priority. (This affects `kas::runner::{DefaultTheme, WgpuBuilder, SoftBuilder, Builder, Runner}`.)

Add CI tests for kas-soft and kas without default features.

Disable `examples/clock.rs` without feature `wgpu` since it requires rounded drawing, currently not implemented by kas-soft.