### PR TITLE
Double-click distance threshold

### DIFF
--- a/crates/kas-core/src/config/config.rs
+++ b/crates/kas-core/src/config/config.rs
@@ -10,6 +10,7 @@ use super::{FontConfig, FontConfigMsg, ThemeConfig, ThemeConfigMsg};
 use crate::ConfigAction;
 use crate::config::Shortcuts;
 use crate::theme::TextClass;
+use core::f32;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::cell::{Ref, RefCell};
@@ -93,6 +94,7 @@ pub struct WindowConfig {
     pub(super) kinetic_decay_sub: f32,
     pub(super) scroll_dist: f32,
     pub(super) pan_dist_thresh: f32,
+    pub(super) double_click_dist_thresh: f32,
     pub(crate) alt_bypass: bool,
     /// Whether navigation focus is enabled for this application window
     pub(crate) nav_focus: bool,
@@ -109,6 +111,7 @@ impl WindowConfig {
             kinetic_decay_sub: f32::NAN,
             scroll_dist: f32::NAN,
             pan_dist_thresh: f32::NAN,
+            double_click_dist_thresh: f32::NAN,
             alt_bypass: false,
             nav_focus: true,
         }
@@ -122,6 +125,7 @@ impl WindowConfig {
         let dpem = base.font.get_dpem(TextClass::Standard) * scale_factor;
         self.scroll_dist = base.event.scroll_dist_em * dpem;
         self.pan_dist_thresh = base.event.pan_dist_thresh * scale_factor;
+        self.double_click_dist_thresh = base.event.double_click_dist_thresh * scale_factor;
     }
 
     /// Access base (unscaled) [`Config`]

--- a/crates/kas-core/src/geom/vector.rs
+++ b/crates/kas-core/src/geom/vector.rs
@@ -345,13 +345,19 @@ macro_rules! impl_vec2 {
                 self.0 * self.0 + self.1 * self.1
             }
 
-            /// Return the L1 (rectilinear / taxicab) distance
+            /// Return the L1 norm: (rectilinear / taxicab) distance
             #[inline]
             pub fn distance_l1(self) -> $f {
                 self.0.abs() + self.1.abs()
             }
 
-            /// Return the L-inf (max) distance
+            /// Return the L2 norm: (Euclidean) distance
+            #[inline]
+            pub fn distance_l2(self) -> $f {
+                self.sum_square().sqrt()
+            }
+
+            /// Return the L-inf norm: max absolute value of components
             #[inline]
             pub fn distance_l_inf(self) -> $f {
                 self.0.abs().max(self.1.abs())

--- a/crates/kas-widgets/src/event_config.rs
+++ b/crates/kas-widgets/src/event_config.rs
@@ -47,20 +47,23 @@ mod EventConfig {
         (0, 8) => "Pan distance threshold:",
         (1, 8) => self.pan_dist_thresh,
 
-        (0, 9) => "Mouse pan:",
-        (1, 9) => self.mouse_pan,
+        (0, 9) => "Double-click distance threshold:",
+        (1, 9) => self.double_click_dist_thresh,
 
-        (0, 10) => "Mouse text pan:",
-        (1, 10) => self.mouse_text_pan,
+        (0, 10) => "Mouse pan:",
+        (1, 10) => self.mouse_pan,
 
-        (1, 11) => self.mouse_wheel_actions,
+        (0, 11) => "Mouse text pan:",
+        (1, 11) => self.mouse_text_pan,
 
-        (1, 12) => self.mouse_nav_focus,
+        (1, 12) => self.mouse_wheel_actions,
 
-        (1, 13) => self.touch_nav_focus,
+        (1, 13) => self.mouse_nav_focus,
 
-        (0, 14) => "Restore default values:",
-        (1, 14) => Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
+        (1, 14) => self.touch_nav_focus,
+
+        (0, 15) => "Restore default values:",
+        (1, 15) => Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
     })]
     #[impl_default(EventConfig::new())]
     pub struct EventConfig {
@@ -83,6 +86,8 @@ mod EventConfig {
         scroll_dist_em: SpinBox<(), f32>,
         #[widget]
         pan_dist_thresh: SpinBox<(), f32>,
+        #[widget]
+        double_click_dist_thresh: SpinBox<(), f32>,
         #[widget]
         mouse_pan: ComboBox<(), MousePan>,
         #[widget]
@@ -164,7 +169,14 @@ mod EventConfig {
                     cx.config().base().event.pan_dist_thresh
                 })
                 .with_step(0.25)
-                .with_msg(EventConfigMsg::PanDistThresh),
+                .with_msg(EventConfigMsg::PanDistThresh)
+                .with_unit("px"),
+                double_click_dist_thresh: SpinBox::new(0.25..=16.0, |cx: &ConfigCx, _| {
+                    cx.config().base().event.double_click_dist_thresh
+                })
+                .with_step(0.25)
+                .with_msg(EventConfigMsg::DoubleClickDistThresh)
+                .with_unit("px"),
                 mouse_pan: ComboBox::new_msg(
                     pan_options,
                     |cx: &ConfigCx, _| cx.config().base().event.mouse_pan,

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -145,7 +145,8 @@ impl<A, T: SpinValue> SpinGuard<A, T> {
             SpinBtn::Up => old_value.add_step(self.step),
         };
 
-        self.value = value.clamp(self.start, self.end);
+        let value = value.clamp(self.start, self.end);
+        self.value = value;
         (value != old_value).then_some(value)
     }
 }


### PR DESCRIPTION
Add an event config item: `double_click_dist_thresh`. Use to fix double-clicks being interrupted by very small amounts of mouse motion.

Fix range clamping in `SpinBox`.