### PR TITLE
Update kas-text; enable font-selector configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ resolver = "2"
 
 [patch.crates-io.kas-text]
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "e97ced7b"
+rev = "dc0b273f"
 
 [patch.crates-io.rfd]
 git = "https://github.com/PolyMeilex/rfd.git"

--- a/crates/kas-core/src/config/font.rs
+++ b/crates/kas-core/src/config/font.rs
@@ -188,8 +188,12 @@ mod defaults {
     }
 
     pub fn fonts() -> BTreeMap<TextClass, FontSelector> {
-        let list = [(TextClass::Editor, FamilySelector::SERIF.into())];
-        list.iter().cloned().collect()
+        let list = [
+            (TextClass::Serif, FamilySelector::SERIF.into()),
+            (TextClass::SansSerif, FamilySelector::SANS_SERIF.into()),
+            (TextClass::Monospace, FamilySelector::MONOSPACE.into()),
+        ];
+        list.into_iter().collect()
     }
 
     pub fn mode() -> u8 {

--- a/crates/kas-core/src/config/font.rs
+++ b/crates/kas-core/src/config/font.rs
@@ -31,7 +31,7 @@ pub struct FontConfig {
     /// Changing this at run-tme is not currently supported.
     ///
     /// TODO: read/write support.
-    #[cfg_attr(feature = "serde", serde(skip, default = "defaults::fonts"))]
+    #[cfg_attr(feature = "serde", serde(default = "defaults::fonts"))]
     fonts: BTreeMap<TextClass, FontSelector>,
 
     /// Text glyph rastering settings

--- a/crates/kas-core/src/config/font.rs
+++ b/crates/kas-core/src/config/font.rs
@@ -31,7 +31,7 @@ pub struct FontConfig {
     /// Changing this at run-tme is not currently supported.
     ///
     /// TODO: read/write support.
-    #[cfg_attr(feature = "serde", serde(skip, default))]
+    #[cfg_attr(feature = "serde", serde(skip, default = "defaults::fonts"))]
     fonts: BTreeMap<TextClass, FontSelector>,
 
     /// Text glyph rastering settings

--- a/crates/kas-core/src/theme/style.rs
+++ b/crates/kas-core/src/theme/style.rs
@@ -136,19 +136,22 @@ impl SelectionStyle {
 /// Fonts are chosen from available (system) fonts depending on the `TextClass`
 /// and [configuration](crate::config::FontConfig).
 /// `TextClass` may affect other font properties, including size and weight.
+///
+/// Some classes by default appear identical to [`TextClass::Standard`] but may
+/// be configured otherwise by the user.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, linearize::Linearize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextClass {
     /// The standard UI font
+    ///
+    /// By default this matches the system UI font.
     Standard,
     /// Label UI font
     ///
     /// This text class should be used by short labels such as those found on
     /// buttons, menus and other UI controls.
     ///
-    /// According to user preference, this may appear identical to
-    /// [`TextClass::Standard`] or may be distinct, e.g. using a larger font
-    /// size or heavier weight.
+    /// Its appearance is normally identical to [`TextClass::Standard`].
     Label,
     /// Small UI font
     ///
@@ -157,5 +160,19 @@ pub enum TextClass {
     /// Editable text
     ///
     /// This text class should be preferred for editable text.
+    ///
+    /// Its appearance is normally identical to [`TextClass::Standard`].
     Editor,
+    /// Serif font
+    ///
+    /// This class may be used where a Serif font is specifically preferred,
+    /// for example in an editor where it is important to be able to distinguish
+    /// all letters.
+    Serif,
+    /// Sans-serif Font
+    ///
+    /// Its appearance is normally identical to [`TextClass::Standard`].
+    SansSerif,
+    /// Monospace font
+    Monospace,
 }


### PR DESCRIPTION
CSS-style font-selectors may now be used in configuration:
```toml
[font.fonts]
Serif = "serif"
SansSerif = "sans-serif"
Monospace = "monospace"
```
Font resolution is improved (see https://github.com/kas-gui/kas-text/pull/110).