### PR TITLE
Remove type parameter D: DrawImpl from kas::theme::dimensions::Window

### DIFF
--- a/crates/kas-core/src/theme/dimensions.rs
+++ b/crates/kas-core/src/theme/dimensions.rs
@@ -160,14 +160,14 @@ impl Dimensions {
     }
 }
 
-/// A convenient implementation of [`crate::window::Window`]
-pub struct Window<D> {
+/// A convenient implementation of [`crate::theme::Window`]
+pub struct Window {
     pub config: Rc<RefCell<Config>>,
     pub dims: Dimensions,
-    pub anim: AnimState<D>,
+    pub anim: AnimState,
 }
 
-impl<D> Window<D> {
+impl Window {
     pub fn new(dims: &Parameters, config: &WindowConfig) -> Self {
         Window {
             config: config.clone_base(),
@@ -187,7 +187,7 @@ impl<D> Window<D> {
     }
 }
 
-impl<D: 'static> super::Window for Window<D> {
+impl super::Window for Window {
     fn size(&self) -> &dyn ThemeSize {
         self
     }
@@ -197,7 +197,7 @@ impl<D: 'static> super::Window for Window<D> {
     }
 }
 
-impl<D: 'static> ThemeSize for Window<D> {
+impl ThemeSize for Window {
     fn scale_factor(&self) -> f32 {
         self.dims.scale
     }

--- a/crates/kas-core/src/theme/flat_theme.rs
+++ b/crates/kas-core/src/theme/flat_theme.rs
@@ -79,7 +79,7 @@ fn dimensions() -> dim::Parameters {
 pub struct DrawHandle<'a, DS: DrawSharedImpl> {
     pub(crate) draw: DrawIface<'a, DS>,
     pub(crate) ev: &'a mut EventState,
-    pub(crate) w: &'a mut dim::Window<DS::Draw>,
+    pub(crate) w: &'a mut dim::Window,
     pub(crate) cols: &'a ColorsLinear,
 }
 
@@ -87,7 +87,7 @@ impl<DS: DrawSharedImpl> Theme<DS> for FlatTheme
 where
     DS::Draw: DrawRoundedImpl,
 {
-    type Window = dim::Window<DS::Draw>;
+    type Window = dim::Window;
     type Draw<'a> = DrawHandle<'a, DS>;
 
     fn init(&mut self, config: &RefCell<Config>) {

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -55,12 +55,12 @@ impl SimpleTheme {
 pub struct DrawHandle<'a, DS: DrawSharedImpl> {
     pub(crate) draw: DrawIface<'a, DS>,
     pub(crate) ev: &'a mut EventState,
-    pub(crate) w: &'a mut dim::Window<DS::Draw>,
+    pub(crate) w: &'a mut dim::Window,
     pub(crate) cols: &'a ColorsLinear,
 }
 
 impl<DS: DrawSharedImpl> Theme<DS> for SimpleTheme {
-    type Window = dim::Window<DS::Draw>;
+    type Window = dim::Window;
     type Draw<'a> = DrawHandle<'a, DS>;
 
     fn init(&mut self, _: &RefCell<Config>) {}

--- a/crates/kas-wgpu/src/shaded_theme.rs
+++ b/crates/kas-wgpu/src/shaded_theme.rs
@@ -68,7 +68,7 @@ const NORMS_RAISED: (f32, f32) = (0.0, 0.7);
 pub struct DrawHandle<'a, DS: DrawSharedImpl> {
     draw: DrawIface<'a, DS>,
     ev: &'a mut EventState,
-    w: &'a mut dim::Window<DS::Draw>,
+    w: &'a mut dim::Window,
     cols: &'a ColorsLinear,
 }
 
@@ -76,7 +76,7 @@ impl<DS: DrawSharedImpl> Theme<DS> for ShadedTheme
 where
     DS::Draw: DrawRoundedImpl + DrawShadedImpl,
 {
-    type Window = dim::Window<DS::Draw>;
+    type Window = dim::Window;
     type Draw<'a> = DrawHandle<'a, DS>;
 
     fn init(&mut self, config: &RefCell<Config>) {


### PR DESCRIPTION
There doesn't seem to be a reason to keep this complication.