### PR TITLE
kas-text update, minor simplifications to the text APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,3 +169,7 @@ members = [
     "examples/file-explorer",
 ]
 resolver = "2"
+
+[patch.crates-io.kas-text]
+git = "https://github.com/kas-gui/kas-text.git"
+rev = "f8d88435996ccacebc4893793dc47580be2251b7"

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -120,6 +120,16 @@ impl<'a, DS: DrawSharedImpl> DrawIface<'a, DS> {
             pass,
         }
     }
+
+    /// Draw text with a colour
+    ///
+    /// Text is drawn from `pos` and clipped to `bounding_box`.
+    ///
+    /// The `text` display must be prepared prior to calling this method.
+    /// Typically this is done using a [`crate::theme::Text`] object.
+    pub fn text(&mut self, pos: Vec2, bounding_box: Quad, text: &TextDisplay, col: Rgba) {
+        self.text_effects(pos, bounding_box, text, &[col], &[]);
+    }
 }
 
 /// Basic draw interface for [`DrawIface`]
@@ -213,21 +223,12 @@ pub trait Draw {
     /// Draw the image in the given `rect`
     fn image(&mut self, id: ImageId, rect: Quad);
 
-    /// Draw text with a colour
-    ///
-    /// Text is drawn from `pos` and clipped to `bounding_box`.
-    ///
-    /// The `text` display must be prepared prior to calling this method.
-    /// Typically this is done using a [`crate::theme::Text`] object.
-    fn text(&mut self, pos: Vec2, bounding_box: Quad, text: &TextDisplay, col: Rgba);
-
     /// Draw text with effects
     ///
     /// Text is drawn from `pos` and clipped to `bounding_box`.
     ///
     /// The `effects` list provides underlining/strikethrough information via
-    /// [`Effect::flags`] and an index [`Effect::e`]. If `effects` is empty,
-    /// this is equivalent to [`Self::text`].
+    /// [`Effect::flags`] and an index [`Effect::e`].
     ///
     /// Text colour lookup uses index `e` and is essentially:
     /// `colors.get(e).unwrap_or(Rgba::BLACK)`.
@@ -290,12 +291,6 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
 
     fn image(&mut self, id: ImageId, rect: Quad) {
         self.shared.draw.draw_image(self.draw, self.pass, id, rect);
-    }
-
-    fn text(&mut self, pos: Vec2, bb: Quad, text: &TextDisplay, col: Rgba) {
-        self.shared
-            .draw
-            .draw_text(self.draw, self.pass, pos, bb, text, col);
     }
 
     fn text_effects(

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -228,10 +228,10 @@ pub trait Draw {
     /// Text is drawn from `pos` and clipped to `bounding_box`.
     ///
     /// The `effects` list provides underlining/strikethrough information via
-    /// [`Effect::flags`] and an index [`Effect::e`].
+    /// [`Effect::flags`] and an index [`Effect::color`].
     ///
-    /// Text colour lookup uses index `e` and is essentially:
-    /// `colors.get(e).unwrap_or(Rgba::BLACK)`.
+    /// Text colour lookup uses index `color` and is essentially:
+    /// `colors.get(color.unwrap_or(Rgba::BLACK)`.
     ///
     /// The `text` display must be prepared prior to calling this method.
     /// Typically this is done using a [`crate::theme::Text`] object.

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -204,10 +204,10 @@ pub trait DrawSharedImpl: Any {
     /// Draw text with effects
     ///
     /// The `effects` list provides underlining/strikethrough information via
-    /// [`Effect::flags`] and an index [`Effect::e`].
+    /// [`Effect::flags`] and an index [`Effect::color`].
     ///
-    /// Text colour lookup uses index `e` and is essentially:
-    /// `colors.get(e).unwrap_or(Rgba::BLACK)`.
+    /// Text colour lookup uses index `color` and is essentially:
+    /// `colors.get(color.unwrap_or(Rgba::BLACK)`.
     fn draw_text_effects(
         &mut self,
         draw: &mut Self::Draw,

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -201,22 +201,10 @@ pub trait DrawSharedImpl: Any {
     /// Draw the image in the given `rect`
     fn draw_image(&self, draw: &mut Self::Draw, pass: PassId, id: ImageId, rect: Quad);
 
-    /// Draw text with a colour
-    fn draw_text(
-        &mut self,
-        draw: &mut Self::Draw,
-        pass: PassId,
-        pos: Vec2,
-        bb: Quad,
-        text: &TextDisplay,
-        col: Rgba,
-    );
-
     /// Draw text with effects
     ///
     /// The `effects` list provides underlining/strikethrough information via
-    /// [`Effect::flags`] and an index [`Effect::e`]. If `effects` is empty,
-    /// this is equivalent to [`Self::draw_text`].
+    /// [`Effect::flags`] and an index [`Effect::e`].
     ///
     /// Text colour lookup uses index `e` and is essentially:
     /// `colors.get(e).unwrap_or(Rgba::BLACK)`.

--- a/crates/kas-core/src/text/mod.rs
+++ b/crates/kas-core/src/text/mod.rs
@@ -15,7 +15,7 @@
 
 pub use kas_text::{
     Align, DPU, Direction, Effect, EffectFlags, Line, LineIterator, MarkerPos, MarkerPosIter,
-    NotReady, OwningVecIter, Status, TextDisplay, Vec2, fonts, format,
+    NotReady, Status, TextDisplay, Vec2, fonts, format,
 };
 
 /// Glyph rastering

--- a/crates/kas-core/src/text/string.rs
+++ b/crates/kas-core/src/text/string.rs
@@ -12,7 +12,7 @@
 use crate::cast::Conv;
 use crate::event::Key;
 use crate::text::format::{FontToken, FormattableText};
-use crate::text::{Effect, EffectFlags};
+use crate::text::{Effect, EffectFlags, fonts::FontSelector};
 
 /// An access key string
 ///
@@ -62,7 +62,7 @@ impl AccessString {
 
                     let e0 = Effect {
                         start,
-                        e: 0,
+                        color: 0,
                         flags: EffectFlags::UNDERLINE,
                     };
 
@@ -71,7 +71,7 @@ impl AccessString {
 
                     let e1 = Effect {
                         start: start + u32::conv(i),
-                        e: 0,
+                        color: 0,
                         flags: EffectFlags::empty(),
                     };
 
@@ -101,15 +101,13 @@ impl AccessString {
 }
 
 impl FormattableText for AccessString {
-    type FontTokenIter<'a> = std::iter::Empty<FontToken>;
-
     #[inline]
     fn as_str(&self) -> &str {
         &self.text
     }
 
     #[inline]
-    fn font_tokens(&self, _: f32) -> Self::FontTokenIter<'_> {
+    fn font_tokens(&self, _: f32, _: FontSelector) -> impl Iterator<Item = FontToken> {
         std::iter::empty()
     }
 

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -278,23 +278,11 @@ impl<'a> DrawCx<'a> {
     ///
     /// Text is clipped to `rect`.
     ///
-    /// This is a convenience method over [`Self::text_with_effects`].
+    /// This is a convenience method over [`Self::text_with_position`].
     ///
     /// The `text` should be prepared before calling this method.
     pub fn text<T: FormattableText>(&mut self, rect: Rect, text: &Text<T>) {
         self.text_with_position(rect.pos, rect, text);
-    }
-
-    /// Draw text with specified color
-    ///
-    /// Text is clipped to `rect` and drawn using `color`.
-    ///
-    /// This is a convenience method over [`Self::text_with_effects`].
-    ///
-    /// The `text` should be prepared before calling this method.
-    pub fn text_with_color<T: FormattableText>(&mut self, rect: Rect, text: &Text<T>, color: Rgba) {
-        let effects = text.effect_tokens();
-        self.text_with_effects(rect.pos, rect, text, &[color], effects);
     }
 
     /// Draw text with effects and an offset
@@ -311,8 +299,22 @@ impl<'a> DrawCx<'a> {
         rect: Rect,
         text: &Text<T>,
     ) {
-        let effects = text.effect_tokens();
-        self.text_with_effects(pos, rect, text, &[], effects);
+        if let Ok(display) = text.display() {
+            self.text_with_effects(pos, rect, display, &[], text.effect_tokens());
+        }
+    }
+
+    /// Draw text with specified color
+    ///
+    /// Text is clipped to `rect` and drawn using `color`.
+    ///
+    /// This is a convenience method over [`Self::text_with_effects`].
+    ///
+    /// The `text` should be prepared before calling this method.
+    pub fn text_with_color<T: FormattableText>(&mut self, rect: Rect, text: &Text<T>, color: Rgba) {
+        if let Ok(display) = text.display() {
+            self.text_with_effects(rect.pos, rect, display, &[color], text.effect_tokens());
+        }
     }
 
     /// Draw text with a given effect list
@@ -334,29 +336,28 @@ impl<'a> DrawCx<'a> {
     /// Text objects may embed their own list of effects, accessible using
     /// [`Text::effect_tokens`]. It is always valid to disregard these
     /// and use a custom `effects` list or empty list.
-    pub fn text_with_effects<T: FormattableText>(
+    #[inline]
+    pub fn text_with_effects(
         &mut self,
         pos: Coord,
         rect: Rect,
-        text: &Text<T>,
+        display: &TextDisplay,
         colors: &[Rgba],
         effects: &[Effect],
     ) {
-        if let Ok(display) = text.display() {
-            if cfg!(debug_assertions) {
-                let num_colors = if colors.is_empty() { 1 } else { colors.len() };
-                let mut i = 0;
-                for effect in effects {
-                    assert!(effect.start >= i);
-                    i = effect.start;
+        if cfg!(debug_assertions) {
+            let num_colors = if colors.is_empty() { 1 } else { colors.len() };
+            let mut i = 0;
+            for effect in effects {
+                assert!(effect.start >= i);
+                i = effect.start;
 
-                    assert!(usize::from(effect.e) < num_colors);
-                }
+                assert!(usize::from(effect.e) < num_colors);
             }
-
-            self.h
-                .text_effects(&self.id, pos, rect, display, colors, effects);
         }
+
+        self.h
+            .text_effects(&self.id, pos, rect, display, colors, effects);
     }
 
     /// Draw some text with a selection

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -343,25 +343,19 @@ impl<'a> DrawCx<'a> {
         effects: &[Effect],
     ) {
         if let Ok(display) = text.display() {
-            if effects.is_empty() {
-                // Use the faster and simpler implementation when we don't have effects
-                self.h
-                    .text(&self.id, pos, rect, display, colors.first().cloned());
-            } else {
-                if cfg!(debug_assertions) {
-                    let num_colors = if colors.is_empty() { 1 } else { colors.len() };
-                    let mut i = 0;
-                    for effect in effects {
-                        assert!(effect.start >= i);
-                        i = effect.start;
+            if cfg!(debug_assertions) {
+                let num_colors = if colors.is_empty() { 1 } else { colors.len() };
+                let mut i = 0;
+                for effect in effects {
+                    assert!(effect.start >= i);
+                    i = effect.start;
 
-                        assert!(usize::from(effect.e) < num_colors);
-                    }
+                    assert!(usize::from(effect.e) < num_colors);
                 }
-
-                self.h
-                    .text_effects(&self.id, pos, rect, display, colors, effects);
             }
+
+            self.h
+                .text_effects(&self.id, pos, rect, display, colors, effects);
         }
     }
 
@@ -550,19 +544,11 @@ pub trait ThemeDraw {
     /// Draw a selection highlight / frame
     fn selection(&mut self, rect: Rect, style: SelectionStyle);
 
-    /// Draw text
-    ///
-    /// The `text` should be prepared before calling this method.
-    fn text(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay, color: Option<Rgba>);
-
     /// Draw text with effects
     ///
-    /// [`ThemeDraw::text`] already supports *font* effects: bold,
-    /// emphasis, text size. In addition, this method supports underline and
-    /// strikethrough effects.
-    ///
-    /// If `effects` is empty or all [`Effect::flags`] are default then it is
-    /// equivalent (and faster) to call [`Self::text`] instead.
+    /// *Font* effects (e.g. bold, italics, text size) must be baked into the
+    /// [`TextDisplay`] during preparation. In contrast, "display" `effects`
+    /// (e.g. color, underline) are applied only when drawing.
     ///
     /// The `text` should be prepared before calling this method.
     fn text_effects(

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -326,7 +326,7 @@ impl<'a> DrawCx<'a> {
     /// Text is then drawn using `colors[0]` except as specified by effects.
     ///
     /// The list of `effects` (if not empty) controls render effects:
-    /// [`Effect::e`] is an index into `colors` while [`Effect::flags`] controls
+    /// [`Effect::color`] is an index into `colors` while [`Effect::flags`] controls
     /// underline and strikethrough. [`Effect::start`] is the text index at
     /// which this effect first takes effect, and must effects must be ordered
     /// such that the sequence of [`Effect::start`] values is strictly
@@ -352,7 +352,7 @@ impl<'a> DrawCx<'a> {
                 assert!(effect.start >= i);
                 i = effect.start;
 
-                assert!(usize::from(effect.e) < num_colors);
+                assert!(usize::from(effect.color) < num_colors);
             }
         }
 

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -348,18 +348,6 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
         }
     }
 
-    fn text(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay, color: Option<Rgba>) {
-        let bb = Quad::conv(rect);
-        let col = color.unwrap_or_else(|| {
-            if self.ev.is_disabled(id) {
-                self.cols.text_disabled
-            } else {
-                self.cols.text
-            }
-        });
-        self.draw.text(pos.cast(), bb, text, col);
-    }
-
     fn text_effects(
         &mut self,
         id: &Id,

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -401,17 +401,17 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
         let effects = [
             Effect {
                 start: 0,
-                e: 0,
+                color: 0,
                 flags: Default::default(),
             },
             Effect {
                 start: range.start.cast(),
-                e: 1,
+                color: 1,
                 flags: Default::default(),
             },
             Effect {
                 start: range.end.cast(),
-                e: 0,
+                color: 0,
                 flags: Default::default(),
             },
         ];

--- a/crates/kas-core/src/theme/text.rs
+++ b/crates/kas-core/src/theme/text.rs
@@ -450,7 +450,7 @@ impl<T: FormattableText> Text<T> {
                 .display
                 .prepare_runs(&self.text, self.direction, self.font, self.dpem)
                 .expect("no suitable font found"),
-            Status::ResizeLevelRuns => self.display.resize_runs(&self.text, self.dpem),
+            Status::ResizeLevelRuns => self.display.resize_runs(&self.text, self.font, self.dpem),
             _ => return,
         }
 

--- a/crates/kas-macros/src/extends.rs
+++ b/crates/kas-macros/src/extends.rs
@@ -80,10 +80,6 @@ impl Methods {
                 (#base).selection(rect, style);
             }
 
-            fn text(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay, color: Option<Rgba>) {
-                (#base).text(id, pos, rect, text, color);
-            }
-
             fn text_effects(
                 &mut self,
                 id: &Id,

--- a/crates/kas-soft/src/draw.rs
+++ b/crates/kas-soft/src/draw.rs
@@ -178,22 +178,6 @@ impl DrawSharedImpl for Shared {
         }
     }
 
-    #[inline]
-    fn draw_text(
-        &mut self,
-        draw: &mut Draw,
-        pass: PassId,
-        pos: Vec2,
-        bb: Quad,
-        text: &text::TextDisplay,
-        col: color::Rgba,
-    ) {
-        let time = std::time::Instant::now();
-        self.text
-            .text(&mut self.images, &mut draw.images, pass, pos, bb, text, col);
-        draw.common.report_dur_text(time.elapsed());
-    }
-
     fn draw_text_effects(
         &mut self,
         draw: &mut Draw,

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -356,22 +356,6 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
         };
     }
 
-    #[inline]
-    fn draw_text(
-        &mut self,
-        draw: &mut Self::Draw,
-        pass: PassId,
-        pos: Vec2,
-        bb: Quad,
-        text: &TextDisplay,
-        col: Rgba,
-    ) {
-        let time = std::time::Instant::now();
-        self.text
-            .text(&mut self.images, &mut draw.images, pass, pos, bb, text, col);
-        draw.common.report_dur_text(time.elapsed());
-    }
-
     fn draw_text_effects(
         &mut self,
         draw: &mut Self::Draw,

--- a/crates/kas-widgets/src/access_label.rs
+++ b/crates/kas-widgets/src/access_label.rs
@@ -134,7 +134,9 @@ mod AccessLabel {
                 && draw.access_key(&self.target, key)
             {
                 // Stop on first successful binding and draw
-                draw.text_with_effects(rect.pos, rect, &self.text, &[], effects);
+                if let Ok(display) = self.text.display() {
+                    draw.text_with_effects(rect.pos, rect, display, &[], effects);
+                }
             } else {
                 draw.text(rect, &self.text);
             }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -182,7 +182,9 @@ impl Component {
                     flags: Default::default(),
                 },
             ];
-            draw.text_with_effects(pos, rect, &self.text, &[], &effects);
+            if let Ok(display) = self.text.display() {
+                draw.text_with_effects(pos, rect, display, &[], &effects);
+            }
         } else {
             draw.text_with_selection(pos, rect, &self.text, self.selection.range());
         }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -168,17 +168,17 @@ impl Component {
             let effects = [
                 Effect {
                     start: 0,
-                    e: 0,
+                    color: 0,
                     flags: Default::default(),
                 },
                 Effect {
                     start: edit_range.start,
-                    e: 0,
+                    color: 0,
                     flags: EffectFlags::UNDERLINE,
                 },
                 Effect {
                     start: edit_range.end,
-                    e: 0,
+                    color: 0,
                     flags: Default::default(),
                 },
             ];


### PR DESCRIPTION
Remove fn `ThemeDraw::text` since effectively it's only a very minor optimisation over `text_effects`.

Remove generics from fn `DrawCx::text_with_effects`. This makes calling the method slightly less convenient but this isn't a big deal (in most cases one of the higher-level text fns is used instead). Moreover, I wish to emphasise that this is a low-level method.

Updates kas-text for kas-gui/kas-text#126.