### PR TITLE
Pin kas-macros version used by kas-core

### DIFF
--- a/crates/kas-core/Cargo.toml
+++ b/crates/kas-core/Cargo.toml
@@ -114,9 +114,12 @@ rustc-hash = "2.0"
 ab_glyph = { version = "0.2.10", optional = true }
 swash = { version = "0.2.4", features = ["scale"] }
 linearize = { version = "0.1.5", features = ["derive"] }
-kas-macros = { version = "0.17.0", path = "../kas-macros" }
 kas-text = "0.9.0"
 easy-cast = "0.5.4" # used in doc links
+
+[dependencies.kas-macros]
+version = "=0.17.0" # pinned because kas-macros makes assumptions about kas-core's internals
+path = "../kas-macros"
 
 [target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
 smithay-clipboard = { version = "0.7.0", optional = true }


### PR DESCRIPTION
These two crates should always have matching versions so that patch versions to kas-macros can use new features in the matching kas-core version.