### PR TITLE
Support `row!` and `column!` within `grid!`, replacing `aligned_row!` and `aligned_column!`

### DIFF
--- a/crates/kas-macros/src/collection.rs
+++ b/crates/kas-macros/src/collection.rs
@@ -66,18 +66,6 @@ impl Parse for CellInfo {
                 } else {
                     Err(Error::new(lit.span(), format!("expected value >= {start}")))
                 }
-            } else if input.parse::<Token![..]>().is_ok() {
-                let plus = input.parse::<Token![+]>();
-                let lit = input.parse::<LitInt>()?;
-                let n: u32 = lit.base10_parse()?;
-
-                if plus.is_ok() {
-                    Ok(start + n - 1)
-                } else if n > start {
-                    Ok(n - 1)
-                } else {
-                    Err(Error::new(lit.span(), format!("expected value > {start}")))
-                }
             } else {
                 Ok(start)
             }

--- a/crates/kas-macros/src/collection.rs
+++ b/crates/kas-macros/src/collection.rs
@@ -5,7 +5,7 @@
 
 //! Collection macro
 
-use crate::parser::{Parser, parse_grid};
+use crate::parser::{Parser, parse_grid, parse_list};
 use proc_macro2::{Span, TokenStream as Toks};
 use quote::{ToTokens, TokenStreamExt, quote};
 use syn::parenthesized;
@@ -204,20 +204,9 @@ pub struct Collection(Vec<Item>);
 pub struct CellCollection(Vec<CellInfo>, Collection);
 
 impl Parse for Collection {
-    fn parse(inner: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream) -> Result<Self> {
         let mut names = NameGenerator::default();
-
-        let mut items = vec![];
-        while !inner.is_empty() {
-            items.push(Item::parse(inner, &mut names)?);
-
-            if inner.is_empty() {
-                break;
-            }
-
-            let _: Token![,] = inner.parse()?;
-        }
-
+        let items = parse_list::<Item>(input, &mut names)?;
         Ok(Collection(items))
     }
 }

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -382,7 +382,7 @@ pub fn widget(_: TokenStream, item: TokenStream) -> TokenStream {
 /// > text wrapping.
 /// >
 /// > _MacroItem_: (`frame` | `column` | `row` | `list` | `float` |
-/// > `aligned_column` | `aligned_row` | `grid`) `!` _MacroArgs_\
+/// > `grid`) `!` _MacroArgs_\
 /// > &nbsp;&nbsp; These layout macros are natively supported in layout syntax.
 /// > They are equivalent to the like-named [macros in `kas::widgets`] aside from
 /// > name resolution.

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -626,12 +626,10 @@ pub fn collection(input: TokenStream) -> TokenStream {
 /// > &nbsp;&nbsp; `(` _Column_ `,` _Row_ `)` `=>` _Item_
 /// >
 /// > _Column_, _Row_ :\
-/// > &nbsp;&nbsp; _LitInt_ | ( _LitInt_ `..` `+` _LitInt_ ) | ( _LitInt_ `..`
-/// > _LitInt_ ) | ( _LitInt_ `..=` _LitInt_ )
+/// > &nbsp;&nbsp; _LitInt_ | ( _LitInt_ `..=` _LitInt_ )
 ///
-/// Here, _Column_ and _Row_ are selected via an index (from 0), a range of
-/// indices, or a start + increment. For example, `2` = `2..+1` = `2..3` =
-/// `2..=2` while `5..+2` = `5..7` = `5..=6`.
+/// Here, _Column_ and _Row_ are selected via an index (from 0) or an inclusive
+/// range, for example `2` or `2..=3`.
 ///
 /// _Item_ may be:
 ///

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -18,6 +18,7 @@ use syn::spanned::Spanned;
 mod collection;
 mod extends;
 mod make_layout;
+mod parser;
 mod scroll_traits;
 mod visitors;
 mod widget;

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -617,19 +617,33 @@ pub fn collection(input: TokenStream) -> TokenStream {
 /// # Syntax
 ///
 /// > _Collection_ :\
-/// > &nbsp;&nbsp; `collection!` `[` _ItemArms_<sup>\?</sup> `]`
+/// > &nbsp;&nbsp; `cell_collection!` `{` _ItemArms_<sup>\?</sup> `}`
 /// >
 /// > _ItemArms_ :\
 /// > &nbsp;&nbsp; (_ItemArm_ `,`)<sup>\*</sup> _ItemArm_ `,`<sup>\?</sup>
 /// >
 /// > _ItemArm_ :\
+/// > &nbsp;&nbsp; _Cell_ | _RowMacro_ | _ColumnMacro_
+/// >
+/// > _Cell_ :\
 /// > &nbsp;&nbsp; `(` _Column_ `,` _Row_ `)` `=>` _Item_
 /// >
 /// > _Column_, _Row_ :\
 /// > &nbsp;&nbsp; _LitInt_ | ( _LitInt_ `..=` _LitInt_ )
+/// >
+/// > _RowMacro_ :\
+/// > &npsb;&nbsp; `row!` `[` (_Item_ `,` | `_` `,`)* _Item_ `]`
+/// >
+/// > _ColumnMacro_ :\
+/// > &npsb;&nbsp; `column!` `[` (_Item_ `,` | `_` `,`)* _Item_ `]`
 ///
 /// Here, _Column_ and _Row_ are selected via an index (from 0) or an inclusive
 /// range, for example `2` or `2..=3`.
+///
+/// A `row!` macro resolves to a list of cells whose column index is one larger
+/// than maximum prior column index and whose row indices count from 0.
+/// As a special case, `_` may be used to skip a cell (infer an empty cell).
+/// A `column!` macro functions similarly.
 ///
 /// _Item_ may be:
 ///

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -4,7 +4,7 @@
 //     https://www.apache.org/licenses/LICENSE-2.0
 
 use crate::collection::{CellInfo, GridDimensions, NameGenerator};
-use crate::parser::{Parser, parse_grid};
+use crate::parser::{Parser, parse_grid, parse_list};
 use crate::widget_args::{Child, ChildIdent};
 use impl_tools_lib::scope::Scope;
 use proc_macro_error2::emit_error;
@@ -338,22 +338,7 @@ impl Layout {
 fn parse_layout_list(input: ParseStream, core_gen: &mut NameGenerator) -> Result<Vec<Layout>> {
     let inner;
     let _ = bracketed!(inner in input);
-    parse_layout_items(&inner, core_gen)
-}
-
-fn parse_layout_items(inner: ParseStream, core_gen: &mut NameGenerator) -> Result<Vec<Layout>> {
-    let mut list = vec![];
-    while !inner.is_empty() {
-        list.push(Layout::parse(inner, core_gen)?);
-
-        if inner.is_empty() {
-            break;
-        }
-
-        let _: Token![,] = inner.parse()?;
-    }
-
-    Ok(list)
+    parse_list::<Layout>(&inner, core_gen)
 }
 
 impl Parser for Layout {

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -459,10 +459,14 @@ fn parse_grid(stor: Ident, inner: ParseStream, core_gen: &mut NameGenerator) -> 
                 let col = dim.cols;
                 let mut row = 0;
                 while !inner2.is_empty() {
-                    let layout = Layout::parse(&inner2, core_gen)?;
-                    let cell = CellInfo::new(col, row);
-                    dim.update(&cell);
-                    cells.push(ListItem { cell, layout });
+                    if let Ok(_) = inner2.parse::<Token![_]>() {
+                        // empty item
+                    } else {
+                        let layout = Layout::parse(&inner2, core_gen)?;
+                        let cell = CellInfo::new(col, row);
+                        dim.update(&cell);
+                        cells.push(ListItem { cell, layout });
+                    }
                     row += 1;
 
                     if inner2.is_empty() {
@@ -482,10 +486,14 @@ fn parse_grid(stor: Ident, inner: ParseStream, core_gen: &mut NameGenerator) -> 
                 let mut col = 0;
                 let row = dim.rows;
                 while !inner2.is_empty() {
-                    let layout = Layout::parse(&inner2, core_gen)?;
-                    let cell = CellInfo::new(col, row);
-                    dim.update(&cell);
-                    cells.push(ListItem { cell, layout });
+                    if let Ok(_) = inner2.parse::<Token![_]>() {
+                        // empty item
+                    } else {
+                        let layout = Layout::parse(&inner2, core_gen)?;
+                        let cell = CellInfo::new(col, row);
+                        dim.update(&cell);
+                        cells.push(ListItem { cell, layout });
+                    }
                     col += 1;
 
                     if inner2.is_empty() {

--- a/crates/kas-macros/src/parser.rs
+++ b/crates/kas-macros/src/parser.rs
@@ -1,0 +1,131 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Common parsing code for collections and layouts
+
+use crate::collection::{CellInfo, GridDimensions, NameGenerator};
+use syn::parse::{ParseStream, Result};
+use syn::{Error, Ident, Token};
+use syn::{braced, bracketed};
+
+#[allow(non_camel_case_types)]
+mod kw {
+    use syn::custom_keyword;
+
+    custom_keyword!(column);
+    custom_keyword!(row);
+}
+
+pub trait Parser {
+    type Output;
+
+    fn parse(input: ParseStream, core_gen: &mut NameGenerator) -> Result<Self::Output>;
+}
+
+pub fn parse_grid<P: Parser>(
+    inner: ParseStream,
+    core_gen: &mut NameGenerator,
+) -> Result<(GridDimensions, Vec<CellInfo>, Vec<P::Output>)> {
+    let mut dim = GridDimensions::default();
+    let mut infos = vec![];
+    let mut items = vec![];
+    while !inner.is_empty() {
+        let mut require_comma = true;
+        if inner.peek2(Token![!]) {
+            let lookahead = inner.lookahead1();
+            if lookahead.peek(kw::column) {
+                let _: kw::column = inner.parse()?;
+                let _: Token![!] = inner.parse()?;
+
+                let inner2;
+                let _ = bracketed!(inner2 in inner);
+                let col = dim.cols;
+                let mut row = 0;
+                while !inner2.is_empty() {
+                    if let Ok(_) = inner2.parse::<Token![_]>() {
+                        // empty item
+                    } else {
+                        let layout = P::parse(&inner2, core_gen)?;
+                        let cell = CellInfo::new(col, row);
+                        dim.update(&cell);
+                        infos.push(cell);
+                        items.push(layout);
+                    }
+                    row += 1;
+
+                    if inner2.is_empty() {
+                        break;
+                    }
+
+                    if let Err(e) = inner2.parse::<Token![,]>() {
+                        return Err(e);
+                    }
+                }
+            } else if lookahead.peek(kw::row) {
+                let _: kw::row = inner.parse()?;
+                let _: Token![!] = inner.parse()?;
+
+                let inner2;
+                let _ = bracketed!(inner2 in inner);
+                let mut col = 0;
+                let row = dim.rows;
+                while !inner2.is_empty() {
+                    if let Ok(_) = inner2.parse::<Token![_]>() {
+                        // empty item
+                    } else {
+                        let layout = P::parse(&inner2, core_gen)?;
+                        let cell = CellInfo::new(col, row);
+                        dim.update(&cell);
+                        infos.push(cell);
+                        items.push(layout);
+                    }
+                    col += 1;
+
+                    if inner2.is_empty() {
+                        break;
+                    }
+
+                    if let Err(e) = inner2.parse::<Token![,]>() {
+                        return Err(e);
+                    }
+                }
+            } else {
+                let ident: Ident = inner.parse()?;
+                let tok: Token![!] = inner.parse()?;
+                let span = ident.span();
+                let span = span.join(tok.span).unwrap_or(span);
+                return Err(Error::new(span, "expected: `column!` or `row!`"));
+            }
+        } else {
+            let cell = inner.parse()?;
+            dim.update(&cell);
+            let _: Token![=>] = inner.parse()?;
+
+            let layout;
+            if inner.peek(syn::token::Brace) {
+                let inner2;
+                let _ = braced!(inner2 in inner);
+                layout = P::parse(&inner2, core_gen)?;
+                require_comma = false;
+            } else {
+                layout = P::parse(inner, core_gen)?;
+            }
+            infos.push(cell);
+            items.push(layout);
+        }
+
+        if inner.is_empty() {
+            break;
+        }
+
+        if let Err(e) = inner.parse::<Token![,]>() {
+            if require_comma {
+                return Err(e);
+            }
+        }
+    }
+
+    Ok((dim, infos, items))
+}

--- a/crates/kas-macros/src/widget.rs
+++ b/crates/kas-macros/src/widget.rs
@@ -22,7 +22,7 @@ use syn::{parse_quote, parse2};
 /// behaviour is a panic.
 pub fn widget(attr_span: Span, scope: &mut Scope) -> Result<()> {
     scope.expand_impl_self();
-    let layout = crate::make_layout::Tree::try_parse(scope)?;
+    let layout = crate::make_layout::Tree::parse_or_dummy(scope);
     let mut have_rect_definition = layout
         .as_ref()
         .map(|tree| tree.rect(&quote! {}).is_some())

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -290,7 +290,7 @@ struct MsgClose(bool);
 mod TextEdit {
     #[widget]
     #[layout(grid! {
-        (0..3, 0) => self.edit,
+        (0..=2, 0) => self.edit,
         (0, 1) => Filler::maximize(),
         (1, 1) => Button::label_msg("&Cancel", MsgClose(false)),
         (2, 1) => Button::label_msg("&Save", MsgClose(true)),

--- a/crates/kas-widgets/src/event_config.rs
+++ b/crates/kas-widgets/src/event_config.rs
@@ -20,50 +20,25 @@ mod EventConfig {
     /// TODO: support undo and/or revert to saved values.
     #[widget]
     #[layout(grid! {
-        (0, 0) => "Hover delay:",
-        (1, 0) => self.menu_delay,
-
-        (0, 1) => "Menu delay:",
-        (1, 1) => self.menu_delay,
-
-        (0, 2) => "Touch-selection delay:",
-        (1, 2) => self.touch_select_delay,
-
-        (0, 3) => "Kinetic scrolling timeout:",
-        (1, 3) => self.kinetic_timeout,
-
-        (0, 4) => "Kinetic decay (relative):",
-        (1, 4) => self.kinetic_decay_mul,
-
-        (0, 5) => "Kinetic decay (absolute):",
-        (1, 5) => self.kinetic_decay_sub,
-
-        (0, 6) => "Kinetic decay when grabbed:",
-        (1, 6) => self.kinetic_grab_sub,
-
-        (0, 7) => "Scroll wheel distance:",
-        (1, 7) => self.scroll_dist_em,
-
-        (0, 8) => "Pan distance threshold:",
-        (1, 8) => self.pan_dist_thresh,
-
-        (0, 9) => "Double-click distance threshold:",
-        (1, 9) => self.double_click_dist_thresh,
-
-        (0, 10) => "Mouse pan:",
-        (1, 10) => self.mouse_pan,
-
-        (0, 11) => "Mouse text pan:",
-        (1, 11) => self.mouse_text_pan,
-
+        row!["Hover delay:", self.menu_delay],
+        row!["Menu delay:", self.menu_delay],
+        row!["Touch-selection delay:", self.touch_select_delay],
+        row!["Kinetic scrolling timeout:", self.kinetic_timeout],
+        row!["Kinetic decay (relative):", self.kinetic_decay_mul],
+        row!["Kinetic decay (absolute):", self.kinetic_decay_sub],
+        row!["Kinetic decay when grabbed:", self.kinetic_grab_sub],
+        row!["Scroll wheel distance:", self.scroll_dist_em],
+        row!["Pan distance threshold:", self.pan_dist_thresh],
+        row!["Double-click distance threshold:", self.double_click_dist_thresh],
+        row!["Mouse pan:", self.mouse_pan],
+        row!["Mouse text pan:", self.mouse_text_pan],
         (1, 12) => self.mouse_wheel_actions,
-
         (1, 13) => self.mouse_nav_focus,
-
         (1, 14) => self.touch_nav_focus,
-
-        (0, 15) => "Restore default values:",
-        (1, 15) => Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
+        row![
+            "Restore default values:",
+            Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
+        ],
     })]
     #[impl_default(EventConfig::new())]
     pub struct EventConfig {

--- a/crates/kas-widgets/src/event_config.rs
+++ b/crates/kas-widgets/src/event_config.rs
@@ -32,9 +32,9 @@ mod EventConfig {
         row!["Double-click distance threshold:", self.double_click_dist_thresh],
         row!["Mouse pan:", self.mouse_pan],
         row!["Mouse text pan:", self.mouse_text_pan],
-        (1, 12) => self.mouse_wheel_actions,
-        (1, 13) => self.mouse_nav_focus,
-        (1, 14) => self.touch_nav_focus,
+        row![_, self.mouse_wheel_actions],
+        row![_, self.mouse_nav_focus],
+        row![_, self.touch_nav_focus],
         row![
             "Restore default values:",
             Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -29,12 +29,10 @@ use std::ops::{Index, IndexMut};
 /// > &nbsp;&nbsp; `(` _Column_ `,` _Row_ `)` `=>` _Item_
 /// >
 /// > _Column_, _Row_ :\
-/// > &nbsp;&nbsp; _LitInt_ | ( _LitInt_ `..` `+` _LitInt_ ) | ( _LitInt_ `..`
-/// > _LitInt_ ) | ( _LitInt_ `..=` _LitInt_ )
+/// > &nbsp;&nbsp; _LitInt_ | ( _LitInt_ `..=` _LitInt_ )
 ///
-/// Here, _Column_ and _Row_ are selected via an index (from 0), a range of
-/// indices, or a start + increment. For example, `2` = `2..+1` = `2..3` =
-/// `2..=2` while `5..+2` = `5..7` = `5..=6`.
+/// Here, _Column_ and _Row_ are selected via an index (from 0) or an inclusive
+/// range, for example `2` or `2..=3`.
 ///
 /// ## Stand-alone usage
 ///
@@ -65,7 +63,7 @@ use std::ops::{Index, IndexMut};
 /// let my_widget = kas_widgets::grid! {
 ///     (0, 0) => "one",
 ///     (1, 0) => "two",
-///     (0..2, 1) => "three",
+///     (0..=1, 1) => "three",
 /// };
 /// ```
 ///
@@ -164,7 +162,7 @@ mod Grid {
     /// let _grid = Grid::new(cell_collection! {
     ///     (0, 0) => "one",
     ///     (1, 0) => "two",
-    ///     (0..2, 1) => "three",
+    ///     (0..=1, 1) => "three",
     /// });
     /// ```
     #[widget]

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -20,24 +20,38 @@ use std::ops::{Index, IndexMut};
 /// # Syntax
 ///
 /// > _Collection_ :\
-/// > &nbsp;&nbsp; `collection!` `[` _ItemArms_<sup>\?</sup> `]`
+/// > &nbsp;&nbsp; `grid!` `{` _ItemArms_<sup>\?</sup> `}`
 /// >
 /// > _ItemArms_ :\
 /// > &nbsp;&nbsp; (_ItemArm_ `,`)<sup>\*</sup> _ItemArm_ `,`<sup>\?</sup>
 /// >
 /// > _ItemArm_ :\
+/// > &nbsp;&nbsp; _Cell_ | _RowMacro_ | _ColumnMacro_
+/// >
+/// > _Cell_ :\
 /// > &nbsp;&nbsp; `(` _Column_ `,` _Row_ `)` `=>` _Item_
 /// >
 /// > _Column_, _Row_ :\
 /// > &nbsp;&nbsp; _LitInt_ | ( _LitInt_ `..=` _LitInt_ )
+/// >
+/// > _RowMacro_ :\
+/// > &npsb;&nbsp; `row!` `[` (_Item_ `,` | `_` `,`)* _Item_ `]`
+/// >
+/// > _ColumnMacro_ :\
+/// > &npsb;&nbsp; `column!` `[` (_Item_ `,` | `_` `,`)* _Item_ `]`
 ///
 /// Here, _Column_ and _Row_ are selected via an index (from 0) or an inclusive
 /// range, for example `2` or `2..=3`.
 ///
+/// A `row!` macro resolves to a list of cells whose column index is one larger
+/// than maximum prior column index and whose row indices count from 0.
+/// As a special case, `_` may be used to skip a cell (infer an empty cell).
+/// A `column!` macro functions similarly.
+///
 /// ## Stand-alone usage
 ///
-/// When used as a stand-alone macro, `grid! [/* ... */]` is just syntactic
-/// sugar for `Grid::new(kas::cell_collection! [/* ... */])`.
+/// When used as a stand-alone macro, `grid! { /* ... */ }` is just syntactic
+/// sugar for `Grid::new(kas::cell_collection! { /* ... */ })`.
 ///
 /// In this case, _Item_ may be:
 ///
@@ -74,10 +88,10 @@ use std::ops::{Index, IndexMut};
 #[macro_export]
 macro_rules! grid {
     ( $( ($cc:expr, $rr:expr) => $ee:expr ),* ) => {
-        $crate::Grid::new( ::kas::cell_collection! [ $( ($cc, $rr) => $ee ),* ] )
+        $crate::Grid::new( ::kas::cell_collection! { $( ($cc, $rr) => $ee ),* } )
     };
     ( $( ($cc:expr, $rr:expr) => $ee:expr ),+ , ) => {
-        $crate::Grid::new( ::kas::cell_collection! [ $( ($cc, $rr) => $ee ),+ ] )
+        $crate::Grid::new( ::kas::cell_collection! { $( ($cc, $rr) => $ee ),+ } )
     };
 }
 

--- a/crates/kas-widgets/src/grid.rs
+++ b/crates/kas-widgets/src/grid.rs
@@ -87,57 +87,8 @@ use std::ops::{Index, IndexMut};
 /// [`with_stretch`]: crate::AdaptWidget::with_stretch
 #[macro_export]
 macro_rules! grid {
-    ( $( ($cc:expr, $rr:expr) => $ee:expr ),* ) => {
-        $crate::Grid::new( ::kas::cell_collection! { $( ($cc, $rr) => $ee ),* } )
-    };
-    ( $( ($cc:expr, $rr:expr) => $ee:expr ),+ , ) => {
-        $crate::Grid::new( ::kas::cell_collection! { $( ($cc, $rr) => $ee ),+ } )
-    };
-}
-
-/// Define a [`Grid`] as a sequence of rows
-///
-/// This is just special convenience syntax for defining a [`Grid`]. See also
-/// [`grid!`] documentation.
-///
-/// # Example
-///
-/// ```
-/// let my_widget = kas_widgets::aligned_column! [
-///     row!["one", "two"],
-///     row!["three", "four"],
-/// ];
-/// ```
-#[macro_export]
-macro_rules! aligned_column {
-    () => {
-        $crate::Grid::new(::kas::cell_collection! [])
-    };
-    ($(row![$($ee:expr),* $(,)?]),+ $(,)?) => {
-        $crate::Grid::new(::kas::cell_collection![aligned_column $(row![$($ee),*]),+])
-    };
-}
-
-/// Define a [`Grid`] as a sequence of columns
-///
-/// This is just special convenience syntax for defining a [`Grid`]. See also
-/// [`grid!`] documentation.
-///
-/// # Example
-///
-/// ```
-/// let my_widget = kas_widgets::aligned_row! [
-///     column!["one", "two"],
-///     column!["three", "four"],
-/// ];
-/// ```
-#[macro_export]
-macro_rules! aligned_row {
-    () => {
-        $crate::Grid::new(::kas::cell_collection! [])
-    };
-    ($(column![$($ee:expr),* $(,)?]),+ $(,)?) => {
-        $crate::Grid::new(::kas::cell_collection![aligned_row $(column![$($ee),*]),+])
+    ( $($tt:tt)* ) => {
+        $crate::Grid::new( ::kas::cell_collection! { $($tt)* } )
     };
 }
 

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -51,15 +51,15 @@ fn calc_ui() -> Window<()> {
         (0, 1) => key_button("&7"),
         (1, 1) => key_button("&8"),
         (2, 1) => key_button("&9"),
-        (3, 1..3) => key_button("&+"),
+        (3, 1..=2) => key_button("&+"),
         (0, 2) => key_button("&4"),
         (1, 2) => key_button("&5"),
         (2, 2) => key_button("&6"),
         (0, 3) => key_button("&1"),
         (1, 3) => key_button("&2"),
         (2, 3) => key_button("&3"),
-        (3, 3..5) => key_button_with("&=", NamedKey::Enter.into()),
-        (0..2, 4) => key_button("&0"),
+        (3, 3..=4) => key_button_with("&=", NamedKey::Enter.into()),
+        (0..=1, 4) => key_button("&0"),
         (2, 4) => key_button("&."),
     };
     let buttons = Frame::new(buttons).with_style(FrameStyle::None).map_any();

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -142,7 +142,7 @@ fn widgets() -> Page<AppData> {
 Пример текста на нескольких языках.
 טקסט לדוגמא במספר שפות.";
 
-    let widgets = aligned_column![
+    let widgets = grid! {
         row!["ScrollLabel", ScrollLabel::new(text).map_any()],
         row![
             "EditBox",
@@ -230,7 +230,7 @@ fn widgets() -> Page<AppData> {
                 .map_any()
         ],
         row!["Child window", popup_edit_box],
-    ];
+    };
 
     let ui = widgets
         .with_state(data)

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -18,9 +18,9 @@ fn main() -> kas::runner::Result<()> {
     let ui = grid! {
         (1, 0) => "Layout demo",
         (2, 0) => CheckBox::new(|_, _| true),
-        (0..3, 1) => ScrollLabel::new(LIPSUM),
+        (0..=2, 1) => ScrollLabel::new(LIPSUM),
         (0, 2) => "abc אבג def".align(AlignHints::CENTER),
-        (1..3, 3) => ScrollLabel::new(CRASIT).align(AlignHints::STRETCH),
+        (1..=2, 3) => ScrollLabel::new(CRASIT).align(AlignHints::STRETCH),
         (0, 3) => EditBox::text("A small\nsample\nof text").with_multi_line(true),
     };
     let window = Window::new(ui, "Layout demo").escapable();

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -438,7 +438,7 @@ mod MandlebrotUI {
         (0, 1) => self.iters_label.align(AlignHints::CENTER),
         (0, 2) => self.slider,
         // extra col span allows use of Label's margin
-        (1..5, 1..4) => self.mbrot,
+        (1..=4, 1..=3) => self.mbrot,
     })]
     struct MandlebrotUI {
         core: widget_core!(),

--- a/tests/layout_macros.rs
+++ b/tests/layout_macros.rs
@@ -33,7 +33,7 @@ fn grid() {
     use_widget(grid! {
         (0, 0) => "top left",
         (1, 0) => "top right",
-        (0..2, 1) => "bottom row (merged)",
+        (0..=1, 1) => "bottom row (merged)",
     });
 }
 

--- a/tests/layout_macros.rs
+++ b/tests/layout_macros.rs
@@ -1,6 +1,6 @@
 use kas::Widget;
 use kas::layout::AlignHints;
-use kas::widgets::{aligned_column, aligned_row, column, float, grid, list, row};
+use kas::widgets::{column, float, grid, list, row};
 
 fn use_widget<W: Widget<Data = ()>>(_: W) {}
 
@@ -40,7 +40,7 @@ fn grid() {
 #[test]
 fn aligned_column() {
     #[rustfmt::skip]
-    use_widget(aligned_column![
+    use_widget(grid![
         row!["one", "two"],
         row!["three", "four"],
     ]);
@@ -48,7 +48,5 @@ fn aligned_column() {
 
 #[test]
 fn aligned_row() {
-    use_widget(aligned_row![column!["one", "two"], column![
-        "three", "four"
-    ],]);
+    use_widget(grid![column!["one", "two"], column!["three", "four"],]);
 }


### PR DESCRIPTION
The primary motivation is that this allows much nicer layout specification for `EventConfig`:
```rust
    #[layout(grid! {
        row!["Hover delay:", self.menu_delay],
        row!["Menu delay:", self.menu_delay],
        row!["Touch-selection delay:", self.touch_select_delay],
        row!["Kinetic scrolling timeout:", self.kinetic_timeout],
        row!["Kinetic decay (relative):", self.kinetic_decay_mul],
        row!["Kinetic decay (absolute):", self.kinetic_decay_sub],
        row!["Kinetic decay when grabbed:", self.kinetic_grab_sub],
        row!["Scroll wheel distance:", self.scroll_dist_em],
        row!["Pan distance threshold:", self.pan_dist_thresh],
        row!["Double-click distance threshold:", self.double_click_dist_thresh],
        row!["Mouse pan:", self.mouse_pan],
        row!["Mouse text pan:", self.mouse_text_pan],
        row![_, self.mouse_wheel_actions],
        row![_, self.mouse_nav_focus],
        row![_, self.touch_nav_focus],
        row![
            "Restore default values:",
            Button::label_msg("&Reset", EventConfigMsg::ResetToDefault),
        ],
    })]
```
This was not possible before since `aligned_column!` did not support using `_` as a placeholder.

Secondary motivation is that this is both a neater API (fewer pub items) and more powerful (it's possible to combine usage of `row!` / `column!` with cell and spanned-cell specifications).

---

Also adds `Layout::Dummy` to reduce secondary errors resulting from a layout parse failure (requires feature `nightly-diagnostics`).

Aside: `nightly-diagnostics` results in warnings on the `Tile::core`, `core_mut` methods. Ideally I would suppress the lint with `#[allow(..)]` here; unfortunately custom proc-macro lints are not yet available.