### PR TITLE
Remove `MultiThemeBuilder`; update ROADMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Every approach has its limitations. Ours are:
 
 In development. Interfaces are not currently stable.
 
+Enough functionality should be present to develop complex GUIs, however some features are still missing (see [the Roadmap](https://github.com/kas-gui/kas/blob/master/ROADMAP.md#future-work).
+
 
 Crates and features
 -------------------

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -249,6 +249,10 @@ To investigate. Possibly use Servo (components), though it may not matter much.
 
 The browser should probably be integrated via a child window (see Winit's `WindowBuilder::with_parent_window`, which is not yet supported everywhere).
 
+### Improved layout support
+
+The current layout system has some issues with margins and alignment; in particular margins should be optional and internal alignment is sometimes necessary.
+
 
 External dependencies
 ----------------------

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -200,11 +200,6 @@ Future work
 These items are not versioned and appear only roughly in the expected order.
 Each should be a decently sized work item (roughly one release).
 
-### Standard geometry types
-
-KAS has ad-hoc geometry types. *Possibly* it would be useful to use third-party
-types instead. See [#95](https://github.com/kas-gui/kas/issues/95).
-
 ### Context menu and undo
 
 KAS supports pop-up menus since 0.4. Context menus are a little different, in
@@ -230,19 +225,6 @@ few standard dialog boxes (e.g. file open/save), not only for consistency but
 also security (e.g. a container may not let an app explore the filesystem).
 Such dialogs should automatically use desktop-provided equivalents where
 available.
-
-### Input Method Editors and virtual keyboards
-
-Winit has at least partial support for IME now. Kas should add support for this
-(mostly this means an additional `Event` variant, one or two API calls to
-enable IME input for the current widget, and adjusting `EditField`).
-
-### Accessibility tools
-
-`AccessKit` would appear to be the defacto Rust API for accessibility tools with
-(limited) support from egui and Xilem toolkits. Widgets could support this via
-additional code in the `update` method, possibly with additional tracking to
-avoid unnecessarily replacing nodes.
 
 ### Internationalisation (i18n)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -175,6 +175,24 @@ For more on *input data*, read the [design document](https://github.com/kas-gui/
 Add traits `Collection` and `CellCollection` representing a list/tuple of widgets.
 Revise layout macros with `.align` / `.pack` / `.margins` adapters.
 
+### 0.16.0 — September 2025
+
+Accessibility support was enabled via AccessKit, sufficient to support screen readers (excepting text input fields). This support uses a new widget method, `fn Tile::role(self, cx) -> Role` where `enum Role` describes common widget capability sets. A number of standard messages were added, with some expectations on support via the `Role` enum. Together, this allows widget tree introspection and (limited) control, even without the AccessKit dependency.
+
+Input Method Editors (IME) also received basic support.
+
+Tooltips (pop-up text on mouse hover) have been implemented.
+
+### 0.17.0 — Unreleased
+
+IME support is improved using the revised winit support for this.
+
+Added `kas-soft` software-rendering backend, providing an alternative to WGPU and enabling substantially smaller binaries.
+
+Revised per-class text support, allowing this to affect font size & style.
+
+Sub-pixel rendering support.
+
 
 Future work
 -----------

--- a/crates/kas-core/src/theme/mod.rs
+++ b/crates/kas-core/src/theme/mod.rs
@@ -31,7 +31,7 @@ pub mod dimensions;
 pub use colors::{Colors, ColorsLinear, ColorsSrgb, InputState};
 pub use draw::{Background, DrawCx};
 pub use flat_theme::FlatTheme;
-pub use multi::{MultiTheme, MultiThemeBuilder};
+pub use multi::MultiTheme;
 pub use simple_theme::SimpleTheme;
 pub use size::SizeCx;
 pub use style::*;

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -742,16 +742,14 @@ cargo run --example gallery --features toml
 fn main() -> kas::runner::Result<()> {
     env_logger::init();
 
-    #[allow(unused_mut)]
-    let mut builder =
-        kas::theme::MultiTheme::builder().add("simple", kas::theme::SimpleTheme::new());
+    let mut theme = kas::theme::MultiTheme::new();
+    theme.add("simple", kas::theme::SimpleTheme::new());
     #[cfg(feature = "wgpu")]
     {
-        builder = builder
-            .add("flat", kas::theme::FlatTheme::new())
-            .add("shaded", kas_wgpu::ShadedTheme::new())
+        let index = theme.add("flat", kas::theme::FlatTheme::new());
+        theme.add("shaded", kas_wgpu::ShadedTheme::new());
+        theme.set_active(index);
     }
-    let theme = builder.build();
     let mut runner = kas::runner::Runner::with_theme(theme).build(())?;
 
     // TODO: use as logo of tab
@@ -770,9 +768,13 @@ fn main() -> kas::runner::Result<()> {
             menu.entry("&Quit", Menu::Quit);
         })
         .menu("&Theme", |menu| {
-            menu.entry("&Simple", Menu::Theme("simple"))
-                .entry("&Flat", Menu::Theme("flat"))
-                .entry("S&haded", Menu::Theme("shaded"));
+            #[allow(unused)]
+            let menu = menu.entry("&Simple", Menu::Theme("simple"));
+            #[cfg(feature = "wgpu")]
+            {
+                menu.entry("&Flat", Menu::Theme("flat"))
+                    .entry("S&haded", Menu::Theme("shaded"));
+            }
         })
         .menu("&Style", |menu| {
             menu.submenu("&Colours", |mut menu| {


### PR DESCRIPTION
`MultiTheme` has a simpler API no longer uses a builder. This is easier to use with feature flags, as in the gallery. The cost is that `MultiTheme` may panic on UI start.

Update the ROADMAP for 0.16 and current 0.17 additions, also adjusting "future work".