### PR TITLE
kas::text::format::Color: use internal 32-bit RGBA value

### DIFF
--- a/crates/kas-core/src/draw/color.rs
+++ b/crates/kas-core/src/draw/color.rs
@@ -360,6 +360,26 @@ impl Rgba8Srgb {
         Self::rgba(s, s, s, a)
     }
 
+    /// Get the red component
+    pub const fn r(self) -> u8 {
+        self.0[0]
+    }
+
+    /// Get the green component
+    pub const fn g(self) -> u8 {
+        self.0[1]
+    }
+
+    /// Get the blue component
+    pub const fn b(self) -> u8 {
+        self.0[2]
+    }
+
+    /// Get the alpha component
+    pub const fn a(self) -> u8 {
+        self.0[3]
+    }
+
     /// Format to a string
     ///
     /// This looks like `#123456` if the alpha component is opaque, otherwise

--- a/crates/kas-core/src/draw/draw.rs
+++ b/crates/kas-core/src/draw/draw.rs
@@ -137,10 +137,10 @@ impl<'a, DS: DrawSharedImpl> DrawIface<'a, DS> {
         col: Rgba,
     ) {
         let tokens = [(0, format::Colors {
-            color: format::Color::from_index(0).unwrap(),
+            color: format::Color::from_rgba(col),
             ..Default::default()
         })];
-        self.text(pos, bounding_box, text, theme, &[col], &tokens);
+        self.text(pos, bounding_box, text, theme, &tokens);
     }
 }
 
@@ -247,7 +247,6 @@ pub trait Draw {
         bounding_box: Quad,
         text: &TextDisplay,
         theme: &ColorsLinear,
-        palette: &[Rgba],
         tokens: &[(u32, format::Colors)],
     );
 
@@ -261,7 +260,6 @@ pub trait Draw {
         bounding_box: Quad,
         text: &TextDisplay,
         theme: &ColorsLinear,
-        palette: &[Rgba],
         decorations: &[(u32, format::Decoration)],
     );
 }
@@ -320,12 +318,11 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
         bb: Quad,
         text: &TextDisplay,
         theme: &ColorsLinear,
-        palette: &[Rgba],
         tokens: &[(u32, format::Colors)],
     ) {
         self.shared
             .draw
-            .draw_text(self.draw, self.pass, pos, bb, text, theme, palette, tokens);
+            .draw_text(self.draw, self.pass, pos, bb, text, theme, tokens);
     }
 
     fn decorate_text(
@@ -334,19 +331,11 @@ impl<'a, DS: DrawSharedImpl> Draw for DrawIface<'a, DS> {
         bb: Quad,
         text: &TextDisplay,
         theme: &ColorsLinear,
-        palette: &[Rgba],
         decorations: &[(u32, format::Decoration)],
     ) {
-        self.shared.draw.decorate_text(
-            self.draw,
-            self.pass,
-            pos,
-            bb,
-            text,
-            theme,
-            palette,
-            decorations,
-        );
+        self.shared
+            .draw
+            .decorate_text(self.draw, self.pass, pos, bb, text, theme, decorations);
     }
 }
 

--- a/crates/kas-core/src/draw/draw_shared.rs
+++ b/crates/kas-core/src/draw/draw_shared.rs
@@ -5,7 +5,6 @@
 
 //! Drawing APIs — shared draw state
 
-use super::color::Rgba;
 use super::{DrawImpl, PassId};
 use crate::ActionRedraw;
 use crate::config::RasterConfig;
@@ -216,7 +215,6 @@ pub trait DrawSharedImpl: Any {
         bounding_box: Quad,
         text: &TextDisplay,
         theme: &ColorsLinear,
-        palette: &[Rgba],
         tokens: &[(u32, format::Colors)],
     );
 
@@ -232,7 +230,6 @@ pub trait DrawSharedImpl: Any {
         bounding_box: Quad,
         text: &TextDisplay,
         theme: &ColorsLinear,
-        palette: &[Rgba],
         decorations: &[(u32, format::Decoration)],
     );
 }

--- a/crates/kas-core/src/text/raster.rs
+++ b/crates/kas-core/src/text/raster.rs
@@ -544,7 +544,6 @@ impl State {
         bb: Quad,
         text: &TextDisplay,
         theme: &ColorsLinear,
-        palette: &[Rgba],
         tokens: &[(u32, Colors)],
         mut draw_quad: impl FnMut(Quad, Rgba),
     ) {
@@ -555,7 +554,7 @@ impl State {
                 .map(|e| e.1 == Default::default())
                 .unwrap_or(true)
         {
-            let col = Color::default().resolve_color(theme, palette, None);
+            let col = Color::default().resolve_color(theme, None);
             self.text_with_color(allocator, queue, pass, pos, bb, text, col);
             return;
         }
@@ -576,12 +575,12 @@ impl State {
                     }
                 };
 
-                let col = token.color.resolve_color(theme, palette, None);
+                let col = token.color.resolve_color(theme, None);
                 queue.push_sprite(pass, glyph.position.into(), bb, col, sprite);
             };
 
             let for_range = |p: kas_text::Vec2, x2, colors: Colors| {
-                let Some(col) = colors.resolve_background_color(theme, palette) else {
+                let Some(col) = colors.resolve_background_color(theme) else {
                     return;
                 };
 
@@ -604,7 +603,6 @@ impl State {
         bb: Quad,
         text: &TextDisplay,
         theme: &ColorsLinear,
-        palette: &[Rgba],
         tokens: &[(u32, Decoration)],
         mut draw_quad: impl FnMut(Quad, Rgba),
     ) {
@@ -635,7 +633,7 @@ impl State {
                 };
 
                 // Known limitation: this cannot depend on the background color.
-                let col = token.color.resolve_color(theme, palette, None);
+                let col = token.color.resolve_color(theme, None);
 
                 match token.style {
                     LineStyle::Solid => draw_quad(quad, col),

--- a/crates/kas-core/src/theme/draw.rs
+++ b/crates/kas-core/src/theme/draw.rs
@@ -303,8 +303,8 @@ impl<'a> DrawCx<'a> {
     ) {
         if let Ok(display) = text.display() {
             let tokens = text.color_tokens();
-            self.text_with_colors(pos, rect, display, &[], tokens);
-            self.decorate_text(pos, rect, display, &[], text.decorations());
+            self.text_with_colors(pos, rect, display, tokens);
+            self.decorate_text(pos, rect, display, text.decorations());
         }
     }
 
@@ -319,13 +319,12 @@ impl<'a> DrawCx<'a> {
     /// The `text` should be prepared before calling this method.
     pub fn text_with_color<T: FormattableText>(&mut self, rect: Rect, text: &Text<T>, color: Rgba) {
         if let Ok(display) = text.display() {
-            let colors = &[color];
             let tokens = [(0, format::Colors {
-                color: format::Color::from_index(0).unwrap(),
+                color: format::Color::from_rgba(color),
                 ..Default::default()
             })];
-            self.text_with_colors(rect.pos, rect, display, colors, &tokens);
-            self.decorate_text(rect.pos, rect, display, colors, text.decorations());
+            self.text_with_colors(rect.pos, rect, display, &tokens);
+            self.decorate_text(rect.pos, rect, display, text.decorations());
         }
     }
 
@@ -348,20 +347,17 @@ impl<'a> DrawCx<'a> {
         pos: Coord,
         rect: Rect,
         display: &TextDisplay,
-        palette: &[Rgba],
         tokens: &[(u32, format::Colors)],
     ) {
         if cfg!(debug_assertions) {
             let mut i = 0;
-            for (start, token) in tokens {
+            for (start, _) in tokens {
                 assert!(*start >= i);
                 i = *start;
-                token.color.validate(palette);
-                token.background.map(|bg| bg.validate(palette));
             }
         }
 
-        self.h.text(&self.id, pos, rect, display, palette, tokens);
+        self.h.text(&self.id, pos, rect, display, tokens);
     }
 
     /// Draw text decorations (e.g. underlines)
@@ -376,21 +372,19 @@ impl<'a> DrawCx<'a> {
         pos: Coord,
         rect: Rect,
         display: &TextDisplay,
-        palette: &[Rgba],
         decorations: &[(u32, format::Decoration)],
     ) {
         if cfg!(debug_assertions) {
             let mut i = 0;
-            for (start, token) in decorations {
+            for (start, _) in decorations {
                 assert!(*start >= i);
                 i = *start;
-                token.color.validate(palette);
             }
         }
 
         if !decorations.is_empty() {
             self.h
-                .decorate_text(&self.id, pos, rect, display, palette, decorations);
+                .decorate_text(&self.id, pos, rect, display, decorations);
         }
     }
 
@@ -573,7 +567,6 @@ pub trait ThemeDraw {
         pos: Coord,
         rect: Rect,
         text: &TextDisplay,
-        palette: &[Rgba],
         tokens: &[(u32, format::Colors)],
     );
 
@@ -590,7 +583,6 @@ pub trait ThemeDraw {
         pos: Coord,
         rect: Rect,
         text: &TextDisplay,
-        palette: &[Rgba],
         decorations: &[(u32, format::Decoration)],
     );
 

--- a/crates/kas-core/src/theme/simple_theme.rs
+++ b/crates/kas-core/src/theme/simple_theme.rs
@@ -352,7 +352,6 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
         pos: Coord,
         rect: Rect,
         text: &TextDisplay,
-        palette: &[Rgba],
         tokens: &[(u32, format::Colors)],
     ) {
         // NOTE: id is passed to allow usage of self.cols.text_disabled if self.ev.is_disabled(id).
@@ -360,8 +359,7 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
         let _ = id;
 
         let bb = Quad::conv(rect);
-        self.draw
-            .text(pos.cast(), bb, text, self.cols, palette, tokens);
+        self.draw.text(pos.cast(), bb, text, self.cols, tokens);
     }
 
     fn decorate_text(
@@ -370,7 +368,6 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
         pos: Coord,
         rect: Rect,
         text: &TextDisplay,
-        palette: &[Rgba],
         decorations: &[(u32, format::Decoration)],
     ) {
         // NOTE: see above note on usage of self.cols.text_disabled.
@@ -378,7 +375,7 @@ impl<'a, DS: DrawSharedImpl> ThemeDraw for DrawHandle<'a, DS> {
 
         let bb = Quad::conv(rect);
         self.draw
-            .decorate_text(pos.cast(), bb, text, self.cols, palette, decorations);
+            .decorate_text(pos.cast(), bb, text, self.cols, decorations);
     }
 
     fn text_cursor(&mut self, id: &Id, pos: Coord, rect: Rect, text: &TextDisplay, byte: usize) {

--- a/crates/kas-macros/src/extends.rs
+++ b/crates/kas-macros/src/extends.rs
@@ -86,10 +86,9 @@ impl Methods {
                 pos: Coord,
                 rect: Rect,
                 text: &TextDisplay,
-                palette: &[Rgba],
                 tokens: &[(u32, ::kas::text::format::Colors)],
             ) {
-                (#base).text(id, pos, rect, text, palette, tokens);
+                (#base).text(id, pos, rect, text, tokens);
             }
 
             fn decorate_text(
@@ -98,10 +97,9 @@ impl Methods {
                 pos: Coord,
                 rect: Rect,
                 text: &TextDisplay,
-                palette: &[Rgba],
                 decorations: &[(u32, ::kas::text::format::Decoration)],
             ) {
-                (#base).decorate_text(id, pos, rect, text, palette, decorations);
+                (#base).decorate_text(id, pos, rect, text, decorations);
             }
 
             fn text_cursor(

--- a/crates/kas-soft/src/draw.rs
+++ b/crates/kas-soft/src/draw.rs
@@ -187,7 +187,6 @@ impl DrawSharedImpl for Shared {
         bb: Quad,
         text: &text::TextDisplay,
         theme: &ColorsLinear,
-        palette: &[color::Rgba],
         tokens: &[(u32, text::format::Colors)],
     ) {
         let time = std::time::Instant::now();
@@ -199,7 +198,6 @@ impl DrawSharedImpl for Shared {
             bb,
             text,
             theme,
-            palette,
             tokens,
             |quad, col| {
                 draw.basic.rect(pass, quad, col);
@@ -216,12 +214,11 @@ impl DrawSharedImpl for Shared {
         bb: Quad,
         text: &text::TextDisplay,
         theme: &ColorsLinear,
-        palette: &[color::Rgba],
         decorations: &[(u32, text::format::Decoration)],
     ) {
         let time = std::time::Instant::now();
         self.text
-            .decorate_text(pos, bb, text, theme, palette, decorations, |quad, col| {
+            .decorate_text(pos, bb, text, theme, decorations, |quad, col| {
                 draw.basic.rect(pass, quad, col);
             });
         draw.common.report_dur_text(time.elapsed());

--- a/crates/kas-wgpu/src/draw/draw_pipe.rs
+++ b/crates/kas-wgpu/src/draw/draw_pipe.rs
@@ -365,7 +365,6 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
         bb: Quad,
         text: &text::TextDisplay,
         theme: &ColorsLinear,
-        palette: &[color::Rgba],
         tokens: &[(u32, text::format::Colors)],
     ) {
         let time = std::time::Instant::now();
@@ -377,7 +376,6 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
             bb,
             text,
             theme,
-            palette,
             tokens,
             |quad, col| {
                 draw.shaded_square.rect(pass, quad, col);
@@ -394,12 +392,11 @@ impl<C: CustomPipe> DrawSharedImpl for DrawPipe<C> {
         bb: Quad,
         text: &text::TextDisplay,
         theme: &ColorsLinear,
-        palette: &[color::Rgba],
         decorations: &[(u32, text::format::Decoration)],
     ) {
         let time = std::time::Instant::now();
         self.text
-            .decorate_text(pos, bb, text, theme, palette, decorations, |quad, col| {
+            .decorate_text(pos, bb, text, theme, decorations, |quad, col| {
                 draw.shaded_square.rect(pass, quad, col);
             });
         draw.common.report_dur_text(time.elapsed());

--- a/crates/kas-widgets/src/access_label.rs
+++ b/crates/kas-widgets/src/access_label.rs
@@ -136,7 +136,7 @@ mod AccessLabel {
             {
                 // Stop on first successful binding and draw
                 if let Ok(display) = self.text.display() {
-                    draw.decorate_text(rect.pos, rect, display, &[], decoration);
+                    draw.decorate_text(rect.pos, rect, display, decoration);
                 }
             }
         }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -178,7 +178,7 @@ impl Component {
             let r0 = if range.start > 0 { 0 } else { 1 };
             &tokens[r0..]
         };
-        draw.text_with_colors(pos, rect, display, &[], tokens);
+        draw.text_with_colors(pos, rect, display, tokens);
 
         if let CurrentAction::ImePreedit { edit_range } = self.current.clone() {
             let tokens = [
@@ -190,7 +190,7 @@ impl Component {
                 (edit_range.end, Default::default()),
             ];
             let r0 = if edit_range.start > 0 { 0 } else { 1 };
-            draw.decorate_text(pos, rect, display, &[], &tokens[r0..]);
+            draw.decorate_text(pos, rect, display, &tokens[r0..]);
         }
 
         if self.editable && draw.ev_state().has_input_focus(self.id_ref()) == Some(true) {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -83,9 +83,9 @@ mod SelectableText {
                 let r0 = if range.start > 0 { 0 } else { 1 };
                 &tokens[r0..]
             };
-            draw.text_with_colors(pos, rect, display, &[], tokens);
+            draw.text_with_colors(pos, rect, display, tokens);
 
-            draw.decorate_text(pos, rect, display, &[], self.text.decorations());
+            draw.decorate_text(pos, rect, display, self.text.decorations());
         }
     }
 


### PR DESCRIPTION
Previously, a palette index was used for text colours. This stores the colour in effect tokens instead.

Advantages:

- Easier to map to from other APIs, e.g. highlighters which don't present colours via a palette
- Saves passing `palette: &[Rgba]` into text drawing functions

Disadvantages:

- Limited to 32-bit (sRGB) colours
- Larger effect tokens (8 bytes instead of 4)

As a space optimisation, completely transparent text will resolve to the theme's text colour instead.