### PR TITLE
Splitter resizing fixes

### DIFF
--- a/crates/kas-core/src/layout/flow_solver.rs
+++ b/crates/kas-core/src/layout/flow_solver.rs
@@ -88,6 +88,7 @@ impl FlowSolver {
                     &storage.rules[start..i],
                     total,
                     width,
+                    true,
                 );
                 storage.breaks.push(i);
                 start = i;
@@ -100,6 +101,7 @@ impl FlowSolver {
                 &storage.rules[start..],
                 total,
                 width,
+                true,
             );
         }
 
@@ -267,7 +269,7 @@ impl FlowSetter {
         if len != 0 {
             let height = rect.size.extract(direction.flipped());
             heights = vec![0; storage.height_rules.len()];
-            SizeRules::solve_widths(&mut heights, &storage.height_rules, height);
+            SizeRules::solve_widths(&mut heights, &storage.height_rules, height, true);
         }
 
         let mut row = FlowSetter {

--- a/crates/kas-core/src/layout/grid_solver.rs
+++ b/crates/kas-core/src/layout/grid_solver.rs
@@ -115,10 +115,10 @@ impl<CSR: DefaultWithLen, RSR: DefaultWithLen, S: GridStorage> GridSolver<CSR, R
         if self.axis.has_fixed {
             if self.axis.is_vertical() {
                 let (widths, rules) = storage.widths_and_rules();
-                SizeRules::solve_widths(widths, rules, self.axis.other_axis);
+                SizeRules::solve_widths(widths, rules, self.axis.other_axis, true);
             } else {
                 let (heights, rules) = storage.heights_and_rules();
-                SizeRules::solve_widths(heights, rules, self.axis.other_axis);
+                SizeRules::solve_widths(heights, rules, self.axis.other_axis, true);
             }
         }
 
@@ -257,7 +257,7 @@ impl<CT: RowTemp, RT: RowTemp, S: GridStorage> GridSetter<CT, RT, S> {
         if cols > 0 {
             let (widths, rules) = storage.widths_and_rules();
             let target = rect.size.0;
-            SizeRules::solve_widths(widths, rules, target);
+            SizeRules::solve_widths(widths, rules, target, true);
 
             w_offsets.as_mut()[0] = 0;
             for i in 1..w_offsets.as_mut().len() {
@@ -271,7 +271,7 @@ impl<CT: RowTemp, RT: RowTemp, S: GridStorage> GridSetter<CT, RT, S> {
         if rows > 0 {
             let (heights, rules) = storage.heights_and_rules();
             let target = rect.size.1;
-            SizeRules::solve_widths(heights, rules, target);
+            SizeRules::solve_widths(heights, rules, target, true);
 
             h_offsets.as_mut()[0] = 0;
             for i in 1..h_offsets.as_mut().len() {

--- a/crates/kas-macros/src/make_layout.rs
+++ b/crates/kas-macros/src/make_layout.rs
@@ -661,7 +661,7 @@ impl Layout {
             Layout::List(stor, dir, list) => {
                 let len = list.len();
                 let mut toks = quote! {
-                    let dim = (#dir, #len);
+                    let dim = (#dir, #len, true);
                     let mut solver = ::kas::layout::RowSolver::new(axis, dim, &mut #core_path.#stor);
                 };
                 for (index, item) in list.iter().enumerate() {
@@ -760,7 +760,7 @@ impl Layout {
             Layout::List(stor, dir, list) => {
                 let len = list.len();
                 let mut toks = quote! {
-                    let dim = (#dir, #len);
+                    let dim = (#dir, #len, true);
                     let mut setter = ::kas::layout::RowSetter::<_, Vec<i32>, _>::new(rect, dim, &mut #core_path.#stor);
                 };
                 for (index, item) in list.iter().enumerate() {

--- a/crates/kas-widgets/src/list.rs
+++ b/crates/kas-widgets/src/list.rs
@@ -270,7 +270,7 @@ mod List {
 
     impl Layout for Self {
         fn size_rules(&mut self, cx: &mut SizeCx, axis: AxisInfo) -> SizeRules {
-            let dim = (self.direction, self.widgets.len());
+            let dim = (self.direction, self.widgets.len(), true);
             let mut solver = RowSolver::new(axis, dim, &mut self.layout);
             for n in 0..self.widgets.len() {
                 if let Some(child) = self.widgets.get_mut_tile(n) {
@@ -282,7 +282,7 @@ mod List {
 
         fn set_rect(&mut self, cx: &mut SizeCx, rect: Rect, hints: AlignHints) {
             self.core.set_rect(rect);
-            let dim = (self.direction, self.widgets.len());
+            let dim = (self.direction, self.widgets.len(), true);
             let mut setter = RowSetter::<D, Vec<i32>, _>::new(rect, dim, &mut self.layout);
 
             for n in 0..self.widgets.len() {

--- a/crates/kas-widgets/src/menu/menubar.rs
+++ b/crates/kas-widgets/src/menu/menubar.rs
@@ -71,7 +71,7 @@ mod MenuBar {
             // but the frame does not adjust the children's rects.
 
             let len = self.widgets.len();
-            let dim = (self.direction, len + 1);
+            let dim = (self.direction, len + 1, true);
             let mut solver = RowSolver::new(axis, dim, &mut self.layout_store);
             let frame_rules = cx.frame(FrameStyle::MenuEntry, axis);
             for (n, child) in self.widgets.iter_mut().enumerate() {
@@ -92,7 +92,7 @@ mod MenuBar {
 
         fn set_rect(&mut self, cx: &mut SizeCx, rect: Rect, _: AlignHints) {
             self.core.set_rect(rect);
-            let dim = (self.direction, self.widgets.len() + 1);
+            let dim = (self.direction, self.widgets.len() + 1, true);
             let mut setter = RowSetter::<D, Vec<i32>, _>::new(rect, dim, &mut self.layout_store);
             let hints = AlignHints::CENTER;
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -144,8 +144,8 @@ mod Splitter {
         }
 
         #[inline]
-        fn dim(&self) -> (D, usize) {
-            (self.direction, self.widgets.len() + self.grips.len())
+        fn dim(&self) -> (D, usize, bool) {
+            (self.direction, self.widgets.len() + self.grips.len(), false)
         }
     }
 

--- a/crates/kas-widgets/src/splitter.rs
+++ b/crates/kas-widgets/src/splitter.rs
@@ -10,7 +10,7 @@ use std::ops::{Index, IndexMut};
 
 use super::{GripMsg, GripPart};
 use kas::Collection;
-use kas::layout::{self, RulesSetter, RulesSolver};
+use kas::layout::{self, RowStorage, RulesSetter, RulesSolver};
 use kas::prelude::*;
 use kas::theme::Feature;
 
@@ -332,8 +332,17 @@ impl<C: Collection, D: Directional> Splitter<C, D> {
         let index = 2 * n + 1;
 
         let hrect = self.grips[n].rect();
-        let width1 = (hrect.pos - self.rect().pos).extract(self.direction);
-        let width2 = (self.rect().size - hrect.size).extract(self.direction) - width1;
+        let mut width1 = (hrect.pos - self.rect().pos).extract(self.direction);
+        let mut width2 = (self.rect().size - hrect.size).extract(self.direction) - width1;
+        let rules = self.data.rules();
+        width1 -= rules[index - 1]
+            .margins_i32()
+            .1
+            .max(rules[index].margins_i32().0);
+        width2 -= rules[index]
+            .margins_i32()
+            .1
+            .max(rules[index + 1].margins_i32().0);
 
         let dim = self.dim();
         let mut setter =


### PR DESCRIPTION
This (mostly) solves the primary issue identified in #665 by disabling re-allocation of above-ideal size for the `Splitter` widget.

Solves the second issue identified in #665: the vanishing margin.

Note that `Splitter` still has slightly surprising behaviour: continuously jiggling the window size by small amounts without ever moving it far will cause splitter widths to converge on what the widths solver considers the fairest distribution of size rather than preserve the user's size adjustments in any way.