### PR TITLE
Remove bool payloads from actions; add `ActionRedraw`, `ActionClose`

### DIFF
--- a/crates/kas-core/src/action.rs
+++ b/crates/kas-core/src/action.rs
@@ -26,6 +26,11 @@ pub struct ActionMoved;
 #[derive(Copy, Clone, Debug, Default)]
 pub struct ActionResize;
 
+/// Action: content must be redrawn
+#[must_use]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct ActionRedraw;
+
 bitflags! {
     /// Action: configuration data updates must be applied
     #[must_use]
@@ -66,5 +71,12 @@ bitflags! {
         ///
         /// See also [`EventState::exit`] which closes the UI (all windows).
         const CLOSE = 1 << 30;
+    }
+}
+
+impl From<ActionRedraw> for WindowAction {
+    #[inline]
+    fn from(_: ActionRedraw) -> Self {
+        WindowAction::REDRAW
     }
 }

--- a/crates/kas-core/src/action.rs
+++ b/crates/kas-core/src/action.rs
@@ -11,37 +11,14 @@ use std::ops::{BitOr, BitOrAssign, Deref};
 
 /// Action: widget has moved/opened/closed
 ///
-/// When the state is `true`, this indicates that the following should happen:
+/// This action indicates that the following should happen:
 ///
 /// -   Re-probe which widget is under the mouse / any touch instance / any
 ///     other location picker since widgets may have moved
 /// -   Redraw the window
 #[must_use]
 #[derive(Copy, Clone, Debug, Default)]
-pub struct ActionMoved(pub bool);
-
-impl BitOr for ActionMoved {
-    type Output = Self;
-    #[inline]
-    fn bitor(self, rhs: Self) -> Self {
-        ActionMoved(self.0 | rhs.0)
-    }
-}
-
-impl BitOrAssign for ActionMoved {
-    #[inline]
-    fn bitor_assign(&mut self, rhs: Self) {
-        self.0 |= rhs.0;
-    }
-}
-
-impl Deref for ActionMoved {
-    type Target = bool;
-    #[inline]
-    fn deref(&self) -> &bool {
-        &self.0
-    }
-}
+pub struct ActionMoved;
 
 /// Action: widget must be resized
 #[must_use]

--- a/crates/kas-core/src/action.rs
+++ b/crates/kas-core/src/action.rs
@@ -16,20 +16,25 @@ use crate::event::{ConfigCx, EventCx, EventState};
 ///     other location picker since widgets may have moved
 /// -   Redraw the window
 #[must_use]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ActionMoved;
 
 /// Action: widget must be resized
 ///
 /// This type implies that either a local or full-window resize is required.
 #[must_use]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ActionResize;
 
 /// Action: content must be redrawn
 #[must_use]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ActionRedraw;
+
+/// Action: close window
+#[must_use]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ActionClose;
 
 bitflags! {
     /// Action: configuration data updates must be applied
@@ -45,38 +50,10 @@ bitflags! {
     }
 }
 
-bitflags! {
-    /// Action required after processing
-    ///
-    /// Some methods operate directly on a context ([`ConfigCx`] or [`EventCx`])
-    /// while others don't reqiure a context but do require that some *action*
-    /// is performed afterwards. This enum is used to convey that action.
-    ///
-    /// A `WindowAction` produced at run-time should be passed to a context, usually
-    /// via [`EventState::action`] (to associate the `WindowAction` with a widget)
-    /// or [`EventState::window_action`] (if no particular widget is relevant).
-    ///
-    /// A `WindowAction` produced before starting the GUI may be discarded, for
-    /// example: `let _ = runner.config_mut().font.set_size(24.0);`.
-    ///
-    /// Two `WindowAction` values may be combined via bit-or (`a | b`).
-    #[must_use]
-    #[derive(Copy, Clone, Debug, Default)]
-    pub struct WindowAction: u32 {
-        /// The whole window requires redrawing
-        ///
-        /// See also [`EventState::redraw`].
-        const REDRAW = 1 << 0;
-        /// The current window should be closed
-        ///
-        /// See also [`EventState::exit`] which closes the UI (all windows).
-        const CLOSE = 1 << 30;
-    }
-}
-
-impl From<ActionRedraw> for WindowAction {
-    #[inline]
-    fn from(_: ActionRedraw) -> Self {
-        WindowAction::REDRAW
-    }
+/// Set of actions which may affect a window
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct WindowActions {
+    pub resize: Option<ActionResize>,
+    pub redraw: Option<ActionRedraw>,
+    pub close: Option<ActionClose>,
 }

--- a/crates/kas-core/src/action.rs
+++ b/crates/kas-core/src/action.rs
@@ -7,7 +7,6 @@
 
 #[allow(unused)]
 use crate::event::{ConfigCx, EventCx, EventState};
-use std::ops::{BitOr, BitOrAssign, Deref};
 
 /// Action: widget has moved/opened/closed
 ///
@@ -21,39 +20,11 @@ use std::ops::{BitOr, BitOrAssign, Deref};
 pub struct ActionMoved;
 
 /// Action: widget must be resized
+///
+/// This type implies that either a local or full-window resize is required.
 #[must_use]
 #[derive(Copy, Clone, Debug, Default)]
-pub struct ActionResize(pub bool);
-
-impl ActionResize {
-    #[inline]
-    pub(crate) fn clear(&mut self) {
-        self.0 = false;
-    }
-}
-
-impl BitOr for ActionResize {
-    type Output = Self;
-    #[inline]
-    fn bitor(self, rhs: Self) -> Self {
-        ActionResize(self.0 | rhs.0)
-    }
-}
-
-impl BitOrAssign for ActionResize {
-    #[inline]
-    fn bitor_assign(&mut self, rhs: Self) {
-        self.0 |= rhs.0;
-    }
-}
-
-impl Deref for ActionResize {
-    type Target = bool;
-    #[inline]
-    fn deref(&self) -> &bool {
-        &self.0
-    }
-}
+pub struct ActionResize;
 
 bitflags! {
     /// Action: configuration data updates must be applied

--- a/crates/kas-core/src/core/events.rs
+++ b/crates/kas-core/src/core/events.rs
@@ -315,14 +315,15 @@ pub trait Events: Widget + Sized {
     /// locally and should implement this method to do so
     /// (thus avoiding the need for a full-window resize).
     ///
-    /// Return `ActionResize(true)` if further resizing is needed, or
-    /// `ActionResize(false)` if resizing is complete.
+    /// Return `Some(ActionResize)` if further resizing is needed, or `None` if
+    /// resizing is complete.
     ///
-    /// The default implementation simply returns `ActionResize(true)`.
+    /// The default implementation simply returns `Some(ActionResize)`.
     #[inline]
-    fn handle_resize(&mut self, cx: &mut ConfigCx, data: &Self::Data) -> ActionResize {
+    #[must_use]
+    fn handle_resize(&mut self, cx: &mut ConfigCx, data: &Self::Data) -> Option<ActionResize> {
         let _ = (cx, data);
-        ActionResize(true)
+        Some(ActionResize)
     }
 
     /// Handler for scrolling

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -41,7 +41,7 @@ pub fn _update<W: Events>(widget: &mut W, cx: &mut ConfigCx, data: &W::Data) {
             cx.update(node);
         }
 
-        if *cx.resize && widget.status().is_sized() {
+        if cx.resize.is_some() && widget.status().is_sized() {
             cx.resize = widget.handle_resize(cx, data);
         }
     }
@@ -96,7 +96,7 @@ pub fn _send<W: Events>(
                 );
             }
 
-            if *cx.resize {
+            if cx.resize.is_some() {
                 debug_assert!(widget.status().is_sized());
                 cx.resize = widget.handle_resize(cx, data);
             }
@@ -144,7 +144,7 @@ pub fn _replay<W: Events>(widget: &mut W, cx: &mut EventCx, data: &<W as Widget>
             );
         }
 
-        if *cx.resize && widget.status().is_sized() {
+        if cx.resize.is_some() && widget.status().is_sized() {
             cx.resize = widget.handle_resize(cx, data);
         }
 

--- a/crates/kas-core/src/event/config_cx.rs
+++ b/crates/kas-core/src/event/config_cx.rs
@@ -23,7 +23,7 @@ use std::ops::{Deref, DerefMut};
 pub struct ConfigCx<'a> {
     pub(super) theme: &'a dyn ThemeSize,
     pub(crate) state: &'a mut EventState,
-    pub(crate) resize: ActionResize,
+    pub(crate) resize: Option<ActionResize>,
     pub(crate) redraw: bool,
 }
 
@@ -35,7 +35,7 @@ impl<'a> ConfigCx<'a> {
         ConfigCx {
             theme: sh,
             state: ev,
-            resize: ActionResize(false),
+            resize: None,
             redraw: false,
         }
     }
@@ -64,7 +64,7 @@ impl<'a> ConfigCx<'a> {
         // (Except redraw: this doesn't matter.)
         let start_resize = std::mem::take(&mut self.resize);
         widget._configure(self, id);
-        self.resize |= start_resize;
+        self.resize = self.resize.or(start_resize);
     }
 
     /// Update a widget
@@ -77,7 +77,7 @@ impl<'a> ConfigCx<'a> {
         // (Except redraw: this doesn't matter.)
         let start_resize = std::mem::take(&mut self.resize);
         widget._update(self);
-        self.resize |= start_resize;
+        self.resize = self.resize.or(start_resize);
     }
 
     /// Configure a text object
@@ -136,7 +136,7 @@ impl<'a> ConfigCx<'a> {
     /// during the traversal unwind if possible.
     #[inline]
     pub fn resize(&mut self) {
-        self.resize = ActionResize(true);
+        self.resize = Some(ActionResize);
     }
 }
 

--- a/crates/kas-core/src/event/config_cx.rs
+++ b/crates/kas-core/src/event/config_cx.rs
@@ -8,7 +8,7 @@
 use crate::event::EventState;
 use crate::text::format::FormattableText;
 use crate::theme::{SizeCx, Text, ThemeSize};
-use crate::{ActionResize, Id, Node};
+use crate::{ActionRedraw, ActionResize, Id, Node};
 use std::any::TypeId;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
@@ -24,7 +24,7 @@ pub struct ConfigCx<'a> {
     pub(super) theme: &'a dyn ThemeSize,
     pub(crate) state: &'a mut EventState,
     pub(crate) resize: Option<ActionResize>,
-    pub(crate) redraw: bool,
+    pub(crate) redraw: Option<ActionRedraw>,
 }
 
 impl<'a> ConfigCx<'a> {
@@ -36,7 +36,7 @@ impl<'a> ConfigCx<'a> {
             theme: sh,
             state: ev,
             resize: None,
-            redraw: false,
+            redraw: None,
         }
     }
 
@@ -126,7 +126,7 @@ impl<'a> ConfigCx<'a> {
     /// during the traversal unwind if possible.
     #[inline]
     pub fn redraw(&mut self) {
-        self.redraw = true;
+        self.redraw = Some(ActionRedraw);
     }
 
     /// Require that the current widget (and its descendants) be resized

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -105,7 +105,7 @@ pub struct EventState {
     pending_sel_focus: Option<PendingSelFocus>,
     pending_nav_focus: PendingNavFocus,
     pub(crate) action: WindowAction,
-    action_moved: ActionMoved,
+    action_moved: Option<ActionMoved>,
 }
 
 impl EventState {
@@ -146,7 +146,7 @@ impl EventState {
             pending_sel_focus: None,
             pending_nav_focus: PendingNavFocus::None,
             action: WindowAction::empty(),
-            action_moved: ActionMoved(false),
+            action_moved: None,
         }
     }
 
@@ -176,7 +176,7 @@ impl EventState {
         cx.configure(node, id);
         let resize = cx.resize;
         // Ignore cx.redraw: we can assume a redraw will happen
-        self.action_moved = ActionMoved(true);
+        self.action_moved = Some(ActionMoved);
         resize
     }
 
@@ -317,7 +317,7 @@ impl EventState {
     /// This updates the widget(s) under mouse and touch events.
     #[inline]
     pub fn region_moved(&mut self) {
-        self.action_moved = ActionMoved(true);
+        self.action_moved = Some(ActionMoved);
     }
 
     /// Notify that a [`WindowAction`] should happen for the whole window
@@ -332,10 +332,10 @@ impl EventState {
         self.action |= WindowAction::CLOSE;
     }
 
-    /// Notify of an [`ActionMoved`]
+    /// Notify of an [`ActionMoved`] or `Option<ActionMoved>`
     #[inline]
-    pub fn action_moved(&mut self, action: ActionMoved) {
-        self.action_moved |= action;
+    pub fn action_moved(&mut self, action: impl Into<Option<ActionMoved>>) {
+        self.action_moved = self.action_moved.or(action.into());
     }
 
     /// Request update to widget `id`

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -208,8 +208,8 @@ impl EventState {
         };
         f(&mut cx);
         let resize = cx.resize.or(cx.resize_window);
-        if cx.redraw {
-            self.action |= WindowAction::REDRAW;
+        if let Some(action) = cx.redraw {
+            self.action |= action.into();
         }
         resize
     }

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -318,7 +318,7 @@ impl<'a> EventCx<'a> {
             self.action |= WindowAction::REDRAW;
         }
 
-        if self.action_moved.0 {
+        if self.action_moved.is_some() {
             let over = node.try_probe(self.mouse.last_position.cast_nearest());
             self.set_over(node, over);
         }

--- a/crates/kas-core/src/event/cx/press/mouse.rs
+++ b/crates/kas-core/src/event/cx/press/mouse.rs
@@ -12,7 +12,7 @@ use crate::event::{
 use crate::geom::{Affine, Coord, DVec2, Vec2};
 use crate::window::WindowErased;
 use crate::window::WindowWidget;
-use crate::{Id, Node, TileExt, WindowAction};
+use crate::{ActionRedraw, Id, Node, TileExt};
 use cast::{CastApprox, CastFloat};
 use std::time::{Duration, Instant};
 use winit::cursor::CursorIcon;
@@ -152,8 +152,8 @@ impl Mouse {
         self.over.clone()
     }
 
-    fn update_grab(&mut self) -> (bool, bool) {
-        let (mut cancel, mut redraw) = (false, false);
+    fn update_grab(&mut self) -> (bool, Option<ActionRedraw>) {
+        let (mut cancel, mut redraw) = (false, None);
         if let Some(grab) = self.grab.as_mut() {
             cancel = grab.cancel;
             if let GrabDetails::Click = grab.details {
@@ -161,11 +161,11 @@ impl Mouse {
                 if grab.start_id == over {
                     if grab.depress.as_ref() != over {
                         grab.depress = over.cloned();
-                        redraw = true;
+                        redraw = Some(ActionRedraw);
                     }
                 } else if grab.depress.is_some() {
                     grab.depress = None;
-                    redraw = true;
+                    redraw = Some(ActionRedraw);
                 }
             }
         }
@@ -313,10 +313,7 @@ impl<'a> EventCx<'a> {
         if cancel {
             self.remove_mouse_grab(node.re(), false);
         }
-
-        if redraw {
-            self.action |= WindowAction::REDRAW;
-        }
+        self.action_redraw(redraw);
 
         if self.action_moved.is_some() {
             let over = node.try_probe(self.mouse.last_position.cast_nearest());

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -9,7 +9,7 @@ use super::{GrabMode, Press, PressSource, velocity};
 use crate::config::EventWindowConfig;
 use crate::event::{Event, EventCx, EventState, FocusSource, NavAdvance, PressStart};
 use crate::geom::{Affine, DVec2, Vec2};
-use crate::{Id, Node, WindowAction};
+use crate::{ActionRedraw, Id, Node};
 use cast::{Cast, CastApprox, CastFloat, Conv};
 use smallvec::SmallVec;
 use winit::event::FingerId;
@@ -33,19 +33,19 @@ pub(super) struct TouchGrab {
 }
 
 impl TouchGrab {
-    fn flush_click_move(&mut self) -> WindowAction {
+    fn flush_click_move(&mut self) -> Option<ActionRedraw> {
         if self.mode == GrabMode::Click {
             if self.start_id == self.over {
                 if self.depress != self.over {
                     self.depress = self.over.clone();
-                    return WindowAction::REDRAW;
+                    return Some(ActionRedraw);
                 }
             } else if self.depress.is_some() {
                 self.depress = None;
-                return WindowAction::REDRAW;
+                return Some(ActionRedraw);
             }
         }
-        WindowAction::empty()
+        None
     }
 }
 
@@ -241,7 +241,7 @@ impl EventState {
         );
         self.opt_redraw(grab.depress.clone());
         self.touch.remove_pan_grab(grab.pan_grab);
-        self.window_action(grab.flush_click_move());
+        self.action_redraw(grab.flush_click_move());
         grab
     }
 }
@@ -250,8 +250,8 @@ impl<'a> EventCx<'a> {
     pub(in crate::event::cx) fn touch_handle_pending(&mut self, mut node: Node<'_>) {
         let mut i = 0;
         while i < self.touch.touch_grab.len() {
-            let action = self.touch.touch_grab[i].flush_click_move();
-            self.state.action |= action;
+            let redraw = self.touch.touch_grab[i].flush_click_move();
+            self.action_redraw(redraw);
 
             if self.touch.touch_grab[i].cancel {
                 let grab = self.remove_touch(i);

--- a/crates/kas-core/src/event/cx/press/touch.rs
+++ b/crates/kas-core/src/event/cx/press/touch.rs
@@ -271,7 +271,7 @@ impl<'a> EventCx<'a> {
             }
         }
 
-        if self.action_moved.0 {
+        if self.action_moved.is_some() {
             for grab in self.touch.touch_grab.iter_mut() {
                 grab.over = node.try_probe(grab.last_position.cast_nearest());
             }

--- a/crates/kas-core/src/event/cx/window.rs
+++ b/crates/kas-core/src/event/cx/window.rs
@@ -58,13 +58,14 @@ impl EventState {
     }
 
     /// Handle all pending items before event loop sleeps
+    #[must_use]
     pub(crate) fn flush_pending<'a>(
         &'a mut self,
         runner: &'a mut dyn RunnerT,
         theme: &'a dyn ThemeSize,
         window: &'a dyn WindowDataErased,
         mut node: Node,
-    ) -> (ActionResize, WindowAction) {
+    ) -> (Option<ActionResize>, WindowAction) {
         if !self.pending_send_targets.is_empty() {
             runner.set_send_targets(&mut self.pending_send_targets);
         }

--- a/crates/kas-core/src/event/cx/window.rs
+++ b/crates/kas-core/src/event/cx/window.rs
@@ -116,8 +116,7 @@ impl EventState {
             }
 
             // Finally, clear the region_moved flag (mouse and touch sub-systems handle this).
-            if cx.action_moved.0 {
-                cx.action_moved.0 = false;
+            if cx.action_moved.take().is_some() {
                 cx.action.insert(WindowAction::REDRAW);
             }
         });

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -28,7 +28,8 @@ pub mod widgets;
 pub mod window;
 
 pub use crate::core::*;
-pub use action::{ActionMoved, ActionRedraw, ActionResize, ConfigAction, WindowAction};
+pub(crate) use action::{ActionClose, WindowActions};
+pub use action::{ActionMoved, ActionRedraw, ActionResize, ConfigAction};
 pub use kas_macros::{autoimpl, extends, impl_default};
 pub use kas_macros::{cell_collection, collection, impl_anon, impl_scope, impl_self};
 pub use kas_macros::{layout, widget, widget_index};

--- a/crates/kas-core/src/lib.rs
+++ b/crates/kas-core/src/lib.rs
@@ -28,7 +28,7 @@ pub mod widgets;
 pub mod window;
 
 pub use crate::core::*;
-pub use action::{ActionMoved, ActionResize, ConfigAction, WindowAction};
+pub use action::{ActionMoved, ActionRedraw, ActionResize, ConfigAction, WindowAction};
 pub use kas_macros::{autoimpl, extends, impl_default};
 pub use kas_macros::{cell_collection, collection, impl_anon, impl_scope, impl_self};
 pub use kas_macros::{layout, widget, widget_index};

--- a/crates/kas-core/src/prelude.rs
+++ b/crates/kas-core/src/prelude.rs
@@ -22,7 +22,7 @@ pub use crate::layout::{Align, AlignHints, AlignPair, AxisInfo, SizeRules, Stret
 #[doc(no_inline)] pub use crate::widget_index;
 #[doc(no_inline)] pub use crate::window::{Window, WindowId};
 #[doc(no_inline)]
-pub use crate::{ActionMoved, ActionResize};
+pub use crate::{ActionMoved, ActionRedraw, ActionResize};
 #[doc(no_inline)] pub use crate::{ChildIndices, Node};
 #[doc(no_inline)]
 pub use crate::{Events, Layout, Role, RoleCx, RoleCxExt, Tile, TileExt, Viewport, Widget};

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -569,7 +569,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         cx.update(self.widget.as_node(data));
         if cx.resize.is_some() {
             self.apply_size(data, false, true);
-        } else if cx.redraw {
+        } else if cx.redraw.is_some() {
             window.request_redraw();
         }
 

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -180,8 +180,8 @@ mod EditBox {
                 return;
             };
 
-            if action.0 {
-                cx.action_moved(action);
+            if let Some(moved) = action {
+                cx.action_moved(moved);
                 self.update_scroll_offset(cx);
             }
         }

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -186,14 +186,14 @@ mod EditBox {
             }
         }
 
-        fn handle_resize(&mut self, cx: &mut ConfigCx, _: &Self::Data) -> ActionResize {
+        fn handle_resize(&mut self, cx: &mut ConfigCx, _: &Self::Data) -> Option<ActionResize> {
             let size = self.inner.rect().size;
             let axis = AxisInfo::new(false, Some(size.1));
             let mut resize = self.inner.size_rules(&mut cx.size_cx(), axis).min_size() > size.0;
             let axis = AxisInfo::new(true, Some(size.0));
             resize |= self.inner.size_rules(&mut cx.size_cx(), axis).min_size() > size.1;
             self.update_content_size(cx);
-            ActionResize(resize)
+            resize.then_some(ActionResize)
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx<'_>, _: &G::Data, scroll: Scroll) {

--- a/crates/kas-widgets/src/scroll.rs
+++ b/crates/kas-widgets/src/scroll.rs
@@ -456,12 +456,12 @@ mod ScrollRegion {
                 .update_offset(cx, data, self.inner.rect(), offset);
         }
 
-        fn handle_resize(&mut self, cx: &mut ConfigCx, _: &Self::Data) -> ActionResize {
+        fn handle_resize(&mut self, cx: &mut ConfigCx, _: &Self::Data) -> Option<ActionResize> {
             let _ = self.size_rules(&mut cx.size_cx(), AxisInfo::new(false, None));
             let width = self.rect().size.0;
             let _ = self.size_rules(&mut cx.size_cx(), AxisInfo::new(true, Some(width)));
             self.set_rect(&mut cx.size_cx(), self.rect(), self.hints);
-            ActionResize(false)
+            None
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx, data: &Self::Data, scroll: Scroll) {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -547,7 +547,7 @@ mod ScrollText {
             }
         }
 
-        fn handle_resize(&mut self, cx: &mut ConfigCx, _: &Self::Data) -> ActionResize {
+        fn handle_resize(&mut self, cx: &mut ConfigCx, _: &Self::Data) -> Option<ActionResize> {
             let size = self.text.rect().size;
             let axis = AxisInfo::new(false, Some(size.1));
             let mut resize = self.text.size_rules(&mut cx.size_cx(), axis).min_size() > size.0;
@@ -556,7 +556,7 @@ mod ScrollText {
             self.text
                 .set_rect(&mut cx.size_cx(), self.text.rect(), Default::default());
             self.update_content_size(cx);
-            ActionResize(resize)
+            resize.then_some(ActionResize)
         }
 
         fn handle_scroll(&mut self, cx: &mut EventCx, _: &Self::Data, scroll: Scroll) {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -541,8 +541,8 @@ mod ScrollText {
                 return;
             };
 
-            if action.0 {
-                cx.action_moved(action);
+            if let Some(moved) = action {
+                cx.action_moved(moved);
                 self.vert_bar.set_value(cx, self.scroll.offset().1);
             }
         }


### PR DESCRIPTION
Actions no longer have a boolean payload. This instead uses e.g. `Option<ActionRedraw>` for optional actions, which allows for return types like `Result<ActionRedraw, SomeError>`.

This is motivation for a new RFC: https://github.com/rust-lang/rfcs/pull/3906