### PR TITLE
UndoStack: store full edit history

### DIFF
--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -13,6 +13,7 @@ use crate::geom::Offset;
 use crate::layout::GridCellInfo;
 #[allow(unused)]
 use crate::messages::{DecrementStep, IncrementStep, SetValueF64};
+use crate::text::CursorRange;
 #[allow(unused)] use crate::{Layout, Tile};
 
 /// Describes a widget's purpose and capabilities
@@ -144,13 +145,8 @@ pub enum Role<'a> {
         text: &'a str,
         /// Whether the text input supports multi-line text
         multi_line: bool,
-        /// The cursor index within `contents`
-        cursor: usize,
-        /// The selection index. Equals `cursor` if the selection is empty.
-        /// May be less than or greater than `cursor`. (Aside: some toolkits
-        /// call this the selection anchor but Kas does not; see
-        /// [`kas::text::SelectionHelper`].)
-        sel_index: usize,
+        /// The cursor index and selection range
+        cursor: CursorRange,
     },
     /// A gripable handle
     ///

--- a/crates/kas-core/src/event/cx/key.rs
+++ b/crates/kas-core/src/event/cx/key.rs
@@ -339,7 +339,7 @@ impl<'a> EventCx<'a> {
         }
 
         if event.state == ElementState::Pressed && !is_synthetic {
-            self.start_key_event(widget, event.logical_key, event.physical_key);
+            self.start_key_event(widget, event.key_without_modifiers, event.physical_key);
         } else if event.state == ElementState::Released
             && self.key_depress.remove(&event.physical_key).is_some()
         {

--- a/crates/kas-core/src/event/cx/nav.rs
+++ b/crates/kas-core/src/event/cx/nav.rs
@@ -209,9 +209,8 @@ impl<'a> EventCx<'a> {
             return;
         }
 
-        if self.sel_focus.is_some() {
-            self.clear_key_focus();
-            self.clear_ime_focus();
+        if let Some(id) = self.sel_focus.clone() {
+            self.clear_sel_socus_on(&id);
         }
 
         if let Some(old) = self.nav_focus.take() {

--- a/crates/kas-core/src/messages.rs
+++ b/crates/kas-core/src/messages.rs
@@ -45,6 +45,8 @@ pub struct SetValueF64(pub f64);
 /// Set an input value from a `String`
 ///
 /// This message may be used to set a text value to an input field.
+///
+/// For targets with undo support this message commits a new undo state.
 #[derive(Clone, Debug)]
 pub struct SetValueText(pub String);
 
@@ -52,6 +54,8 @@ pub struct SetValueText(pub String);
 ///
 /// This acts the same as typing or pasting the text: replace an existing
 /// selection or insert at the cursor position.
+///
+/// For targets with undo support this message commits a new undo state.
 #[derive(Clone, Debug)]
 pub struct ReplaceSelectedText(pub String);
 

--- a/crates/kas-core/src/text/mod.rs
+++ b/crates/kas-core/src/text/mod.rs
@@ -24,7 +24,7 @@ pub use kas_text::{
 pub mod raster;
 
 mod selection;
-pub use selection::SelectionHelper;
+pub use selection::{CursorRange, SelectionHelper};
 
 mod string;
 pub use string::AccessString;

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -15,7 +15,7 @@ use unicode_segmentation::UnicodeSegmentation;
 ///
 /// This is essentially a pair of indices: the selection index and the edit
 /// index.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CursorRange {
     sel: usize,
     edit: usize,

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -6,98 +6,77 @@
 //! Tools for text selection
 
 use crate::theme::Text;
+use kas_macros::autoimpl;
 use kas_text::format::FormattableText;
 use std::ops::Range;
 use unicode_segmentation::UnicodeSegmentation;
 
-/// Text-selection logic
+/// Cursor index / selection range
 ///
-/// This struct holds the index of the edit cursor and selection position, which
-/// together form a range. There is no requirement on the order of these two
-/// positions. Each may be adjusted independently.
-///
-/// Additionally, this struct holds the selection anchor index. This usually
-/// equals the selection index, but when using double-click or triple-click
-/// selection, the anchor represents the initially-clicked position while the
-/// selection index represents the expanded position.
-#[derive(Clone, Debug, Default)]
-pub struct SelectionHelper {
-    edit: usize,
+/// This is essentially a pair of indices: the selection index and the edit
+/// index.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CursorRange {
     sel: usize,
-    anchor: usize,
+    edit: usize,
 }
 
-impl SelectionHelper {
-    /// Construct from `(edit, selection)` positions
-    ///
-    /// The anchor position is set to the selection position.
-    pub fn new(edit: usize, selection: usize) -> Self {
-        SelectionHelper {
-            edit,
-            sel: selection,
-            anchor: selection,
+impl From<usize> for CursorRange {
+    #[inline]
+    fn from(index: usize) -> Self {
+        CursorRange {
+            sel: index,
+            edit: index,
         }
     }
+}
 
-    /// Reset to the default state
+impl From<Range<usize>> for CursorRange {
+    #[inline]
+    fn from(range: Range<usize>) -> Self {
+        CursorRange {
+            sel: range.start,
+            edit: range.end,
+        }
+    }
+}
+
+impl CursorRange {
+    /// Construct from `(selection, edit)` positions
     ///
-    /// All positions are set to 0.
-    pub fn clear(&mut self) {
-        *self = Self::default();
+    /// Constructs as a range, with the cursor at the `edit` position.
+    ///
+    /// See also:
+    ///
+    /// - `Default`: an empty cursor at index 0
+    /// - `From<usize>`: construct from an index (empty selection)
+    /// - `From<Range<usize>>`: construct from a range (potentially non-empty
+    ///   selection; edit position is set to the range's end)
+    #[inline]
+    pub fn new(sel: usize, edit: usize) -> Self {
+        CursorRange { sel, edit }
     }
 
     /// True if the selection index equals the cursor index
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.edit == self.sel
     }
+
     /// Clear selection without changing the edit index
+    #[inline]
     pub fn set_empty(&mut self) {
         self.sel = self.edit;
-        self.anchor = self.edit;
-    }
-
-    /// Set the cursor index and clear the selection
-    pub fn set_all(&mut self, index: usize) {
-        self.edit = index;
-        self.sel = index;
-        self.anchor = index;
-    }
-
-    /// Get the cursor index
-    pub fn edit_index(&self) -> usize {
-        self.edit
-    }
-    /// Set the cursor index without adjusting the selection index
-    pub fn set_edit_index(&mut self, index: usize) {
-        self.edit = index;
     }
 
     /// Get the selection index
     pub fn sel_index(&self) -> usize {
         self.sel
     }
-    /// Set the selection index without adjusting the edit index
-    ///
-    /// The anchor index is also set to the selection index.
-    pub fn set_sel_index(&mut self, index: usize) {
-        self.sel = index;
-        self.anchor = index;
-    }
-    /// Set the selection index only
-    ///
-    /// Prefer [`Self::set_sel_index`] unless you know you don't want to set the anchor.
-    pub fn set_sel_index_only(&mut self, index: usize) {
-        self.sel = index;
-    }
 
-    /// Apply new limit to the maximum length
-    ///
-    /// Call this method if the string changes under the selection to ensure
-    /// that the selection does not exceed the length of the new string.
-    pub fn set_max_len(&mut self, len: usize) {
-        self.edit = self.edit.min(len);
-        self.sel = self.sel.min(len);
-        self.anchor = self.anchor.min(len);
+    /// Get the edit cursor index
+    pub fn edit_index(&self) -> usize {
+        self.edit
     }
 
     /// Get the selection range
@@ -111,6 +90,75 @@ impl SelectionHelper {
         }
         range
     }
+}
+
+/// Text-selection logic
+///
+/// This struct holds a [`CursorRange`]. There is no requirement on the order of these two
+/// positions. Each may be adjusted independently.
+///
+/// Additionally, this struct holds the selection anchor index. This usually
+/// equals the selection index, but when using double-click or triple-click
+/// selection, the anchor represents the initially-clicked position while the
+/// selection index represents the expanded position.
+#[derive(Clone, Debug, Default)]
+#[autoimpl(Deref, DerefMut using self.cursor)]
+pub struct SelectionHelper {
+    cursor: CursorRange,
+    anchor: usize,
+}
+
+impl<T: Into<CursorRange>> From<T> for SelectionHelper {
+    fn from(x: T) -> Self {
+        let cursor = x.into();
+        SelectionHelper {
+            cursor,
+            anchor: cursor.sel,
+        }
+    }
+}
+
+impl SelectionHelper {
+    /// Set the cursor position, clearing the selection
+    #[inline]
+    pub fn set_cursor(&mut self, index: usize) {
+        self.cursor.sel = index;
+        self.cursor.edit = index;
+        self.anchor = index;
+    }
+
+    /// Set the cursor index without adjusting the selection index
+    #[inline]
+    pub fn set_edit_index(&mut self, index: usize) {
+        self.edit = index;
+    }
+
+    /// Set the selection index without adjusting the edit index
+    ///
+    /// The anchor index is also set to the selection index.
+    #[inline]
+    pub fn set_sel_index(&mut self, index: usize) {
+        self.sel = index;
+        self.anchor = index;
+    }
+    /// Set the selection index only
+    ///
+    /// Prefer [`Self::set_sel_index`] unless you know you don't want to set the anchor.
+    #[inline]
+    pub fn set_sel_index_only(&mut self, index: usize) {
+        self.sel = index;
+    }
+
+    /// Apply new limit to the maximum length
+    ///
+    /// Call this method if the string changes under the selection to ensure
+    /// that the selection does not exceed the length of the new string.
+    #[inline]
+    pub fn set_max_len(&mut self, len: usize) {
+        self.edit = self.edit.min(len);
+        self.sel = self.sel.min(len);
+        self.anchor = self.anchor.min(len);
+    }
 
     /// Set the anchor to the edit position
     ///
@@ -118,6 +166,7 @@ impl SelectionHelper {
     /// position is also set to the edit position.
     ///
     /// [`Self::expand`] may be used to expand the selection from this anchor.
+    #[inline]
     pub fn set_anchor(&mut self, clear: bool) {
         self.anchor = self.edit;
         if clear {
@@ -125,23 +174,9 @@ impl SelectionHelper {
         }
     }
 
-    /// Set the anchor position to the start of the selection range
-    pub fn set_anchor_to_range_start(&mut self) {
-        self.anchor = self.range().start;
-    }
-
-    /// Get the range from the anchor position to the edit position
-    ///
-    /// This is used following [`Self::set_anchor_to_range_start`] to get the
-    /// IME pre-edit range.
-    pub fn anchor_to_edit_range(&self) -> Range<usize> {
-        debug_assert!(self.anchor <= self.edit);
-        self.anchor..self.edit
-    }
-
     /// Expand the selection from the range between edit and anchor positions
     ///
-    /// This moves both edit index and selection index. To obtain repeatable
+    /// This moves the cursor range. To obtain repeatable
     /// behaviour on drag-selection, set the anchor ([`Self::set_anchor`])
     /// initially, then set the edit position and call this method each time
     /// the cursor moves.

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -190,4 +190,21 @@ impl SelectionHelper {
         self.sel = start;
         self.edit = end;
     }
+
+    /// Adjust all indices for a deletion from the source text
+    pub fn delete_range(&mut self, range: Range<usize>) {
+        let len = range.len();
+        let adjust = |index: usize| -> usize {
+            if index >= range.end {
+                index - len
+            } else if index > range.start {
+                range.start
+            } else {
+                index
+            }
+        };
+        self.edit = adjust(self.edit);
+        self.sel = adjust(self.sel);
+        self.anchor = adjust(self.anchor);
+    }
 }

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -679,6 +679,22 @@ impl Text<String> {
         self.set_max_status(Status::New);
     }
 
+    /// Set text to a raw `&str`
+    ///
+    /// Returns `true` when new `text` contents do not match old contents. In
+    /// this case the new `text` is assigned, but the caller must also call
+    /// [`Text::prepare`] afterwards.
+    #[inline]
+    pub fn set_str(&mut self, text: &str) -> bool {
+        if self.text.as_str() == text {
+            return false; // no change
+        }
+
+        self.text = text.to_string();
+        self.set_max_status(Status::New);
+        true
+    }
+
     /// Set text to a raw `String`
     ///
     /// Returns `true` when new `text` contents do not match old contents. In

--- a/crates/kas-widgets/src/dialog.rs
+++ b/crates/kas-widgets/src/dialog.rs
@@ -315,8 +315,9 @@ mod TextEdit {
             }
         }
 
-        /// Set text
+        /// Set text, clearing undo history
         pub fn set_text(&mut self, cx: &mut EventState, text: impl ToString) {
+            self.edit.clear(cx);
             self.edit.set_string(cx, text.to_string());
         }
 

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -169,6 +169,7 @@ mod EditBox {
             } else if self.is_editable()
                 && let Some(SetValueText(string)) = cx.try_pop()
             {
+                self.pre_commit();
                 self.set_string(cx, string);
                 G::edit(&mut self.inner, cx, data);
                 G::activate(&mut self.inner, cx, data);
@@ -244,7 +245,25 @@ mod EditBox {
             self.inner.clone_string()
         }
 
+        /// Clear text contents and undo history
+        #[inline]
+        pub fn clear(&mut self, cx: &mut EventState) {
+            self.inner.clear(cx);
+        }
+
+        /// Commit outstanding changes to the undo history
+        ///
+        /// Call this *before* changing the text with `set_str` or `set_string`
+        /// to commit changes to the undo history.
+        #[inline]
+        pub fn pre_commit(&mut self) {
+            self.inner.pre_commit();
+        }
+
         // Set text contents from a `str`
+        ///
+        /// This does not interact with undo history; see also [`Self::clear`],
+        /// [`Self::pre_commit`].
         #[inline]
         pub fn set_str(&mut self, cx: &mut EventState, text: &str) {
             if self.inner.set_str(cx, text) {
@@ -253,6 +272,9 @@ mod EditBox {
         }
 
         /// Set text contents from a `String`
+        ///
+        /// This does not interact with undo history; see also [`Self::clear`],
+        /// [`Self::pre_commit`].
         ///
         /// This method does not call action handlers on the [`EditGuard`].
         #[inline]

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -171,8 +171,7 @@ mod EditBox {
             {
                 self.pre_commit();
                 self.set_string(cx, string);
-                G::edit(&mut self.inner, cx, data);
-                G::activate(&mut self.inner, cx, data);
+                self.inner.call_guard_edit(cx, data);
                 return;
             } else if let Some(&ReplaceSelectedText(_)) = cx.try_peek() {
                 self.inner.handle_messages(cx, data);

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -355,6 +355,7 @@ mod EditField {
                             let start = end - before_bytes;
                             if self.as_str().is_char_boundary(start) {
                                 self.text.replace_range(start..end, "");
+                                self.selection.delete_range(start..end);
                             } else {
                                 log::warn!("buggy IME tried to delete range not at char boundary");
                             }

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -520,6 +520,9 @@ mod EditField {
         }
 
         /// Clear text contents and undo history
+        ///
+        /// This method does not call any [`EditGuard`] actions; consider also
+        /// calling [`Self::call_guard_edit`].
         #[inline]
         pub fn clear(&mut self, cx: &mut EventState) {
             self.last_edit = Some(EditOp::Initial);
@@ -541,6 +544,9 @@ mod EditField {
         /// This does not interact with undo history; see also [`Self::clear`],
         /// [`Self::pre_commit`].
         ///
+        /// This method does not call any [`EditGuard`] actions; consider also
+        /// calling [`Self::call_guard_edit`].
+        ///
         /// Returns `true` if the text may have changed.
         #[inline]
         pub fn set_str(&mut self, cx: &mut EventState, text: &str) -> bool {
@@ -556,6 +562,9 @@ mod EditField {
         ///
         /// This does not interact with undo history; see also [`Self::clear`],
         /// [`Self::pre_commit`].
+        ///
+        /// This method does not call any [`EditGuard`] actions; consider also
+        /// calling [`Self::call_guard_edit`].
         ///
         /// Returns `true` if the text is ready and may have changed.
         pub fn set_string(&mut self, cx: &mut EventState, string: String) -> bool {
@@ -577,9 +586,23 @@ mod EditField {
         /// This does not interact with undo history; see also [`Self::clear`],
         /// [`Self::pre_commit`].
         ///
-        /// This method does not call action handlers on the [`EditGuard`].
+        /// This method does not call any [`EditGuard`] actions; consider also
+        /// calling [`Self::call_guard_edit`].
+        #[inline]
         pub fn replace_selected_text(&mut self, cx: &mut EventCx, text: &str) {
             self.received_text(cx, text);
+        }
+
+        /// Call the [`EditGuard`]'s `activate` method
+        #[inline]
+        pub fn call_guard_activate(&mut self, cx: &mut EventCx, data: &G::Data) {
+            G::activate(self, cx, data);
+        }
+
+        /// Call the [`EditGuard`]'s `edit` method
+        #[inline]
+        pub fn call_guard_edit(&mut self, cx: &mut EventCx, data: &G::Data) {
+            G::edit(self, cx, data);
         }
 
         /// Access the cursor index / selection range

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -275,7 +275,7 @@ mod EditField {
                         let opt_cmd = cx
                             .config()
                             .shortcuts()
-                            .try_match(cx.modifiers(), &event.logical_key);
+                            .try_match(cx.modifiers(), &event.key_without_modifiers);
                         if let Some(cmd) = opt_cmd {
                             match self.control_key(cx, data, cmd, Some(event.physical_key)) {
                                 Ok(r) => r,

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -84,7 +84,10 @@ pub trait EditGuard: Sized {
 
     /// Edit guard
     ///
-    /// This function is called when contents are updated by the user.
+    /// This function is called after the text is updated (including by keyboard
+    /// input, an undo action or by a message like
+    /// [`kas::messages::SetValueText`]). The exceptions are setter methods like
+    /// [`clear`](EditField::clear) and [`set_string`](EditField::set_string).
     fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }

--- a/crates/kas-widgets/src/edit/mod.rs
+++ b/crates/kas-widgets/src/edit/mod.rs
@@ -16,13 +16,24 @@ pub use guard::*;
 use std::fmt::Debug;
 use std::ops::Range;
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 enum LastEdit {
     #[default]
     None,
-    Insert,
-    Delete,
+    KeyInput(bool),
+    Ime,
+    Delete(bool),
     Paste,
+    Set,
+}
+
+impl LastEdit {
+    fn is_mergable(self) -> bool {
+        match self {
+            LastEdit::KeyInput(true) | LastEdit::Delete(true) => true,
+            _ => false,
+        }
+    }
 }
 
 enum EditAction {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -96,7 +96,7 @@ mod SelectableText {
                 core: Default::default(),
                 text: Text::new(text, TextClass::Standard, true),
                 text_fn: None,
-                selection: SelectionHelper::new(0, 0),
+                selection: SelectionHelper::default(),
                 has_sel_focus: false,
                 input_handler: Default::default(),
             }

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -454,11 +454,11 @@ mod SpinBox {
                 Some(self.edit.guard.value.sub_step(self.edit.guard.step))
             } else if let Some(SetValueText(string)) = cx.try_pop() {
                 self.edit.set_string(cx, string);
-                SpinGuard::edit(&mut self.edit, cx, data);
+                self.edit.call_guard_edit(cx, data);
                 self.edit.guard.parsed
             } else if let Some(ReplaceSelectedText(text)) = cx.try_pop() {
                 self.edit.replace_selected_text(cx, &text);
-                SpinGuard::edit(&mut self.edit, cx, data);
+                self.edit.call_guard_edit(cx, data);
                 self.edit.guard.parsed
             } else {
                 None

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -457,7 +457,7 @@ mod SpinBox {
                 SpinGuard::edit(&mut self.edit, cx, data);
                 self.edit.guard.parsed
             } else if let Some(ReplaceSelectedText(text)) = cx.try_pop() {
-                self.edit.replace_selection(cx, &text);
+                self.edit.replace_selected_text(cx, &text);
                 SpinGuard::edit(&mut self.edit, cx, data);
                 self.edit.guard.parsed
             } else {

--- a/examples/text-editor/text-editor.rs
+++ b/examples/text-editor/text-editor.rs
@@ -119,6 +119,7 @@ mod Editor {
                     }
                 };
 
+                self.editor.clear(cx);
                 self.editor.set_string(cx, text);
                 self.editor.guard_mut().edited = false;
             } else if let Some(Saved(result)) = cx.try_pop() {
@@ -157,6 +158,7 @@ mod Editor {
         fn do_action(&mut self, cx: &mut EventCx<'_>, action: EditorAction) {
             match action {
                 EditorAction::New => {
+                    self.editor.clear(cx);
                     self.editor.set_string(cx, String::new());
                     self.editor.guard_mut().edited = false;
                     self.file = None;


### PR DESCRIPTION
Revise `EditField` to store the full edit history (instead of only the last change) internally. This isn't fully sufficient (sometimes undo history needs to be unified across multiple widgets; view widgets should perhaps store history externally), but is a definite improvement.

A few other tweaks to `EditField` are included especially regarding focus tracking.

Fixes shortcuts like <kbd>Ctrl + Shift + Z</kbd>, at least on platforms where [`key_without_modifiers`](https://docs.rs/winit/0.31.0-beta.2/winit/event/struct.KeyEvent.html#structfield.key_without_modifiers) is supported.