### PR TITLE
Release automation; bump kas-text and pin winit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Publish to crates.io
+on:
+  push:
+    tags: ['[0-9].[0-9].*', '[0-9].[1-9][0-9].*']
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release  # Optional: for enhanced security
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libfontconfig1-dev
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - name: Publish kas-macros
+      working-directory: ./crates/kas-macros
+      run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    - name: Publish kas-core
+      working-directory: ./crates/kas-core
+      run: cargo publish --features wayland
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    - name: Publish kas-widgets
+      working-directory: ./crates/kas-widgets
+      run: cargo publish --features kas/wayland
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    - name: Publish kas-image
+      working-directory: ./crates/kas-image
+      run: cargo publish --features kas/wayland
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    - name: Publish kas-view
+      working-directory: ./crates/kas-view
+      run: cargo publish --features kas/wayland
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    - name: Publish kas-soft
+      working-directory: ./crates/kas-soft
+      run: cargo publish --features wayland
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    - name: Publish kas-wgpu
+      working-directory: ./crates/kas-wgpu
+      run: cargo publish --features kas/wayland
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    - name: Publish kas-dylib
+      working-directory: ./crates/kas-dylib
+      run: cargo publish --features kas-core/wayland
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    - name: Publish kas
+      working-directory: ./
+      run: cargo publish --features wayland
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,3 @@ members = [
     "examples/file-explorer",
 ]
 resolver = "2"
-
-[patch.crates-io.kas-text]
-git = "https://github.com/kas-gui/kas-text.git"
-rev = "dc0b273f"

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -114,6 +114,9 @@ rustc-hash = "2.0"
 ab_glyph = { version = "0.2.10", optional = true }
 swash = { version = "0.2.4", features = ["scale"] }
 linearize = { version = "0.1.5", features = ["derive"] }
+kas-macros = { version = "0.16.0", path = "../kas-macros" }
+kas-text = "0.9.0"
+easy-cast = "0.5.4" # used in doc links
 
 [target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
 smithay-clipboard = { version = "0.7.0", optional = true }
@@ -121,16 +124,6 @@ smithay-clipboard = { version = "0.7.0", optional = true }
 [target.'cfg(not(target_os = "android"))'.dependencies]
 arboard = { version = "3.2.0", optional = true, default-features = false }
 
-
-[dependencies.kas-macros]
-version = "0.16.0"
-path = "../kas-macros"
-
-[dependencies.kas-text]
-version = "0.8.0"
-
-[dependencies.easy-cast]
-version = "0.5.4" # used in doc links
 
 [dependencies.winit]
 # Provides translations for several winit types

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -124,10 +124,8 @@ smithay-clipboard = { version = "0.7.0", optional = true }
 [target.'cfg(not(target_os = "android"))'.dependencies]
 arboard = { version = "3.2.0", optional = true, default-features = false }
 
-
 [dependencies.winit]
-# Provides translations for several winit types
-version = "0.31.0-beta.2"
+version = "=0.31.0-beta.2"
 default-features = false
 
 [lints.clippy]

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -21,7 +21,6 @@ log = "0.4"
 smallvec = "1.6.1"
 unicode-segmentation = "1.7"
 thiserror = "2.0.3"
-kas-macros = { version = "0.16.0", path = "../kas-macros" }
 linear-map = "1.2.0"
 
 # We must rename this package since macros expect kas to be in scope:

--- a/crates/kas-widgets/src/scroll_bar.rs
+++ b/crates/kas-widgets/src/scroll_bar.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 /// Scroll bar mode
 ///
 /// The default value is [`ScrollBarMode::Auto`].
-#[kas_macros::impl_default(ScrollBarMode::Auto)]
+#[impl_default(ScrollBarMode::Auto)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ScrollBarMode {
     /// Automatically enable/disable scroll bars as required when resized.


### PR DESCRIPTION
Add release automation using trusted-publishing.

Bump kas-text (https://github.com/kas-gui/kas-text/pull/117).

Pin the current winit pre-release version.