### PR TITLE
Prepare 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,166 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] — 2026-01-26
+
+Significant additions include improved Input Method Editor (IME) support, font selection, font rendering (gamma correction and sub-pixel rendering support), several small input handling improvements, better resizing, a new text `Editor` component, revised image widgets `Sprite` and `Image`, a new `kas-soft` rendering backend and significantly revised view widget clerks.
+
+Known issues: this release uses a pinned pre-release of winit which breaks AccessKit support.
+
+### Dependencies
+
+-   Bump MSRV to 1.92.0 (#621)
+-   Update winit to 0.31.0-beta.2 (pinned) (#583)
+-   Update wgpu to 28.0.0 (#584, #621)
+-   Update kas-text to 0.9.0 (#590, #599, #634, #646)
+-   Remove dark-light (#637)
+
+### Feature flags
+
+-   Flag `minimal` no longer implies `wgpu` (#622)
+-   Flag `default` (of `kas`) no longer implies `view`, `resvg`, `markdown`, `spawn`, `accesskit` (#568)
+-   Flag `image` (of `kas-widgets`, `kas-core`, `kas`) no longer automatically enables all available formats (#568)
+-   Add flag `image-default-format` to `kas-wigdgets` to enable all formats (#568)
+-   Add flags `avif`, `jpeg`, `png`, `webp` to `kas-wigdgets` to enable individual formats (#568)
+-   Kas enables its own flags `view`, `markdown` and `resvg` as a dev-dependency (#568)
+
+### Configuration
+
+-   Support selection of font (generic) family, size and weight based on `TextClass` (#618, #634)
+-   Revise text raster config (#620)
+-   Add `double_click_dist_thresh` event configuration (#623)
+
+### Macros
+
+-   Let `#[derive_widget]` support overriding of more `Tile` methods (#612)
+-   Remove `widget_set_rect!` macro (#613)
+-   Remove `aligned_row!` and `aligned_column!` (#630)
+-   Support `row!` and `column!` within `grid!` (#630)
+
+### Widget traits and lifecycle
+
+-   Add traits `WidgetCore`, `WidgetCoreRect` (#613)
+-   Add fns `Tile::{core, core_mut}` where `Self: Sized` (#615)
+-   Remove `Clone` support for widgets (#613)
+-   Replace trait `Scrollable` with `Viewport` (#594, #597, #598)
+-   Remove fns `Events::{configure_recurse, update_recurse}`
+-   Add fn `Events::recurse_indices` for configure/update recursion control (#581)
+-   Add fn `Events::post_configure` (#581)
+-   Add fn `Events::handle_resize` (#589)
+-   Move fn `probe` to trait `Events` (#563, #564)
+-   Move fn `try_probe` to trait `Tile` (#567)
+-   Enforce during configure that widget `Id` is valid (#573)
+-   Support non-rectangular hit-testing (#563)
+-   Validate that `#[layout]` specifications only refer to known fields (#579)
+-   Improved validation of paired method impls (#586)
+
+### Window management
+
+-   Add parameter `modal` to fn `EventCx::add_window` (#565)
+-   Prefer `PresentMode::Mailbox` (#584)
+-   Revise `SolveCache` API (#588)
+-   Revise `kas::runner::{Runner, *Builder, *Theme}` (#622)
+
+### Message handling
+
+-   New trait `ReadMessage` impl'd by `MessageStack` (#565)
+
+### Sizing functionality
+
+-   Pass `SizeCx` by `&mut` (#581)
+-   Let `SizeCx` deref mut to `EventState` (#581)
+-   Rename `SizeRules::solve_seq` -> `solve_widths` and publically document (#614)
+-   Support for prioritised rules-solving (#612)
+-   Let `SizeRules` margins default to zero (remove constructor parameter) (#578)
+-   Add fns `SizeRules::{with_margin, with_margins}` (#578)
+-   Add fn `SizeCx::logical` (#578, #579)
+-   Replace fn `AxisInfo::sub_other` with `map_other` (#581)
+-   Do not stretch `Stretch::None` widgets in `SizeRules::solve_widths` (#578)
+-   Do not allow larger-than-ideal size while any item has less-than-ideal size (#614)
+-   Do not allow items with `Stretch` priority lower than that of the highest item to be larger than their ideal size (#614)
+
+### Draw and theme functionality
+
+-   Add fns `DrawCx::{colors, draw_rounded}` (#577)
+-   Add fn `{Rgb, Rgba}::desaturate` (#577)
+-   Revise fns `DrawShared::image_*` (#627, #639)
+-   Remove `MultiThemeBuilder` (#628)
+-   Add `MarkStyle::{Plus, Minus}` (#632)
+-   Add fn `DrawCx::text_with_color` and paramter `colors` to fn `text_with_effects` (#636)
+-   Rename fns `DrawCx::text_pos` -> `text_with_position`, `text_selected` -> `text_with_selection` (#636)
+
+### Event handling
+
+-   Let `EventCx` impl `Deref<Target = ConfigCx>` (#599)
+-   Revise component `TextInput` with support for touch taps (#605)
+-   Add component `ClickInputAction` (#597)
+-   Rename variant `Event::CursorMove` -> `PointerMove` (#605)
+-   Move fn `EventState::exit` to `EventCx` (#570)
+-   Add fn `id` to `AdaptEventCx`, `AdaptConfigCx` (#572)
+-   Add fn `EventState::close_own_window` (#588)
+-   Remove some `Action` variants (#588, #591)
+-   Add `ActionMoved`, `ActionResize`, `ActionRedraw`, `ActionClose` (#588, #589, #633)
+-   Add `ConfigAction` and `WindowAction` (#591)
+
+### Text processing
+
+-   Revise enum `TextClass` to variants `Standard, Label, Small, Editor` (#618)
+-   Remove fns `ConfigCx::text_configure`, `SizeCx::text_rules` (#636)
+-   Remove `kas::text::Text` (#636)
+-   `kas::theme::Text` now supports `mut` access to text object (#572)
+-   Add paramameter `max_lines` to fn `measure_height` (#590)
+-   Multiple font selection improvements in `kas-text` backend
+
+### Text editing
+
+-   Revise input handling: `TextInputAction` component (#566)
+-   Revise `SelectionHelper` fns (#566)
+-   Improved support for Input Method Editors (IME) (#583, #603, #605, #642)
+-   Full undo history for text editors (#641)
+-   Add `kas-widgets::edit::Editor` component (#643)
+-   Call `EditGuard::update` only without input focus (#643)
+-   Revise when `EditGuard::{focus_gained, focus_lost}` are called (#643)
+-   Replace fn `Editor::set_error_state` with `set_error` with optional tooltip message (#644)
+
+### Rendering
+
+-   Add `kas-soft` software-rendering backend (#610)
+-   Gamma-correct text rendering for `kas-wgpu` (#618)
+-   Sub-pixel rendering for `kas-soft` (#620)
+
+### Widgets
+
+-   Rename `ScrollRegion` -> `ClipRegion` (#595)
+-   Replace `ScrollBars` and `ScrollBarRegion` with `ScrollRegion` (#595)
+-   Replace `format_data!` and `format_value!` with `format_text!` and `format_label!` (#618)
+-   Add `Flow` widget (horizontal only) (#615)
+-   Remove fn `Grid::edit` (#589)
+-   Revise `Text` constructors (#572)
+-   Add parameter `inner: &mut W` to `Adapt` closures
+-   Rename fn `AdaptWidget::margins` -> `with_margin_style` and support in macro layout syntax (#616)
+-   Add fn `List::truncate` (#575)
+-   Add fn `AdaptWidget::with_stretch` (#592)
+-   `Stack` now only uses the active page to infer its minimum size (#590)
+
+### Image widgets
+
+-   Rename `kas-resvg` -> `kas-image` (#577)
+-   Revise `kas-image::Scaling` (#578)
+-   Rename `kas-image::Image` -> `Sprite`, requiring explicit allocation and raster upload (#579, #627)
+-   Add `kas-image::Image` as a high-level image widget (#579)
+
+### View widgets
+
+-   Reorganise: add `kas::view::clerk` and move/rename multiple `kas::view` items (#574)
+-   Remove `FilterBoxListView` without replacement (#574)
+-   Remove struct `GeneratorClerk` (#574)
+-   Rename `kas::view::DataGenerator` -> `kas::view::clerk::KeyedGenerator` (#574)
+-   Add `kas::view::clerk::IndexedGenerator` (#574)
+-   Split trait `DataClerk` into `Clerk`, `AsyncClerk` and `TokenClerk` (#574)
+-   Add `Clerk::mock_item` for explicit control over sizing before data is available (#573)
+-   Revise `Tab`-key navigation for `ListView` and `GridView` (#596)
+-   Add const `Driver::TAB_NAVIGABLE` (#596)
+
 ## [0.16.1] — 2025-09-20
 
 ### Window management

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.92.0"
 
 [package]
 name = "kas"
-version = "0.16.1"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -135,15 +135,15 @@ x11 = ["kas-core/x11", "kas-soft?/wayland"]
 unsafe_node = ["kas-core/unsafe_node"]
 
 [dependencies]
-kas-core = { version = "0.16.1", path = "crates/kas-core" }
-kas-dylib = { version = "0.16.0", path = "crates/kas-dylib", optional = true }
-kas-widgets = { version = "0.16.1", path = "crates/kas-widgets" }
-kas-view = { version = "0.16.0", path = "crates/kas-view", optional = true }
-kas-image = { version = "0.16.0", path = "crates/kas-image", optional = true }
-kas-soft = { version = "0.16.0", path = "crates/kas-soft", optional = true }
+kas-core = { version = "0.17.0", path = "crates/kas-core" }
+kas-dylib = { version = "0.17.0", path = "crates/kas-dylib", optional = true }
+kas-widgets = { version = "0.17.0", path = "crates/kas-widgets" }
+kas-view = { version = "0.17.0", path = "crates/kas-view", optional = true }
+kas-image = { version = "0.17.0", path = "crates/kas-image", optional = true }
+kas-soft = { version = "0.17.0", path = "crates/kas-soft", optional = true }
 
 [dependencies.kas-wgpu]
-version = "0.16.0"
+version = "0.17.0"
 path = "crates/kas-wgpu"
 optional = true
 default-features = false

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -185,13 +185,7 @@ Tooltips (pop-up text on mouse hover) have been implemented.
 
 ### 0.17.0 — Unreleased
 
-IME support is improved using the revised winit support for this.
-
-Added `kas-soft` software-rendering backend, providing an alternative to WGPU and enabling substantially smaller binaries.
-
-Revised per-class text support, allowing this to affect font size & style.
-
-Sub-pixel rendering support.
+Significant additions include improved Input Method Editor (IME) support, font selection, font rendering (gamma correction and sub-pixel rendering support), several small input handling improvements, better resizing, a new text `Editor` component, revised image widgets `Sprite` and `Image`, a new `kas-soft` rendering backend and significantly revised view widget clerks.
 
 
 Future work

--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-core"
-version = "0.16.1"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -114,7 +114,7 @@ rustc-hash = "2.0"
 ab_glyph = { version = "0.2.10", optional = true }
 swash = { version = "0.2.4", features = ["scale"] }
 linearize = { version = "0.1.5", features = ["derive"] }
-kas-macros = { version = "0.16.0", path = "../kas-macros" }
+kas-macros = { version = "0.17.0", path = "../kas-macros" }
 kas-text = "0.9.0"
 easy-cast = "0.5.4" # used in doc links
 

--- a/crates/kas-core/src/runner/mod.rs
+++ b/crates/kas-core/src/runner/mod.rs
@@ -242,7 +242,8 @@ enum ProxyAction {
 #[cfg(feature = "accesskit")]
 impl From<accesskit_winit::Event> for ProxyAction {
     fn from(event: accesskit_winit::Event) -> Self {
-        ProxyAction::AccessKit(event.window_id, event.window_event)
+        compile_error!("AccessKit is not compatible with the current winit version")
+        // ProxyAction::AccessKit(event.window_id, event.window_event)
     }
 }
 

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -240,8 +240,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         let winit_id = window.id();
 
         #[cfg(feature = "accesskit")]
-        let accesskit =
-            accesskit_winit::Adapter::with_event_loop_proxy(el, &window, el.create_proxy());
+        let accesskit = todo!(); // FIXME: accesskit_winit::Adapter::with_event_loop_proxy(el, &window, el.create_proxy());
 
         let window = WindowData {
             window,
@@ -307,7 +306,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
         };
 
         #[cfg(feature = "accesskit")]
-        window.accesskit.process_event(&window.window, &event);
+        todo!(); // FIXME: window.accesskit.process_event(&window.window, &event);
 
         let (apply_size, resize, poll) = match event {
             WindowEvent::Moved(_) | WindowEvent::Destroyed => return false,
@@ -481,7 +480,7 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
                 let resize = self.ev_state.with(shared, theme.size(), window, |cx| {
                     cx.handle_accesskit_action(self.widget.as_node(data), request);
                 });
-                if *resize {
+                if resize.is_some() {
                     self.apply_size(data, false, true);
                 }
             }

--- a/crates/kas-dylib/Cargo.toml
+++ b/crates/kas-dylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-dylib"
-version = "0.16.0"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -29,9 +29,9 @@ soft = ["dep:kas-soft"]
 docs_rs = ["kas-core/wayland"]
 
 [dependencies]
-kas-core = { version = "0.16.0", path = "../kas-core", default-features = false }
-kas-widgets = { version = "0.16.0", path = "../kas-widgets" }
-kas-image = { version = "0.16.0", path = "../kas-image", default-features = false, optional = true }
-kas-view = { version = "0.16.0", path = "../kas-view", default-features = false, optional = true }
-kas-wgpu = { version = "0.16.0", path = "../kas-wgpu", default-features = false, optional = true }
-kas-soft = { version = "0.16.0", path = "../kas-soft", default-features = false, optional = true }
+kas-core = { version = "0.17.0", path = "../kas-core", default-features = false }
+kas-widgets = { version = "0.17.0", path = "../kas-widgets" }
+kas-image = { version = "0.17.0", path = "../kas-image", default-features = false, optional = true }
+kas-view = { version = "0.17.0", path = "../kas-view", default-features = false, optional = true }
+kas-wgpu = { version = "0.17.0", path = "../kas-wgpu", default-features = false, optional = true }
+kas-soft = { version = "0.17.0", path = "../kas-soft", default-features = false, optional = true }

--- a/crates/kas-image/Cargo.toml
+++ b/crates/kas-image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-image"
-version = "0.16.0"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -48,7 +48,7 @@ image = { version = "0.25.1", default-features = false, optional = true }
 
 [dependencies.kas]
 # We must rename this package since macros expect kas to be in scope:
-version = "0.16.0"
+version = "0.17.0"
 package = "kas-core"
 path = "../kas-core"
 features = ["spawn"]

--- a/crates/kas-macros/Cargo.toml
+++ b/crates/kas-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-macros"
-version = "0.16.0"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/kas-soft/Cargo.toml
+++ b/crates/kas-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-soft"
-version = "0.16.0"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -35,7 +35,7 @@ softbuffer = { version = "0.4.6", default-features = false }
 
 [dependencies.kas]
 # Rename package purely for convenience:
-version = "0.16.0"
+version = "0.17.0"
 package = "kas-core"
 path = "../kas-core"
 

--- a/crates/kas-view/Cargo.toml
+++ b/crates/kas-view/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-view"
-version = "0.16.0"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -17,12 +17,12 @@ exclude = ["/screenshots"]
 features = ["kas/wayland"]
 
 [dependencies]
-kas-widgets = { version = "0.16.0", path = "../kas-widgets" }
+kas-widgets = { version = "0.17.0", path = "../kas-widgets" }
 log = "0.4"
 linear-map = "1.2.0"
 
 # We must rename this package since macros expect kas to be in scope:
-kas = { version = "0.16.0", package = "kas-core", path = "../kas-core" }
+kas = { version = "0.17.0", package = "kas-core", path = "../kas-core" }
 
 [lints.clippy]
 collapsible_else_if = "allow"

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-wgpu"
-version = "0.16.0"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -33,7 +33,7 @@ guillotiere = "0.6.0"
 
 [dependencies.kas]
 # Rename package purely for convenience:
-version = "0.16.0"
+version = "0.17.0"
 package = "kas-core"
 path = "../kas-core"
 

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-widgets"
-version = "0.16.1"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -24,7 +24,7 @@ thiserror = "2.0.3"
 linear-map = "1.2.0"
 
 # We must rename this package since macros expect kas to be in scope:
-kas = { version = "0.16.1", package = "kas-core", path = "../kas-core" }
+kas = { version = "0.17.0", package = "kas-core", path = "../kas-core" }
 
 [lints.clippy]
 collapsible_else_if = "allow"

--- a/examples/file-explorer/Cargo.toml
+++ b/examples/file-explorer/Cargo.toml
@@ -15,6 +15,6 @@ log = "0.4.28"
 image = "0.25.8"
 
 [dependencies.kas]
-version = "0.16.0"
+version = "0.17.0"
 path = "../.."
 features = ["image", "view", "spawn"]

--- a/examples/mandlebrot/Cargo.toml
+++ b/examples/mandlebrot/Cargo.toml
@@ -10,8 +10,8 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-kas = { version = "0.16.0", features = ["wgpu"], path = "../.." }
-kas-wgpu = { version = "0.16.0", path = "../../crates/kas-wgpu" }
+kas = { version = "0.17.0", features = ["wgpu"], path = "../.." }
+kas-wgpu = { version = "0.17.0", path = "../../crates/kas-wgpu" }
 chrono = "0.4"
 env_logger = "0.11"
 log = "0.4"

--- a/examples/text-editor/Cargo.toml
+++ b/examples/text-editor/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-kas = { version = "0.16.0", features = ["wgpu"], path = "../.." }
+kas = { version = "0.17.0", features = ["wgpu"], path = "../.." }
 env_logger = "0.11"
 log = "0.4"
 rfd = "0.17.2"


### PR DESCRIPTION
The CHANGELOG is long. Summary:

> Significant additions include improved Input Method Editor (IME) support, font selection, font rendering (gamma correction and sub-pixel rendering support), several small input handling improvements, better resizing, a new text `Editor` component, revised image widgets `Sprite` and `Image`, a new `kas-soft` rendering backend and significantly revised view widget clerks.
>
> Known issues: this release uses a pinned pre-release of winit which breaks AccessKit support.

I believe it is worth putting out this release despite the known issue since there have been a lot of changes since the last release.