### PR TITLE
Fix doc link to Id::try_from_u64 being feature-gated

### DIFF
--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -567,8 +567,11 @@ impl Id {
     /// This conversion is infallible but not free.
     ///
     /// The result may be used in equality checks (with a *very* small risk of
-    /// false positive due to hash collision) and may be passed to
-    /// [`Self::try_from_u64`].
+    /// false positive due to hash collision).
+    #[cfg_attr(
+        feature = "accesskit",
+        doc = "The result may also be passed to [`Self::try_from_u64`]."
+    )]
     pub fn to_nzu64(&self) -> NonZeroU64 {
         self.0.to_nzu64()
     }

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -86,7 +86,7 @@ impl IntOrPtr {
         if self.is_ptr() {
             let p = usize::conv(self.0.get() & MASK_PTR);
             let a: Arc = unsafe { transmute(p) };
-            let slice: &[usize] = &**a;
+            let slice: &[usize] = &a;
             let slice: &[usize] = unsafe { transmute(slice) };
             forget(a);
             Some(slice)

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -162,13 +162,17 @@ impl IntOrPtr {
         }
     }
 
+    fn bits_from_u64(n: u64) -> Option<IntOrPtr> {
+        (n & USE_MASK == USE_BITS).then(|| {
+            // TODO: sanity checks
+            IntOrPtr(NonZeroU64::new(n).unwrap(), PhantomData)
+        })
+    }
+
     #[cfg(feature = "accesskit")]
     fn try_from_u64(n: u64) -> Option<IntOrPtr> {
         match n & USE_MASK {
-            USE_BITS => {
-                // TODO: sanity checks
-                Some(IntOrPtr(NonZeroU64::new(n).unwrap(), PhantomData))
-            }
+            USE_BITS => Self::bits_from_u64(n),
             USE_PTR => {
                 let mut result = None;
                 let r = &mut result;
@@ -574,6 +578,13 @@ impl Id {
     )]
     pub fn to_nzu64(&self) -> NonZeroU64 {
         self.0.to_nzu64()
+    }
+
+    /// Try converting a `u64` to an `Id`, supporting only bit-packed representations
+    #[cfg_attr(not(feature = "internal_doc"), doc(hidden))]
+    #[cfg_attr(docsrs, doc(cfg(internal_doc)))]
+    pub fn bits_from_u64(n: u64) -> Option<Self> {
+        IntOrPtr::bits_from_u64(n).map(Id)
     }
 
     /// Try converting a `u64` to an `Id`

--- a/crates/kas-core/src/event/cx/timer.rs
+++ b/crates/kas-core/src/event/cx/timer.rs
@@ -84,7 +84,7 @@ impl EventState {
             self.time_updates.push((time, id, handle));
         }
 
-        self.time_updates.sort_by(|a, b| b.0.cmp(&a.0)); // reverse sort
+        self.time_updates.sort_by_key(|b| std::cmp::Reverse(b.0));
     }
 
     /// Schedule a frame timer update
@@ -138,6 +138,6 @@ impl<'a> EventCx<'a> {
             self.send_event(widget.re(), update.1, Event::Timer(update.2));
         }
 
-        self.time_updates.sort_by(|a, b| b.0.cmp(&a.0)); // reverse sort
+        self.time_updates.sort_by_key(|b| std::cmp::Reverse(b.0));
     }
 }

--- a/examples/reformat-id.rs
+++ b/examples/reformat-id.rs
@@ -59,7 +59,7 @@ fn main() {
         }
     };
 
-    if let Some(id) = Id::try_from_u64(n) {
+    if let Some(id) = Id::bits_from_u64(n) {
         let path: Vec<usize> = id.iter().collect();
         println!("{id}: {path:?}");
     } else {


### PR DESCRIPTION
Fixes the CI failure caused by #661 which somehow wasn't apparent in the UI when I merged it (possibly the page needed a refresh).

Tested locally with and without accesskit.