### PR TITLE
ListView: add fns with_load_ahead, with_min_alloc_len

### DIFF
--- a/crates/kas-view/src/clerk.rs
+++ b/crates/kas-view/src/clerk.rs
@@ -3,32 +3,41 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! Data clerks
+//! A clerk (pronounced "klark" or "klerk") is:
+//!
+//! > One who occupationally provides assistance by working with records,
+//! > accounts, letters, etc.; an office worker.
+//!
+//! (See [clerk - Wiktionary](https://en.wiktionary.org/wiki/clerk).)
 //!
 //! # Interfaces
 //!
-//! A clerk manages a view or query over a data set using an `Index` type
-//! specified by the [view controller](crate#view-controller). For
-//! [`ListView`](crate::ListView), `Index = usize`.
+//! Each [view controller](crate#view-controller) uses a clerk to access data
+//! records. Clerks are user-defined types and must implement [`Clerk`]:
 //!
-//! All clerks must implement [`Clerk`]:
+//! All clerks must implement [`Clerk`] as well as at least one of the other
+//! traits below:
 //!
 //! -   [`Clerk`] covers the base functionality required by all clerks
 //!
-//! ## Data generators
+//! The `Index` type parameter used by [`Clerk`] must correspond to the view
+//! controller; for example [`ListView`](crate::ListView) requires
+//! `Index = usize`.
 //!
-//! Generator clerks construct owned items. One of the following traits must be
-//! implemented:
+//! ## Generator Clerks
+//!
+//! A generator clerk constructs owned data items on demand and must implement
+//! one of the following traits:
 //!
 //! -   [`IndexedGenerator`] provides a very simple interface: `update` and
 //!     `generate`.
 //! -   [`KeyedGenerator`] is slightly more complex, supporting a custom key
 //!     type (thus allowing data items to be tracked through changing indices).
 //!
-//! ## Async data access
+//! ## Async Clerks
 //!
-//! Async clerks allow borrowed access to locally cached items. Such clerks must
-//! implement both [`AsyncClerk`] and [`TokenClerk`]:
+//! An async clerk allows borrowed access to locally cached items. Such clerks
+//! must implement both [`AsyncClerk`] and [`TokenClerk`]:
 //!
 //! -   [`AsyncClerk`] supports async data access with a local cache and batched
 //!     item retrieval.

--- a/examples/file-explorer/src/viewer/dir.rs
+++ b/examples/file-explorer/src/viewer/dir.rs
@@ -129,11 +129,23 @@ mod DirView {
             .with_style(FrameStyle::EditBox)
             .with_margin_style(MarginStyle::None)
     )]
-    #[derive(Default)]
     pub struct DirView {
         core: widget_core!(),
         #[widget]
         list: ScrollRegion<ListView<Clerk, crate::tile::Driver, kas::dir::Down>>,
+    }
+
+    impl Self {
+        pub fn new() -> Self {
+            DirView {
+                core: Default::default(),
+                list: ScrollRegion::new_viewport(
+                    ListView::default()
+                        .with_load_ahead(2)
+                        .with_min_alloc_len(100),
+                ),
+            }
+        }
     }
 
     impl Events for Self {

--- a/examples/file-explorer/src/viewer/mod.rs
+++ b/examples/file-explorer/src/viewer/mod.rs
@@ -5,5 +5,5 @@ mod dir;
 use kas::prelude::*;
 
 pub fn viewer() -> impl Widget<Data = crate::Data> {
-    dir::DirView::default()
+    dir::DirView::new()
 }


### PR DESCRIPTION
Support (predictive) load-ahead and load cache for `ListView` view widgets, and use in the file explorer.

Note that load-ahead and caching could instead be implemented in the async clerk. This would be "better" (in that only the minimum amount of data is cached, not whole widgets) but would require significant revisions to the file explorer and also would require using `Sprite` over custom code rendering images and SVG to (GPU) buffers instead of using the `Image` and `Svg` widgets.

Since this approach only really requires a couple of lines in the (`file-explorer`) app this approach will be preferable for many users.