### PR TITLE
Add fns send_{async,spawn}_opt; allow send_async to target AppData and send targets

### DIFF
--- a/crates/kas-core/src/core/events.rs
+++ b/crates/kas-core/src/core/events.rs
@@ -74,6 +74,10 @@ use crate::{Id, geom::Coord};
 /// Sizing must happen after initial configuration but is not necessarily
 /// repeated after reconfiguration. See [`Layout#sizing`].
 ///
+/// ### Event handling
+///
+/// See [Event handling model](crate::event#event-handling-model).
+///
 /// [`#widget`]: macros::widget
 pub trait Events: Widget + Sized {
     /// Does this widget have a different appearance on mouse over?

--- a/crates/kas-core/src/core/impls.rs
+++ b/crates/kas-core/src/core/impls.rs
@@ -154,19 +154,12 @@ pub fn _replay<W: Events>(widget: &mut W, cx: &mut EventCx, data: &<W as Widget>
         if let Some(scroll) = cx.post_send(index) {
             widget.handle_scroll(cx, data, scroll);
         }
+    } else if cfg!(debug_assertions) && id != widget.id_ref() {
+        log::debug!("_replay: broken path {id} after {}", widget.identify());
+    }
 
-        if cx.has_msg() {
-            widget.handle_messages(cx, data);
-        }
-    } else if id == widget.id_ref() {
+    if cx.has_msg() {
         widget.handle_messages(cx, data);
-    } else {
-        // This implies use of send_async / send_spawn from a widget which was
-        // unmapped or removed.
-        #[cfg(debug_assertions)]
-        log::debug!("_replay: {} cannot find path to {id}", widget.identify());
-
-        cx.drop_unsent();
     }
 }
 

--- a/crates/kas-core/src/core/widget_id.rs
+++ b/crates/kas-core/src/core/widget_id.rs
@@ -368,9 +368,12 @@ impl Id {
 
     /// Is the identifier valid?
     ///
-    /// Default-constructed identifiers are invalid. Comparing invalid ids is
-    /// considered a logic error and thus will panic in debug builds.
-    /// This method may be used to check an identifier's validity.
+    /// A valid [`Id`] represents a [path](Self::iter). Valid [`Id`] values are
+    /// assigned through [widget configuration](crate::Events#configuration).
+    ///
+    /// [`Id::default()`] is not valid. Most operations on invalid [`Id`] values
+    /// will panic (attempting to perform such an operations is considered a
+    /// logic error).
     pub fn is_valid(&self) -> bool {
         self.0.get() != Variant::Invalid
     }

--- a/crates/kas-core/src/event/cx/mod.rs
+++ b/crates/kas-core/src/event/cx/mod.rs
@@ -89,7 +89,7 @@ pub struct EventState {
     // Set of messages awaiting sending
     send_queue: VecDeque<(Id, Erased)>,
     // Set of futures of messages together with id of sending widget
-    fut_messages: Vec<(Id, Pin<Box<dyn Future<Output = Erased>>>)>,
+    fut_messages: Vec<(Id, Pin<Box<dyn Future<Output = Option<Erased>>>>)>,
     pub(super) pending_send_targets: Vec<(TypeId, Id)>,
     action_moved: Option<ActionMoved>,
     pub(crate) action_redraw: Option<ActionRedraw>,

--- a/crates/kas-core/src/event/cx/send.rs
+++ b/crates/kas-core/src/event/cx/send.rs
@@ -212,11 +212,6 @@ impl<'a> EventCx<'a> {
         self.runner.message_stack().get_op_count()
     }
 
-    /// Drop messages above the stack base.
-    pub(crate) fn drop_unsent(&mut self) {
-        self.runner.message_stack_mut().drop_unsent();
-    }
-
     /// Set a scroll action
     ///
     /// When setting [`Scroll::Rect`], use the widget's own coordinate space.

--- a/crates/kas-core/src/runner/mod.rs
+++ b/crates/kas-core/src/runner/mod.rs
@@ -95,11 +95,6 @@ impl MessageStack {
         self.stack.push(msg);
     }
 
-    /// Drop messages above the stack base.
-    pub(crate) fn drop_unsent(&mut self) {
-        self.stack.drain(self.base..);
-    }
-
     /// Drop remaining messages and reset
     pub(crate) fn clear(&mut self) {
         for msg in self.stack.drain(..) {

--- a/crates/kas-core/src/runner/shared.rs
+++ b/crates/kas-core/src/runner/shared.rs
@@ -212,9 +212,6 @@ pub(crate) trait RunnerT {
     /// Set send targets
     fn set_send_targets(&mut self, targets: &mut Vec<(TypeId, Id)>);
 
-    /// Find a send target for `type_id`, if any
-    fn send_target_for(&self, type_id: TypeId) -> Option<Id>;
-
     /// Attempt to get clipboard contents
     ///
     /// In case of failure, paste actions will simply fail. The implementation
@@ -327,11 +324,6 @@ impl<Data: AppData, G: GraphicsInstance, T: Theme<G::Shared>> RunnerT for Shared
         for (type_id, id) in targets.drain(..) {
             self.send_targets.insert(type_id, id);
         }
-    }
-
-    /// Find a send target for `type_id`, if any
-    fn send_target_for(&self, type_id: TypeId) -> Option<Id> {
-        self.send_targets.get(&type_id).cloned()
     }
 
     fn get_clipboard(&mut self) -> Option<String> {

--- a/examples/file-explorer/src/tile.rs
+++ b/examples/file-explorer/src/tile.rs
@@ -152,7 +152,7 @@ mod Tile {
                 write!(self.generic, "{}", entry.display()).unwrap();
 
                 let path = self.path.clone();
-                cx.send_spawn(self.id(), async move { detect(&path) });
+                cx.send_spawn_opt(self.id(), async move { detect(&path) });
             }
 
             // Always reset the page to 0 on change
@@ -160,7 +160,7 @@ mod Tile {
         }
 
         fn handle_messages(&mut self, cx: &mut EventCx, _: &Self::Data) {
-            if let Some(Some(SendBoxedWidget(w))) = cx.try_pop() {
+            if let Some(SendBoxedWidget(w)) = cx.try_pop() {
                 self.stack.truncate(cx, 1);
                 self.stack.push(cx, &self.generic, Page::new_boxed(w));
                 self.stack.set_active(cx, &self.generic, 1);


### PR DESCRIPTION
Previously `EventState::send_async` and derivatives would panic if `Id::default()` was used; now this may be used in the same ways as by `EventState::send`. This closes #666.

Also adds fns `send_async_opt` and `send_spawn_opt` to support futures which resolve to `None`.