### PR TITLE
0.17.1: fix kas-soft docs; let Backspace key delete grapheme clusters in Editor 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.1 for kas-wgpu] — 2026-01-30
+## [0.17.1] — 2026-01-30 – 2026-02-03
 
 ### Fixes
 
 -   Fix upload of RGBA text sprites (i.e. Emojis) in kas_wgpu (#651)
+-   Fix docs.rs build for kas-soft (#652)
+
+### Changed
+
+-   Let Backspace key delete one grapheme cluster (#652)
+
 
 ## [0.17.0] — 2026-01-26
 

--- a/crates/kas-soft/Cargo.toml
+++ b/crates/kas-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-soft"
-version = "0.17.0"
+version = "0.17.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/kas-soft/Cargo.toml
+++ b/crates/kas-soft/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 documentation = "https://docs.rs/kas-soft/"
 
 [package.metadata.docs.rs]
-features = ["kas/wayland"]
+features = ["wayland"]
 
 [features]
 # Enable DRM/KMS backend

--- a/crates/kas-widgets/Cargo.toml
+++ b/crates/kas-widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-widgets"
-version = "0.17.0"
+version = "0.17.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -322,25 +322,19 @@ impl Editor {
             Command::Left | Command::Home if !shift && have_sel => {
                 Action::Move(selection.start, None)
             }
-            Command::Left if cursor > 0 => {
-                let mut cursor = GraphemeCursor::new(cursor, len, true);
-                cursor
-                    .prev_boundary(self.text.text(), 0)
-                    .unwrap()
-                    .map(|index| Action::Move(index, None))
-                    .unwrap_or(Action::None)
-            }
+            Command::Left if cursor > 0 => GraphemeCursor::new(cursor, len, true)
+                .prev_boundary(self.text.text(), 0)
+                .unwrap()
+                .map(|index| Action::Move(index, None))
+                .unwrap_or(Action::None),
             Command::Right | Command::End if !shift && have_sel => {
                 Action::Move(selection.end, None)
             }
-            Command::Right if cursor < len => {
-                let mut cursor = GraphemeCursor::new(cursor, len, true);
-                cursor
-                    .next_boundary(self.text.text(), 0)
-                    .unwrap()
-                    .map(|index| Action::Move(index, None))
-                    .unwrap_or(Action::None)
-            }
+            Command::Right if cursor < len => GraphemeCursor::new(cursor, len, true)
+                .next_boundary(self.text.text(), 0)
+                .unwrap()
+                .map(|index| Action::Move(index, None))
+                .unwrap_or(Action::None),
             Command::WordLeft if cursor > 0 => {
                 let mut iter = self.text.text()[0..cursor].split_word_bound_indices();
                 let mut p = iter.next_back().map(|(index, _)| index).unwrap_or(0);
@@ -444,15 +438,11 @@ impl Editor {
                 .unwrap()
                 .map(|next| Action::Delete(cursor..next, EditOp::Delete))
                 .unwrap_or(Action::None),
-            Command::DelBack if editable => {
-                // We always delete one code-point, not one grapheme cluster:
-                let prev = self.text.text()[0..cursor]
-                    .char_indices()
-                    .next_back()
-                    .map(|(i, _)| i)
-                    .unwrap_or(0);
-                Action::Delete(prev..cursor, EditOp::Delete)
-            }
+            Command::DelBack if editable => GraphemeCursor::new(cursor, len, true)
+                .prev_boundary(self.text.text(), 0)
+                .unwrap()
+                .map(|prev| Action::Delete(prev..cursor, EditOp::Delete))
+                .unwrap_or(Action::None),
             Command::DelWord if editable => {
                 let next = self.text.text()[cursor..]
                     .split_word_bound_indices()

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -37,7 +37,6 @@ fn calc_ui() -> Window<()> {
         .with_width_em(5.0, 10.0)
         .with_margin_style(kas::theme::MarginStyle::None);
 
-    // We use map_any to avoid passing input data (not wanted by buttons):
     let buttons = grid! {
         // Key bindings: C, Del
         (0, 0) => Button::label_msg("&clear", Key::Named(NamedKey::Clear))
@@ -62,6 +61,7 @@ fn calc_ui() -> Window<()> {
         (0..=1, 4) => key_button("&0"),
         (2, 4) => key_button("&."),
     };
+    // We use map_any to avoid passing input data (not wanted by buttons):
     let buttons = Frame::new(buttons).with_style(FrameStyle::None).map_any();
 
     let ui = Adapt::new(column![display, buttons], Calculator::new())


### PR DESCRIPTION
Fixes docs.rs build config for kas-soft.

Let the <kbd>Backspace</kbd> key delete a grapheme cluster instead of a code point. (I don't recall why this didn't do so in the past.)