### PR TITLE
Add inner: &mut W parameter to Adapt closures and revise `DrawShared::image_*` fns

### DIFF
--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -93,7 +93,7 @@ pub trait DrawShared {
     /// Allocate an image
     ///
     /// Use [`SharedState::image_upload`] to set contents of the new image.
-    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageHandle, AllocError>;
+    fn image_alloc(&mut self, size: Size) -> Result<ImageHandle, AllocError>;
 
     /// Upload an image to the GPU
     ///
@@ -117,7 +117,7 @@ pub trait DrawShared {
 
 impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
     #[inline]
-    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageHandle, AllocError> {
+    fn image_alloc(&mut self, size: Size) -> Result<ImageHandle, AllocError> {
         self.draw
             .image_alloc(size)
             .map(|id| ImageHandle(id, Rc::new(())))
@@ -156,7 +156,7 @@ pub trait DrawSharedImpl: Any {
     /// Allocate an image
     ///
     /// Use [`DrawSharedImpl::image_upload`] to set contents of the new image.
-    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, AllocError>;
+    fn image_alloc(&mut self, size: Size) -> Result<ImageId, AllocError>;
 
     /// Upload an image to the GPU
     ///

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -100,10 +100,12 @@ pub trait DrawShared {
     /// This should be called at least once on each image before display. May be
     /// called again to update the image contents.
     ///
-    /// `handle` must refer to an allocation of some size `(w, h)`, such that
-    /// `data.len() == b * w * h` where `b` is the number of bytes per pixel,
-    /// according to `format`. Data must be in row-major order.
-    fn image_upload(&mut self, handle: &ImageHandle, data: &[u8], format: ImageFormat);
+    /// `handle` must refer to an allocation of some size matching `size`.
+    ///
+    /// The image `data` must have `data.len() == b * w * h` where
+    /// `(w, h) == size.cast()` and `b` is the number of bytes per pixel
+    /// (according to `format`). Data must be in row-major order.
+    fn image_upload(&mut self, handle: &ImageHandle, size: Size, data: &[u8], format: ImageFormat);
 
     /// Potentially free an image
     ///
@@ -124,8 +126,8 @@ impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
     }
 
     #[inline]
-    fn image_upload(&mut self, handle: &ImageHandle, data: &[u8], format: ImageFormat) {
-        self.draw.image_upload(handle.0, data, format);
+    fn image_upload(&mut self, handle: &ImageHandle, size: Size, data: &[u8], format: ImageFormat) {
+        self.draw.image_upload(handle.0, size, data, format);
     }
 
     #[inline]
@@ -162,7 +164,7 @@ pub trait DrawSharedImpl: Any {
     ///
     /// This should be called at least once on each image before display. May be
     /// called again to update the image contents.
-    fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat);
+    fn image_upload(&mut self, id: ImageId, size: Size, data: &[u8], format: ImageFormat);
 
     /// Free an image allocation
     fn image_free(&mut self, id: ImageId);

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -8,7 +8,6 @@
 use super::color::Rgba;
 use super::{DrawImpl, PassId};
 use crate::ActionRedraw;
-use crate::cast::Cast;
 use crate::config::RasterConfig;
 use crate::geom::{Quad, Size, Vec2};
 use crate::text::{Effect, TextDisplay};
@@ -168,7 +167,7 @@ impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
 
     #[inline]
     fn image_size(&self, handle: &ImageHandle) -> Option<Size> {
-        self.draw.image_size(handle.0).map(|size| size.cast())
+        self.draw.image_size(handle.0)
     }
 }
 
@@ -205,7 +204,7 @@ pub trait DrawSharedImpl: Any {
     fn image_free(&mut self, id: ImageId);
 
     /// Query an image's size
-    fn image_size(&self, id: ImageId) -> Option<(u32, u32)>;
+    fn image_size(&self, id: ImageId) -> Option<Size>;
 
     /// Draw the image in the given `rect`
     fn draw_image(&self, draw: &mut Self::Draw, pass: PassId, id: ImageId, rect: Quad);

--- a/crates/kas-core/src/draw/mod.rs
+++ b/crates/kas-core/src/draw/mod.rs
@@ -48,7 +48,7 @@ use crate::geom::{Quad, Size};
 
 pub use draw::{Draw, DrawIface, DrawImpl};
 pub use draw_rounded::{DrawRounded, DrawRoundedImpl};
-pub use draw_shared::{AllocError, ImageFormat, ImageHandle, ImageId};
+pub use draw_shared::{AllocError, ImageFormat, ImageHandle, ImageId, UploadError};
 pub use draw_shared::{DrawShared, DrawSharedImpl, SharedState};
 use std::time::{Duration, Instant};
 

--- a/crates/kas-core/src/draw/mod.rs
+++ b/crates/kas-core/src/draw/mod.rs
@@ -43,7 +43,7 @@ mod draw_rounded;
 mod draw_shared;
 
 use crate::cast::Cast;
-use crate::geom::Quad;
+use crate::geom::{Quad, Size};
 #[allow(unused)] use crate::theme::DrawCx;
 
 pub use draw::{Draw, DrawIface, DrawImpl};
@@ -73,7 +73,7 @@ pub struct Allocation {
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(docsrs, doc(cfg(internal_doc)))]
 pub trait Allocator {
-    fn allocate(&mut self, size: (u32, u32)) -> Result<Allocation, AllocError>;
+    fn allocate(&mut self, size: Size) -> Result<Allocation, AllocError>;
     fn deallocate(&mut self, atlas: u32, alloc: u32);
 }
 

--- a/crates/kas-image/Cargo.toml
+++ b/crates/kas-image/Cargo.toml
@@ -38,6 +38,7 @@ png = ["dep:image", "image/png"]
 webp = ["dep:image", "image/webp"]
 
 [dependencies]
+log = "0.4"
 tiny-skia = { version = "0.11.0" }
 resvg = { version = "0.45.0", optional = true }
 usvg = { version = "0.45.0", optional = true }

--- a/crates/kas-image/src/canvas.rs
+++ b/crates/kas-image/src/canvas.rs
@@ -208,11 +208,11 @@ mod Canvas {
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
             if let Some((program, mut pixmap)) = cx.try_pop::<(P, Pixmap)>() {
                 debug_assert!(matches!(self.inner.get_mut(), State::Rendering));
-                let size = (pixmap.width(), pixmap.height());
+                let size = (pixmap.width(), pixmap.height()).cast();
                 let ds = cx.draw_shared();
 
                 if let Some(im_size) = self.image.as_ref().and_then(|h| ds.image_size(h))
-                    && im_size != Size::conv(size)
+                    && im_size != size
                     && let Some(handle) = self.image.take()
                 {
                     ds.image_free(handle);
@@ -228,12 +228,12 @@ mod Canvas {
 
                 cx.redraw();
 
-                let rect_size: (u32, u32) = self.rect().size.cast();
+                let own_size = self.rect().size;
                 let state = self.inner.get_mut();
-                if rect_size != size {
+                if own_size != size {
                     // Possible if a redraw was in progress when set_rect was called
 
-                    pixmap = if let Some(px) = Pixmap::new(rect_size.0, rect_size.1) {
+                    pixmap = if let Some(px) = Pixmap::new(own_size.0.cast(), own_size.1.cast()) {
                         px
                     } else {
                         *state = State::Initial(program);

--- a/crates/kas-image/src/canvas.rs
+++ b/crates/kas-image/src/canvas.rs
@@ -223,10 +223,11 @@ mod Canvas {
                 }
 
                 if let Some(handle) = self.image.as_ref() {
-                    ds.image_upload(handle, size, pixmap.data(), ImageFormat::Rgba8);
+                    match ds.image_upload(handle, size, pixmap.data(), ImageFormat::Rgba8) {
+                        Ok(_) => cx.redraw(),
+                        Err(err) => log::warn!("Canvas: image upload failed: {err}"),
+                    }
                 }
-
-                cx.redraw();
 
                 let own_size = self.rect().size;
                 let state = self.inner.get_mut();

--- a/crates/kas-image/src/canvas.rs
+++ b/crates/kas-image/src/canvas.rs
@@ -223,7 +223,7 @@ mod Canvas {
                 }
 
                 if let Some(handle) = self.image.as_ref() {
-                    ds.image_upload(handle, pixmap.data(), ImageFormat::Rgba8);
+                    ds.image_upload(handle, size, pixmap.data(), ImageFormat::Rgba8);
                 }
 
                 cx.redraw();

--- a/crates/kas-image/src/image.rs
+++ b/crates/kas-image/src/image.rs
@@ -168,12 +168,12 @@ mod Image {
                     // TODO(opt): we converted to RGBA8 since this is the only format common
                     // to both the image and wgpu crates. It may not be optimal however.
                     // It also assumes that the image colour space is sRGB.
-                    let size = image.dimensions();
+                    let size = image.dimensions().cast();
 
                     let draw = cx.draw_shared();
                     match draw.image_alloc(size) {
                         Ok(handle) => {
-                            draw.image_upload(&handle, &image, kas::draw::ImageFormat::Rgba8);
+                            draw.image_upload(&handle, size, &image, kas::draw::ImageFormat::Rgba8);
                             self.raw.set(cx, handle);
                         }
                         Err(err) => {

--- a/crates/kas-image/src/image.rs
+++ b/crates/kas-image/src/image.rs
@@ -171,15 +171,19 @@ mod Image {
                     let size = image.dimensions().cast();
 
                     let draw = cx.draw_shared();
-                    match draw.image_alloc(size) {
-                        Ok(handle) => {
-                            draw.image_upload(&handle, size, &image, kas::draw::ImageFormat::Rgba8);
-                            self.raw.set(cx, handle);
-                        }
+                    let handle = match draw.image_alloc(size) {
+                        Ok(handle) => handle,
                         Err(err) => {
-                            warn_about_error("Failed to allocate image", &err);
+                            log::warn!("Image: allocate failed: {err}");
+                            return;
                         }
-                    }
+                    };
+
+                    match draw.image_upload(&handle, size, &image, kas::draw::ImageFormat::Rgba8) {
+                        Ok(_) => cx.redraw(),
+                        Err(err) => log::warn!("Image: image upload failed: {err}"),
+                    };
+                    self.raw.set(cx, handle);
                 } else {
                     self.raw.clear(cx);
                 }

--- a/crates/kas-image/src/sprite.rs
+++ b/crates/kas-image/src/sprite.rs
@@ -57,6 +57,24 @@ mod Sprite {
             }
         }
 
+        /// Access the current [`ImageHandle`], if any
+        ///
+        /// This handle may be used with [`DrawShared`](kas::draw::DrawShared)
+        /// methods.
+        #[inline]
+        pub fn handle(&self) -> Option<&ImageHandle> {
+            self.handle.as_ref()
+        }
+
+        /// Get the image buffer size
+        ///
+        /// This is the size of the image last assigned using [`Sprite::set`].
+        /// Initially it is [`Size::ZERO`].
+        #[inline]
+        pub fn image_size(&self) -> Size {
+            self.image_size
+        }
+
         /// Remove image (set empty)
         pub fn clear(&mut self, cx: &mut EventCx) {
             if let Some(handle) = self.handle.take() {

--- a/crates/kas-image/src/svg.rs
+++ b/crates/kas-image/src/svg.rs
@@ -299,11 +299,11 @@ mod Svg {
 
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
             if let Some(pixmap) = cx.try_pop::<Pixmap>() {
-                let size = (pixmap.width(), pixmap.height());
+                let size = (pixmap.width(), pixmap.height()).cast();
                 let ds = cx.draw_shared();
 
                 if let Some(im_size) = self.image.as_ref().and_then(|h| ds.image_size(h))
-                    && im_size != Size::conv(size)
+                    && im_size != size
                     && let Some(handle) = self.image.take()
                 {
                     ds.image_free(handle);
@@ -325,9 +325,8 @@ mod Svg {
                     }
                 };
 
-                let own_size: (u32, u32) = self.rect().size.cast();
-                if size != own_size
-                    && let Some(fut) = self.inner.resize(own_size)
+                if size != self.rect().size
+                    && let Some(fut) = self.inner.resize(self.rect().size.cast())
                 {
                     cx.send_spawn(self.id(), fut);
                 }

--- a/crates/kas-image/src/svg.rs
+++ b/crates/kas-image/src/svg.rs
@@ -314,7 +314,7 @@ mod Svg {
                 }
 
                 if let Some(handle) = self.image.as_ref() {
-                    ds.image_upload(handle, pixmap.data(), ImageFormat::Rgba8);
+                    ds.image_upload(handle, size, pixmap.data(), ImageFormat::Rgba8);
                 }
 
                 cx.redraw();

--- a/crates/kas-image/src/svg.rs
+++ b/crates/kas-image/src/svg.rs
@@ -314,10 +314,12 @@ mod Svg {
                 }
 
                 if let Some(handle) = self.image.as_ref() {
-                    ds.image_upload(handle, size, pixmap.data(), ImageFormat::Rgba8);
+                    match ds.image_upload(handle, size, pixmap.data(), ImageFormat::Rgba8) {
+                        Ok(_) => cx.redraw(),
+                        Err(err) => log::warn!("Svg: image upload failed: {err}"),
+                    }
                 }
 
-                cx.redraw();
                 self.inner = match std::mem::take(&mut self.inner) {
                     State::None => State::None,
                     State::Initial(source) | State::Rendering(source) | State::Ready(source, _) => {

--- a/crates/kas-soft/src/atlas.rs
+++ b/crates/kas-soft/src/atlas.rs
@@ -128,12 +128,12 @@ impl<F: Format> Allocator for Atlases<F> {
     /// Allocate space within a texture atlas
     ///
     /// Fails if `size` is zero in any dimension.
-    fn allocate(&mut self, size: (u32, u32)) -> Result<Allocation, AllocError> {
+    fn allocate(&mut self, size: Size) -> Result<Allocation, AllocError> {
         if size.0 == 0 || size.1 == 0 {
             return Err(AllocError);
         }
 
-        let (atlas, alloc, tex_size) = self.allocate_space((size.0.cast(), size.1.cast()))?;
+        let (atlas, alloc, tex_size) = self.allocate_space((size.0, size.1))?;
 
         let origin = (alloc.rectangle.min.x.cast(), alloc.rectangle.min.y.cast());
 
@@ -571,10 +571,13 @@ impl Shared {
     }
 
     /// Allocate an image
-    pub fn alloc(&mut self, size: (u32, u32)) -> Result<ImageId, AllocError> {
+    pub fn alloc(&mut self, size: Size) -> Result<ImageId, AllocError> {
         let id = self.next_image_id();
         let alloc = self.atlas_rgba.allocate(size)?;
-        let image = Image { size, alloc };
+        let image = Image {
+            size: size.cast(),
+            alloc,
+        };
         self.images.insert(id, image);
         Ok(id)
     }
@@ -641,16 +644,16 @@ impl SpriteAllocator for Shared {
     }
 
     fn alloc_mask(&mut self, size: (u32, u32)) -> Result<Allocation, AllocError> {
-        self.atlas_mask.allocate(size)
+        self.atlas_mask.allocate(size.cast())
     }
 
     fn alloc_rgba_mask(&mut self, mut size: (u32, u32)) -> Result<Allocation, AllocError> {
         size.0 += 2; // allow for correct filtering
-        self.atlas_rgba_mask.allocate(size)
+        self.atlas_rgba_mask.allocate(size.cast())
     }
 
     fn alloc_rgba(&mut self, size: (u32, u32)) -> Result<Allocation, AllocError> {
-        self.atlas_rgba.allocate(size)
+        self.atlas_rgba.allocate(size.cast())
     }
 }
 

--- a/crates/kas-soft/src/atlas.rs
+++ b/crates/kas-soft/src/atlas.rs
@@ -583,7 +583,7 @@ impl Shared {
     }
 
     /// Upload an image
-    pub fn upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat) {
+    pub fn upload(&mut self, id: ImageId, size: Size, data: &[u8], format: ImageFormat) {
         match format {
             ImageFormat::Rgba8 => (),
         }

--- a/crates/kas-soft/src/draw.rs
+++ b/crates/kas-soft/src/draw.rs
@@ -7,7 +7,9 @@
 
 use super::{atlas, basic};
 use kas::cast::Cast;
-use kas::draw::{AllocError, DrawImpl, DrawSharedImpl, PassId, PassType, WindowCommon};
+use kas::draw::{
+    AllocError, DrawImpl, DrawSharedImpl, PassId, PassType, UploadError, WindowCommon,
+};
 use kas::draw::{ImageFormat, ImageId, color};
 use kas::geom::{Quad, Size, Vec2};
 use kas::prelude::{Offset, Rect};
@@ -156,8 +158,14 @@ impl DrawSharedImpl for Shared {
     }
 
     #[inline]
-    fn image_upload(&mut self, id: ImageId, size: Size, data: &[u8], format: ImageFormat) {
-        self.images.upload(id, size, data, format);
+    fn image_upload(
+        &mut self,
+        id: ImageId,
+        size: Size,
+        data: &[u8],
+        format: ImageFormat,
+    ) -> Result<(), UploadError> {
+        self.images.upload(id, size, data, format)
     }
 
     #[inline]

--- a/crates/kas-soft/src/draw.rs
+++ b/crates/kas-soft/src/draw.rs
@@ -151,7 +151,7 @@ impl DrawSharedImpl for Shared {
     }
 
     #[inline]
-    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, AllocError> {
+    fn image_alloc(&mut self, size: Size) -> Result<ImageId, AllocError> {
         self.images.alloc(size)
     }
 

--- a/crates/kas-soft/src/draw.rs
+++ b/crates/kas-soft/src/draw.rs
@@ -156,8 +156,8 @@ impl DrawSharedImpl for Shared {
     }
 
     #[inline]
-    fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat) {
-        self.images.upload(id, data, format);
+    fn image_upload(&mut self, id: ImageId, size: Size, data: &[u8], format: ImageFormat) {
+        self.images.upload(id, size, data, format);
     }
 
     #[inline]

--- a/crates/kas-soft/src/draw.rs
+++ b/crates/kas-soft/src/draw.rs
@@ -174,7 +174,7 @@ impl DrawSharedImpl for Shared {
     }
 
     #[inline]
-    fn image_size(&self, id: ImageId) -> Option<(u32, u32)> {
+    fn image_size(&self, id: ImageId) -> Option<Size> {
         self.images.image_size(id)
     }
 

--- a/crates/kas-wgpu/src/draw/atlases.rs
+++ b/crates/kas-wgpu/src/draw/atlases.rs
@@ -263,12 +263,12 @@ impl<I: bytemuck::Pod> Allocator for Pipeline<I> {
     /// Allocate space within a texture atlas
     ///
     /// Fails if `size` is zero in any dimension.
-    fn allocate(&mut self, size: (u32, u32)) -> Result<Allocation, AllocError> {
+    fn allocate(&mut self, size: Size) -> Result<Allocation, AllocError> {
         if size.0 == 0 || size.1 == 0 {
             return Err(AllocError);
         }
 
-        let (atlas, alloc, tex_size) = self.allocate_space((size.0.cast(), size.1.cast()))?;
+        let (atlas, alloc, tex_size) = self.allocate_space((size.0, size.1))?;
 
         let origin = (alloc.rectangle.min.x.cast(), alloc.rectangle.min.y.cast());
 

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -335,9 +335,15 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
     }
 
     #[inline]
-    fn image_upload(&mut self, id: ImageId, size: Size, data: &[u8], format: ImageFormat) {
+    fn image_upload(
+        &mut self,
+        id: ImageId,
+        size: Size,
+        data: &[u8],
+        format: ImageFormat,
+    ) -> Result<(), UploadError> {
         self.images
-            .upload(&self.device, &self.queue, id, size, data, format);
+            .upload(&self.device, &self.queue, id, size, data, format)
     }
 
     #[inline]

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -352,7 +352,7 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
     }
 
     #[inline]
-    fn image_size(&self, id: ImageId) -> Option<(u32, u32)> {
+    fn image_size(&self, id: ImageId) -> Option<Size> {
         self.images.image_size(id)
     }
 

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -330,7 +330,7 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
     }
 
     #[inline]
-    fn image_alloc(&mut self, size: (u32, u32)) -> Result<ImageId, AllocError> {
+    fn image_alloc(&mut self, size: Size) -> Result<ImageId, AllocError> {
         self.images.alloc(size)
     }
 

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -335,9 +335,9 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
     }
 
     #[inline]
-    fn image_upload(&mut self, id: ImageId, data: &[u8], format: ImageFormat) {
+    fn image_upload(&mut self, id: ImageId, size: Size, data: &[u8], format: ImageFormat) {
         self.images
-            .upload(&self.device, &self.queue, id, data, format);
+            .upload(&self.device, &self.queue, id, size, data, format);
     }
 
     #[inline]

--- a/crates/kas-wgpu/src/draw/images.rs
+++ b/crates/kas-wgpu/src/draw/images.rs
@@ -10,9 +10,9 @@ use std::collections::HashMap;
 use std::mem::size_of;
 
 use super::{ShaderManager, atlases};
-use kas::cast::Conv;
+use kas::cast::{Cast, Conv};
 use kas::draw::{AllocError, Allocation, Allocator, ImageFormat, ImageId, PassId};
-use kas::geom::{Quad, Vec2};
+use kas::geom::{Quad, Size, Vec2};
 use kas::text::raster::{RenderQueue, Sprite, SpriteAllocator, SpriteType, UnpreparedSprite};
 
 #[derive(Debug)]
@@ -233,10 +233,13 @@ impl Images {
     }
 
     /// Allocate an image
-    pub fn alloc(&mut self, size: (u32, u32)) -> Result<ImageId, AllocError> {
+    pub fn alloc(&mut self, size: Size) -> Result<ImageId, AllocError> {
         let id = self.next_image_id();
         let alloc = self.atlas_rgba.allocate(size)?;
-        let image = Image { size, alloc };
+        let image = Image {
+            size: size.cast(),
+            alloc,
+        };
         self.images.insert(id, image);
         Ok(id)
     }
@@ -389,18 +392,18 @@ impl SpriteAllocator for Images {
     }
 
     fn alloc_mask(&mut self, size: (u32, u32)) -> Result<Allocation, AllocError> {
-        self.atlas_mask.allocate(size)
+        self.atlas_mask.allocate(size.cast())
     }
 
     fn alloc_rgba_mask(&mut self, size: (u32, u32)) -> Result<Allocation, AllocError> {
         self.atlas_rgba_mask
             .as_mut()
             .expect("subpixel rendering feature is unavailable")
-            .allocate(size)
+            .allocate(size.cast())
     }
 
     fn alloc_rgba(&mut self, size: (u32, u32)) -> Result<Allocation, AllocError> {
-        self.atlas_rgba.allocate(size)
+        self.atlas_rgba.allocate(size.cast())
     }
 }
 

--- a/crates/kas-wgpu/src/draw/images.rs
+++ b/crates/kas-wgpu/src/draw/images.rs
@@ -250,6 +250,7 @@ impl Images {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         id: ImageId,
+        size: Size,
         data: &[u8],
         format: ImageFormat,
     ) {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -341,7 +341,7 @@ Demonstration of *as-you-type* formatting from **Markdown**.
 
     let ui = ui
         .with_state(Data::default())
-        .on_update(|_, data, app_data: &AppData| data.disabled = app_data.disabled)
+        .on_update(|_, _, data, app_data: &AppData| data.disabled = app_data.disabled)
         .on_message(|_, data, MsgDirection| {
             data.dir = match data.dir {
                 Direction::Up => Direction::Right,

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -47,7 +47,7 @@ fn make_ui() -> impl Widget<Data = ()> {
                 cx.request_frame_timer(TIMER);
             }
         })
-        .on_timer(TIMER, |cx, timer, _| {
+        .on_timer(TIMER, |cx, _, timer, _| {
             if let Some(last) = timer.last {
                 let now = Instant::now();
                 timer.elapsed += now - last;

--- a/examples/sync-counter.rs
+++ b/examples/sync-counter.rs
@@ -53,7 +53,7 @@ fn counter(title: &str) -> Window<Count> {
 
     let ui = ui
         .with_state(initial)
-        .on_update(|_, state, count| state.0 = *count)
+        .on_update(|_, _, state, count| state.0 = *count)
         .on_message(|_, state, SetValue(v)| state.1 = v);
     Window::new(ui, title).escapable()
 }


### PR DESCRIPTION
Draft because: I'm undecided whether this is a good design; the purpose of `Adapt` is to add user-controllable state.