### PR TITLE
kas-wgpu v0.17.1: fix upload of rgba text sprites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1 for kas-wgpu] — 2026-01-30
+
+### Fixes
+
+-   Fix upload of RGBA text sprites (i.e. Emojis) in kas_wgpu (#651)
+
 ## [0.17.0] — 2026-01-26
 
 Significant additions include improved Input Method Editor (IME) support, font selection, font rendering (gamma correction and sub-pixel rendering support), several small input handling improvements, better resizing, a new text `Editor` component, revised image widgets `Sprite` and `Image`, a new `kas-soft` rendering backend and significantly revised view widget clerks.

--- a/crates/kas-wgpu/Cargo.toml
+++ b/crates/kas-wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-wgpu"
-version = "0.17.0"
+version = "0.17.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/kas-wgpu/src/draw/images.rs
+++ b/crates/kas-wgpu/src/draw/images.rs
@@ -288,6 +288,7 @@ impl Images {
         encoder: &mut wgpu::CommandEncoder,
         text: &mut kas::text::raster::State,
     ) {
+        self.atlas_rgba.prepare(device);
         self.atlas_mask.prepare(device);
         if let Some(pipeline) = self.atlas_rgba_mask.as_mut() {
             pipeline.prepare(device);


### PR DESCRIPTION
Without this fix colour emojis cause a crash in kas-wgpu.