### PR TITLE
Tooltip for editor error state

### DIFF
--- a/crates/kas-core/src/window/window.rs
+++ b/crates/kas-core/src/window/window.rs
@@ -358,8 +358,8 @@ mod Window {
                     cx.drag_window();
                     Used
                 }
-                Event::Timer(handle) if handle == crate::event::Mouse::TIMER_HOVER => {
-                    cx.hover_timer_expiry(self);
+                Event::Timer(handle) if handle == crate::event::Mouse::TIMER_TOOLTIP => {
+                    cx.timer_expiry_tooltip(self);
                     Used
                 }
                 _ => Unused,

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -118,6 +118,11 @@ mod EditBox {
     }
 
     impl Tile for Self {
+        #[inline]
+        fn tooltip(&self) -> Option<&str> {
+            self.deref().tooltip()
+        }
+
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             Role::ScrollRegion {
                 offset: self.scroll.offset(),

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -171,6 +171,11 @@ mod EditField {
             true
         }
 
+        #[inline]
+        fn tooltip(&self) -> Option<&str> {
+            self.editor.tooltip()
+        }
+
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             Role::TextInput {
                 text: self.text.as_str(),
@@ -524,10 +529,10 @@ mod EditField {
 
         /// Call the [`EditGuard`]'s `edit` method
         ///
-        /// This call also clears the [error state](Editor::set_error_state).
+        /// This call also clears the error state (see [`Editor::set_error`]).
         #[inline]
         pub fn call_guard_edit(&mut self, cx: &mut EventCx, data: &G::Data) {
-            self.set_error_state(cx, false);
+            self.clear_error();
             self.guard.edit(&mut self.editor, cx, data);
         }
     }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -13,6 +13,7 @@ use kas::prelude::*;
 use kas::text::{CursorRange, NotReady, SelectionHelper};
 use kas::theme::{Text, TextClass};
 use kas::util::UndoStack;
+use std::borrow::Cow;
 use unicode_segmentation::{GraphemeCursor, UnicodeSegmentation};
 
 /// Editor component
@@ -30,6 +31,7 @@ pub struct Editor {
     pub(super) has_key_focus: bool,
     pub(super) current: CurrentAction,
     error_state: bool,
+    error_message: Option<Cow<'static, str>>,
     pub(super) input_handler: TextInput,
 }
 
@@ -50,6 +52,7 @@ impl Editor {
             has_key_focus: false,
             current: CurrentAction::None,
             error_state: false,
+            error_message: None,
             input_handler: Default::default(),
         }
     }
@@ -195,6 +198,15 @@ impl Editor {
 
             cx.set_ime_cursor_area(&self.id, rect + Offset::conv(self.pos));
         }
+    }
+
+    pub(super) fn clear_error(&mut self) {
+        self.error_state = false;
+        self.error_message = None;
+    }
+
+    pub(super) fn tooltip(&self) -> Option<&str> {
+        self.error_message.as_ref().map(|s| &**s)
     }
 
     /// Call before an edit to (potentially) commit current state based on last_edit
@@ -677,8 +689,8 @@ impl Editor {
     /// This does not interact with undo history or call action handlers on the
     /// guard.
     ///
-    /// This method does not call any [`EditGuard`] actions; consider also
-    /// calling [`EditField::call_guard_edit`].
+    /// This method clears the error state but does not call any [`EditGuard`]
+    /// actions; consider also calling [`EditField::call_guard_edit`].
     ///
     /// Returns `true` if the text is ready and may have changed.
     pub fn set_string(&mut self, cx: &mut EventState, string: String) -> bool {
@@ -691,7 +703,7 @@ impl Editor {
         let len = self.text.str_len();
         self.selection.set_max_len(len);
         self.edit_x_coord = None;
-        self.set_error_state(cx, false);
+        self.clear_error();
         self.text.prepare()
     }
 
@@ -700,8 +712,8 @@ impl Editor {
     /// This does not interact with undo history or call action handlers on the
     /// guard.
     ///
-    /// This method does not call any [`EditGuard`] actions; consider also
-    /// calling [`EditField::call_guard_edit`].
+    /// This method clears the error state but does not call any [`EditGuard`]
+    /// actions; consider also calling [`EditField::call_guard_edit`].
     ///
     /// Returns `true` if the text is ready and may have changed.
     #[inline]
@@ -719,7 +731,7 @@ impl Editor {
             self.selection.set_cursor(index + text.len());
         }
         self.edit_x_coord = None;
-        self.set_error_state(cx, false);
+        self.clear_error();
         self.text.prepare()
     }
 
@@ -777,15 +789,17 @@ impl Editor {
         self.error_state
     }
 
-    /// Set the error state
+    /// Mark the input as erroneous with an optional message
     ///
-    /// When true, the input field's background is drawn red.
-    /// This state is cleared by [`Self::set_string`].
-    // TODO: possibly change type to Option<String> and display the error
-    pub fn set_error_state(&mut self, cx: &mut EventState, error_state: bool) {
-        if error_state != self.error_state {
-            self.error_state = error_state;
-            cx.redraw(&self.id);
-        }
+    /// This state should be set from [`EditGuard::edit`] when appropriate. The
+    /// state is cleared immediately before calling [`EditGuard::edit`] and also
+    /// in case a text is directly assigned (e.g. using [`Self::set_string`]).
+    ///
+    /// When set, the input field's background is drawn red. If a message is
+    /// supplied, then a tooltip will be available on mouse-hover.
+    pub fn set_error(&mut self, cx: &mut EventState, message: Option<Cow<'static, str>>) {
+        self.error_state = true;
+        self.error_message = message;
+        cx.redraw(&self.id);
     }
 }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -206,7 +206,7 @@ impl Editor {
     }
 
     pub(super) fn tooltip(&self) -> Option<&str> {
-        self.error_message.as_ref().map(|s| &**s)
+        self.error_message.as_deref()
     }
 
     /// Call before an edit to (potentially) commit current state based on last_edit

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -164,7 +164,7 @@ mod StringGuard {
             if self.edited {
                 self.edited = false;
                 if let Some(ref on_afl) = self.on_afl {
-                    return on_afl(cx, data, edit.as_str());
+                    on_afl(cx, data, edit.as_str());
                 }
             } else {
                 // Reset data on focus loss (update is inhibited with focus).

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -87,7 +87,7 @@ pub trait EditGuard: Sized {
     /// [`kas::messages::SetValueText`]). The exceptions are setter methods like
     /// [`clear`](Editor::clear) and [`set_string`](Editor::set_string).
     ///
-    /// The guard may set the [error state](Editor::set_error_state) here.
+    /// The guard may call [`Editor::set_error`] here.
     /// The error state is cleared immediately before calling this method.
     fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
@@ -238,8 +238,9 @@ mod ParseGuard {
 
         fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &A) {
             self.parsed = edit.as_str().parse().ok();
-            let is_err = self.parsed.is_none();
-            edit.set_error_state(cx, is_err);
+            if self.parsed.is_none() {
+                edit.set_error(cx, Some("parse failure".into()));
+            }
         }
     }
 }
@@ -293,7 +294,9 @@ mod InstantParseGuard {
 
         fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &A) {
             let result = edit.as_str().parse();
-            edit.set_error_state(cx, result.is_err());
+            if result.is_err() {
+                edit.set_error(cx, Some("parse failure".into()));
+            }
             if let Ok(value) = result {
                 (self.on_afl)(cx, value);
             }

--- a/crates/kas-widgets/src/spin_box.rs
+++ b/crates/kas-widgets/src/spin_box.rs
@@ -182,7 +182,9 @@ impl<A, T: SpinValue> EditGuard for SpinGuard<A, T> {
             self.parsed = None;
             is_err = true;
         };
-        edit.set_error_state(cx, is_err);
+        if is_err {
+            edit.set_error(cx, Some("parse failure".into()));
+        }
     }
 }
 


### PR DESCRIPTION
This revises how editor errors are set, supporting a tooltip:
<img width="614" height="106" alt="image" src="https://github.com/user-attachments/assets/fc56355b-79a1-4b91-afa2-dd149eabcf67" />

Also fixes closure of tooltips while the mouse keeps moving.