### PR TITLE
Update kas-text; RTL fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,4 +172,4 @@ resolver = "2"
 
 [patch.crates-io.kas-text]
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "dc34ef6212dbe8ba539d50a0a3bff1bf2cbad102"
+rev = "a087ae3c083fb8e7f73282514b556ecc9083c95a"

--- a/crates/kas-core/src/config/shortcuts.rs
+++ b/crates/kas-core/src/config/shortcuts.rs
@@ -78,9 +78,16 @@ impl Shortcuts {
             let shortcuts = [
                 (NamedKey::ArrowLeft.into(), Command::WordLeft),
                 (NamedKey::ArrowRight.into(), Command::WordRight),
+                (NamedKey::Delete.into(), Command::DelWordBack),
             ];
+            map.extend(shortcuts.iter().cloned());
 
-            map.insert(NamedKey::Delete.into(), Command::DelWordBack);
+            let modifiers = ModifiersState::ALT | ModifiersState::SHIFT;
+            let map = self.map.entry(modifiers).or_insert_with(Default::default);
+            let shortcuts = [
+                (NamedKey::ArrowLeft.into(), Command::WordLeft),
+                (NamedKey::ArrowRight.into(), Command::WordRight),
+            ];
             map.extend(shortcuts.iter().cloned());
         }
 
@@ -166,6 +173,14 @@ impl Shortcuts {
                 (NamedKey::ArrowDown.into(), Command::DocEnd),
                 (NamedKey::ArrowLeft.into(), Command::Home),
                 (NamedKey::ArrowRight.into(), Command::End),
+            ];
+            map.extend(shortcuts.iter().cloned());
+        } else {
+            let shortcuts = [
+                (NamedKey::ArrowLeft.into(), Command::WordLeft),
+                (NamedKey::ArrowRight.into(), Command::WordRight),
+                (NamedKey::Home.into(), Command::DocHome),
+                (NamedKey::End.into(), Command::DocEnd),
             ];
             map.extend(shortcuts.iter().cloned());
         }

--- a/crates/kas-core/src/text/raster.rs
+++ b/crates/kas-core/src/text/raster.rs
@@ -587,6 +587,7 @@ impl State {
 
                 let a = Vec2(p.0, run.line_top());
                 let b = Vec2(x2, run.line_bottom());
+                debug_assert!(a <= b, "expected {a:?} <= {b:?}");
                 if let Some(quad) = Quad::from_coords(a, b).intersection(&bb) {
                     draw_quad(quad, col);
                 }

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -86,9 +86,17 @@ mod EditBox {
 
             let mut bar_rect = Rect::ZERO;
             if self.multi_line() {
+                // Set bar position, dependent on text direction. TODO: move on text-dir-change.
                 let bar_width = cx.scroll_bar_width();
-                let x1 = rect.pos.0 + rect.size.0;
-                let x0 = x1 - bar_width;
+                let (x0, x1);
+                if !self.inner.text_is_rtl() {
+                    x1 = rect.pos.0 + rect.size.0;
+                    x0 = x1 - bar_width;
+                } else {
+                    x0 = rect.pos.0;
+                    x1 = x0 + bar_width;
+                    rect.pos.0 = x1;
+                }
                 bar_rect = Rect::new(Coord(x0, rect.pos.1), Size(bar_width, rect.size.1));
                 rect.size.0 = (rect.size.0 - bar_width - self.inner_margin).max(0);
             }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -684,7 +684,7 @@ impl Editor {
     fn cmd_action(
         &mut self,
         cx: &mut EventCx,
-        cmd: Command,
+        mut cmd: Command,
         code: Option<PhysicalKey>,
     ) -> Result<EventAction, NotReady> {
         let editable = self.editable;
@@ -696,6 +696,16 @@ impl Editor {
         let selection = self.selection.range();
         let have_sel = selection.end > selection.start;
         let string;
+
+        if self.text_is_rtl() {
+            match cmd {
+                Command::Left => cmd = Command::Right,
+                Command::Right => cmd = Command::Left,
+                Command::WordLeft => cmd = Command::WordRight,
+                Command::WordRight => cmd = Command::WordLeft,
+                _ => (),
+            };
+        }
 
         enum Action<'a> {
             None,

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -1032,6 +1032,16 @@ impl Editor {
         self.text.clone_string()
     }
 
+    /// Get the (horizontal) text direction
+    ///
+    /// This returns `true` if the text is inferred to have right-to-left;
+    /// in other cases (including when the text is empty) it returns `false`.
+    /// TODO: support defaulting to RTL.
+    #[inline]
+    pub fn text_is_rtl(&self) -> bool {
+        self.text.text_is_rtl()
+    }
+
     /// Commit outstanding changes to the undo history
     ///
     /// Call this *before* changing the text with `set_str` or `set_string`


### PR DESCRIPTION
Updates kas-text with a number of fixes; see https://github.com/kas-gui/kas-text/pull/136.

Lets `EditBox` and `ScrollText` widgets put the vertical scroll-bar on the left when text is RTL. This is a quick hack which doesn't move the bar until a resize happens and with no way to force RTL direction (e.g. for an empty `EditBox`); TODO notes remain.

The `Editor` now reverses left/right keys on RTL text to match the dominant text direction, while continuing to move the cursor in a logically-consistent manner (not visually-consistent) with bidirectional text.

Enables shortcuts like Ctrl+Shift+Right to select text one word at a time.