### PR TITLE
Add kas_widgets::edit::Editor

### DIFF
--- a/crates/kas-view/src/filter.rs
+++ b/crates/kas-view/src/filter.rs
@@ -6,7 +6,7 @@
 //! Filters over data
 
 use kas::event::EventCx;
-use kas_widgets::{EditField, EditGuard};
+use kas_widgets::edit::{EditGuard, Editor};
 use std::fmt::Debug;
 
 /// Ability to set filter
@@ -97,7 +97,7 @@ pub struct KeystrokeGuard;
 impl EditGuard for KeystrokeGuard {
     type Data = ();
 
-    fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &Self::Data) {
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Self::Data) {
         cx.push(SetFilter(edit.as_str().to_string()));
     }
 }
@@ -110,7 +110,7 @@ impl EditGuard for AflGuard {
     type Data = ();
 
     #[inline]
-    fn focus_lost(edit: &mut EditField<Self>, cx: &mut EventCx, _: &Self::Data) {
+    fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Self::Data) {
         cx.push(SetFilter(edit.as_str().to_string()));
     }
 }

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -29,9 +29,9 @@ mod EditBox {
     /// ### Messages
     ///
     /// [`SetValueText`] may be used to replace the entire text and
-    /// [`ReplaceSelectedText`] may be used to replace selected text, where
-    /// [`Self::is_editable`]. This triggers the action handlers
-    /// [`EditGuard::edit`] followed by [`EditGuard::activate`].
+    /// [`ReplaceSelectedText`] may be used to replace selected text when this
+    /// widget is [editable](Editor::is_editable). This triggers the action
+    /// handlers [`EditGuard::edit`] followed by [`EditGuard::activate`].
     ///
     /// [`kas::messages::SetScrollOffset`] may be used to set the scroll offset.
     #[autoimpl(Default, Debug where G: trait)]
@@ -233,18 +233,6 @@ mod EditBox {
             self.vert_bar.set_value(cx, self.scroll.offset().1);
         }
 
-        /// Get text contents
-        #[inline]
-        pub fn as_str(&self) -> &str {
-            self.inner.as_str()
-        }
-
-        /// Get the text contents as a `String`
-        #[inline]
-        pub fn clone_string(&self) -> String {
-            self.inner.clone_string()
-        }
-
         /// Clear text contents and undo history
         #[inline]
         pub fn clear(&mut self, cx: &mut EventState) {
@@ -403,18 +391,6 @@ impl<G: EditGuard> EditBox<G> {
         self
     }
 
-    /// Get whether this `EditField` is editable
-    #[inline]
-    pub fn is_editable(&self) -> bool {
-        self.inner.is_editable()
-    }
-
-    /// Set whether this `EditField` is editable
-    #[inline]
-    pub fn set_editable(&mut self, editable: bool) {
-        self.inner.set_editable(editable);
-    }
-
     /// Set whether this `EditBox` uses multi-line mode
     ///
     /// This setting has two effects: the vertical size allocation is increased
@@ -429,26 +405,12 @@ impl<G: EditGuard> EditBox<G> {
         self
     }
 
-    /// True if the editor uses multi-line mode
-    ///
-    /// See also: [`Self::with_multi_line`]
-    #[inline]
-    pub fn multi_line(&self) -> bool {
-        self.inner.multi_line()
-    }
-
     /// Set the text class used
     #[inline]
     #[must_use]
     pub fn with_class(mut self, class: TextClass) -> Self {
         self.inner = self.inner.with_class(class);
         self
-    }
-
-    /// Get the text class used
-    #[inline]
-    pub fn class(&self) -> TextClass {
-        self.inner.class()
     }
 
     /// Adjust the height allocation
@@ -477,27 +439,5 @@ impl<G: EditGuard> EditBox<G> {
     pub fn with_width_em(mut self, min_em: f32, ideal_em: f32) -> Self {
         self.set_width_em(min_em, ideal_em);
         self
-    }
-
-    /// Get whether the widget has edit focus
-    ///
-    /// This is true when the widget is editable and has keyboard focus.
-    #[inline]
-    pub fn has_edit_focus(&self) -> bool {
-        self.inner.has_edit_focus()
-    }
-
-    /// Get whether the input state is erroneous
-    #[inline]
-    pub fn has_error(&self) -> bool {
-        self.inner.has_error()
-    }
-
-    /// Set the error state
-    ///
-    /// When true, the input field's background is drawn red.
-    /// This state is cleared by [`Self::set_string`].
-    pub fn set_error_state(&mut self, cx: &mut EventState, error_state: bool) {
-        self.inner.set_error_state(cx, error_state);
     }
 }

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -13,6 +13,7 @@ use kas::messages::{ReplaceSelectedText, SetValueText};
 use kas::prelude::*;
 use kas::theme::{Background, FrameStyle, TextClass};
 use std::fmt::{Debug, Display};
+use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
 #[impl_self]
@@ -294,6 +295,20 @@ mod EditBox {
         pub fn guard_mut(&mut self) -> &mut G {
             &mut self.inner.guard
         }
+    }
+}
+
+impl<G: EditGuard> Deref for EditBox<G> {
+    type Target = Editor;
+
+    fn deref(&self) -> &Editor {
+        self.inner.deref()
+    }
+}
+
+impl<G: EditGuard> DerefMut for EditBox<G> {
+    fn deref_mut(&mut self) -> &mut Editor {
+        self.inner.deref_mut()
     }
 }
 

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -272,6 +272,17 @@ mod EditBox {
             }
         }
 
+        /// Replace selected text
+        ///
+        /// This does not interact with undo history or call action handlers on the
+        /// guard.
+        #[inline]
+        pub fn replace_selected_text(&mut self, cx: &mut EventState, text: &str) {
+            if self.inner.replace_selected_text(cx, text) {
+                self.update_content_size(cx);
+            }
+        }
+
         /// Access the edit guard
         #[inline]
         pub fn guard(&self) -> &G {

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -534,49 +534,6 @@ mod EditField {
             self.save_undo_state(Some(EditOp::Synthetic));
         }
 
-        /// Set text contents from a `str`
-        ///
-        /// This does not interact with undo history; see also [`Self::clear`],
-        /// [`Self::pre_commit`].
-        ///
-        /// This method does not call any [`EditGuard`] actions; consider also
-        /// calling [`Self::call_guard_edit`].
-        ///
-        /// Returns `true` if the text may have changed.
-        #[inline]
-        pub fn set_str(&mut self, cx: &mut EventState, text: &str) -> bool {
-            if self.text.as_str() != text {
-                self.set_string(cx, text.to_string());
-                true
-            } else {
-                false
-            }
-        }
-
-        /// Set text contents from a `String`
-        ///
-        /// This does not interact with undo history; see also [`Self::clear`],
-        /// [`Self::pre_commit`].
-        ///
-        /// This method does not call any [`EditGuard`] actions; consider also
-        /// calling [`Self::call_guard_edit`].
-        ///
-        /// Returns `true` if the text is ready and may have changed.
-        pub fn set_string(&mut self, cx: &mut EventState, string: String) -> bool {
-            self.cancel_selection_and_ime(cx);
-
-            if !self.text.set_string(string) || !self.text.prepare() {
-                return false;
-            }
-
-            let len = self.text.str_len();
-            self.selection.set_max_len(len);
-            self.edit_x_coord = None;
-            cx.redraw(&self);
-            self.set_error_state(cx, false);
-            true
-        }
-
         /// Replace selected text
         ///
         /// This does not interact with undo history; see also [`Self::clear`],

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -6,14 +6,14 @@
 //! The [`EditField`] and [`EditBox`] widgets, plus supporting items
 
 use super::*;
-use kas::event::components::{TextInput, TextInputAction};
-use kas::event::{CursorIcon, ElementState, FocusSource, PhysicalKey, Scroll};
-use kas::event::{Ime, ImePurpose, ImeSurroundingText};
+use kas::event::Ime;
+use kas::event::components::TextInputAction;
+use kas::event::{CursorIcon, ElementState, FocusSource, PhysicalKey};
 use kas::geom::Vec2;
 use kas::messages::{ReplaceSelectedText, SetValueText};
 use kas::prelude::*;
-use kas::text::{CursorRange, Effect, EffectFlags, NotReady, SelectionHelper};
-use kas::theme::{Text, TextClass};
+use kas::text::{CursorRange, Effect, EffectFlags, NotReady};
+use kas::theme::TextClass;
 use kas::util::UndoStack;
 use std::fmt::{Debug, Display};
 use std::ops::Range;
@@ -67,21 +67,15 @@ mod EditField {
     ///
     /// This is a [`Viewport`] widget.
     #[autoimpl(Debug where G: trait)]
+    #[autoimpl(Deref, DerefMut using self.editor)]
     #[widget]
     pub struct EditField<G: EditGuard = DefaultGuard<()>> {
         core: widget_core!(),
-        editable: bool,
         width: (f32, f32),
         lines: (f32, f32),
-        text: Text<String>,
-        selection: SelectionHelper,
-        edit_x_coord: Option<f32>,
+        editor: Editor,
         last_edit: Option<EditOp>,
         undo_stack: UndoStack<(String, CursorRange)>,
-        has_key_focus: bool,
-        current: CurrentAction,
-        error_state: bool,
-        input_handler: TextInput,
         /// The associated [`EditGuard`] implementation
         pub guard: G,
     }
@@ -121,6 +115,7 @@ mod EditField {
         }
 
         fn set_rect(&mut self, cx: &mut SizeCx, rect: Rect, mut hints: AlignHints) {
+            self.editor.pos = rect.pos;
             hints.vert = Some(if self.multi_line() {
                 Align::Default
             } else {
@@ -206,6 +201,7 @@ mod EditField {
         }
 
         fn configure(&mut self, cx: &mut ConfigCx) {
+            self.editor.id = self.id();
             self.text.configure(&mut cx.size_cx());
             G::configure(self, cx);
         }
@@ -414,7 +410,7 @@ mod EditField {
                     self.request_key_focus(cx, FocusSource::Pointer);
                     Used
                 }
-                event => match self.input_handler.handle(cx, self.id(), event) {
+                event => match self.editor.input_handler.handle(cx, self.core.id(), event) {
                     TextInputAction::Used => Used,
                     TextInputAction::Unused => Unused,
                     TextInputAction::PressStart {
@@ -432,7 +428,9 @@ mod EditField {
                         self.set_cursor_from_coord(cx, coord);
                         self.selection.set_anchor(clear);
                         if repeats > 1 {
-                            self.selection.expand(&self.text, repeats >= 3);
+                            self.editor
+                                .selection
+                                .expand(&self.editor.text, repeats >= 3);
                         }
 
                         self.request_key_focus(cx, FocusSource::Pointer);
@@ -442,7 +440,9 @@ mod EditField {
                         if self.current == CurrentAction::Selection {
                             self.set_cursor_from_coord(cx, coord);
                             if repeats > 1 {
-                                self.selection.expand(&self.text, repeats >= 3);
+                                self.editor
+                                    .selection
+                                    .expand(&self.editor.text, repeats >= 3);
                             }
                         }
 
@@ -505,18 +505,11 @@ mod EditField {
         pub fn new(guard: G) -> EditField<G> {
             EditField {
                 core: Default::default(),
-                editable: true,
                 width: (8.0, 16.0),
                 lines: (1.0, 1.0),
-                text: Text::new(String::new(), TextClass::Editor, false),
-                selection: Default::default(),
-                edit_x_coord: None,
+                editor: Editor::new(),
                 last_edit: Some(EditOp::Initial),
                 undo_stack: UndoStack::new(),
-                has_key_focus: false,
-                current: CurrentAction::None,
-                error_state: false,
-                input_handler: Default::default(),
                 guard,
             }
         }
@@ -588,7 +581,8 @@ mod EditField {
                 return false;
             }
 
-            self.selection.set_max_len(self.text.str_len());
+            let len = self.text.str_len();
+            self.selection.set_max_len(len);
             self.edit_x_coord = None;
             cx.redraw(&self);
             self.set_error_state(cx, false);
@@ -631,137 +625,6 @@ mod EditField {
             self.edit_x_coord = None;
             self.selection = range.into().into();
         }
-
-        /// Enable IME if not already enabled
-        fn enable_ime(&mut self, cx: &mut EventCx) {
-            if self.current.is_none() {
-                let hint = Default::default();
-                let purpose = ImePurpose::Normal;
-                let surrounding_text = self.ime_surrounding_text();
-                cx.request_ime_focus(self.id(), hint, purpose, surrounding_text);
-            }
-        }
-
-        /// Cancel on-going selection and IME actions
-        ///
-        /// This should be called if e.g. key-input interrupts the current
-        /// action.
-        fn cancel_selection_and_ime(&mut self, cx: &mut EventState) {
-            if self.current == CurrentAction::Selection {
-                self.input_handler.stop_selecting();
-                self.current = CurrentAction::None;
-            } else if self.current.is_ime_enabled() {
-                self.clear_ime();
-                cx.cancel_ime_focus(self.id_ref());
-            }
-        }
-
-        /// Clean up IME state
-        ///
-        /// One should also call [`EventCx::cancel_ime_focus`] unless this is
-        /// implied.
-        fn clear_ime(&mut self) {
-            if self.current.is_ime_enabled() {
-                let action = std::mem::replace(&mut self.current, CurrentAction::None);
-                if let CurrentAction::ImePreedit { edit_range } = action {
-                    self.selection.set_cursor(edit_range.start.cast());
-                    self.text.replace_range(edit_range.cast(), "");
-                }
-            }
-        }
-
-        fn ime_surrounding_text(&self) -> Option<ImeSurroundingText> {
-            const MAX_TEXT_BYTES: usize = ImeSurroundingText::MAX_TEXT_BYTES;
-
-            let sel_range = self.selection.range();
-            let edit_range = match self.current.clone() {
-                CurrentAction::ImePreedit { edit_range } => Some(edit_range.cast()),
-                _ => None,
-            };
-            let mut range = edit_range.clone().unwrap_or(sel_range);
-            let initial_range = range.clone();
-            let edit_len = edit_range.clone().map(|r| r.len()).unwrap_or(0);
-
-            if let Ok(Some((_, line_range))) = self.text.find_line(range.start) {
-                range.start = line_range.start;
-            }
-            if let Ok(Some((_, line_range))) = self.text.find_line(range.end) {
-                range.end = line_range.end;
-            }
-
-            if range.len() - edit_len > MAX_TEXT_BYTES {
-                range.end = range.end.min(initial_range.end + MAX_TEXT_BYTES / 2);
-                while !self.as_str().is_char_boundary(range.end) {
-                    range.end -= 1;
-                }
-
-                if range.len() - edit_len > MAX_TEXT_BYTES {
-                    range.start = range.start.max(initial_range.start - MAX_TEXT_BYTES / 2);
-                    while !self.as_str().is_char_boundary(range.start) {
-                        range.start += 1;
-                    }
-                }
-            }
-
-            let start = range.start;
-            let mut text = String::with_capacity(range.len() - edit_len);
-            if let Some(er) = edit_range {
-                text.push_str(&self.as_str()[range.start..er.start]);
-                text.push_str(&self.as_str()[er.end..range.end]);
-            } else {
-                text = self.as_str()[range].to_string();
-            }
-
-            let cursor = self.selection.edit_index().saturating_sub(start);
-            // Terminology difference: our sel_index is called 'anchor'
-            // SelectionHelper::anchor is not the same thing.
-            let sel_index = self.selection.sel_index().saturating_sub(start);
-            ImeSurroundingText::new(text, cursor, sel_index)
-                .inspect_err(|err| {
-                    // TODO: use Display for err not Debug
-                    log::warn!("EditField::ime_surrounding_text failed: {err:?}")
-                })
-                .ok()
-        }
-
-        // Call only if self.ime_focus
-        fn set_ime_cursor_area(&self, cx: &mut EventState) {
-            if let Ok(text) = self.text.display() {
-                let range = match self.current.clone() {
-                    CurrentAction::ImeStart => self.selection.range(),
-                    CurrentAction::ImePreedit { edit_range } => edit_range.cast(),
-                    _ => return,
-                };
-
-                let (m1, m2);
-                if range.is_empty() {
-                    let mut iter = text.text_glyph_pos(range.start);
-                    m1 = iter.next();
-                    m2 = iter.next();
-                } else {
-                    m1 = text.text_glyph_pos(range.start).next_back();
-                    m2 = text.text_glyph_pos(range.end).next();
-                }
-
-                let rect = if let Some((c1, c2)) = m1.zip(m2) {
-                    let left = c1.pos.0.min(c2.pos.0);
-                    let right = c1.pos.0.max(c2.pos.0);
-                    let top = (c1.pos.1 - c1.ascent).min(c2.pos.1 - c2.ascent);
-                    let bottom = (c1.pos.1 - c1.descent).max(c2.pos.1 - c2.ascent);
-                    let p1 = Vec2(left, top).cast_floor();
-                    let p2 = Vec2(right, bottom).cast_ceil();
-                    Rect::from_coords(p1, p2)
-                } else if let Some(c) = m1.or(m2) {
-                    let p1 = Vec2(c.pos.0, c.pos.1 - c.ascent).cast_floor();
-                    let p2 = Vec2(c.pos.0, c.pos.1 - c.descent).cast_ceil();
-                    Rect::from_coords(p1, p2)
-                } else {
-                    return;
-                };
-
-                cx.set_ime_cursor_area(self.id_ref(), rect + Offset::conv(self.rect().pos));
-            }
-        }
     }
 }
 
@@ -769,12 +632,8 @@ impl<A: 'static> EditField<DefaultGuard<A>> {
     /// Construct an `EditField` with the given inital `text` (no event handling)
     #[inline]
     pub fn text<S: ToString>(text: S) -> Self {
-        let text = text.to_string();
-        let len = text.len();
         EditField {
-            editable: true,
-            text: Text::new(text, TextClass::Editor, false),
-            selection: SelectionHelper::from(len),
+            editor: Editor::from(text),
             ..Default::default()
         }
     }
@@ -1320,9 +1179,9 @@ impl<G: EditGuard> EditField<G> {
             }
             Action::UndoRedo(redo) => {
                 if let Some((text, cursor)) = self.undo_stack.undo_or_redo(redo) {
-                    if self.text.set_str(text) {
-                        self.edit_x_coord = None;
-                        self.error_state = false;
+                    if self.editor.text.set_str(text) {
+                        self.editor.edit_x_coord = None;
+                        self.editor.error_state = false;
                     }
                     self.selection = (*cursor).into();
                     EditAction::Edit
@@ -1345,45 +1204,5 @@ impl<G: EditGuard> EditField<G> {
                 Used
             }
         })
-    }
-
-    // Set cursor position. It is assumed that the text has not changed.
-    fn set_cursor_from_coord(&mut self, cx: &mut EventCx, coord: Coord) {
-        let rel_pos = (coord - self.rect().pos).cast();
-        if let Ok(index) = self.text.text_index_nearest(rel_pos) {
-            if index != self.selection.edit_index() {
-                self.selection.set_edit_index(index);
-                self.set_view_offset_from_cursor(cx);
-                self.edit_x_coord = None;
-                cx.redraw();
-            }
-        }
-    }
-
-    fn set_primary(&self, cx: &mut EventCx) {
-        if self.has_key_focus && !self.selection.is_empty() && cx.has_primary() {
-            let range = self.selection.range();
-            cx.set_primary(String::from(&self.text.as_str()[range]));
-        }
-    }
-
-    /// Update view_offset after the cursor index changes
-    ///
-    /// It is assumed that the text has not changed.
-    ///
-    /// A redraw is assumed since the cursor moved.
-    fn set_view_offset_from_cursor(&mut self, cx: &mut EventCx) {
-        let cursor = self.selection.edit_index();
-        if let Some(marker) = self
-            .text
-            .text_glyph_pos(cursor)
-            .ok()
-            .and_then(|mut m| m.next_back())
-        {
-            let y0 = (marker.pos.1 - marker.ascent).cast_floor();
-            let pos = self.rect().pos + Offset(marker.pos.0.cast_nearest(), y0);
-            let size = Size(0, i32::conv_ceil(marker.pos.1 - marker.descent) - y0);
-            cx.set_scroll(Scroll::Rect(Rect { pos, size }));
-        }
     }
 }

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -202,7 +202,9 @@ mod EditField {
 
         fn update(&mut self, cx: &mut ConfigCx, data: &G::Data) {
             let size = self.content_size();
-            self.guard.update(&mut self.editor, cx, data);
+            if !self.has_input_focus() {
+                self.guard.update(&mut self.editor, cx, data);
+            }
             if size != self.content_size() {
                 cx.resize();
             }

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -197,12 +197,12 @@ mod EditField {
         fn configure(&mut self, cx: &mut ConfigCx) {
             self.editor.id = self.id();
             self.text.configure(&mut cx.size_cx());
-            G::configure(self, cx);
+            self.guard.configure(&mut self.editor, cx);
         }
 
         fn update(&mut self, cx: &mut ConfigCx, data: &G::Data) {
             let size = self.content_size();
-            G::update(self, cx, data);
+            self.guard.update(&mut self.editor, cx, data);
             if size != self.content_size() {
                 cx.resize();
             }
@@ -230,14 +230,14 @@ mod EditField {
                 Event::KeyFocus => {
                     self.has_key_focus = true;
                     self.set_view_offset_from_cursor(cx);
-                    G::focus_gained(self, cx, data);
+                    self.guard.focus_gained(&mut self.editor, cx, data);
                     self.enable_ime(cx);
                     Used
                 }
                 Event::LostKeyFocus => {
                     self.has_key_focus = false;
                     cx.redraw();
-                    G::focus_lost(self, cx, data);
+                    self.guard.focus_lost(&mut self.editor, cx, data);
                     Used
                 }
                 Event::LostSelFocus => {
@@ -507,7 +507,7 @@ mod EditField {
         /// Call the [`EditGuard`]'s `activate` method
         #[inline]
         pub fn call_guard_activate(&mut self, cx: &mut EventCx, data: &G::Data) {
-            G::activate(self, cx, data);
+            self.guard.activate(&mut self.editor, cx, data);
         }
 
         /// Call the [`EditGuard`]'s `edit` method
@@ -516,7 +516,7 @@ mod EditField {
         #[inline]
         pub fn call_guard_edit(&mut self, cx: &mut EventCx, data: &G::Data) {
             self.set_error_state(cx, false);
-            G::edit(self, cx, data);
+            self.guard.edit(&mut self.editor, cx, data);
         }
     }
 }
@@ -688,7 +688,7 @@ impl<G: EditGuard> EditField<G> {
             CmdAction::Used | CmdAction::Cursor => Used,
             CmdAction::Activate => {
                 cx.depress_with_key(&self, code);
-                G::activate(self, cx, data)
+                self.guard.activate(&mut self.editor, cx, data)
             }
             CmdAction::Edit => {
                 self.call_guard_edit(cx, data);

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -230,14 +230,18 @@ mod EditField {
                 Event::KeyFocus => {
                     self.has_key_focus = true;
                     self.set_view_offset_from_cursor(cx);
-                    self.guard.focus_gained(&mut self.editor, cx, data);
+                    if !self.current.is_ime_enabled() {
+                        self.guard.focus_gained(&mut self.editor, cx, data);
+                    }
                     self.enable_ime(cx);
                     Used
                 }
                 Event::LostKeyFocus => {
                     self.has_key_focus = false;
                     cx.redraw();
-                    self.guard.focus_lost(&mut self.editor, cx, data);
+                    if !self.current.is_ime_enabled() {
+                        self.guard.focus_lost(&mut self.editor, cx, data);
+                    }
                     Used
                 }
                 Event::LostSelFocus => {
@@ -277,6 +281,9 @@ mod EditField {
                 }
                 Event::Ime(ime) => match ime {
                     Ime::Enabled => {
+                        if !self.has_key_focus {
+                            self.guard.focus_gained(&mut self.editor, cx, data);
+                        }
                         match self.current {
                             CurrentAction::None => {
                                 self.current = CurrentAction::ImeStart;
@@ -294,6 +301,9 @@ mod EditField {
                     }
                     Ime::Disabled => {
                         self.clear_ime();
+                        if !self.has_key_focus {
+                            self.guard.focus_lost(&mut self.editor, cx, data);
+                        }
                         Used
                     }
                     Ime::Preedit { text, cursor } => {

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -59,9 +59,9 @@ mod EditField {
     /// ### Messages
     ///
     /// [`SetValueText`] may be used to replace the entire text and
-    /// [`ReplaceSelectedText`] may be used to replace selected text, where
-    /// [`Self::is_editable`]. This triggers the action handlers
-    /// [`EditGuard::edit`] followed by [`EditGuard::activate`].
+    /// [`ReplaceSelectedText`] may be used to replace selected text when this
+    /// widget is [editable](Editor::is_editable)]. This triggers the action
+    /// handlers [`EditGuard::edit`] followed by [`EditGuard::activate`].
     ///
     /// ### Special behaviour
     ///
@@ -514,18 +514,6 @@ mod EditField {
             }
         }
 
-        /// Get text contents
-        #[inline]
-        pub fn as_str(&self) -> &str {
-            self.text.as_str()
-        }
-
-        /// Get the text contents as a `String`
-        #[inline]
-        pub fn clone_string(&self) -> String {
-            self.text.clone_string()
-        }
-
         /// Clear text contents and undo history
         ///
         /// This method does not call any [`EditGuard`] actions; consider also
@@ -611,19 +599,6 @@ mod EditField {
         #[inline]
         pub fn call_guard_edit(&mut self, cx: &mut EventCx, data: &G::Data) {
             G::edit(self, cx, data);
-        }
-
-        /// Access the cursor index / selection range
-        #[inline]
-        pub fn cursor_range(&self) -> CursorRange {
-            *self.selection
-        }
-
-        /// Set the cursor index / range
-        #[inline]
-        pub fn set_cursor_range(&mut self, range: impl Into<CursorRange>) {
-            self.edit_x_coord = None;
-            self.selection = range.into().into();
         }
     }
 }
@@ -723,18 +698,6 @@ impl<G: EditGuard> EditField<G> {
         self
     }
 
-    /// Get whether this `EditField` is editable
-    #[inline]
-    pub fn is_editable(&self) -> bool {
-        self.editable
-    }
-
-    /// Set whether this `EditField` is editable
-    #[inline]
-    pub fn set_editable(&mut self, editable: bool) {
-        self.editable = editable;
-    }
-
     /// Set whether this `EditField` uses multi-line mode
     ///
     /// This method does two things:
@@ -752,26 +715,12 @@ impl<G: EditGuard> EditField<G> {
         self
     }
 
-    /// True if the editor uses multi-line mode
-    ///
-    /// See also: [`Self::with_multi_line`]
-    #[inline]
-    pub fn multi_line(&self) -> bool {
-        self.text.wrap()
-    }
-
     /// Set the text class used
     #[inline]
     #[must_use]
     pub fn with_class(mut self, class: TextClass) -> Self {
         self.text.set_class(class);
         self
-    }
-
-    /// Get the text class used
-    #[inline]
-    pub fn class(&self) -> TextClass {
-        self.text.class()
     }
 
     /// Adjust the height allocation
@@ -800,30 +749,6 @@ impl<G: EditGuard> EditField<G> {
     pub fn with_width_em(mut self, min_em: f32, ideal_em: f32) -> Self {
         self.set_width_em(min_em, ideal_em);
         self
-    }
-
-    /// Get whether the widget has edit focus
-    ///
-    /// This is true when the widget is editable and has keyboard focus.
-    #[inline]
-    pub fn has_edit_focus(&self) -> bool {
-        self.editable && self.has_key_focus
-    }
-
-    /// Get whether the input state is erroneous
-    #[inline]
-    pub fn has_error(&self) -> bool {
-        self.error_state
-    }
-
-    /// Set the error state
-    ///
-    /// When true, the input field's background is drawn red.
-    /// This state is cleared by [`Self::set_string`].
-    // TODO: possibly change type to Option<String> and display the error
-    pub fn set_error_state(&mut self, cx: &mut EventState, error_state: bool) {
-        self.error_state = error_state;
-        cx.redraw(self);
     }
 
     /// Request key focus, if we don't have it or IME

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -1,0 +1,234 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Text editor component
+
+use super::*;
+use kas::event::components::TextInput;
+use kas::event::{ImePurpose, ImeSurroundingText, Scroll};
+use kas::geom::Vec2;
+use kas::prelude::*;
+use kas::text::SelectionHelper;
+use kas::theme::{Text, TextClass};
+
+/// Editor component
+#[autoimpl(Debug)]
+pub struct Editor {
+    // TODO(opt): id, pos are duplicated here since macros don't let us put the core here
+    pub(super) id: Id,
+    pub(super) pos: Coord,
+    pub(super) editable: bool,
+    pub(super) text: Text<String>,
+    pub(super) selection: SelectionHelper,
+    pub(super) edit_x_coord: Option<f32>,
+    pub(super) has_key_focus: bool,
+    pub(super) current: CurrentAction,
+    pub(super) error_state: bool,
+    pub(super) input_handler: TextInput,
+}
+
+/// API for use by `EditField`
+impl Editor {
+    /// Construct a default instance (empty string)
+    #[inline]
+    pub(super) fn new() -> Self {
+        Editor {
+            id: Id::default(),
+            pos: Coord::ZERO,
+            editable: true,
+            text: Text::new(String::new(), TextClass::Editor, false),
+            selection: Default::default(),
+            edit_x_coord: None,
+            has_key_focus: false,
+            current: CurrentAction::None,
+            error_state: false,
+            input_handler: Default::default(),
+        }
+    }
+
+    /// Construct from a string
+    #[inline]
+    pub(super) fn from<S: ToString>(text: S) -> Self {
+        let text = text.to_string();
+        let len = text.len();
+        Editor {
+            text: Text::new(text, TextClass::Editor, false),
+            selection: SelectionHelper::from(len),
+            ..Editor::new()
+        }
+    }
+
+    /// Enable IME if not already enabled
+    pub(super) fn enable_ime(&mut self, cx: &mut EventCx) {
+        if self.current.is_none() {
+            let hint = Default::default();
+            let purpose = ImePurpose::Normal;
+            let surrounding_text = self.ime_surrounding_text();
+            cx.request_ime_focus(self.id.clone(), hint, purpose, surrounding_text);
+        }
+    }
+
+    /// Cancel on-going selection and IME actions
+    ///
+    /// This should be called if e.g. key-input interrupts the current
+    /// action.
+    pub(super) fn cancel_selection_and_ime(&mut self, cx: &mut EventState) {
+        if self.current == CurrentAction::Selection {
+            self.input_handler.stop_selecting();
+            self.current = CurrentAction::None;
+        } else if self.current.is_ime_enabled() {
+            self.clear_ime();
+            cx.cancel_ime_focus(&self.id);
+        }
+    }
+
+    /// Clean up IME state
+    ///
+    /// One should also call [`EventCx::cancel_ime_focus`] unless this is
+    /// implied.
+    pub(super) fn clear_ime(&mut self) {
+        if self.current.is_ime_enabled() {
+            let action = std::mem::replace(&mut self.current, CurrentAction::None);
+            if let CurrentAction::ImePreedit { edit_range } = action {
+                self.selection.set_cursor(edit_range.start.cast());
+                self.text.replace_range(edit_range.cast(), "");
+            }
+        }
+    }
+
+    pub(super) fn ime_surrounding_text(&self) -> Option<ImeSurroundingText> {
+        const MAX_TEXT_BYTES: usize = ImeSurroundingText::MAX_TEXT_BYTES;
+
+        let sel_range = self.selection.range();
+        let edit_range = match self.current.clone() {
+            CurrentAction::ImePreedit { edit_range } => Some(edit_range.cast()),
+            _ => None,
+        };
+        let mut range = edit_range.clone().unwrap_or(sel_range);
+        let initial_range = range.clone();
+        let edit_len = edit_range.clone().map(|r| r.len()).unwrap_or(0);
+
+        if let Ok(Some((_, line_range))) = self.text.find_line(range.start) {
+            range.start = line_range.start;
+        }
+        if let Ok(Some((_, line_range))) = self.text.find_line(range.end) {
+            range.end = line_range.end;
+        }
+
+        if range.len() - edit_len > MAX_TEXT_BYTES {
+            range.end = range.end.min(initial_range.end + MAX_TEXT_BYTES / 2);
+            while !self.text.as_str().is_char_boundary(range.end) {
+                range.end -= 1;
+            }
+
+            if range.len() - edit_len > MAX_TEXT_BYTES {
+                range.start = range.start.max(initial_range.start - MAX_TEXT_BYTES / 2);
+                while !self.text.as_str().is_char_boundary(range.start) {
+                    range.start += 1;
+                }
+            }
+        }
+
+        let start = range.start;
+        let mut text = String::with_capacity(range.len() - edit_len);
+        if let Some(er) = edit_range {
+            text.push_str(&self.text.as_str()[range.start..er.start]);
+            text.push_str(&self.text.as_str()[er.end..range.end]);
+        } else {
+            text = self.text.as_str()[range].to_string();
+        }
+
+        let cursor = self.selection.edit_index().saturating_sub(start);
+        // Terminology difference: our sel_index is called 'anchor'
+        // SelectionHelper::anchor is not the same thing.
+        let sel_index = self.selection.sel_index().saturating_sub(start);
+        ImeSurroundingText::new(text, cursor, sel_index)
+            .inspect_err(|err| {
+                // TODO: use Display for err not Debug
+                log::warn!("Editor::ime_surrounding_text failed: {err:?}")
+            })
+            .ok()
+    }
+
+    /// Call to set IME position only while IME is active
+    pub(super) fn set_ime_cursor_area(&self, cx: &mut EventState) {
+        if let Ok(text) = self.text.display() {
+            let range = match self.current.clone() {
+                CurrentAction::ImeStart => self.selection.range(),
+                CurrentAction::ImePreedit { edit_range } => edit_range.cast(),
+                _ => return,
+            };
+
+            let (m1, m2);
+            if range.is_empty() {
+                let mut iter = text.text_glyph_pos(range.start);
+                m1 = iter.next();
+                m2 = iter.next();
+            } else {
+                m1 = text.text_glyph_pos(range.start).next_back();
+                m2 = text.text_glyph_pos(range.end).next();
+            }
+
+            let rect = if let Some((c1, c2)) = m1.zip(m2) {
+                let left = c1.pos.0.min(c2.pos.0);
+                let right = c1.pos.0.max(c2.pos.0);
+                let top = (c1.pos.1 - c1.ascent).min(c2.pos.1 - c2.ascent);
+                let bottom = (c1.pos.1 - c1.descent).max(c2.pos.1 - c2.ascent);
+                let p1 = Vec2(left, top).cast_floor();
+                let p2 = Vec2(right, bottom).cast_ceil();
+                Rect::from_coords(p1, p2)
+            } else if let Some(c) = m1.or(m2) {
+                let p1 = Vec2(c.pos.0, c.pos.1 - c.ascent).cast_floor();
+                let p2 = Vec2(c.pos.0, c.pos.1 - c.descent).cast_ceil();
+                Rect::from_coords(p1, p2)
+            } else {
+                return;
+            };
+
+            cx.set_ime_cursor_area(&self.id, rect + Offset::conv(self.pos));
+        }
+    }
+
+    // Set cursor position. It is assumed that the text has not changed.
+    pub(super) fn set_cursor_from_coord(&mut self, cx: &mut EventCx, coord: Coord) {
+        let rel_pos = (coord - self.pos).cast();
+        if let Ok(index) = self.text.text_index_nearest(rel_pos) {
+            if index != self.selection.edit_index() {
+                self.selection.set_edit_index(index);
+                self.set_view_offset_from_cursor(cx);
+                self.edit_x_coord = None;
+                cx.redraw();
+            }
+        }
+    }
+
+    /// Set primary clipboard (mouse buffer) contents from selection
+    pub(super) fn set_primary(&self, cx: &mut EventCx) {
+        if self.has_key_focus && !self.selection.is_empty() && cx.has_primary() {
+            let range = self.selection.range();
+            cx.set_primary(String::from(&self.text.as_str()[range]));
+        }
+    }
+
+    /// Update view_offset after the cursor index changes
+    ///
+    /// It is assumed that the text has not changed.
+    ///
+    /// A redraw is assumed since the cursor moved.
+    pub(super) fn set_view_offset_from_cursor(&mut self, cx: &mut EventCx) {
+        let cursor = self.selection.edit_index();
+        if let Some(marker) = self
+            .text
+            .text_glyph_pos(cursor)
+            .ok()
+            .and_then(|mut m| m.next_back())
+        {
+            let y0 = (marker.pos.1 - marker.ascent).cast_floor();
+            let pos = self.pos + Offset(marker.pos.0.cast_nearest(), y0);
+            let size = Size(0, i32::conv_ceil(marker.pos.1 - marker.descent) - y0);
+            cx.set_scroll(Scroll::Rect(Rect { pos, size }));
+        }
+    }
+}

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -10,7 +10,7 @@ use kas::event::components::TextInput;
 use kas::event::{ImePurpose, ImeSurroundingText, Scroll};
 use kas::geom::Vec2;
 use kas::prelude::*;
-use kas::text::SelectionHelper;
+use kas::text::{CursorRange, SelectionHelper};
 use kas::theme::{Text, TextClass};
 
 /// Editor component
@@ -230,5 +230,93 @@ impl Editor {
             let size = Size(0, i32::conv_ceil(marker.pos.1 - marker.descent) - y0);
             cx.set_scroll(Scroll::Rect(Rect { pos, size }));
         }
+    }
+}
+
+/// API for use by `EditGuard` implementations
+impl Editor {
+    /// Get a reference to the widget's identifier
+    #[inline]
+    pub fn id_ref(&self) -> &Id {
+        &self.id
+    }
+
+    /// Get the widget's identifier
+    #[inline]
+    pub fn id(&self) -> Id {
+        self.id.clone()
+    }
+
+    /// Get text contents
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.text.as_str()
+    }
+
+    /// Get the text contents as a `String`
+    #[inline]
+    pub fn clone_string(&self) -> String {
+        self.text.clone_string()
+    }
+
+    /// Access the cursor index / selection range
+    #[inline]
+    pub fn cursor_range(&self) -> CursorRange {
+        *self.selection
+    }
+
+    /// Set the cursor index / range
+    #[inline]
+    pub fn set_cursor_range(&mut self, range: impl Into<CursorRange>) {
+        self.edit_x_coord = None;
+        self.selection = range.into().into();
+    }
+
+    /// Get whether this `EditField` is editable
+    #[inline]
+    pub fn is_editable(&self) -> bool {
+        self.editable
+    }
+
+    /// Set whether this `EditField` is editable
+    #[inline]
+    pub fn set_editable(&mut self, editable: bool) {
+        self.editable = editable;
+    }
+
+    /// True if the editor uses multi-line mode
+    #[inline]
+    pub fn multi_line(&self) -> bool {
+        self.text.wrap()
+    }
+
+    /// Get the text class used
+    #[inline]
+    pub fn class(&self) -> TextClass {
+        self.text.class()
+    }
+
+    /// Get whether the widget has edit focus
+    ///
+    /// This is true when the widget is editable and has keyboard focus.
+    #[inline]
+    pub fn has_edit_focus(&self) -> bool {
+        self.editable && self.has_key_focus
+    }
+
+    /// Get whether the input state is erroneous
+    #[inline]
+    pub fn has_error(&self) -> bool {
+        self.error_state
+    }
+
+    /// Set the error state
+    ///
+    /// When true, the input field's background is drawn red.
+    /// This state is cleared by [`Self::set_string`].
+    // TODO: possibly change type to Option<String> and display the error
+    pub fn set_error_state(&mut self, cx: &mut EventState, error_state: bool) {
+        self.error_state = error_state;
+        cx.redraw(&self.id);
     }
 }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -259,6 +259,48 @@ impl Editor {
         self.text.clone_string()
     }
 
+    /// Set text contents from a `str`
+    ///
+    /// This does not interact with undo history; see also [`Self::clear`],
+    /// [`Self::pre_commit`].
+    ///
+    /// This method does not call any [`EditGuard`] actions; consider also
+    /// calling [`EditField::call_guard_edit`].
+    ///
+    /// Returns `true` if the text may have changed.
+    #[inline]
+    pub fn set_str(&mut self, cx: &mut EventState, text: &str) -> bool {
+        if self.text.as_str() != text {
+            self.set_string(cx, text.to_string());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Set text contents from a `String`
+    ///
+    /// This does not interact with undo history; see also [`Self::clear`],
+    /// [`Self::pre_commit`].
+    ///
+    /// This method does not call any [`EditGuard`] actions; consider also
+    /// calling [`EditField::call_guard_edit`].
+    ///
+    /// Returns `true` if the text is ready and may have changed.
+    pub fn set_string(&mut self, cx: &mut EventState, string: String) -> bool {
+        self.cancel_selection_and_ime(cx);
+
+        if !self.text.set_string(string) || !self.text.prepare() {
+            return false;
+        }
+
+        let len = self.text.str_len();
+        self.selection.set_max_len(len);
+        self.edit_x_coord = None;
+        self.set_error_state(cx, false);
+        true
+    }
+
     /// Access the cursor index / selection range
     #[inline]
     pub fn cursor_range(&self) -> CursorRange {

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -763,12 +763,12 @@ impl Editor {
         self.text.class()
     }
 
-    /// Get whether the widget has edit focus
+    /// Get whether the widget has input focus
     ///
-    /// This is true when the widget is editable and has keyboard focus.
+    /// This is true when the widget is has keyboard or IME focus.
     #[inline]
-    pub fn has_edit_focus(&self) -> bool {
-        self.editable && self.has_key_focus
+    pub fn has_input_focus(&self) -> bool {
+        self.has_key_focus || self.current.is_ime_enabled()
     }
 
     /// Get whether the input state is erroneous

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -29,7 +29,7 @@ pub struct Editor {
     undo_stack: UndoStack<(String, CursorRange)>,
     pub(super) has_key_focus: bool,
     pub(super) current: CurrentAction,
-    pub(super) error_state: bool,
+    error_state: bool,
     pub(super) input_handler: TextInput,
 }
 
@@ -553,7 +553,6 @@ impl Editor {
                 if let Some((text, cursor)) = self.undo_stack.undo_or_redo(redo) {
                     if self.text.set_str(text) {
                         self.edit_x_coord = None;
-                        self.error_state = false;
                     }
                     self.selection = (*cursor).into();
                     CmdAction::Edit
@@ -784,7 +783,9 @@ impl Editor {
     /// This state is cleared by [`Self::set_string`].
     // TODO: possibly change type to Option<String> and display the error
     pub fn set_error_state(&mut self, cx: &mut EventState, error_state: bool) {
-        self.error_state = error_state;
-        cx.redraw(&self.id);
+        if error_state != self.error_state {
+            self.error_state = error_state;
+            cx.redraw(&self.id);
+        }
     }
 }

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -87,7 +87,7 @@ pub trait EditGuard: Sized {
     /// This function is called after the text is updated (including by keyboard
     /// input, an undo action or by a message like
     /// [`kas::messages::SetValueText`]). The exceptions are setter methods like
-    /// [`clear`](EditField::clear) and [`set_string`](Editor::set_string).
+    /// [`clear`](Editor::clear) and [`set_string`](Editor::set_string).
     fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -87,7 +87,7 @@ pub trait EditGuard: Sized {
     /// This function is called after the text is updated (including by keyboard
     /// input, an undo action or by a message like
     /// [`kas::messages::SetValueText`]). The exceptions are setter methods like
-    /// [`clear`](EditField::clear) and [`set_string`](EditField::set_string).
+    /// [`clear`](EditField::clear) and [`set_string`](Editor::set_string).
     fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -88,6 +88,9 @@ pub trait EditGuard: Sized {
     /// input, an undo action or by a message like
     /// [`kas::messages::SetValueText`]). The exceptions are setter methods like
     /// [`clear`](Editor::clear) and [`set_string`](Editor::set_string).
+    ///
+    /// The guard may set the [error state](Editor::set_error_state) here.
+    /// The error state is cleared immediately before calling this method.
     fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -3,25 +3,23 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! The [`EditField`] and [`EditBox`] widgets, plus supporting items
+//! The [`EditGuard`] trait and some implementations
 
-use super::{EditField, Editor};
+use super::Editor;
 use kas::prelude::*;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::str::FromStr;
 
-/// Event-handling *guard* for [`EditField`], [`EditBox`]
+/// Event-handling *guard* for an [`Editor`]
 ///
 /// This is the most generic interface; see also constructors of [`EditField`],
 /// [`EditBox`] for common use-cases.
 ///
-/// All methods on this trait are passed a reference to the [`EditField`] as
-/// parameter. The guard itself is a public field: `edit.guard`.
-///
 /// All methods have a default implementation which does nothing.
 ///
 /// [`EditBox`]: super::EditBox
+/// [`EditField`]: super::EditField
 pub trait EditGuard: Sized {
     /// Data type
     type Data;
@@ -29,7 +27,7 @@ pub trait EditGuard: Sized {
     /// Configure guard
     ///
     /// This function is called when the attached widget is configured.
-    fn configure(edit: &mut EditField<Self>, cx: &mut ConfigCx) {
+    fn configure(&mut self, edit: &mut Editor, cx: &mut ConfigCx) {
         let _ = (edit, cx);
     }
 
@@ -38,13 +36,13 @@ pub trait EditGuard: Sized {
     /// This function is called when input data is updated.
     ///
     /// Note that this method may be called during editing as a result of a
-    /// message sent by [`Self::edit`] or another cause. It is recommended to
+    /// message sent by the [`Editor`] or another cause. It is recommended to
     /// ignore updates for editable widgets with
     /// [key focus](Editor::has_edit_focus) to avoid overwriting user input;
     /// [`Self::focus_lost`] may update the content instead.
     /// For read-only fields this is not recommended (but `has_edit_focus` will
     /// not be true anyway).
-    fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &Self::Data) {
+    fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }
 
@@ -59,9 +57,9 @@ pub trait EditGuard: Sized {
     /// -   If the field is editable, calls [`Self::focus_lost`] and returns
     ///     returns [`Used`].
     /// -   If the field is not editable, returns [`Unused`].
-    fn activate(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Self::Data) -> IsUsed {
+    fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) -> IsUsed {
         if edit.is_editable() {
-            Self::focus_lost(edit, cx, data);
+            self.focus_lost(edit, cx, data);
             Used
         } else {
             Unused
@@ -71,14 +69,14 @@ pub trait EditGuard: Sized {
     /// Focus-gained guard
     ///
     /// This function is called when the widget gains keyboard input focus.
-    fn focus_gained(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Self::Data) {
+    fn focus_gained(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }
 
     /// Focus-lost guard
     ///
     /// This function is called when the widget loses keyboard input focus.
-    fn focus_lost(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Self::Data) {
+    fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }
 
@@ -91,7 +89,7 @@ pub trait EditGuard: Sized {
     ///
     /// The guard may set the [error state](Editor::set_error_state) here.
     /// The error state is cleared immediately before calling this method.
-    fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Self::Data) {
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }
 }
@@ -157,29 +155,29 @@ mod StringGuard {
     impl EditGuard for Self {
         type Data = A;
 
-        fn focus_lost(edit: &mut EditField<Self>, cx: &mut EventCx, data: &A) {
-            if edit.guard.edited {
-                edit.guard.edited = false;
-                if let Some(ref on_afl) = edit.guard.on_afl {
+        fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &A) {
+            if self.edited {
+                self.edited = false;
+                if let Some(ref on_afl) = self.on_afl {
                     return on_afl(cx, data, edit.as_str());
                 }
             }
 
             // Reset data on focus loss (update is inhibited with focus).
             // No need if we just sent a message (should cause an update).
-            let string = (edit.guard.value_fn)(data);
+            let string = (self.value_fn)(data);
             edit.set_string(cx, string);
         }
 
-        fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &A) {
+        fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &A) {
             if !edit.has_edit_focus() {
-                let string = (edit.guard.value_fn)(data);
+                let string = (self.value_fn)(data);
                 edit.set_string(cx, string);
             }
         }
 
-        fn edit(edit: &mut EditField<Self>, _: &mut EventCx, _: &Self::Data) {
-            edit.guard.edited = true;
+        fn edit(&mut self, _: &mut Editor, _: &mut EventCx, _: &Self::Data) {
+            self.edited = true;
         }
     }
 }
@@ -227,28 +225,28 @@ mod ParseGuard {
     impl EditGuard for Self {
         type Data = A;
 
-        fn focus_lost(edit: &mut EditField<Self>, cx: &mut EventCx, data: &A) {
-            if let Some(value) = edit.guard.parsed.take() {
-                (edit.guard.on_afl)(cx, value);
+        fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &A) {
+            if let Some(value) = self.parsed.take() {
+                (self.on_afl)(cx, value);
             } else {
                 // Reset data on focus loss (update is inhibited with focus).
                 // No need if we just sent a message (should cause an update).
-                let value = (edit.guard.value_fn)(data);
+                let value = (self.value_fn)(data);
                 edit.set_string(cx, format!("{value}"));
             }
         }
 
-        fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &A) {
-            edit.guard.parsed = edit.as_str().parse().ok();
-            let is_err = edit.guard.parsed.is_none();
+        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &A) {
+            self.parsed = edit.as_str().parse().ok();
+            let is_err = self.parsed.is_none();
             edit.set_error_state(cx, is_err);
         }
 
-        fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &A) {
+        fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &A) {
             if !edit.has_edit_focus() {
-                let value = (edit.guard.value_fn)(data);
+                let value = (self.value_fn)(data);
                 edit.set_string(cx, format!("{value}"));
-                edit.guard.parsed = None;
+                self.parsed = None;
             }
         }
     }
@@ -291,23 +289,23 @@ mod InstantParseGuard {
     impl EditGuard for Self {
         type Data = A;
 
-        fn focus_lost(edit: &mut EditField<Self>, cx: &mut EventCx, data: &A) {
+        fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &A) {
             // Always reset data on focus loss
-            let value = (edit.guard.value_fn)(data);
+            let value = (self.value_fn)(data);
             edit.set_string(cx, format!("{value}"));
         }
 
-        fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &A) {
+        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &A) {
             let result = edit.as_str().parse();
             edit.set_error_state(cx, result.is_err());
             if let Ok(value) = result {
-                (edit.guard.on_afl)(cx, value);
+                (self.on_afl)(cx, value);
             }
         }
 
-        fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &A) {
+        fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &A) {
             if !edit.has_edit_focus() {
-                let value = (edit.guard.value_fn)(data);
+                let value = (self.value_fn)(data);
                 edit.set_string(cx, format!("{value}"));
             }
         }

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -68,14 +68,15 @@ pub trait EditGuard: Sized {
 
     /// Focus-gained guard
     ///
-    /// This function is called when the widget gains keyboard input focus.
+    /// This function is called when the widget gains keyboard or IME focus.
     fn focus_gained(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }
 
     /// Focus-lost guard
     ///
-    /// This function is called when the widget loses keyboard input focus.
+    /// This function is called after the widget has lost both keyboard and IME
+    /// focus.
     fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
     }

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -5,7 +5,7 @@
 
 //! The [`EditField`] and [`EditBox`] widgets, plus supporting items
 
-use super::EditField;
+use super::{EditField, Editor};
 use kas::prelude::*;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
@@ -39,8 +39,8 @@ pub trait EditGuard: Sized {
     ///
     /// Note that this method may be called during editing as a result of a
     /// message sent by [`Self::edit`] or another cause. It is recommended to
-    /// ignore updates for editable widgets with key focus
-    /// ([`EditField::has_edit_focus`]) to avoid overwriting user input;
+    /// ignore updates for editable widgets with
+    /// [key focus](Editor::has_edit_focus) to avoid overwriting user input;
     /// [`Self::focus_lost`] may update the content instead.
     /// For read-only fields this is not recommended (but `has_edit_focus` will
     /// not be true anyway).
@@ -237,7 +237,8 @@ mod ParseGuard {
 
         fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &A) {
             edit.guard.parsed = edit.as_str().parse().ok();
-            edit.set_error_state(cx, edit.guard.parsed.is_none());
+            let is_err = edit.guard.parsed.is_none();
+            edit.set_error_state(cx, is_err);
         }
 
         fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &A) {

--- a/crates/kas-widgets/src/edit/mod.rs
+++ b/crates/kas-widgets/src/edit/mod.rs
@@ -51,9 +51,16 @@ impl EditOp {
     }
 }
 
-enum EditAction {
-    None,
+enum CmdAction {
+    /// Key not used, no action
+    Unused,
+    /// Key used, no action
+    Used,
+    /// Cursor and/or selection changed
+    Cursor,
+    /// Enter key in single-line editor
     Activate,
+    /// Text was edited by key command
     Edit,
 }
 

--- a/crates/kas-widgets/src/edit/mod.rs
+++ b/crates/kas-widgets/src/edit/mod.rs
@@ -7,10 +7,12 @@
 
 mod edit_box;
 mod edit_field;
+mod editor;
 mod guard;
 
 pub use edit_box::EditBox;
 pub use edit_field::EditField;
+use editor::Editor;
 pub use guard::*;
 
 use std::fmt::Debug;

--- a/crates/kas-widgets/src/edit/mod.rs
+++ b/crates/kas-widgets/src/edit/mod.rs
@@ -12,7 +12,7 @@ mod guard;
 
 pub use edit_box::EditBox;
 pub use edit_field::EditField;
-use editor::Editor;
+pub use editor::Editor;
 pub use guard::*;
 
 use std::fmt::Debug;

--- a/crates/kas-widgets/src/lib.rs
+++ b/crates/kas-widgets/src/lib.rs
@@ -16,7 +16,7 @@
 //! -   [`adapt`] provides [`Adapt`], [`AdaptWidget`], [`AdaptWidgetAny`] and supporting items
 //!     (the items mentioned are re-export here).
 //! -   [`dialog`] provides [`MessageBox`](dialog::MessageBox), ...
-//! -   [`edit`] provides [`EditBox`], [`EditField`] widgets, [`EditGuard`] trait and some impls
+//! -   [`edit`] provides text-editing functionality; the [`EditBox`] and [`EditField`] widgets are re-export here
 //! -   [`menu`] provides a [`MenuBar`](menu::MenuBar), [`SubMenu`](menu::SubMenu), ...
 //!
 //! ## Container widgets
@@ -95,7 +95,7 @@ pub use access_label::AccessLabel;
 pub use button::Button;
 pub use check_box::{CheckBox, CheckButton};
 pub use combobox::ComboBox;
-pub use edit::{EditBox, EditField, EditGuard};
+pub use edit::{EditBox, EditField};
 pub use event_config::EventConfig;
 pub use filler::Filler;
 pub use float::Float;

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -156,7 +156,8 @@ impl<A, T: SpinValue> EditGuard for SpinGuard<A, T> {
 
     fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &A) {
         edit.guard.value = (edit.guard.state_fn)(cx, data);
-        edit.set_string(cx, edit.guard.value.to_string());
+        let text = edit.guard.value.to_string();
+        edit.set_string(cx, text);
     }
 
     fn focus_lost(edit: &mut EditField<Self>, cx: &mut EventCx, _: &A) {
@@ -164,7 +165,8 @@ impl<A, T: SpinValue> EditGuard for SpinGuard<A, T> {
             edit.guard.value = value;
             cx.push(ValueMsg(value));
         } else {
-            edit.set_string(cx, edit.guard.value.to_string());
+            let text = edit.guard.value.to_string();
+            edit.set_string(cx, text);
         }
     }
 

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -163,13 +163,12 @@ impl<A, T: SpinValue> EditGuard for SpinGuard<A, T> {
         edit.set_string(cx, text);
     }
 
-    fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &A) {
+    fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &A) {
         if let Some(value) = self.parsed.take() {
             self.value = value;
             cx.push(ValueMsg(value));
         } else {
-            let text = self.value.to_string();
-            edit.set_string(cx, text);
+            self.update(edit, cx, data);
         }
     }
 

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -5,7 +5,10 @@
 
 //! SpinBox widget
 
-use crate::{EditField, EditGuard, MarkButton};
+use crate::{
+    MarkButton,
+    edit::{EditField, EditGuard, Editor},
+};
 use kas::messages::{DecrementStep, IncrementStep, ReplaceSelectedText, SetValueF64, SetValueText};
 use kas::prelude::*;
 use kas::theme::{Background, FrameStyle, MarkStyle, Text, TextClass};
@@ -154,30 +157,30 @@ impl<A, T: SpinValue> SpinGuard<A, T> {
 impl<A, T: SpinValue> EditGuard for SpinGuard<A, T> {
     type Data = A;
 
-    fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &A) {
-        edit.guard.value = (edit.guard.state_fn)(cx, data);
-        let text = edit.guard.value.to_string();
+    fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &A) {
+        self.value = (self.state_fn)(cx, data);
+        let text = self.value.to_string();
         edit.set_string(cx, text);
     }
 
-    fn focus_lost(edit: &mut EditField<Self>, cx: &mut EventCx, _: &A) {
-        if let Some(value) = edit.guard.parsed.take() {
-            edit.guard.value = value;
+    fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &A) {
+        if let Some(value) = self.parsed.take() {
+            self.value = value;
             cx.push(ValueMsg(value));
         } else {
-            let text = edit.guard.value.to_string();
+            let text = self.value.to_string();
             edit.set_string(cx, text);
         }
     }
 
-    fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &A) {
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &A) {
         let is_err;
         if let Ok(value) = edit.as_str().parse::<T>() {
-            edit.guard.value = value.clamp(edit.guard.start, edit.guard.end);
-            edit.guard.parsed = Some(edit.guard.value);
+            self.value = value.clamp(self.start, self.end);
+            self.parsed = Some(self.value);
             is_err = false;
         } else {
-            edit.guard.parsed = None;
+            self.parsed = None;
             is_err = true;
         };
         edit.set_error_state(cx, is_err);

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -13,7 +13,9 @@
 use kas::prelude::*;
 use kas::view::clerk::{Clerk, GeneratorChanges, IndexedGenerator, Len};
 use kas::view::{Driver, ListView};
-use kas::widgets::{column, *};
+use kas::widgets::edit::{EditBox, EditGuard, Editor};
+use kas::widgets::{Button, CheckButton, Label, RadioButton, ScrollRegion, Separator, Text};
+use kas::widgets::{column, row};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
@@ -97,19 +99,19 @@ struct ListEntryGuard(usize);
 impl EditGuard for ListEntryGuard {
     type Data = MyItem;
 
-    fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &MyItem) {
+    fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &MyItem) {
         if !edit.has_edit_focus() {
             edit.set_string(cx, data.1.to_string());
         }
     }
 
-    fn activate(edit: &mut EditField<Self>, cx: &mut EventCx, _: &MyItem) -> IsUsed {
-        cx.push(Control::Select(edit.guard.0));
+    fn activate(&mut self, _: &mut Editor, cx: &mut EventCx, _: &MyItem) -> IsUsed {
+        cx.push(Control::Select(self.0));
         Used
     }
 
-    fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &MyItem) {
-        cx.push(Control::Update(edit.guard.0, edit.clone_string()));
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &MyItem) {
+        cx.push(Control::Update(self.0, edit.clone_string()));
     }
 }
 

--- a/examples/data-list-view.rs
+++ b/examples/data-list-view.rs
@@ -100,9 +100,7 @@ impl EditGuard for ListEntryGuard {
     type Data = MyItem;
 
     fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &MyItem) {
-        if !edit.has_edit_focus() {
-            edit.set_string(cx, data.1.to_string());
-        }
+        edit.set_string(cx, data.1.to_string());
     }
 
     fn activate(&mut self, _: &mut Editor, cx: &mut EventCx, _: &MyItem) -> IsUsed {

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -20,7 +20,7 @@
 //! is still fast.
 
 use kas::prelude::*;
-use kas::widgets::edit::{EditBox, EditField, EditGuard};
+use kas::widgets::edit::{EditBox, EditGuard, Editor};
 use kas::widgets::{Button, Label, List, RadioButton, ScrollRegion, Separator, Text};
 use kas::widgets::{column, row};
 
@@ -81,13 +81,13 @@ struct ListEntryGuard(usize);
 impl EditGuard for ListEntryGuard {
     type Data = Data;
 
-    fn activate(edit: &mut EditField<Self>, cx: &mut EventCx, _: &Data) -> IsUsed {
-        cx.push(SelectEntry(edit.guard.0));
+    fn activate(&mut self, _: &mut Editor, cx: &mut EventCx, _: &Data) -> IsUsed {
+        cx.push(SelectEntry(self.0));
         Used
     }
 
-    fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Data) {
-        if data.active == edit.guard.0 {
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Data) {
+        if data.active == self.0 {
             cx.push(Control::UpdateCurrent(edit.clone_string()));
         }
     }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -17,6 +17,7 @@ use kas::dir::{Down, Right};
 use kas::image::Svg;
 use kas::prelude::*;
 use kas::theme::{MarginStyle, TextClass};
+use kas::widgets::edit::{EditGuard, Editor};
 use kas::widgets::{column, *};
 use kas::window::Popup;
 use std::ops::Range;
@@ -89,12 +90,12 @@ fn widgets() -> Page<AppData> {
     impl EditGuard for Guard {
         type Data = Data;
 
-        fn activate(edit: &mut EditField<Self>, cx: &mut EventCx, _: &Data) -> IsUsed {
+        fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Data) -> IsUsed {
             cx.push(Item::Edit(edit.clone_string()));
             Used
         }
 
-        fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &Data) {
+        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Data) {
             // 7a is the colour of *magic*!
             let is_err = edit.as_str().len() % (7 + 1) == 0;
             edit.set_error_state(cx, is_err);
@@ -286,11 +287,11 @@ fn editor() -> Page<AppData> {
     impl EditGuard for Guard {
         type Data = Data;
 
-        fn update(edit: &mut EditField<Self>, cx: &mut ConfigCx, data: &Data) {
+        fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &Data) {
             cx.set_disabled(edit.id(), data.disabled);
         }
 
-        fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, data: &Data) {
+        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Data) {
             let result = Markdown::new(edit.as_str());
             edit.set_error_state(cx, result.is_err());
             let text = result.unwrap_or_else(|err| Markdown::new(&format!("{err}")).unwrap());
@@ -461,7 +462,7 @@ fn filter_list() -> Page<AppData> {
     impl EditGuard for MonthYearFilterGuard {
         type Data = ();
 
-        fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &Self::Data) {
+        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Self::Data) {
             let mut filter = MonthYearFilter {
                 text: edit.as_str().to_uppercase(),
                 month_end: edit.as_str().len(),
@@ -490,8 +491,8 @@ fn filter_list() -> Page<AppData> {
                 filter.year_denom = 10u32.pow((filter.text.len() - i).cast());
             }
 
-            if filter != edit.guard.0 {
-                edit.guard.0 = filter;
+            if filter != self.0 {
+                self.0 = filter;
                 cx.push(FilterUpdate);
             }
 

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -96,7 +96,8 @@ fn widgets() -> Page<AppData> {
 
         fn edit(edit: &mut EditField<Self>, cx: &mut EventCx, _: &Data) {
             // 7a is the colour of *magic*!
-            edit.set_error_state(cx, edit.as_str().len() % (7 + 1) == 0);
+            let is_err = edit.as_str().len() % (7 + 1) == 0;
+            edit.set_error_state(cx, is_err);
         }
     }
 

--- a/examples/text-editor/text-editor.rs
+++ b/examples/text-editor/text-editor.rs
@@ -6,7 +6,7 @@
 //! A simple text editor
 
 use kas::prelude::*;
-use kas::widgets::{Button, EditBox, EditField, EditGuard, Filler, column, dialog, row};
+use kas::widgets::{Button, EditBox, Filler, column, dialog, edit, row};
 use rfd::FileHandle;
 
 #[autoimpl(Clone, Debug, PartialEq, Eq)]
@@ -43,11 +43,11 @@ fn menus() -> impl Widget<Data = ()> {
 struct Guard {
     edited: bool,
 }
-impl EditGuard for Guard {
+impl edit::EditGuard for Guard {
     type Data = ();
 
-    fn edit(edit: &mut EditField<Self>, _: &mut EventCx<'_>, _: &Self::Data) {
-        edit.guard.edited = true;
+    fn edit(&mut self, _: &mut edit::Editor, _: &mut EventCx<'_>, _: &Self::Data) {
+        self.edited = true;
     }
 }
 


### PR DESCRIPTION
Move much of the internals of `EditField` to a new struct, `Editor`. This allows `EditGuard` methods to take receiver `&mut self` and `&mut EditGuard` instead of `&mut EditField`. This may also be useful for code-share with other editor widgets.

`EditGuard` methods are tweaked:

- `focus_gained` is called when the first of keyboard or IME focus is obtained
- `focus_lost` is called when both are lost
- `update` is called only without input focus
- `focus_lost` calls `update` in the default impl