### PR TITLE
Revise text configuration/draw methods

### DIFF
--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -218,8 +218,8 @@ pub trait Draw {
     ///
     /// Text is drawn from `pos` and clipped to `bounding_box`.
     ///
-    /// The `text` object must be configured and prepared prior to calling this
-    /// method (see [`crate::theme::Text`] or [`crate::text::Text`]).
+    /// The `text` display must be prepared prior to calling this method.
+    /// Typically this is done using a [`crate::theme::Text`] object.
     fn text(&mut self, pos: Vec2, bounding_box: Quad, text: &TextDisplay, col: Rgba);
 
     /// Draw text with effects
@@ -233,8 +233,8 @@ pub trait Draw {
     /// Text colour lookup uses index `e` and is essentially:
     /// `colors.get(e).unwrap_or(Rgba::BLACK)`.
     ///
-    /// The `text` object must be configured and prepared prior to calling this
-    /// method (see [`crate::theme::Text`] or [`crate::text::Text`]).
+    /// The `text` display must be prepared prior to calling this method.
+    /// Typically this is done using a [`crate::theme::Text`] object.
     fn text_effects(
         &mut self,
         pos: Vec2,

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -240,8 +240,8 @@ pub trait Draw {
         pos: Vec2,
         bounding_box: Quad,
         text: &TextDisplay,
-        effects: &[Effect],
         colors: &[Rgba],
+        effects: &[Effect],
     );
 }
 
@@ -304,12 +304,12 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
         pos: Vec2,
         bb: Quad,
         text: &TextDisplay,
-        effects: &[Effect],
         colors: &[Rgba],
+        effects: &[Effect],
     ) {
         self.shared
             .draw
-            .draw_text_effects(self.draw, self.pass, pos, bb, text, effects, colors);
+            .draw_text_effects(self.draw, self.pass, pos, bb, text, colors, effects);
     }
 }
 

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -235,7 +235,7 @@ pub trait DrawSharedImpl: Any {
         pos: Vec2,
         bb: Quad,
         text: &TextDisplay,
-        effects: &[Effect],
         colors: &[Rgba],
+        effects: &[Effect],
     );
 }

--- a/crates/kas-core/src/event/config_cx.rs
+++ b/crates/kas-core/src/event/config_cx.rs
@@ -6,8 +6,7 @@
 //! Configuration context
 
 use crate::event::EventState;
-use crate::text::format::FormattableText;
-use crate::theme::{SizeCx, Text, ThemeSize};
+use crate::theme::{SizeCx, ThemeSize};
 use crate::{ActionRedraw, ActionResize, Id, Node};
 use std::any::TypeId;
 use std::fmt::Debug;
@@ -78,36 +77,6 @@ impl<'a> ConfigCx<'a> {
         let start_resize = std::mem::take(&mut self.resize);
         widget._update(self);
         self.resize = self.resize.or(start_resize);
-    }
-
-    /// Configure a text object
-    ///
-    /// Font selection depends on the [`TextClass`], [theme configuration] and
-    /// the loaded [fonts][crate::text::fonts]. Font size depends on the
-    /// [`TextClass`], [theme configuration] and scale factor.
-    ///
-    /// [`TextClass`]: crate::theme::TextClass
-    /// [theme configuration]: crate::config::ThemeConfig
-    #[inline]
-    pub fn text_configure<T: FormattableText>(&self, text: &mut Text<T>) {
-        let class = text.class();
-        self.theme.text_configure(text, class);
-    }
-
-    /// Configure a text object with custom font size
-    ///
-    /// Font selection depends on the [`TextClass`], [theme configuration] and
-    /// the loaded [fonts][crate::text::fonts].
-    ///
-    /// Font size must be specified in `dpem`: physical pixels per font Em.
-    /// The default font size is available through [`SizeCx::dpem`].
-    ///
-    /// [`TextClass`]: crate::theme::TextClass
-    /// [theme configuration]: crate::config::ThemeConfig
-    #[inline]
-    pub fn text_configure_with_dpem<T: FormattableText>(&self, text: &mut Text<T>, dpem: f32) {
-        let class = text.class();
-        self.theme.text_configure_with_dpem(text, class, dpem);
     }
 
     /// Set a target for messages of a specific type when sent to `Id::default()`

--- a/crates/kas-core/src/text/mod.rs
+++ b/crates/kas-core/src/text/mod.rs
@@ -15,7 +15,7 @@
 
 pub use kas_text::{
     Align, DPU, Direction, Effect, EffectFlags, Line, MarkerPos, MarkerPosIter, NotReady,
-    OwningVecIter, Status, Text, TextDisplay, Vec2, fonts, format,
+    OwningVecIter, Status, TextDisplay, Vec2, fonts, format,
 };
 
 /// Glyph rastering

--- a/crates/kas-core/src/text/raster.rs
+++ b/crates/kas-core/src/text/raster.rs
@@ -542,8 +542,8 @@ impl State {
         pos: Vec2,
         bb: Quad,
         text: &TextDisplay,
-        effects: &[Effect],
         colors: &[Rgba],
+        effects: &[Effect],
         mut draw_quad: impl FnMut(Quad, Rgba),
     ) {
         // Optimisation: use cheaper TextDisplay::runs method

--- a/crates/kas-core/src/theme/dimensions.rs
+++ b/crates/kas-core/src/theme/dimensions.rs
@@ -18,6 +18,7 @@ use crate::config::{Config, WindowConfig};
 use crate::dir::Directional;
 use crate::geom::{Rect, Size, Vec2};
 use crate::layout::{AlignPair, AxisInfo, FrameRules, Margins, SizeRules, Stretch};
+use crate::text::fonts::FontSelector;
 
 crate::impl_scope! {
     /// Parameterisation of [`Dimensions`]
@@ -201,6 +202,10 @@ impl<D: 'static> ThemeSize for Window<D> {
         self.dims.scale
     }
 
+    fn font(&self, class: TextClass) -> FontSelector {
+        self.config.borrow().font.get_font_selector(class)
+    }
+
     fn dpem(&self, class: TextClass) -> f32 {
         self.dims.dpem[class]
     }
@@ -338,16 +343,6 @@ impl<D: 'static> ThemeSize for Window<D> {
             }
             FrameStyle::EditBox => FrameRules::new_sym(self.dims.frame, 0, outer),
         }
-    }
-
-    fn text_configure(&self, text: &mut dyn SizableText, class: TextClass) {
-        let dpem = self.dims.dpem[class];
-        self.text_configure_with_dpem(text, class, dpem);
-    }
-
-    fn text_configure_with_dpem(&self, text: &mut dyn SizableText, class: TextClass, dpem: f32) {
-        let font = self.config.borrow().font.get_font_selector(class);
-        text.set_font(font, dpem);
     }
 
     fn text_rules(&self, text: &mut dyn SizableText, wrap: bool, axis: AxisInfo) -> SizeRules {

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -281,8 +281,7 @@ impl<'a> DrawCx<'a> {
     /// This method supports a number of text effects: bold, emphasis, text
     /// size, underline and strikethrough.
     ///
-    /// [`ConfigCx::text_configure`] should be called prior to this method to
-    /// select a font, font size and wrap options (based on the [`TextClass`]).
+    /// The `text` should be prepared before calling this method.
     pub fn text<T: FormattableText>(&mut self, rect: Rect, text: &Text<T>) {
         self.text_pos(rect.pos, rect, text);
     }
@@ -294,8 +293,7 @@ impl<'a> DrawCx<'a> {
     /// This method supports a number of text effects: bold, emphasis, text
     /// size, underline and strikethrough.
     ///
-    /// [`ConfigCx::text_configure`] should be called prior to this method to
-    /// select a font, font size and wrap options (based on the [`TextClass`]).
+    /// The `text` should be prepared before calling this method.
     pub fn text_pos<T: FormattableText>(&mut self, pos: Coord, rect: Rect, text: &Text<T>) {
         let effects = text.effect_tokens();
         self.text_with_effects(pos, rect, text, effects);
@@ -355,8 +353,7 @@ impl<'a> DrawCx<'a> {
     ///
     /// The text cursor is draw from `rect.pos` and clipped to `rect`.
     ///
-    /// [`ConfigCx::text_configure`] should be called prior to this method to
-    /// select a font, font size and wrap options (based on the [`TextClass`]).
+    /// The `text` should be prepared before calling this method.
     pub fn text_cursor<T: FormattableText>(
         &mut self,
         pos: Coord,
@@ -516,8 +513,7 @@ pub trait ThemeDraw {
 
     /// Draw text
     ///
-    /// [`ConfigCx::text_configure`] should be called prior to this method to
-    /// select a font, font size and wrap options (based on the [`TextClass`]).
+    /// The `text` should be prepared before calling this method.
     fn text(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay);
 
     /// Draw text with effects
@@ -529,8 +525,7 @@ pub trait ThemeDraw {
     /// If `effects` is empty or all [`Effect::flags`] are default then it is
     /// equivalent (and faster) to call [`Self::text`] instead.
     ///
-    /// [`ConfigCx::text_configure`] should be called prior to this method to
-    /// select a font, font size and wrap options (based on the [`TextClass`]).
+    /// The `text` should be prepared before calling this method.
     fn text_effects(
         &mut self,
         id: &Id,
@@ -552,8 +547,7 @@ pub trait ThemeDraw {
 
     /// Draw an edit marker at the given `byte` index on this `text`
     ///
-    /// [`ConfigCx::text_configure`] should be called prior to this method to
-    /// select a font, font size and wrap options (based on the [`TextClass`]).
+    /// The `text` should be prepared before calling this method.
     fn text_cursor(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay, byte: usize);
 
     /// Draw UI element: check box

--- a/crates/kas-core/src/theme/mod.rs
+++ b/crates/kas-core/src/theme/mod.rs
@@ -35,7 +35,7 @@ pub use multi::MultiTheme;
 pub use simple_theme::SimpleTheme;
 pub use size::SizeCx;
 pub use style::*;
-pub use text::{SizableText, Text};
+pub use text::Text;
 pub use theme_dst::ThemeDst;
 pub use traits::{Theme, Window};
 

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -348,13 +348,15 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
         }
     }
 
-    fn text(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay) {
+    fn text(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay, color: Option<Rgba>) {
         let bb = Quad::conv(rect);
-        let col = if self.ev.is_disabled(id) {
-            self.cols.text_disabled
-        } else {
-            self.cols.text
-        };
+        let col = color.unwrap_or_else(|| {
+            if self.ev.is_disabled(id) {
+                self.cols.text_disabled
+            } else {
+                self.cols.text
+            }
+        });
         self.draw.text(pos.cast(), bb, text, col);
     }
 
@@ -364,16 +366,22 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
         pos: Coord,
         rect: Rect,
         text: &TextDisplay,
+        colors: &[Rgba],
         effects: &[Effect],
     ) {
         let bb = Quad::conv(rect);
-        let col = if self.ev.is_disabled(id) {
-            self.cols.text_disabled
-        } else {
-            self.cols.text
-        };
+        let col;
+        let mut colors = colors;
+        if colors.is_empty() {
+            col = [if self.ev.is_disabled(id) {
+                self.cols.text_disabled
+            } else {
+                self.cols.text
+            }];
+            colors = &col;
+        }
         self.draw
-            .text_effects(pos.cast(), bb, text, effects, &[col]);
+            .text_effects(pos.cast(), bb, text, colors, effects);
     }
 
     fn text_selected_range(
@@ -420,7 +428,7 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
             },
         ];
         let colors = [col, sel_col];
-        self.draw.text_effects(pos, bb, text, &effects, &colors);
+        self.draw.text_effects(pos, bb, text, &colors, &effects);
     }
 
     fn text_cursor(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay, byte: usize) {

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -11,7 +11,7 @@ use crate::dir::Directional;
 use crate::event::EventState;
 use crate::geom::Rect;
 use crate::layout::{AlignPair, AxisInfo, FrameRules, LogicalBuilder, Margins, SizeRules};
-use crate::text::format::FormattableText;
+use crate::text::{fonts::FontSelector, format::FormattableText};
 use std::ops::{Deref, DerefMut};
 
 #[allow(unused)]
@@ -77,6 +77,11 @@ impl<'a> SizeCx<'a> {
     /// Build [`SizeRules`] from the input size in logical pixels
     pub fn logical(&self, width: f32, height: f32) -> LogicalBuilder {
         LogicalBuilder::new((width, height), self.scale_factor())
+    }
+
+    /// Get the configured font selector for `class`
+    pub fn font(&self, class: TextClass) -> FontSelector {
+        self.w.font(class)
     }
 
     /// Get the default font size for `class`
@@ -186,8 +191,7 @@ impl<'a> SizeCx<'a> {
     /// wish to adjust the result.
     ///
     /// Note: this method partially prepares the `text` object. It is not
-    /// required to call this method but it is required to call
-    /// [`ConfigCx::text_configure`] before text display for correct results.
+    /// required to call this method.
     pub fn text_rules<T: FormattableText>(&self, text: &mut Text<T>, axis: AxisInfo) -> SizeRules {
         let wrap = text.wrap();
         self.w.text_rules(text, wrap, axis)
@@ -199,6 +203,9 @@ impl<'a> SizeCx<'a> {
 pub trait ThemeSize {
     /// Get the scale factor
     fn scale_factor(&self) -> f32;
+
+    /// Get the configured font selector for `class`
+    fn font(&self, class: TextClass) -> FontSelector;
 
     /// Get the default font size for `class`
     ///
@@ -233,14 +240,6 @@ pub trait ThemeSize {
 
     /// Size of a frame around another element
     fn frame(&self, style: FrameStyle, axis_is_vertical: bool) -> FrameRules;
-
-    /// Set font and font size from `class`
-    fn text_configure(&self, text: &mut dyn SizableText, class: TextClass);
-
-    /// Set font from `class`, using a custom font size
-    ///
-    /// The default font size is available using [`Self::dpem`].
-    fn text_configure_with_dpem(&self, text: &mut dyn SizableText, class: TextClass, dpem: f32);
 
     /// Get [`SizeRules`] for a text element
     ///

--- a/crates/kas-core/src/theme/size.rs
+++ b/crates/kas-core/src/theme/size.rs
@@ -5,13 +5,13 @@
 
 //! "Handle" types used by themes
 
-use super::{Feature, FrameStyle, MarginStyle, SizableText, Text, TextClass};
+use super::{Feature, FrameStyle, MarginStyle, TextClass};
 use crate::autoimpl;
 use crate::dir::Directional;
 use crate::event::EventState;
 use crate::geom::Rect;
-use crate::layout::{AlignPair, AxisInfo, FrameRules, LogicalBuilder, Margins, SizeRules};
-use crate::text::{fonts::FontSelector, format::FormattableText};
+use crate::layout::{AlignPair, FrameRules, LogicalBuilder, Margins, SizeRules};
+use crate::text::fonts::FontSelector;
 use std::ops::{Deref, DerefMut};
 
 #[allow(unused)]
@@ -45,6 +45,7 @@ impl<'a> SizeCx<'a> {
     /// Construct from [`EventState`] and a [`ThemeSize`]
     #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
     #[cfg_attr(docsrs, doc(cfg(internal_doc)))]
+    #[inline]
     pub fn new(ev: &'a mut EventState, w: &'a dyn ThemeSize) -> Self {
         SizeCx { ev, w }
     }
@@ -70,16 +71,19 @@ impl<'a> SizeCx<'a> {
     /// This value may change during a program's execution (e.g. when a window
     /// is moved to a different monitor); in this case all widgets will be
     /// resized via [`crate::Layout::size_rules`].
+    #[inline]
     pub fn scale_factor(&self) -> f32 {
         self.w.scale_factor()
     }
 
     /// Build [`SizeRules`] from the input size in logical pixels
+    #[inline]
     pub fn logical(&self, width: f32, height: f32) -> LogicalBuilder {
         LogicalBuilder::new((width, height), self.scale_factor())
     }
 
     /// Get the configured font selector for `class`
+    #[inline]
     pub fn font(&self, class: TextClass) -> FontSelector {
         self.w.font(class)
     }
@@ -93,18 +97,27 @@ impl<'a> SizeCx<'a> {
     ///
     /// This method returns the size of 1 Em in physical pixels, derived from
     /// the font size in use by the theme and the screen's scale factor.
+    #[inline]
     pub fn dpem(&self, class: TextClass) -> f32 {
         self.w.dpem(class)
+    }
+
+    /// Get the `(min, ideal)` line length for text which wraps
+    #[inline]
+    pub fn wrapped_line_len(&self, class: TextClass, dpem: f32) -> (i32, i32) {
+        self.w.wrapped_line_len(class, dpem)
     }
 
     /// The smallest reasonable size for a visible (non-frame) component
     ///
     /// This is used as a suggestion by some heuristics.
+    #[inline]
     pub fn min_element_size(&self) -> i32 {
         self.w.min_element_size()
     }
 
     /// The minimum size of a scrollable area
+    #[inline]
     pub fn min_scroll_size(&self, axis: impl Directional, class: Option<TextClass>) -> i32 {
         let class = class.unwrap_or(TextClass::Standard);
         self.w.min_scroll_size(axis.is_vertical(), class)
@@ -115,6 +128,7 @@ impl<'a> SizeCx<'a> {
     /// This is the length in line with the control. The size on the opposite
     /// axis is assumed to be equal to the feature size as reported by
     /// [`Self::feature`].
+    #[inline]
     pub fn grip_len(&self) -> i32 {
         self.w.grip_len()
     }
@@ -122,46 +136,55 @@ impl<'a> SizeCx<'a> {
     /// The width of a vertical scroll bar
     ///
     /// This value is also available through [`Self::feature`].
+    #[inline]
     pub fn scroll_bar_width(&self) -> i32 {
         self.w.scroll_bar_width()
     }
 
     /// Get margin size
+    #[inline]
     pub fn margins(&self, style: MarginStyle) -> Margins {
         self.w.margins(style)
     }
 
     /// Get margins for [`MarginStyle::Inner`]
+    #[inline]
     pub fn inner_margins(&self) -> Margins {
         self.w.margins(MarginStyle::Inner)
     }
 
     /// Get margins for [`MarginStyle::Tiny`]
+    #[inline]
     pub fn tiny_margins(&self) -> Margins {
         self.w.margins(MarginStyle::Tiny)
     }
 
     /// Get margins for [`MarginStyle::Small`]
+    #[inline]
     pub fn small_margins(&self) -> Margins {
         self.w.margins(MarginStyle::Small)
     }
 
     /// Get margins for [`MarginStyle::Large`]
+    #[inline]
     pub fn large_margins(&self) -> Margins {
         self.w.margins(MarginStyle::Large)
     }
 
     /// Get margins for [`MarginStyle::Text`]
+    #[inline]
     pub fn text_margins(&self) -> Margins {
         self.w.margins(MarginStyle::Text)
     }
 
     /// Size rules for a feature
+    #[inline]
     pub fn feature(&self, feature: Feature, axis: impl Directional) -> SizeRules {
         self.w.feature(feature, axis.is_vertical())
     }
 
     /// Size of a frame around another element
+    #[inline]
     pub fn frame(&self, style: FrameStyle, axis: impl Directional) -> FrameRules {
         self.w.frame(style, axis.is_vertical())
     }
@@ -173,28 +196,6 @@ impl<'a> SizeCx<'a> {
     #[inline]
     pub fn align_feature(&self, feature: Feature, rect: Rect, align: AlignPair) -> Rect {
         self.w.align_feature(feature, rect, align)
-    }
-
-    /// Get [`SizeRules`] for a text element
-    ///
-    /// The [`TextClass`] is used to select a font and controls whether line
-    /// wrapping is enabled.
-    ///
-    /// Horizontal size without wrapping is simply the size the text.
-    /// Horizontal size with wrapping is bounded to some width dependant on the
-    /// theme, and may have non-zero [`Stretch`] depending on the size.
-    ///
-    /// Vertical size is the size of the text with or without wrapping, but with
-    /// the minimum at least the height of one line of text.
-    ///
-    /// Widgets with editable text contents or internal scrolling enabled may
-    /// wish to adjust the result.
-    ///
-    /// Note: this method partially prepares the `text` object. It is not
-    /// required to call this method.
-    pub fn text_rules<T: FormattableText>(&self, text: &mut Text<T>, axis: AxisInfo) -> SizeRules {
-        let wrap = text.wrap();
-        self.w.text_rules(text, wrap, axis)
     }
 }
 
@@ -211,6 +212,9 @@ pub trait ThemeSize {
     ///
     /// Units are physical pixels per Em.
     fn dpem(&self, class: TextClass) -> f32;
+
+    /// Get the `(min, ideal)` line length for text which wraps
+    fn wrapped_line_len(&self, class: TextClass, dpem: f32) -> (i32, i32);
 
     /// The smallest reasonable size for a visible (non-frame) component
     ///
@@ -240,9 +244,4 @@ pub trait ThemeSize {
 
     /// Size of a frame around another element
     fn frame(&self, style: FrameStyle, axis_is_vertical: bool) -> FrameRules;
-
-    /// Get [`SizeRules`] for a text element
-    ///
-    /// Parameter `wrap`: whether long lines automatically wrap.
-    fn text_rules(&self, text: &mut dyn SizableText, wrap: bool, axis: AxisInfo) -> SizeRules;
 }

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -125,22 +125,6 @@ impl<T: FormattableText> Text<T> {
         }
     }
 
-    /// Replace the [`TextDisplay`]
-    ///
-    /// This may be used with [`Self::new`] to reconstruct an object which was
-    /// disolved [`into_parts`][Self::into_parts].
-    #[inline]
-    pub fn with_display(mut self, display: TextDisplay) -> Self {
-        self.display = display;
-        self
-    }
-
-    /// Decompose into parts
-    #[inline]
-    pub fn into_parts(self) -> (TextDisplay, T) {
-        (self.display, self.text)
-    }
-
     /// Set text class (inline)
     ///
     /// `TextClass::Edit(false)` has special handling: line wrapping is disabled

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -24,24 +24,18 @@ use std::num::NonZeroUsize;
 /// -   A [`TextDisplay`]
 /// -   A [`FontSelector`]
 /// -   Type-setting configuration. Values have reasonable defaults:
-///     -   The font is derived from the [`TextClass`] by
-///         [`ConfigCx::text_configure`]. Otherwise, the default font will be
-///         the first loaded font: see [`crate::text::fonts`].
+///     -   The font is derived from the [`TextClass`] by [`Self::configure`],
+///         otherwise using [`FontSelector::default()`].
 ///     -   The font size is derived from the [`TextClass`] by
-///         [`ConfigCx::text_configure`]. Otherwise, the default font size is
-///         16px (the web default).
+///         [`Self::configure`], otherwise using a default size of 16px.
 ///     -   Default text direction and alignment is inferred from the text.
 ///
 /// This struct tracks the [`TextDisplay`]'s
 /// [state of preparation][TextDisplay#status-of-preparation] and will perform
-/// steps as required. Normal usage of this struct is as follows:
-/// -   Configure by calling [`ConfigCx::text_configure`]
-/// -   (Optionally) check size requirements by calling [`SizeCx::text_rules`]
-/// -   Set the size and prepare by calling [`Self::set_rect`]
-/// -   Draw by calling [`DrawCx::text`] (and/or other text methods)
-///
-/// The size according to [`Self::rect`] may be adjusted to that of
-/// the text; see [`Self::set_align`].
+/// steps as required. Typical usage of this struct is as follows:
+/// -   Construct with some text and [`TextClass`]
+/// -   Configure by calling [`Self::configure`]
+/// -   Size and draw using [`Layout`] methods
 #[derive(Clone, Debug)]
 pub struct Text<T: FormattableText> {
     rect: Rect,
@@ -165,6 +159,30 @@ impl<T: FormattableText> Text<T> {
         &mut self.text
     }
 
+    /// Set the font and font size (dpem) according to configuration
+    ///
+    /// Font selection depends on the [`TextClass`], [theme configuration] and
+    /// the loaded [fonts][crate::text::fonts]. Font size depends on the
+    /// [`TextClass`], [theme configuration] and scale factor.
+    ///
+    /// Alternatively, one may call [`Self::set_font`] and
+    /// [`Self::set_font_size`] or use the default values (without respecting
+    /// [theme configuration]).
+    ///
+    /// [theme configuration]: crate::config::ThemeConfig
+    pub fn configure(&mut self, cx: &mut SizeCx) {
+        let font = cx.font(self.class);
+        let dpem = cx.dpem(self.class);
+        if font != self.font {
+            self.font = font;
+            self.dpem = dpem;
+            self.set_max_status(Status::New);
+        } else if dpem != self.dpem {
+            self.dpem = dpem;
+            self.set_max_status(Status::ResizeLevelRuns);
+        }
+    }
+
     /// Force full repreparation of text
     ///
     /// This may be required after calling [`Self::text_mut`].
@@ -241,18 +259,19 @@ impl<T: FormattableText> Text<T> {
         self.wrap = wrap;
     }
 
-    /// Get the default font
+    /// Get the font selector
     #[inline]
     pub fn font(&self) -> FontSelector {
         self.font
     }
 
-    /// Set the default [`FontSelector`]
+    /// Set the font selector
     ///
-    /// This is derived from the [`TextClass`] by [`ConfigCx::text_configure`].
+    /// Typically, [`Self::configure`] is called to set the font selector from
+    /// the [`TextClass`] and configuration. This method sets the font selector
+    /// directly.
     ///
-    /// This `font` is used by all unformatted texts and by any formatted
-    /// texts which don't immediately set formatting.
+    /// Note that effect tokens may further affect the font selector.
     ///
     /// It is necessary to [`prepare`][Self::prepare] the text after calling this.
     #[inline]
@@ -263,19 +282,19 @@ impl<T: FormattableText> Text<T> {
         }
     }
 
-    /// Get the default font size (pixels)
+    /// Get the font size (pixels)
     #[inline]
     pub fn font_size(&self) -> f32 {
         self.dpem
     }
 
-    /// Set the default font size (pixels)
+    /// Set the font size (pixels)
     ///
-    /// This is derived from the [`TextClass`] by [`ConfigCx::text_configure`].
+    /// Typically, [`Self::configure`] is called to set the font size from
+    /// the [`TextClass`] and configuration. This method sets the font size
+    /// directly.
     ///
-    /// This is a scaling factor used to convert font sizes, with units
-    /// `pixels/Em`. Equivalently, this is the line-height in pixels.
-    /// See [`crate::text::fonts`] documentation.
+    /// Note that effect tokens may further affect the font size.
     ///
     /// To calculate this from text size in Points, use `dpem = dpp * pt_size`
     /// where the dots-per-point is usually `dpp = scale_factor * 96.0 / 72.0`
@@ -690,9 +709,6 @@ pub trait SizableText {
     /// Get the text class
     fn class(&self) -> TextClass;
 
-    /// Set font face and size
-    fn set_font(&mut self, font: FontSelector, dpem: f32);
-
     /// Measure required width, up to some `max_width`
     fn measure_width(&mut self, max_width: f32) -> f32;
 
@@ -704,17 +720,6 @@ impl<T: FormattableText> SizableText for Text<T> {
     #[inline]
     fn class(&self) -> TextClass {
         self.class
-    }
-
-    fn set_font(&mut self, font: FontSelector, dpem: f32) {
-        if font != self.font {
-            self.font = font;
-            self.dpem = dpem;
-            self.set_max_status(Status::New);
-        } else if dpem != self.dpem {
-            self.dpem = dpem;
-            self.set_max_status(Status::ResizeLevelRuns);
-        }
     }
 
     fn measure_width(&mut self, max_width: f32) -> f32 {

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -82,7 +82,7 @@ impl<T: FormattableText> Layout for Text<T> {
             }
         }
         self.rect = rect;
-        self.prepare();
+        self.rewrap();
     }
 
     fn draw(&self, mut draw: DrawCx) {
@@ -474,6 +474,17 @@ impl<T: FormattableText> Text<T> {
 
         self.prepare_runs();
         debug_assert!(self.status >= Status::LevelRuns);
+        self.rewrap();
+        true
+    }
+
+    /// Re-wrap
+    ///
+    /// This is a partial form of re-preparation
+    fn rewrap(&mut self) {
+        if self.status < Status::LevelRuns {
+            return;
+        }
 
         if self.status == Status::LevelRuns {
             let align_width = self.rect.size.0.cast();
@@ -488,7 +499,6 @@ impl<T: FormattableText> Text<T> {
         }
 
         self.status = Status::Ready;
-        true
     }
 
     /// Re-prepare, requesting a redraw or resize as required

--- a/crates/kas-core/src/widgets/label.rs
+++ b/crates/kas-core/src/widgets/label.rs
@@ -33,7 +33,7 @@ mod Label {
     #[derive(Debug)]
     #[widget]
     #[layout(self.text)]
-    pub struct Label<T: FormattableText + 'static> {
+    pub struct Label<T: FormattableText + 'static = String> {
         core: widget_core!(),
         text: Text<T>,
     }

--- a/crates/kas-core/src/widgets/label.rs
+++ b/crates/kas-core/src/widgets/label.rs
@@ -133,7 +133,7 @@ mod Label {
         type Data = ();
 
         fn configure(&mut self, cx: &mut ConfigCx) {
-            cx.text_configure(&mut self.text);
+            self.text.configure(&mut cx.size_cx());
         }
     }
 

--- a/crates/kas-macros/src/extends.rs
+++ b/crates/kas-macros/src/extends.rs
@@ -80,8 +80,8 @@ impl Extends {
                 (#base).selection(rect, style);
             }
 
-            fn text(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay) {
-                (#base).text(id, pos, rect, text);
+            fn text(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay, color: Option<Rgba>) {
+                (#base).text(id, pos, rect, text, color);
             }
 
             fn text_effects(
@@ -90,9 +90,10 @@ impl Extends {
                 pos: Coord,
                 rect: Rect,
                 text: &TextDisplay,
+                colors: &[Rgba],
                 effects: &[::kas::text::Effect],
             ) {
-                (#base).text_effects(id, pos, rect, text, effects);
+                (#base).text_effects(id, pos, rect, text, colors, effects);
             }
 
             fn text_selected_range(

--- a/crates/kas-soft/src/draw.rs
+++ b/crates/kas-soft/src/draw.rs
@@ -207,8 +207,8 @@ impl DrawSharedImpl for Shared {
         pos: Vec2,
         bb: Quad,
         text: &text::TextDisplay,
-        effects: &[text::Effect],
         colors: &[color::Rgba],
+        effects: &[text::Effect],
     ) {
         let time = std::time::Instant::now();
         self.text.text_effects(
@@ -218,8 +218,8 @@ impl DrawSharedImpl for Shared {
             pos,
             bb,
             text,
-            effects,
             colors,
+            effects,
             |quad, col| {
                 draw.basic.rect(pass, quad, col);
             },

--- a/crates/kas-view/src/driver.rs
+++ b/crates/kas-view/src/driver.rs
@@ -46,7 +46,7 @@ use std::default::Default;
 /// struct MyDriver;
 /// impl<Key> Driver<Key, f32> for MyDriver {
 ///     const TAB_NAVIGABLE: bool = false;
-///     type Widget = Text<f32, String>;
+///     type Widget = Text<f32>;
 ///
 ///     fn make(&mut self, _: &Key) -> Self::Widget {
 ///         Text::new_gen(|_, data: &f32| data.to_string())
@@ -116,7 +116,7 @@ macro_rules! impl_via_to_string {
     ($t:ty) => {
         impl<Key> Driver<Key, $t> for View {
             const TAB_NAVIGABLE: bool = false;
-            type Widget = Text<$t, String>;
+            type Widget = Text<$t>;
 
             fn make(&mut self, _: &Key) -> Self::Widget {
                 Text::new_gen(|_, data: &$t| data.to_string())

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -386,8 +386,8 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
         pos: Vec2,
         bb: Quad,
         text: &TextDisplay,
-        effects: &[Effect],
         colors: &[Rgba],
+        effects: &[Effect],
     ) {
         let time = std::time::Instant::now();
         self.text.text_effects(
@@ -397,8 +397,8 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
             pos,
             bb,
             text,
-            effects,
             colors,
+            effects,
             |quad, col| {
                 draw.shaded_square.rect(pass, quad, col);
             },

--- a/crates/kas-widgets/src/access_label.rs
+++ b/crates/kas-widgets/src/access_label.rs
@@ -156,7 +156,7 @@ mod AccessLabel {
 
         fn configure(&mut self, cx: &mut ConfigCx) {
             self.target = self.id();
-            cx.text_configure(&mut self.text);
+            self.text.configure(&mut cx.size_cx());
         }
     }
 }

--- a/crates/kas-widgets/src/access_label.rs
+++ b/crates/kas-widgets/src/access_label.rs
@@ -134,7 +134,7 @@ mod AccessLabel {
                 && draw.access_key(&self.target, key)
             {
                 // Stop on first successful binding and draw
-                draw.text_with_effects(rect.pos, rect, &self.text, effects);
+                draw.text_with_effects(rect.pos, rect, &self.text, &[], effects);
             } else {
                 draw.text(rect, &self.text);
             }

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -208,7 +208,7 @@ mod EditField {
         }
 
         fn configure(&mut self, cx: &mut ConfigCx) {
-            cx.text_configure(&mut self.text);
+            self.text.configure(&mut cx.size_cx());
             G::configure(self, cx);
         }
 

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -167,9 +167,9 @@ mod EditField {
                         flags: Default::default(),
                     },
                 ];
-                draw.text_with_effects(pos, rect, &self.text, &effects);
+                draw.text_with_effects(pos, rect, &self.text, &[], &effects);
             } else {
-                draw.text_selected(pos, rect, &self.text, self.selection.range());
+                draw.text_with_selection(pos, rect, &self.text, self.selection.range());
             }
 
             if self.editable && draw.ev_state().has_key_focus(self.id_ref()).0 {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -69,9 +69,9 @@ mod SelectableText {
             let pos = self.rect().pos - offset;
 
             if self.selection.is_empty() {
-                draw.text_pos(pos, rect, &self.text);
+                draw.text_with_position(pos, rect, &self.text);
             } else {
-                draw.text_selected(pos, rect, &self.text, self.selection.range());
+                draw.text_with_selection(pos, rect, &self.text, self.selection.range());
             }
         }
     }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -238,7 +238,7 @@ mod SelectableText {
         }
 
         fn configure(&mut self, cx: &mut ConfigCx) {
-            cx.text_configure(&mut self.text);
+            self.text.configure(&mut cx.size_cx());
         }
 
         fn update(&mut self, cx: &mut ConfigCx, data: &A) {

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -390,7 +390,7 @@ mod SpinBox {
         }
 
         fn configure(&mut self, cx: &mut ConfigCx) {
-            cx.text_configure(&mut self.unit);
+            self.unit.configure(&mut cx.size_cx());
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, data: &A, event: Event) -> IsUsed {

--- a/crates/kas-widgets/src/text.rs
+++ b/crates/kas-widgets/src/text.rs
@@ -9,6 +9,9 @@ use kas::prelude::*;
 use kas::text::format::FormattableText;
 use kas::theme::{self, TextClass};
 
+// NOTE: Text maintains a copy of the (formatted) string internally. Most
+// importantly this allows change detection.
+
 #[impl_self]
 mod Text {
     /// A text label (derived from data)
@@ -28,7 +31,7 @@ mod Text {
     /// default.
     #[widget]
     #[layout(self.text)]
-    pub struct Text<A, T: Default + FormattableText + 'static> {
+    pub struct Text<A, T: Default + FormattableText + 'static = String> {
         core: widget_core!(),
         text: theme::Text<T>,
         text_fn: Box<dyn Fn(&ConfigCx, &A, &mut T) -> bool>,

--- a/crates/kas-widgets/src/text.rs
+++ b/crates/kas-widgets/src/text.rs
@@ -181,7 +181,7 @@ mod Text {
         type Data = A;
 
         fn configure(&mut self, cx: &mut ConfigCx) {
-            cx.text_configure(&mut self.text);
+            self.text.configure(&mut cx.size_cx());
         }
 
         fn update(&mut self, cx: &mut ConfigCx, data: &A) {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -108,7 +108,7 @@ fn widgets() -> Page<AppData> {
         #[layout(row! [self.text, Button::label_msg("&Edit", MsgEdit)])]
         struct {
             core: widget_core!(),
-            #[widget] text: Text<Data, String> = format_text!(data: &Data, "{}", &data.text),
+            #[widget] text: Text<Data> = format_text!(data: &Data, "{}", &data.text),
             #[widget(&())] popup: Popup<TextEdit> = Popup::new(TextEdit::new("", true), Direction::Down),
         }
         impl Events for Self {

--- a/examples/mandlebrot/mandlebrot.rs
+++ b/examples/mandlebrot/mandlebrot.rs
@@ -443,13 +443,13 @@ mod MandlebrotUI {
     struct MandlebrotUI {
         core: widget_core!(),
         #[widget(&self.loc)]
-        label: Text<String, String>,
+        label: Text<String>,
         #[widget]
         title: Label<&'static str>,
         #[widget]
         buttons: TitleBarButtons,
         #[widget(&self.iters)]
-        iters_label: Reserve<Text<i32, String>>,
+        iters_label: Reserve<Text<i32>>,
         #[widget(&self.iters)]
         slider: Slider<i32, i32, kas::dir::Up>,
         #[widget(&self.iters)]

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -89,7 +89,7 @@ mod ColourSquare {
 
         fn configure(&mut self, cx: &mut ConfigCx) {
             self.loading_text.set_align((Align::Center, Align::Center));
-            cx.text_configure(&mut self.loading_text);
+            self.loading_text.configure(&mut cx.size_cx());
         }
 
         fn update(&mut self, cx: &mut ConfigCx, data: &AppData) {


### PR DESCRIPTION
The `clock` example now uses `kas::theme::Text`. Removes `kas::text::Text` (this remains part of `kas_text` but is no longer exposed).

Removes fn `ConfigCx::text_configure` and `SizeCx::text_rules`.

`DrawCx`'s text methods now support colours: added `fn text_with_color`; added argument `colors: &[Rgba]` to fn `text_with_effects`.

Renamed `DrawCx::text_pos` → `text_with_position` and `text_selected` → `text_with_selection`.