### PR TITLE
Remove feature dark-light

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ stable = ["default", "view", "image-default-formats", "canvas", "svg", "markdown
 # Enables all "recommended" features for nightly rustc
 nightly = ["stable", "nightly-diagnostics", "kas-core/nightly"]
 # Additional, less recommendation-worthy features
-experimental = ["dark-light", "unsafe_node"]
+experimental = ["unsafe_node"]
 
 # Enable dynamic linking (faster linking via an extra run-time dependency):
 dynamic = ["dep:kas-dylib"]
@@ -115,11 +115,6 @@ webp = ["image", "kas-image/webp"]
 svg = ["dep:kas-image", "kas-image/svg", "kas-dylib?/image"]
 # Enable Canvas widget
 canvas = ["dep:kas-image", "kas-image/canvas", "kas-dylib?/image"]
-
-# Automatically detect usage of dark theme
-#
-# Not a default dependency; see https://github.com/emilk/egui/issues/2388
-dark-light = ["kas-core/dark-light"]
 
 # Support spawning async tasks
 spawn = ["kas-core/spawn"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,3 @@ resolver = "2"
 [patch.crates-io.kas-text]
 git = "https://github.com/kas-gui/kas-text.git"
 rev = "dc0b273f"
-
-[patch.crates-io.rfd]
-git = "https://github.com/PolyMeilex/rfd.git"
-rev = "cbabff1c26e35d0b47ebed348905104f3500e9e9"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -26,7 +26,7 @@ stable = ["minimal", "clipboard", "markdown", "spawn", "x11", "serde", "toml", "
 # Enables all "recommended" features for nightly rustc
 nightly = ["stable", "nightly-diagnostics"]
 # Additional, less recommendation-worthy features
-experimental = ["dark-light", "unsafe_node"]
+experimental = ["unsafe_node"]
 
 # Enables better proc-macro diagnostics (including warnings); nightly only.
 nightly-diagnostics = ["kas-macros/nightly"]
@@ -82,9 +82,6 @@ x11 = ["winit/x11"]
 # Enable serde integration (mainly config read/write)
 serde = ["dep:serde", "kas-text/serde", "winit/serde"]
 
-# Automatically detect usage of dark theme
-dark-light = ["dep:dark-light"]
-
 # Support spawning async tasks
 spawn = ["dep:async-global-executor"]
 
@@ -106,7 +103,6 @@ serde_json = { version = "1.0.61", optional = true }
 serde_yaml2 = { version = "0.1.2", optional = true }
 ron = { version = "0.12.0", package = "ron", optional = true }
 toml = { version = "0.9.4", package = "toml", optional = true }
-dark-light = { version = "2.0", optional = true }
 raw-window-handle = "0.6.0"
 async-global-executor = { version = "3.1.0", optional = true }
 cfg-if = "1.0.0"

--- a/crates/kas-core/src/config/theme.rs
+++ b/crates/kas-core/src/config/theme.rs
@@ -168,18 +168,8 @@ impl ThemeConfig {
 mod defaults {
     use super::*;
 
-    #[cfg(not(feature = "dark-light"))]
     pub fn default_scheme() -> String {
         "light".to_string()
-    }
-
-    #[cfg(feature = "dark-light")]
-    pub fn default_scheme() -> String {
-        use dark_light::Mode;
-        match dark_light::detect() {
-            Ok(Mode::Dark) => "dark".to_string(),
-            _ => "light".to_string(),
-        }
     }
 
     pub fn color_schemes() -> BTreeMap<String, ColorsSrgb> {

--- a/crates/kas-image/Cargo.toml
+++ b/crates/kas-image/Cargo.toml
@@ -40,8 +40,8 @@ webp = ["dep:image", "image/webp"]
 [dependencies]
 log = "0.4"
 tiny-skia = { version = "0.11.0" }
-resvg = { version = "0.45.0", optional = true }
-usvg = { version = "0.45.0", optional = true }
+resvg = { version = "0.46.0", optional = true }
+usvg = { version = "0.46.0", optional = true }
 once_cell = "1.17.0"
 thiserror = "2.0.3"
 image = { version = "0.25.1", default-features = false, optional = true }

--- a/examples/text-editor/Cargo.toml
+++ b/examples/text-editor/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 kas = { version = "0.16.0", features = ["wgpu"], path = "../.." }
 env_logger = "0.11"
 log = "0.4"
-rfd = "0.15.4"
+rfd = "0.17.2"
 
 [[bin]]
 name = "text-editor"


### PR DESCRIPTION
Remove the [dark-light](https://crates.io/crates/dark-light) dependency and feature.

Motivation: the crate is not being well maintained, and is causing build failures (in one of its dependencies, `ashpd`, which is not up-to-date).

Further motivation: this small feature required a huge number of additional dependencies. This PR removes the size of the full dependency tree (`cargo tree --all-features|wc -l`) from 1173 to 1048.

Note: further work would be required for run-time switching detection.
Further note: winit already has the `WindowEvent::ThemeChanged` event for run-time detection, though it supports few platforms.