### PR TITLE
IME fix and input/selection focus deconfliction

### DIFF
--- a/crates/kas-core/src/event/event.rs
+++ b/crates/kas-core/src/event/event.rs
@@ -26,6 +26,10 @@ use crate::{Id, dir::Direction, window::WindowId};
 pub enum Ime<'a> {
     /// Notifies when the IME was enabled.
     ///
+    /// This may mean, for example, that a virtual keyboard is now active with
+    /// focus on the recipient. This event does not mean that physical keyboard
+    /// input is disabled (or that it should be ignored).
+    ///
     /// The widget should call [`EventState::set_ime_cursor_area`] immediately
     /// and each time the area changes (relative to the widget's coordinate
     /// space), until [`Ime::Disabled`] is received. Failure to do so will

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -351,13 +351,9 @@ impl<'a> DrawCx<'a> {
                 if cfg!(debug_assertions) {
                     let num_colors = if colors.is_empty() { 1 } else { colors.len() };
                     let mut i = 0;
-                    let mut first = false;
                     for effect in effects {
-                        if !first {
-                            assert!(effect.start > i);
-                        }
+                        assert!(effect.start >= i);
                         i = effect.start;
-                        first = false;
 
                         assert!(usize::from(effect.e) < num_colors);
                     }

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -287,9 +287,19 @@ mod EditField {
                 }
                 Event::Ime(ime) => match ime {
                     Ime::Enabled => {
-                        self.input_handler.stop_selecting();
-                        self.current = CurrentAction::ImeStart;
-                        self.set_ime_cursor_area(cx);
+                        match self.current {
+                            CurrentAction::None => {
+                                self.current = CurrentAction::ImeStart;
+                                self.set_ime_cursor_area(cx);
+                            }
+                            CurrentAction::ImeStart | CurrentAction::ImePreedit { .. } => {
+                                // already enabled
+                            }
+                            CurrentAction::Selection => {
+                                // Do not interrupt selection
+                                cx.cancel_ime_focus(self.id_ref());
+                            }
+                        }
                         Used
                     }
                     Ime::Disabled => {

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -128,7 +128,7 @@ mod EditField {
             });
             self.text.set_rect(cx, rect, hints);
             self.text.ensure_no_left_overhang();
-            if self.current.is_ime() {
+            if self.current.is_ime_enabled() {
                 self.set_ime_cursor_area(cx);
             }
         }
@@ -422,7 +422,7 @@ mod EditField {
                         clear,
                         repeats,
                     } => {
-                        if self.current.is_ime() {
+                        if self.current.is_ime_enabled() {
                             self.clear_ime();
                             cx.cancel_ime_focus(self.id_ref());
                         }
@@ -439,25 +439,29 @@ mod EditField {
                         Used
                     }
                     TextInputAction::PressMove { coord, repeats } => {
-                        self.set_cursor_from_coord(cx, coord);
-                        if repeats > 1 {
-                            self.selection.expand(&self.text, repeats >= 3);
+                        if self.current == CurrentAction::Selection {
+                            self.set_cursor_from_coord(cx, coord);
+                            if repeats > 1 {
+                                self.selection.expand(&self.text, repeats >= 3);
+                            }
                         }
 
                         Used
                     }
                     TextInputAction::PressEnd { coord } => {
-                        if self.current.is_ime() {
+                        if self.current.is_ime_enabled() {
                             self.clear_ime();
                             cx.cancel_ime_focus(self.id_ref());
                         }
-                        if self.current != CurrentAction::Selection {
+                        self.save_undo_state(Some(EditOp::Cursor));
+                        if self.current == CurrentAction::Selection {
+                            self.set_primary(cx);
+                        } else {
                             self.set_cursor_from_coord(cx, coord);
                             self.selection.set_empty();
                         }
                         self.current = CurrentAction::None;
 
-                        self.set_primary(cx);
                         self.request_key_focus(cx, FocusSource::Pointer);
                         self.enable_ime(cx);
                         Used
@@ -646,7 +650,7 @@ mod EditField {
             if self.current == CurrentAction::Selection {
                 self.input_handler.stop_selecting();
                 self.current = CurrentAction::None;
-            } else if self.current.is_ime() {
+            } else if self.current.is_ime_enabled() {
                 self.clear_ime();
                 cx.cancel_ime_focus(self.id_ref());
             }
@@ -657,7 +661,7 @@ mod EditField {
         /// One should also call [`EventCx::cancel_ime_focus`] unless this is
         /// implied.
         fn clear_ime(&mut self) {
-            if self.current.is_ime() {
+            if self.current.is_ime_enabled() {
                 let action = std::mem::replace(&mut self.current, CurrentAction::None);
                 if let CurrentAction::ImePreedit { edit_range } = action {
                     self.selection.set_cursor(edit_range.start.cast());
@@ -965,7 +969,7 @@ impl<G: EditGuard> EditField<G> {
 
     /// Request key focus, if we don't have it or IME
     fn request_key_focus(&self, cx: &mut EventState, source: FocusSource) {
-        if !self.has_key_focus && !self.current.is_ime() {
+        if !self.has_key_focus && !self.current.is_ime_enabled() {
             cx.request_key_focus(self.id(), source);
         }
     }

--- a/crates/kas-widgets/src/edit/mod.rs
+++ b/crates/kas-widgets/src/edit/mod.rs
@@ -79,7 +79,10 @@ impl CurrentAction {
         *self == CurrentAction::None
     }
 
-    fn is_ime(&self) -> bool {
+    /// Check whether IME is enabled
+    ///
+    /// This does not imply a pre-edit (or any IME input).
+    fn is_ime_enabled(&self) -> bool {
         matches!(
             self,
             CurrentAction::ImeStart | CurrentAction::ImePreedit { .. }


### PR DESCRIPTION
Relax debug-mode validation of text effects: require increasing but not strictly-increasing order by start index.

Deconflict text selection and input focus: do not request input focus until mouse button release.