### PR TITLE
Impl Send + Sync for (widget) Id, ImageHandle

### DIFF
--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -24,9 +24,8 @@ use std::time::Instant;
 /// ```ignore
 /// # use kas::draw::{DrawIface, DrawRoundedImpl, DrawSharedImpl, DrawCx, DrawRounded, color::Rgba};
 /// # use kas::geom::Rect;
-/// # struct CircleWidget<DS> {
+/// # struct CircleWidget {
 /// #     rect: Rect,
-/// #     _pd: std::marker::PhantomData<DS>,
 /// # }
 /// impl CircleWidget {
 ///     fn draw(&self, mut draw: DrawCx) {

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -13,7 +13,7 @@ use crate::geom::{Quad, Size, Vec2};
 use crate::text::{Effect, TextDisplay};
 use std::any::Any;
 use std::num::NonZeroU32;
-use std::rc::Rc;
+use std::sync::Arc;
 use thiserror::Error;
 
 /// Identifier for an image allocation
@@ -25,7 +25,7 @@ pub struct ImageId(NonZeroU32);
 /// Serves both to identify an allocated image and to track the number of users
 /// via reference counting.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ImageHandle(ImageId, Rc<()>);
+pub struct ImageHandle(ImageId, Arc<()>);
 
 impl ImageHandle {
     /// Convert to an [`ImageId`]
@@ -144,7 +144,7 @@ impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
     fn image_alloc(&mut self, format: ImageFormat, size: Size) -> Result<ImageHandle, AllocError> {
         self.draw
             .image_alloc(format, size)
-            .map(|id| ImageHandle(id, Rc::new(())))
+            .map(|id| ImageHandle(id, Arc::new(())))
     }
 
     #[inline]
@@ -158,7 +158,7 @@ impl<DS: DrawSharedImpl> DrawShared for SharedState<DS> {
 
     #[inline]
     fn image_free(&mut self, handle: ImageHandle) {
-        if let Ok(()) = Rc::try_unwrap(handle.1) {
+        if let Ok(()) = Arc::try_unwrap(handle.1) {
             self.draw.image_free(handle.0);
         }
     }

--- a/crates/kas-core/src/runner/window.rs
+++ b/crates/kas-core/src/runner/window.rs
@@ -54,9 +54,8 @@ struct WindowData<G: GraphicsInstance> {
 /// Per-window data
 #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
 #[cfg_attr(docsrs, doc(cfg(internal_doc)))]
-#[autoimpl(Debug ignore self._data, self.widget, self.ev_state, self.theme_and_window)]
+#[autoimpl(Debug ignore self.widget, self.ev_state, self.theme_and_window)]
 pub struct Window<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> {
-    _data: std::marker::PhantomData<A>,
     pub(super) widget: Box<dyn WindowWidget<Data = A>>,
     ev_state: EventState,
     theme_and_window: Option<(T::Window, WindowData<G>)>,
@@ -73,7 +72,6 @@ impl<A: AppData, G: GraphicsInstance, T: Theme<G::Shared>> Window<A, G, T> {
     ) -> Self {
         let config = WindowConfig::new(config);
         Window {
-            _data: std::marker::PhantomData,
             widget: widget.0,
             ev_state: EventState::new(window_id, config, platform),
             theme_and_window: None,

--- a/crates/kas-core/src/widgets/adapt.rs
+++ b/crates/kas-core/src/widgets/adapt.rs
@@ -11,6 +11,7 @@ use crate::layout::{AlignHints, AxisInfo, SizeRules};
 use crate::theme::SizeCx;
 use crate::{Layout, Widget};
 use kas_macros::{autoimpl, impl_self};
+use std::marker::PhantomData;
 
 #[impl_self]
 mod MapAny {
@@ -26,7 +27,7 @@ mod MapAny {
     #[autoimpl(Clone, Default where W: trait)]
     #[derive_widget]
     pub struct MapAny<A, W: Widget<Data = ()>> {
-        _a: std::marker::PhantomData<A>,
+        _a: PhantomData<dyn Fn(A) + Send + Sync>,
         /// The inner widget
         #[widget = &()]
         pub inner: W,
@@ -40,7 +41,7 @@ mod MapAny {
         /// Construct
         pub fn new(inner: W) -> Self {
             MapAny {
-                _a: std::marker::PhantomData,
+                _a: PhantomData,
                 inner,
             }
         }

--- a/crates/kas-macros/src/lib.rs
+++ b/crates/kas-macros/src/lib.rs
@@ -470,7 +470,7 @@ pub fn layout(_: TokenStream, item: TokenStream) -> TokenStream {
 ///         #[widget = (self.map_fn)(data)]
 ///         pub inner: W,
 ///         map_fn: F,
-///         _data: PhantomData<A>,
+///         _a: std::marker::PhantomData<dyn Fn(A) + Send + Sync>,
 ///     }
 ///
 ///     impl Widget for Self {

--- a/crates/kas-widgets/src/adapt/adapt.rs
+++ b/crates/kas-widgets/src/adapt/adapt.rs
@@ -197,7 +197,7 @@ mod Map {
         #[widget = (self.map_fn)(data)]
         pub inner: W,
         map_fn: F,
-        _data: PhantomData<A>,
+        _a: PhantomData<dyn Fn(A) + Send + Sync>,
     }
 
     impl Widget for Self {
@@ -213,7 +213,7 @@ mod Map {
             Map {
                 inner,
                 map_fn,
-                _data: PhantomData,
+                _a: PhantomData,
             }
         }
     }

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -99,7 +99,7 @@ pub trait EditGuard: Sized {
 /// This guard should probably not be used for a functional user-interface but
 /// may be useful in mock UIs.
 #[autoimpl(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct DefaultGuard<A>(PhantomData<A>);
+pub struct DefaultGuard<A>(PhantomData<dyn Fn(A) + Send + Sync>);
 impl<A: 'static> EditGuard for DefaultGuard<A> {
     type Data = A;
 }

--- a/crates/kas-widgets/src/separator.rs
+++ b/crates/kas-widgets/src/separator.rs
@@ -18,7 +18,7 @@ mod Separator {
     #[widget]
     pub struct Separator<A> {
         core: widget_core!(),
-        _pd: PhantomData<A>,
+        _a: PhantomData<dyn Fn(A) + Send + Sync>,
     }
 
     impl Self {
@@ -27,7 +27,7 @@ mod Separator {
         pub fn new() -> Self {
             Separator {
                 core: Default::default(),
-                _pd: PhantomData,
+                _a: PhantomData,
             }
         }
     }


### PR DESCRIPTION
This uses atomic reference counting to support `Send + Sync` in `Id` and `ImageHandle`. This has a small performance cost and isn't strictly-speaking required for a single-threaded UI, but has some utility (for example, allowing a worker thread to construct a new widget then send it to the UI thread).

The `DB` used by `Id` to support `try_from_u64` (required for AccessKit compatibility) is now global locked behind a `Mutex` instead of thread-local. Ideally it would just be `static mut` but accessible to only the primary UI thread, but this should be good enough. (Better yet, we wouldn't need this hack for AccessKit interoperability.)

Widgets `MapAny`, `Map`, `Separator` and edit-guard `DefaultGuard` now use `PhantomData<dyn Fn(A) + Send + Sync>` instead of `PhantomData<A>` to make them [contravariant](https://doc.rust-lang.org/stable/reference/subtyping.html#variance) with respect to A and let them impl `Send + Sync` independent of `A`.