### PR TITLE
Update file-explorer: support SVGs

### DIFF
--- a/crates/kas-widgets/src/stack.rs
+++ b/crates/kas-widgets/src/stack.rs
@@ -495,6 +495,17 @@ impl<A> Stack<A> {
         page
     }
 
+    /// Remove all children at index greater than or equal to `len`
+    ///
+    /// If `len` is greater than or equal to the current length this has no effect.
+    pub fn truncate(&mut self, cx: &mut ConfigCx, len: usize) {
+        self.widgets.truncate(len);
+
+        if self.active >= len {
+            cx.region_moved();
+        }
+    }
+
     /// Append child widgets from an iterator
     ///
     /// The new pages are not made active (the active index may be changed to

--- a/examples/file-explorer/Cargo.toml
+++ b/examples/file-explorer/Cargo.toml
@@ -17,4 +17,4 @@ image = "0.25.8"
 [dependencies.kas]
 version = "0.17.0"
 path = "../.."
-features = ["image", "view", "spawn"]
+features = ["image", "svg", "view", "spawn"]


### PR DESCRIPTION
Also revises Tile code to make widgets on demand (more scalable to large numbers of types; also suits `Svg`'s API better).