### PR TITLE
Re-write word-mode text selection and remove `SelectionHelper`

### DIFF
--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -125,9 +125,7 @@ pub enum Role<'a> {
         /// The cursor index within `contents`
         cursor: usize,
         /// The selection index. Equals `cursor` if the selection is empty.
-        /// May be less than or greater than `cursor`. (Aside: some toolkits
-        /// call this the selection anchor but Kas does not; see
-        /// [`kas::text::SelectionHelper`].)
+        /// May be less than or greater than `cursor`.
         sel_index: usize,
     },
     /// Editable text

--- a/crates/kas-core/src/core/role.rs
+++ b/crates/kas-core/src/core/role.rs
@@ -126,7 +126,7 @@ pub enum Role<'a> {
         cursor: usize,
         /// The selection index. Equals `cursor` if the selection is empty.
         /// May be less than or greater than `cursor`.
-        sel_index: usize,
+        anchor: usize,
     },
     /// Editable text
     ///
@@ -134,7 +134,7 @@ pub enum Role<'a> {
     ///
     /// [`kas::messages::SetValueText`] may be used to replace the entire
     /// text. [`kas::messages::ReplaceSelectedText`] may be used to insert text
-    /// at `cursor`, replacing all text between `cursor` and `sel_index`.
+    /// at `cursor`, replacing all text between `cursor` and `anchor`.
     TextInput {
         /// Text contents
         ///

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -601,30 +601,30 @@ impl TextInput {
     /// otherwise it is expanded in word mode.
     pub fn expand_range(
         text: &str,
-        range: CursorRange,
+        mut range: CursorRange,
         line_range: Option<&dyn Fn(usize) -> Option<std::ops::Range<usize>>>,
     ) -> CursorRange {
-        let mut anchor = range.sel_index();
-        let mut cursor = range.edit_index();
-        let index = cursor;
-        if cursor < anchor {
-            std::mem::swap(&mut anchor, &mut cursor);
+        let index = range.cursor;
+        if range.cursor < range.anchor {
+            range.reverse();
         }
 
         if let Some(line_range) = line_range {
-            anchor = line_range(anchor).map(|r| r.start).unwrap_or(0);
-            cursor = line_range(cursor).map(|r| r.end).unwrap_or(text.len());
+            range.anchor = line_range(range.anchor).map(|r| r.start).unwrap_or(0);
+            range.cursor = line_range(range.cursor)
+                .map(|r| r.end)
+                .unwrap_or(text.len());
         } else {
             'outer: {
                 let mut iter = text.unicode_word_indices();
                 for (start, word) in iter.by_ref() {
-                    if start <= anchor
+                    if start <= range.anchor
                         && let end = start + word.len()
-                        && anchor <= end
+                        && range.anchor <= end
                     {
-                        anchor = start;
-                        if cursor <= end {
-                            cursor = end;
+                        range.anchor = start;
+                        if range.cursor <= end {
+                            range.cursor = end;
                             break 'outer;
                         }
                         break;
@@ -632,49 +632,42 @@ impl TextInput {
                 }
 
                 for (start, word) in iter {
-                    if start <= cursor
+                    if start <= range.cursor
                         && let end = start + word.len()
-                        && cursor <= end
+                        && range.cursor <= end
                     {
-                        cursor = end;
+                        range.cursor = end;
                         break 'outer;
                     }
                 }
             }
         }
 
-        if (index * 2 < anchor + cursor) == (anchor < cursor) {
-            std::mem::swap(&mut anchor, &mut cursor);
+        if (index * 2 < range.anchor + range.cursor) == (range.anchor < range.cursor) {
+            range.reverse();
         }
-        CursorRange::from(anchor..cursor)
+        range
     }
 
     /// Utility function to adjust an already-expanded range in word or line mode
     pub fn adjust_range(
         text: &str,
-        range: CursorRange,
+        mut range: CursorRange,
         index: usize,
         repeats: u32,
         line_range: Option<&dyn Fn(usize) -> Option<std::ops::Range<usize>>>,
     ) -> CursorRange {
-        let mut anchor = range.sel_index();
-        let mut cursor = range.edit_index();
-
-        if anchor < cursor && index <= anchor || anchor > cursor && index >= anchor {
-            cursor = anchor;
+        if range.anchor < range.cursor && index <= range.anchor
+            || range.anchor > range.cursor && index >= range.anchor
+        {
+            range.cursor = range.anchor;
             if repeats > 1 {
-                let range = TextInput::expand_range(
-                    text,
-                    CursorRange::from(anchor..cursor),
-                    line_range.filter(|_| repeats >= 3),
-                );
-                anchor = range.sel_index();
-                cursor = range.edit_index();
+                range = TextInput::expand_range(text, range, line_range.filter(|_| repeats >= 3));
             }
         }
 
-        if anchor <= cursor && anchor < index {
-            cursor = if repeats <= 1 {
+        if range.anchor <= range.cursor && range.anchor < index {
+            range.cursor = if repeats <= 1 {
                 index
             } else if repeats >= 3
                 && let Some(line_range) = line_range
@@ -695,8 +688,8 @@ impl TextInput {
                     })
                     .unwrap_or(text.len())
             }
-        } else if cursor <= anchor && index < anchor {
-            cursor = if repeats <= 1 {
+        } else if range.cursor <= range.anchor && index < range.anchor {
+            range.cursor = if repeats <= 1 {
                 index
             } else if repeats >= 3
                 && let Some(line_range) = line_range
@@ -716,7 +709,7 @@ impl TextInput {
             }
         }
 
-        CursorRange::from(anchor..cursor)
+        range
     }
 }
 

--- a/crates/kas-core/src/event/components.rs
+++ b/crates/kas-core/src/event/components.rs
@@ -8,9 +8,11 @@
 use super::*;
 use crate::cast::traits::*;
 use crate::geom::{Coord, Offset, Rect, Size, Vec2};
+use crate::text::CursorRange;
 use crate::{ActionMoved, Id};
 use kas_macros::{autoimpl, impl_default};
 use std::time::Instant;
+use unicode_segmentation::UnicodeSegmentation;
 
 const TIMER_SELECT: TimerHandle = TimerHandle::new(1 << 60, true);
 const TIMER_KINETIC: TimerHandle = TimerHandle::new((1 << 60) + 1, true);
@@ -591,6 +593,130 @@ impl TextInput {
         if self.is_selecting() {
             self.phase = TextPhase::None;
         }
+    }
+
+    /// Utility function to expand a selection to word or line mode
+    ///
+    /// If `line_range` is provided, the selection is expanded in line mode,
+    /// otherwise it is expanded in word mode.
+    pub fn expand_range(
+        text: &str,
+        range: CursorRange,
+        line_range: Option<&dyn Fn(usize) -> Option<std::ops::Range<usize>>>,
+    ) -> CursorRange {
+        let mut anchor = range.sel_index();
+        let mut cursor = range.edit_index();
+        let index = cursor;
+        if cursor < anchor {
+            std::mem::swap(&mut anchor, &mut cursor);
+        }
+
+        if let Some(line_range) = line_range {
+            anchor = line_range(anchor).map(|r| r.start).unwrap_or(0);
+            cursor = line_range(cursor).map(|r| r.end).unwrap_or(text.len());
+        } else {
+            'outer: {
+                let mut iter = text.unicode_word_indices();
+                for (start, word) in iter.by_ref() {
+                    if start <= anchor
+                        && let end = start + word.len()
+                        && anchor <= end
+                    {
+                        anchor = start;
+                        if cursor <= end {
+                            cursor = end;
+                            break 'outer;
+                        }
+                        break;
+                    }
+                }
+
+                for (start, word) in iter {
+                    if start <= cursor
+                        && let end = start + word.len()
+                        && cursor <= end
+                    {
+                        cursor = end;
+                        break 'outer;
+                    }
+                }
+            }
+        }
+
+        if (index * 2 < anchor + cursor) == (anchor < cursor) {
+            std::mem::swap(&mut anchor, &mut cursor);
+        }
+        CursorRange::from(anchor..cursor)
+    }
+
+    /// Utility function to adjust an already-expanded range in word or line mode
+    pub fn adjust_range(
+        text: &str,
+        range: CursorRange,
+        index: usize,
+        repeats: u32,
+        line_range: Option<&dyn Fn(usize) -> Option<std::ops::Range<usize>>>,
+    ) -> CursorRange {
+        let mut anchor = range.sel_index();
+        let mut cursor = range.edit_index();
+
+        if anchor < cursor && index <= anchor || anchor > cursor && index >= anchor {
+            cursor = anchor;
+            if repeats > 1 {
+                let range = TextInput::expand_range(
+                    text,
+                    CursorRange::from(anchor..cursor),
+                    line_range.filter(|_| repeats >= 3),
+                );
+                anchor = range.sel_index();
+                cursor = range.edit_index();
+            }
+        }
+
+        if anchor <= cursor && anchor < index {
+            cursor = if repeats <= 1 {
+                index
+            } else if repeats >= 3
+                && let Some(line_range) = line_range
+            {
+                line_range(index).map(|r| r.end).unwrap_or(text.len())
+            } else {
+                let start = text[..index]
+                    .split_word_bound_indices()
+                    .next_back()
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+
+                text[start..]
+                    .split_word_bound_indices()
+                    .find_map(|(i, _)| {
+                        let pos = start + i;
+                        (pos >= index).then_some(pos)
+                    })
+                    .unwrap_or(text.len())
+            }
+        } else if cursor <= anchor && index < anchor {
+            cursor = if repeats <= 1 {
+                index
+            } else if repeats >= 3
+                && let Some(line_range) = line_range
+            {
+                line_range(index).map(|r| r.start).unwrap_or(0)
+            } else {
+                let end = text[index..]
+                    .char_indices()
+                    .nth(1)
+                    .map(|(i, _)| index + i)
+                    .unwrap_or(text.len());
+                text[..end]
+                    .split_word_bound_indices()
+                    .rev()
+                    .find_map(|(i, _)| (i <= index).then_some(i))
+                    .unwrap_or(0)
+            }
+        }
+
+        CursorRange::from(anchor..cursor)
     }
 }
 

--- a/crates/kas-core/src/text/mod.rs
+++ b/crates/kas-core/src/text/mod.rs
@@ -26,6 +26,6 @@ mod string;
 mod text;
 
 pub use display::ConfiguredDisplay;
-pub use selection::{CursorRange, SelectionHelper};
+pub use selection::CursorRange;
 pub use string::AccessString;
 pub use text::Text;

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -7,7 +7,6 @@
 
 use kas_macros::autoimpl;
 use std::ops::Range;
-use unicode_segmentation::UnicodeSegmentation;
 
 /// Cursor index / selection range
 ///
@@ -156,58 +155,6 @@ impl SelectionHelper {
         self.edit = self.edit.min(len);
         self.sel = self.sel.min(len);
         self.anchor = self.anchor.min(len);
-    }
-
-    /// Expand the selection from the range between edit and anchor positions
-    ///
-    /// This moves both the selection and edit indices, using the anchor as a
-    /// fixed point (note that this method is the only means by which the
-    /// selection and anchor positions may diverge).
-    ///
-    /// The selection is expanded by words or lines (if `lines`). Line expansion
-    /// requires that text has been prepared (see [`Text::prepare`][super::Text::prepare]).
-    ///
-    /// Input `line_range` should map a text index to the range of the enclosing
-    /// line (if available).
-    pub fn expand(
-        &mut self,
-        text: &str,
-        line_range: &dyn Fn(usize) -> Option<std::ops::Range<usize>>,
-        lines: bool,
-    ) {
-        let mut range = self.edit..self.anchor;
-        if range.start > range.end {
-            std::mem::swap(&mut range.start, &mut range.end);
-        }
-        let (mut start, mut end);
-        if !lines {
-            end = text[range.start..]
-                .char_indices()
-                .nth(1)
-                .map(|(i, _)| range.start + i)
-                .unwrap_or(text.len());
-            start = text[0..end]
-                .split_word_bound_indices()
-                .next_back()
-                .map(|(index, _)| index)
-                .unwrap_or(0);
-            end = text[start..]
-                .split_word_bound_indices()
-                .find_map(|(index, _)| {
-                    let pos = start + index;
-                    (pos >= range.end).then_some(pos)
-                })
-                .unwrap_or(text.len());
-        } else {
-            start = line_range(range.start).map(|r| r.start).unwrap_or(0);
-            end = line_range(range.end).map(|r| r.end).unwrap_or(text.len());
-        }
-
-        if self.edit * 2 < start + end {
-            std::mem::swap(&mut start, &mut end);
-        }
-        self.sel = start;
-        self.edit = end;
     }
 
     /// Adjust all indices for a deletion from the source text

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -139,13 +139,6 @@ impl SelectionHelper {
         self.sel = index;
         self.anchor = index;
     }
-    /// Set the selection index only
-    ///
-    /// Prefer [`Self::set_sel_index`] unless you know you don't want to set the anchor.
-    #[inline]
-    pub fn set_sel_index_only(&mut self, index: usize) {
-        self.sel = index;
-    }
 
     /// Apply new limit to the maximum length
     ///

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -203,7 +203,7 @@ impl SelectionHelper {
             end = line_range(range.end).map(|r| r.end).unwrap_or(text.len());
         }
 
-        if self.edit < self.sel {
+        if self.edit * 2 < start + end {
             std::mem::swap(&mut start, &mut end);
         }
         self.sel = start;

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -7,22 +7,21 @@
 
 use std::ops::Range;
 
-/// Cursor index / selection range
-///
-/// This is essentially a pair of indices: the selection index and the edit
-/// index.
+/// Cursor index and selection range
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CursorRange {
-    sel: usize,
-    edit: usize,
+    /// The start or end of the selection.
+    pub anchor: usize,
+    /// The cursor (edit) index.
+    pub cursor: usize,
 }
 
 impl From<usize> for CursorRange {
     #[inline]
     fn from(index: usize) -> Self {
         CursorRange {
-            sel: index,
-            edit: index,
+            anchor: index,
+            cursor: index,
         }
     }
 }
@@ -31,54 +30,37 @@ impl From<Range<usize>> for CursorRange {
     #[inline]
     fn from(range: Range<usize>) -> Self {
         CursorRange {
-            sel: range.start,
-            edit: range.end,
+            anchor: range.start,
+            cursor: range.end,
         }
     }
 }
 
 impl CursorRange {
-    /// Construct from `(selection, edit)` positions
-    ///
-    /// Constructs as a range, with the cursor at the `edit` position.
-    ///
-    /// See also:
-    ///
-    /// - `Default`: an empty cursor at index 0
-    /// - `From<usize>`: construct from an index (empty selection)
-    /// - `From<Range<usize>>`: construct from a range (potentially non-empty
-    ///   selection; edit position is set to the range's end)
-    #[inline]
-    pub fn new(sel: usize, edit: usize) -> Self {
-        CursorRange { sel, edit }
-    }
-
     /// True if the selection index equals the cursor index
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.edit == self.sel
+        self.cursor == self.anchor
     }
 
-    /// Get the selection index
-    pub fn sel_index(&self) -> usize {
-        self.sel
-    }
-
-    /// Get the edit index (also known as the cursor)
-    pub fn edit_index(&self) -> usize {
-        self.edit
-    }
-
-    /// Get the selection range
+    /// Convert to a [`Range`], increasing
     ///
-    /// This range is from the edit index to the selection index or reversed,
-    /// whichever is increasing.
-    pub fn range(&self) -> Range<usize> {
-        let mut range = self.edit..self.sel;
-        if range.start > range.end {
-            std::mem::swap(&mut range.start, &mut range.end);
+    /// The return value has `range.start <= range.end`.
+    pub fn to_range(&self) -> Range<usize> {
+        let mut range = *self;
+        if range.anchor > range.cursor {
+            range.reverse();
         }
-        range
+        range.anchor..range.cursor
+    }
+
+    /// Reverse the selection
+    ///
+    /// Swaps the selection and edit indices. The result of [`Self::to_range`] is
+    /// not affected by this method.
+    #[inline]
+    pub fn reverse(&mut self) {
+        std::mem::swap(&mut self.anchor, &mut self.cursor);
     }
 
     /// Clear selection
@@ -86,32 +68,16 @@ impl CursorRange {
     /// Sets the selection index to the edit index.
     #[inline]
     pub fn clear_selection(&mut self) {
-        self.sel = self.edit;
+        self.anchor = self.cursor;
     }
 
     /// Set the cursor position and clear the selection
     ///
     /// Both indices are set to `index`.
     #[inline]
-    pub fn set_cursor(&mut self, index: usize) {
-        self.sel = index;
-        self.edit = index;
-    }
-
-    /// Set the cursor index
-    ///
-    /// Does not adjust the selection index.
-    #[inline]
-    pub fn set_edit_index(&mut self, index: usize) {
-        self.edit = index;
-    }
-
-    /// Set the selection index
-    ///
-    /// Does not adjust the cursor (edit index).
-    #[inline]
-    pub fn set_sel_index(&mut self, index: usize) {
-        self.sel = index;
+    pub fn set_position(&mut self, index: usize) {
+        self.anchor = index;
+        self.cursor = index;
     }
 
     /// Apply new limit to the maximum length
@@ -120,8 +86,8 @@ impl CursorRange {
     /// that the selection does not exceed the length of the new string.
     #[inline]
     pub fn set_max_len(&mut self, len: usize) {
-        self.edit = self.edit.min(len);
-        self.sel = self.sel.min(len);
+        self.cursor = self.cursor.min(len);
+        self.anchor = self.anchor.min(len);
     }
 
     /// Adjust all indices for a deletion from the source text
@@ -136,7 +102,7 @@ impl CursorRange {
                 index
             }
         };
-        self.edit = adjust(self.edit);
-        self.sel = adjust(self.sel);
+        self.cursor = adjust(self.cursor);
+        self.anchor = adjust(self.anchor);
     }
 }

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -158,26 +158,11 @@ impl SelectionHelper {
         self.anchor = self.anchor.min(len);
     }
 
-    /// Set the anchor to the edit position
-    ///
-    /// This is used to start a drag-selection. If `clear`, then the selection
-    /// position is also set to the edit position.
-    ///
-    /// [`Self::expand`] may be used to expand the selection from this anchor.
-    #[inline]
-    pub fn set_anchor(&mut self, clear: bool) {
-        self.anchor = self.edit;
-        if clear {
-            self.sel = self.edit;
-        }
-    }
-
     /// Expand the selection from the range between edit and anchor positions
     ///
-    /// This moves the cursor range. To obtain repeatable
-    /// behaviour on drag-selection, set the anchor ([`Self::set_anchor`])
-    /// initially, then set the edit position and call this method each time
-    /// the cursor moves.
+    /// This moves both the selection and edit indices, using the anchor as a
+    /// fixed point (note that this method is the only means by which the
+    /// selection and anchor positions may diverge).
     ///
     /// The selection is expanded by words or lines (if `lines`). Line expansion
     /// requires that text has been prepared (see [`Text::prepare`][super::Text::prepare]).

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -5,7 +5,6 @@
 
 //! Tools for text selection
 
-use kas_macros::autoimpl;
 use std::ops::Range;
 
 /// Cursor index / selection range
@@ -81,69 +80,38 @@ impl CursorRange {
         }
         range
     }
-}
 
-/// Text-selection logic
-///
-/// This struct holds a [`CursorRange`]. There is no requirement on the order of these two
-/// positions. Each may be adjusted independently.
-///
-/// Additionally, this struct holds the selection anchor index. This usually
-/// equals the selection index, but when using double-click or triple-click
-/// selection, the anchor represents the initially-clicked position while the
-/// selection index represents the expanded position.
-#[derive(Clone, Debug, Default)]
-#[autoimpl(Deref, DerefMut using self.cursor)]
-pub struct SelectionHelper {
-    cursor: CursorRange,
-    anchor: usize,
-}
-
-impl<T: Into<CursorRange>> From<T> for SelectionHelper {
-    fn from(x: T) -> Self {
-        let cursor = x.into();
-        SelectionHelper {
-            cursor,
-            anchor: cursor.sel,
-        }
-    }
-}
-
-impl SelectionHelper {
     /// Clear selection
     ///
-    /// Sets the selection and anchor indices to the edit index.
+    /// Sets the selection index to the edit index.
     #[inline]
     pub fn clear_selection(&mut self) {
         self.sel = self.edit;
-        self.anchor = self.edit;
     }
 
     /// Set the cursor position and clear the selection
     ///
-    /// All three indices are set to `index`.
+    /// Both indices are set to `index`.
     #[inline]
     pub fn set_cursor(&mut self, index: usize) {
-        self.cursor.sel = index;
-        self.cursor.edit = index;
-        self.anchor = index;
+        self.sel = index;
+        self.edit = index;
     }
 
     /// Set the cursor index
     ///
-    /// Does not adjust the selection index or anchor.
+    /// Does not adjust the selection index.
     #[inline]
     pub fn set_edit_index(&mut self, index: usize) {
         self.edit = index;
     }
 
-    /// Set the selection index and anchor
+    /// Set the selection index
     ///
     /// Does not adjust the cursor (edit index).
     #[inline]
     pub fn set_sel_index(&mut self, index: usize) {
         self.sel = index;
-        self.anchor = index;
     }
 
     /// Apply new limit to the maximum length
@@ -154,7 +122,6 @@ impl SelectionHelper {
     pub fn set_max_len(&mut self, len: usize) {
         self.edit = self.edit.min(len);
         self.sel = self.sel.min(len);
-        self.anchor = self.anchor.min(len);
     }
 
     /// Adjust all indices for a deletion from the source text
@@ -171,6 +138,5 @@ impl SelectionHelper {
         };
         self.edit = adjust(self.edit);
         self.sel = adjust(self.sel);
-        self.anchor = adjust(self.anchor);
     }
 }

--- a/crates/kas-core/src/text/selection.rs
+++ b/crates/kas-core/src/text/selection.rs
@@ -61,18 +61,12 @@ impl CursorRange {
         self.edit == self.sel
     }
 
-    /// Clear selection without changing the edit index
-    #[inline]
-    pub fn set_empty(&mut self) {
-        self.sel = self.edit;
-    }
-
     /// Get the selection index
     pub fn sel_index(&self) -> usize {
         self.sel
     }
 
-    /// Get the edit cursor index
+    /// Get the edit index (also known as the cursor)
     pub fn edit_index(&self) -> usize {
         self.edit
     }
@@ -117,7 +111,18 @@ impl<T: Into<CursorRange>> From<T> for SelectionHelper {
 }
 
 impl SelectionHelper {
-    /// Set the cursor position, clearing the selection
+    /// Clear selection
+    ///
+    /// Sets the selection and anchor indices to the edit index.
+    #[inline]
+    pub fn clear_selection(&mut self) {
+        self.sel = self.edit;
+        self.anchor = self.edit;
+    }
+
+    /// Set the cursor position and clear the selection
+    ///
+    /// All three indices are set to `index`.
     #[inline]
     pub fn set_cursor(&mut self, index: usize) {
         self.cursor.sel = index;
@@ -125,15 +130,17 @@ impl SelectionHelper {
         self.anchor = index;
     }
 
-    /// Set the cursor index without adjusting the selection index
+    /// Set the cursor index
+    ///
+    /// Does not adjust the selection index or anchor.
     #[inline]
     pub fn set_edit_index(&mut self, index: usize) {
         self.edit = index;
     }
 
-    /// Set the selection index without adjusting the edit index
+    /// Set the selection index and anchor
     ///
-    /// The anchor index is also set to the selection index.
+    /// Does not adjust the cursor (edit index).
     #[inline]
     pub fn set_sel_index(&mut self, index: usize) {
         self.sel = index;

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -904,7 +904,7 @@ impl Part {
                     self.replace_range(edit_range.clone(), text);
                     edit_range.end = edit_range.start + text.len();
                     if let Some((start, end)) = cursor {
-                        self.selection.set_sel_index_only(edit_range.start + start);
+                        self.selection.set_sel_index(edit_range.start + start);
                         self.selection.set_edit_index(edit_range.start + end);
                     } else {
                         self.selection.set_cursor(edit_range.start + text.len());

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -25,7 +25,7 @@ use kas::geom::{Rect, Vec2};
 use kas::layout::{AlignHints, AxisInfo, SizeRules};
 use kas::prelude::*;
 use kas::text::fonts::FontSelector;
-use kas::text::{CursorRange, Direction, NotReady, SelectionHelper, Status, TextDisplay, format};
+use kas::text::{CursorRange, Direction, NotReady, Status, TextDisplay, format};
 use kas::theme::{Background, DrawCx, SizeCx, TextClass};
 use kas::util::UndoStack;
 use kas::{Layout, autoimpl};
@@ -141,7 +141,7 @@ pub struct Part {
     display: TextDisplay,
     highlight: highlight::Cache,
     text: String,
-    selection: SelectionHelper,
+    selection: CursorRange,
     edit_x_coord: Option<f32>,
     last_edit: Option<EditOp>,
     undo_stack: UndoStack<(String, CursorRange)>,
@@ -417,7 +417,7 @@ impl Part {
     /// Access the cursor index / selection range
     #[inline]
     pub fn cursor_range(&self) -> CursorRange {
-        *self.selection
+        self.selection
     }
 
     /// Check whether the text is fully prepared and ready for usage
@@ -1037,7 +1037,7 @@ impl Part {
 
                     TextInput::adjust_range(
                         self.text.as_str(),
-                        *self.selection,
+                        self.selection,
                         index,
                         repeats,
                         Some(&|index| self.display.find_line(index).map(|r| r.1)),
@@ -1065,8 +1065,8 @@ impl Part {
             },
         };
 
-        if range != *self.selection {
-            self.selection = range.into();
+        if range != self.selection {
+            self.selection = range;
             self.set_view_offset_from_cursor(cx);
             self.edit_x_coord = None;
             cx.redraw();
@@ -1163,7 +1163,6 @@ impl Part {
 
         let cursor = self.selection.edit_index().saturating_sub(start);
         // Terminology difference: our sel_index is called 'anchor'
-        // SelectionHelper::anchor is not the same thing.
         let sel_index = self.selection.sel_index().saturating_sub(start);
         ImeSurroundingText::new(text, cursor, sel_index)
             .inspect_err(|err| {
@@ -1226,7 +1225,7 @@ impl Part {
 
         self.last_edit = edit;
         self.undo_stack
-            .try_push((self.as_str().to_string(), *self.selection));
+            .try_push((self.as_str().to_string(), self.selection));
     }
 
     /// Request key focus, if we don't have it or IME
@@ -1540,7 +1539,7 @@ impl Part {
                         self.status = Status::New;
                         self.edit_x_coord = None;
                     }
-                    self.selection = (*cursor).into();
+                    self.selection = *cursor;
                     EventAction::Edit
                 } else {
                     EventAction::Used
@@ -1683,7 +1682,7 @@ impl Editor {
     /// Access the cursor index / selection range
     #[inline]
     pub fn cursor_range(&self) -> CursorRange {
-        *self.part.selection
+        self.part.selection
     }
 
     /// Set the cursor index / range
@@ -1693,7 +1692,7 @@ impl Editor {
     #[inline]
     pub fn set_cursor_range(&mut self, range: CursorRange) {
         self.part.edit_x_coord = None;
-        self.part.selection = range.into();
+        self.part.selection = range;
     }
 
     /// Get whether this text-edit widget is read-only

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -772,8 +772,7 @@ impl Part {
         }
 
         let mut event_action = EventAction::Used;
-        let old_range = self.selection.range();
-        match event {
+        let range = match event {
             Event::NavFocus(source) if source == FocusSource::Key => {
                 if !self.input_handler.is_selecting() {
                     self.request_key_focus(cx, source);
@@ -982,8 +981,7 @@ impl Part {
             }
             Event::PressEnd { press, .. } if press.is_tertiary() => {
                 let rel_pos = (press.coord - self.rect().pos).cast();
-                let index = self.display.text_index_nearest(rel_pos);
-                self.selection.set_edit_index(index);
+                let mut index = self.display.text_index_nearest(rel_pos);
                 self.cancel_selection_and_ime(cx);
                 self.request_key_focus(cx, FocusSource::Pointer);
 
@@ -992,9 +990,10 @@ impl Part {
 
                     let range = self.trim_paste(&content);
                     self.replace_range(index..index, &content[range.clone()]);
-                    self.selection.set_cursor(index + range.len());
+                    index += range.len();
                     event_action = EventAction::Edit;
                 }
+                index.into()
             }
             event => match self.input_handler.handle(cx, self.id.clone(), event) {
                 TextInputAction::Used => return EventAction::Used,
@@ -1008,25 +1007,25 @@ impl Part {
                         self.clear_ime();
                         cx.cancel_ime_focus(&self.id);
                     }
+                    self.request_key_focus(cx, FocusSource::Pointer);
                     self.save_undo_state(Some(EditOp::Cursor));
                     self.current = CurrentAction::Selection;
 
                     let rel_pos = (coord - self.rect().pos).cast();
-                    let index = self.display.text_index_nearest(rel_pos);
-                    self.selection.set_edit_index(index);
-                    if clear {
-                        self.selection.clear_selection();
-                    }
+                    let cursor = self.display.text_index_nearest(rel_pos);
+                    let anchor = if clear { cursor } else { self.selection.sel_index() };
 
+                    let range = CursorRange::from(anchor..cursor);
                     if repeats > 1 {
-                        self.selection.expand(
+                        TextInput::expand_range(
                             self.text.as_str(),
-                            &|index| self.display.find_line(index).map(|r| r.1),
-                            repeats >= 3,
-                        );
+                            range,
+                            (repeats >= 3)
+                                .then_some(&|index| self.display.find_line(index).map(|r| r.1)),
+                        )
+                    } else {
+                        range
                     }
-
-                    self.request_key_focus(cx, FocusSource::Pointer);
                 }
                 TextInputAction::PressMove { coord, repeats } => {
                     if self.current != CurrentAction::Selection {
@@ -1035,15 +1034,14 @@ impl Part {
 
                     let rel_pos = (coord - self.rect().pos).cast();
                     let index = self.display.text_index_nearest(rel_pos);
-                    self.selection.set_edit_index(index);
 
-                    if repeats > 1 {
-                        self.selection.expand(
-                            self.text.as_str(),
-                            &|index| self.display.find_line(index).map(|r| r.1),
-                            repeats >= 3,
-                        );
-                    }
+                    TextInput::adjust_range(
+                        self.text.as_str(),
+                        *self.selection,
+                        index,
+                        repeats,
+                        Some(&|index| self.display.find_line(index).map(|r| r.1)),
+                    )
                 }
                 TextInputAction::PressEnd { coord } => {
                     if self.current.is_ime_enabled() {
@@ -1067,7 +1065,8 @@ impl Part {
             },
         };
 
-        if old_range != self.selection.range() {
+        if range != *self.selection {
+            self.selection = range.into();
             self.set_view_offset_from_cursor(cx);
             self.edit_x_coord = None;
             cx.redraw();

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -1013,7 +1013,9 @@ impl Part {
                     self.current = CurrentAction::Selection;
 
                     self.set_cursor_from_coord(cx, coord);
-                    self.selection.set_anchor(clear);
+                    if clear {
+                        self.selection.clear_selection();
+                    }
                     if repeats > 1 {
                         self.selection.expand(
                             self.text.as_str(),

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -771,15 +771,17 @@ impl Part {
             return EventAction::Unused;
         }
 
+        let mut event_action = EventAction::Used;
+        let old_range = self.selection.range();
         match event {
             Event::NavFocus(source) if source == FocusSource::Key => {
                 if !self.input_handler.is_selecting() {
                     self.request_key_focus(cx, source);
                 }
-                EventAction::Used
+                return EventAction::Used;
             }
-            Event::NavFocus(_) => EventAction::Used,
-            Event::LostNavFocus => EventAction::Used,
+            Event::NavFocus(_) => return EventAction::Used,
+            Event::LostNavFocus => return EventAction::Used,
             Event::SelFocus(source) => {
                 // NOTE: sel focus implies key focus since we only request
                 // the latter. We must set before calling self.set_primary.
@@ -788,13 +790,13 @@ impl Part {
                     self.set_primary(cx);
                 }
 
-                EventAction::Used
+                return EventAction::Used;
             }
             Event::KeyFocus => {
                 self.has_key_focus = true;
                 self.set_view_offset_from_cursor(cx);
 
-                if self.current.is_none() {
+                return if self.current.is_none() {
                     let hint = Default::default();
                     let purpose = ImePurpose::Normal;
                     let surrounding_text = self.ime_surrounding_text();
@@ -802,16 +804,16 @@ impl Part {
                     EventAction::FocusGained
                 } else {
                     EventAction::Used
-                }
+                };
             }
             Event::LostKeyFocus => {
                 self.has_key_focus = false;
                 cx.redraw();
-                if !self.current.is_ime_enabled() {
+                return if !self.current.is_ime_enabled() {
                     EventAction::FocusLost
                 } else {
                     EventAction::Used
-                }
+                };
             }
             Event::LostSelFocus => {
                 // NOTE: we can assume that we will receive Ime::Disabled if IME is active
@@ -821,19 +823,19 @@ impl Part {
                 }
                 self.input_handler.stop_selecting();
                 cx.redraw();
-                EventAction::Used
+                return EventAction::Used;
             }
             Event::Command(cmd, code) => match self.cmd_action(cx, cmd, code) {
                 Ok(action) => {
                     if matches!(action, EventAction::Cursor) {
                         self.set_view_offset_from_cursor(cx);
                     }
-                    action
+                    return action;
                 }
-                Err(NotReady) => EventAction::Used,
+                Err(NotReady) => return EventAction::Used,
             },
             Event::Key(event, false) if event.state == ElementState::Pressed && !self.read_only => {
-                if let Some(text) = &event.text {
+                return if let Some(text) = &event.text {
                     self.save_undo_state(Some(EditOp::KeyInput));
                     self.cancel_selection_and_ime(cx);
 
@@ -861,7 +863,7 @@ impl Part {
                     } else {
                         EventAction::Unused
                     }
-                }
+                };
             }
             Event::Ime(ime) => match ime {
                 Ime::Enabled => {
@@ -878,19 +880,19 @@ impl Part {
                             cx.cancel_ime_focus(&self.id);
                         }
                     }
-                    if !self.has_key_focus {
+                    return if !self.has_key_focus {
                         EventAction::FocusGained
                     } else {
                         EventAction::Used
-                    }
+                    };
                 }
                 Ime::Disabled => {
                     self.clear_ime();
-                    if !self.has_key_focus {
+                    return if !self.has_key_focus {
                         EventAction::FocusLost
                     } else {
                         EventAction::Used
-                    }
+                    };
                 }
                 Ime::Preedit { text, cursor } => {
                     self.save_undo_state(None);
@@ -914,7 +916,7 @@ impl Part {
                         edit_range: edit_range.cast(),
                     };
                     self.edit_x_coord = None;
-                    EventAction::Preedit
+                    return EventAction::Preedit;
                 }
                 Ime::Commit { text } => {
                     self.save_undo_state(Some(EditOp::Ime));
@@ -931,7 +933,7 @@ impl Part {
                         edit_range: self.selection.range().cast(),
                     };
                     self.edit_x_coord = None;
-                    EventAction::Edit
+                    return EventAction::Edit;
                 }
                 Ime::DeleteSurrounding {
                     before_bytes,
@@ -969,37 +971,34 @@ impl Part {
                         cx.update_ime_surrounding_text(&self.id, text);
                     }
 
-                    EventAction::Used
+                    return EventAction::Used;
                 }
             },
             Event::PressStart(press) if press.is_tertiary() => {
-                match press.grab_click(self.id.clone()).complete(cx) {
+                return match press.grab_click(self.id.clone()).complete(cx) {
                     Unused => EventAction::Unused,
                     Used => EventAction::Used,
-                }
+                };
             }
             Event::PressEnd { press, .. } if press.is_tertiary() => {
-                self.set_cursor_from_coord(cx, press.coord);
+                let rel_pos = (press.coord - self.rect().pos).cast();
+                let index = self.display.text_index_nearest(rel_pos);
+                self.selection.set_edit_index(index);
                 self.cancel_selection_and_ime(cx);
                 self.request_key_focus(cx, FocusSource::Pointer);
 
                 if let Some(content) = cx.get_primary() {
                     self.save_undo_state(Some(EditOp::Clipboard));
 
-                    let index = self.selection.edit_index();
                     let range = self.trim_paste(&content);
-
                     self.replace_range(index..index, &content[range.clone()]);
                     self.selection.set_cursor(index + range.len());
-                    self.edit_x_coord = None;
-                    EventAction::Edit
-                } else {
-                    EventAction::Used
+                    event_action = EventAction::Edit;
                 }
             }
             event => match self.input_handler.handle(cx, self.id.clone(), event) {
-                TextInputAction::Used => EventAction::Used,
-                TextInputAction::Unused => EventAction::Unused,
+                TextInputAction::Used => return EventAction::Used,
+                TextInputAction::Unused => return EventAction::Unused,
                 TextInputAction::PressStart {
                     coord,
                     clear,
@@ -1012,10 +1011,13 @@ impl Part {
                     self.save_undo_state(Some(EditOp::Cursor));
                     self.current = CurrentAction::Selection;
 
-                    self.set_cursor_from_coord(cx, coord);
+                    let rel_pos = (coord - self.rect().pos).cast();
+                    let index = self.display.text_index_nearest(rel_pos);
+                    self.selection.set_edit_index(index);
                     if clear {
                         self.selection.clear_selection();
                     }
+
                     if repeats > 1 {
                         self.selection.expand(
                             self.text.as_str(),
@@ -1025,21 +1027,23 @@ impl Part {
                     }
 
                     self.request_key_focus(cx, FocusSource::Pointer);
-                    EventAction::Used
                 }
                 TextInputAction::PressMove { coord, repeats } => {
-                    if self.current == CurrentAction::Selection {
-                        self.set_cursor_from_coord(cx, coord);
-                        if repeats > 1 {
-                            self.selection.expand(
-                                self.text.as_str(),
-                                &|index| self.display.find_line(index).map(|r| r.1),
-                                repeats >= 3,
-                            );
-                        }
+                    if self.current != CurrentAction::Selection {
+                        return EventAction::Used;
                     }
 
-                    EventAction::Used
+                    let rel_pos = (coord - self.rect().pos).cast();
+                    let index = self.display.text_index_nearest(rel_pos);
+                    self.selection.set_edit_index(index);
+
+                    if repeats > 1 {
+                        self.selection.expand(
+                            self.text.as_str(),
+                            &|index| self.display.find_line(index).map(|r| r.1),
+                            repeats >= 3,
+                        );
+                    }
                 }
                 TextInputAction::PressEnd { coord } => {
                     if self.current.is_ime_enabled() {
@@ -1050,16 +1054,25 @@ impl Part {
                     if self.current == CurrentAction::Selection {
                         self.set_primary(cx);
                     } else {
-                        self.set_cursor_from_coord(cx, coord);
+                        let rel_pos = (coord - self.rect().pos).cast();
+                        let index = self.display.text_index_nearest(rel_pos);
+                        self.selection.set_edit_index(index);
                         self.selection.clear_selection();
                     }
                     self.current = CurrentAction::None;
 
                     self.request_key_focus(cx, FocusSource::Pointer);
-                    EventAction::Used
+                    return EventAction::Used;
                 }
             },
+        };
+
+        if old_range != self.selection.range() {
+            self.set_view_offset_from_cursor(cx);
+            self.edit_x_coord = None;
+            cx.redraw();
         }
+        event_action
     }
 
     /// Replace a section of text
@@ -1537,22 +1550,6 @@ impl Part {
         };
 
         Ok(action)
-    }
-
-    /// Set cursor position. It is assumed that the text has not changed.
-    ///
-    /// Committing undo state is the responsibility of the caller.
-    fn set_cursor_from_coord(&mut self, cx: &mut EventCx, coord: Coord) {
-        let rel_pos: Vec2 = (coord - self.rect.pos).cast();
-        if self.is_prepared() {
-            let index = self.display.text_index_nearest(rel_pos.into());
-            if index != self.selection.edit_index() {
-                self.selection.set_edit_index(index);
-                self.set_view_offset_from_cursor(cx);
-                self.edit_x_coord = None;
-                cx.redraw();
-            }
-        }
     }
 
     /// Set primary clipboard (mouse buffer) contents from selection

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -395,7 +395,7 @@ impl Part {
         let len = text.len();
         self.text = text;
         let index = if self.wrap { 0 } else { len };
-        self.selection.set_cursor(index);
+        self.selection.set_position(index);
         self
     }
 
@@ -645,7 +645,7 @@ impl Part {
         }
 
         let pos = self.rect.pos - offset;
-        let range: Range<u32> = self.selection.range().cast();
+        let range: Range<u32> = self.selection.to_range().cast();
 
         let color_tokens = self.highlight.color_tokens();
         let default_colors = format::Colors {
@@ -754,7 +754,7 @@ impl Part {
                 pos,
                 rect,
                 &self.display,
-                self.selection.edit_index(),
+                self.selection.cursor,
                 Some(colors.cursor),
             );
         }
@@ -838,9 +838,9 @@ impl Part {
                     self.save_undo_state(Some(EditOp::KeyInput));
                     self.cancel_selection_and_ime(cx);
 
-                    let selection = self.selection.range();
+                    let selection = self.selection.to_range();
                     self.replace_range(selection.clone(), text);
-                    self.selection.set_cursor(selection.start + text.len());
+                    self.selection.set_position(selection.start + text.len());
                     self.edit_x_coord = None;
 
                     EventAction::Edit
@@ -896,7 +896,7 @@ impl Part {
                 Ime::Preedit { text, cursor } => {
                     self.save_undo_state(None);
                     let mut edit_range = match self.current.clone() {
-                        CurrentAction::ImeStart if cursor.is_some() => self.selection.range(),
+                        CurrentAction::ImeStart if cursor.is_some() => self.selection.to_range(),
                         CurrentAction::ImeStart => return EventAction::Used,
                         CurrentAction::ImePreedit { edit_range } => edit_range.cast(),
                         _ => return EventAction::Used,
@@ -905,10 +905,10 @@ impl Part {
                     self.replace_range(edit_range.clone(), text);
                     edit_range.end = edit_range.start + text.len();
                     if let Some((start, end)) = cursor {
-                        self.selection.set_sel_index(edit_range.start + start);
-                        self.selection.set_edit_index(edit_range.start + end);
+                        self.selection.anchor = edit_range.start + start;
+                        self.selection.cursor = edit_range.start + end;
                     } else {
-                        self.selection.set_cursor(edit_range.start + text.len());
+                        self.selection.set_position(edit_range.start + text.len());
                     }
 
                     self.current = CurrentAction::ImePreedit {
@@ -920,16 +920,16 @@ impl Part {
                 Ime::Commit { text } => {
                     self.save_undo_state(Some(EditOp::Ime));
                     let edit_range = match self.current.clone() {
-                        CurrentAction::ImeStart => self.selection.range(),
+                        CurrentAction::ImeStart => self.selection.to_range(),
                         CurrentAction::ImePreedit { edit_range } => edit_range.cast(),
                         _ => return EventAction::Used,
                     };
 
                     self.replace_range(edit_range.clone(), text);
-                    self.selection.set_cursor(edit_range.start + text.len());
+                    self.selection.set_position(edit_range.start + text.len());
 
                     self.current = CurrentAction::ImePreedit {
-                        edit_range: self.selection.range().cast(),
+                        edit_range: self.selection.to_range().cast(),
                     };
                     self.edit_x_coord = None;
                     return EventAction::Edit;
@@ -940,7 +940,7 @@ impl Part {
                 } => {
                     self.save_undo_state(None);
                     let edit_range = match self.current.clone() {
-                        CurrentAction::ImeStart => self.selection.range(),
+                        CurrentAction::ImeStart => self.selection.to_range(),
                         CurrentAction::ImePreedit { edit_range } => edit_range.cast(),
                         _ => return EventAction::Used,
                     };
@@ -1013,7 +1013,7 @@ impl Part {
 
                     let rel_pos = (coord - self.rect().pos).cast();
                     let cursor = self.display.text_index_nearest(rel_pos);
-                    let anchor = if clear { cursor } else { self.selection.sel_index() };
+                    let anchor = if clear { cursor } else { self.selection.anchor };
 
                     let range = CursorRange::from(anchor..cursor);
                     if repeats > 1 {
@@ -1054,7 +1054,7 @@ impl Part {
                     } else {
                         let rel_pos = (coord - self.rect().pos).cast();
                         let index = self.display.text_index_nearest(rel_pos);
-                        self.selection.set_edit_index(index);
+                        self.selection.cursor = index;
                         self.selection.clear_selection();
                     }
                     self.current = CurrentAction::None;
@@ -1111,7 +1111,7 @@ impl Part {
         if self.current.is_ime_enabled() {
             let action = std::mem::replace(&mut self.current, CurrentAction::None);
             if let CurrentAction::ImePreedit { edit_range } = action {
-                self.selection.set_cursor(edit_range.start.cast());
+                self.selection.set_position(edit_range.start.cast());
                 self.replace_range(edit_range.cast(), "");
             }
         }
@@ -1120,7 +1120,7 @@ impl Part {
     fn ime_surrounding_text(&self) -> Option<ImeSurroundingText> {
         const MAX_TEXT_BYTES: usize = ImeSurroundingText::MAX_TEXT_BYTES;
 
-        let sel_range = self.selection.range();
+        let sel_range = self.selection.to_range();
         let edit_range = match self.current.clone() {
             CurrentAction::ImePreedit { edit_range } => Some(edit_range.cast()),
             _ => None,
@@ -1161,9 +1161,9 @@ impl Part {
             text = self.as_str()[range].to_string();
         }
 
-        let cursor = self.selection.edit_index().saturating_sub(start);
+        let cursor = self.selection.cursor.saturating_sub(start);
         // Terminology difference: our sel_index is called 'anchor'
-        let sel_index = self.selection.sel_index().saturating_sub(start);
+        let sel_index = self.selection.anchor.saturating_sub(start);
         ImeSurroundingText::new(text, cursor, sel_index)
             .inspect_err(|err| {
                 // TODO: use Display for err not Debug
@@ -1179,7 +1179,7 @@ impl Part {
         }
 
         let range = match self.current.clone() {
-            CurrentAction::ImeStart => self.selection.range(),
+            CurrentAction::ImeStart => self.selection.to_range(),
             CurrentAction::ImePreedit { edit_range } => edit_range.cast(),
             _ => return,
         };
@@ -1263,10 +1263,10 @@ impl Part {
         let editable = !self.read_only;
         let mut shift = cx.modifiers().shift_key();
         let mut buf = [0u8; 4];
-        let cursor = self.selection.edit_index();
+        let cursor = self.selection.cursor;
         let len = self.as_str().len();
         let multi_line = self.wrap;
-        let selection = self.selection.range();
+        let selection = self.selection.to_range();
         let have_sel = selection.end > selection.start;
         let string;
 
@@ -1451,7 +1451,7 @@ impl Part {
                 Action::Delete(prev..cursor, EditOp::Delete)
             }
             Command::SelectAll => {
-                self.selection.set_sel_index(0);
+                self.selection.anchor = 0;
                 shift = true; // hack
                 Action::Move(len, None)
             }
@@ -1511,18 +1511,18 @@ impl Part {
                     index..index
                 };
                 self.replace_range(range, s);
-                self.selection.set_cursor(index + s.len());
+                self.selection.set_position(index + s.len());
                 self.edit_x_coord = None;
                 EventAction::Edit
             }
             Action::Delete(sel, _) => {
                 self.replace_range(sel.clone(), "");
-                self.selection.set_cursor(sel.start);
+                self.selection.set_position(sel.start);
                 self.edit_x_coord = None;
                 EventAction::Edit
             }
             Action::Move(index, x_coord) => {
-                self.selection.set_edit_index(index);
+                self.selection.cursor = index;
                 if !shift {
                     self.selection.clear_selection();
                 } else {
@@ -1553,7 +1553,7 @@ impl Part {
     /// Set primary clipboard (mouse buffer) contents from selection
     fn set_primary(&self, cx: &mut EventCx) {
         if self.has_key_focus && !self.selection.is_empty() && cx.has_primary() {
-            let range = self.selection.range();
+            let range = self.selection.to_range();
             cx.set_primary(String::from(&self.as_str()[range]));
         }
     }
@@ -1564,7 +1564,7 @@ impl Part {
     ///
     /// A redraw is assumed since the cursor moved.
     fn set_view_offset_from_cursor(&mut self, cx: &mut EventCx) {
-        let cursor = self.selection.edit_index();
+        let cursor = self.selection.cursor;
         if self.is_prepared()
             && let Some(marker) = self.display.text_glyph_pos(cursor).next_back()
         {
@@ -1672,9 +1672,11 @@ impl Editor {
     pub fn replace_selected_text(&mut self, cx: &mut EventState, text: &str) {
         self.part.cancel_selection_and_ime(cx);
 
-        let selection = self.part.selection.range();
+        let selection = self.part.selection.to_range();
         self.part.replace_range(selection.clone(), text);
-        self.part.selection.set_cursor(selection.start + text.len());
+        self.part
+            .selection
+            .set_position(selection.start + text.len());
         self.part.edit_x_coord = None;
         self.error_state = None;
     }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -817,7 +817,7 @@ impl Part {
                 // NOTE: we can assume that we will receive Ime::Disabled if IME is active
                 if !self.selection.is_empty() {
                     self.save_undo_state(None);
-                    self.selection.set_empty();
+                    self.selection.clear_selection();
                 }
                 self.input_handler.stop_selecting();
                 cx.redraw();
@@ -1049,7 +1049,7 @@ impl Part {
                         self.set_primary(cx);
                     } else {
                         self.set_cursor_from_coord(cx, coord);
-                        self.selection.set_empty();
+                        self.selection.clear_selection();
                     }
                     self.current = CurrentAction::None;
 
@@ -1484,7 +1484,7 @@ impl Part {
         let action = match action {
             Action::None => unreachable!(),
             Action::Deselect => {
-                self.selection.set_empty();
+                self.selection.clear_selection();
                 cx.redraw();
                 EventAction::Cursor
             }
@@ -1511,7 +1511,7 @@ impl Part {
             Action::Move(index, x_coord) => {
                 self.selection.set_edit_index(index);
                 if !shift {
-                    self.selection.set_empty();
+                    self.selection.clear_selection();
                 } else {
                     self.set_primary(cx);
                 }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -71,7 +71,7 @@ mod ScrollTextCore {
             };
 
             let pos = self.rect().pos - offset;
-            let range: std::ops::Range<u32> = self.selection.range().cast();
+            let range: std::ops::Range<u32> = self.selection.to_range().cast();
 
             let mut tokens = [(0, format::Colors::default()); 3];
             let tokens = if range.is_empty() {
@@ -94,8 +94,8 @@ mod ScrollTextCore {
         fn role(&self, _: &mut dyn RoleCx) -> Role<'_> {
             Role::TextLabel {
                 text: self.text.as_str(),
-                cursor: self.selection.edit_index(),
-                sel_index: self.selection.sel_index(),
+                cursor: self.selection.cursor,
+                anchor: self.selection.anchor,
             }
         }
     }
@@ -200,7 +200,7 @@ mod ScrollTextCore {
 
         fn set_primary(&self, cx: &mut EventCx) {
             if self.has_sel_focus && !self.selection.is_empty() && cx.has_primary() {
-                let range = self.selection.range();
+                let range = self.selection.to_range();
                 cx.set_primary(String::from(&self.text.as_str()[range]));
             }
         }
@@ -253,14 +253,14 @@ mod ScrollTextCore {
                         return Used;
                     }
                     Command::SelectAll => {
-                        self.selection.set_sel_index(0);
-                        self.selection.set_edit_index(self.text.str_len());
+                        self.selection.anchor = 0;
+                        self.selection.cursor = self.text.str_len();
                         self.set_primary(cx);
                         cx.redraw();
                         return Used;
                     }
                     Command::Cut | Command::Copy => {
-                        let range = self.selection.range();
+                        let range = self.selection.to_range();
                         cx.set_clipboard((self.text.as_str()[range]).to_string());
                         return Used;
                     }
@@ -293,7 +293,7 @@ mod ScrollTextCore {
 
                         let rel_pos = (coord - self.rect().pos).cast();
                         let cursor = self.text.unchecked_display().text_index_nearest(rel_pos);
-                        let anchor = if clear { cursor } else { self.selection.sel_index() };
+                        let anchor = if clear { cursor } else { self.selection.anchor };
 
                         let range = CursorRange::from(anchor..cursor);
                         if repeats > 1 {
@@ -329,7 +329,7 @@ mod ScrollTextCore {
 
             if range != self.selection {
                 self.selection = range;
-                self.set_view_offset_from_cursor(cx, range.edit_index());
+                self.set_view_offset_from_cursor(cx, range.cursor);
                 cx.redraw();
             }
             Used

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -10,7 +10,7 @@ use kas::event::components::{ScrollComponent, TextInput, TextInputAction};
 use kas::event::{CursorIcon, FocusSource, Scroll};
 use kas::prelude::*;
 use kas::text::format::{self, FormattableText};
-use kas::text::{CursorRange, SelectionHelper, Text};
+use kas::text::{CursorRange, Text};
 use kas::theme::TextClass;
 
 #[impl_self]
@@ -35,7 +35,7 @@ mod ScrollTextCore {
         core: widget_core!(),
         text: Text<T>,
         text_fn: Option<Box<dyn Fn(&ConfigCx, &A) -> T + Send>>,
-        selection: SelectionHelper,
+        selection: CursorRange,
         has_sel_focus: bool,
         input_handler: TextInput,
     }
@@ -110,7 +110,7 @@ mod ScrollTextCore {
                 core: Default::default(),
                 text: Text::new(text, TextClass::Standard, true),
                 text_fn: None,
-                selection: SelectionHelper::default(),
+                selection: CursorRange::default(),
                 has_sel_focus: false,
                 input_handler: Default::default(),
             }
@@ -312,7 +312,7 @@ mod ScrollTextCore {
 
                         TextInput::adjust_range(
                             self.text.as_str(),
-                            *self.selection,
+                            self.selection,
                             index,
                             repeats,
                             Some(&line_range),
@@ -327,8 +327,8 @@ mod ScrollTextCore {
                 },
             };
 
-            if range != *self.selection {
-                self.selection = range.into();
+            if range != self.selection {
+                self.selection = range;
                 self.set_view_offset_from_cursor(cx, range.edit_index());
                 cx.redraw();
             }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -258,7 +258,7 @@ mod ScrollTextCore {
             match event {
                 Event::Command(cmd, _) => match cmd {
                     Command::Escape | Command::Deselect if !self.selection.is_empty() => {
-                        self.selection.set_empty();
+                        self.selection.clear_selection();
                         cx.redraw();
                         Used
                     }
@@ -285,7 +285,7 @@ mod ScrollTextCore {
                 }
                 Event::LostSelFocus => {
                     self.has_sel_focus = false;
-                    self.selection.set_empty();
+                    self.selection.clear_selection();
                     cx.redraw();
                     Used
                 }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -198,17 +198,6 @@ mod ScrollTextCore {
             self
         }
 
-        fn set_cursor_from_coord(&mut self, cx: &mut EventCx, coord: Coord) {
-            let rel_pos = (coord - self.rect().pos).cast();
-            if let Ok(index) = self.text.text_index_nearest(rel_pos) {
-                if index != self.selection.edit_index() {
-                    self.selection.set_edit_index(index);
-                    self.set_view_offset_from_cursor(cx, index);
-                    cx.redraw();
-                }
-            }
-        }
-
         fn set_primary(&self, cx: &mut EventCx) {
             if self.has_sel_focus && !self.selection.is_empty() && cx.has_primary() {
                 let range = self.selection.range();
@@ -255,52 +244,56 @@ mod ScrollTextCore {
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
+            let old_range = self.selection.range();
             match event {
                 Event::Command(cmd, _) => match cmd {
                     Command::Escape | Command::Deselect if !self.selection.is_empty() => {
                         self.selection.clear_selection();
                         cx.redraw();
-                        Used
+                        return Used;
                     }
                     Command::SelectAll => {
                         self.selection.set_sel_index(0);
                         self.selection.set_edit_index(self.text.str_len());
                         self.set_primary(cx);
                         cx.redraw();
-                        Used
+                        return Used;
                     }
                     Command::Cut | Command::Copy => {
                         let range = self.selection.range();
                         cx.set_clipboard((self.text.as_str()[range]).to_string());
-                        Used
+                        return Used;
                     }
-                    _ => Unused,
+                    _ => return Unused,
                 },
                 Event::SelFocus(source) => {
                     self.has_sel_focus = true;
                     if source == FocusSource::Pointer {
                         self.set_primary(cx);
                     }
-                    Used
+                    return Used;
                 }
                 Event::LostSelFocus => {
                     self.has_sel_focus = false;
                     self.selection.clear_selection();
                     cx.redraw();
-                    Used
+                    return Used;
                 }
                 event => match self.input_handler.handle(cx, self.id(), event) {
-                    TextInputAction::Used => Used,
-                    TextInputAction::Unused => Unused,
+                    TextInputAction::Used => return Used,
+                    TextInputAction::Unused => return Unused,
                     TextInputAction::PressStart {
                         coord,
                         clear,
                         repeats,
                     } => {
-                        self.set_cursor_from_coord(cx, coord);
+                        let rel_pos = (coord - self.rect().pos).cast();
+                        let index = self.text.unchecked_display().text_index_nearest(rel_pos);
+                        self.selection.set_edit_index(index);
                         if clear {
                             self.selection.clear_selection();
                         }
+
                         if repeats > 1 {
                             self.selection.expand(
                                 self.text.as_str(),
@@ -312,10 +305,12 @@ mod ScrollTextCore {
                         if !self.has_sel_focus {
                             cx.request_sel_focus(self.id(), FocusSource::Pointer);
                         }
-                        Used
                     }
                     TextInputAction::PressMove { coord, repeats } => {
-                        self.set_cursor_from_coord(cx, coord);
+                        let rel_pos = (coord - self.rect().pos).cast();
+                        let index = self.text.unchecked_display().text_index_nearest(rel_pos);
+                        self.selection.set_edit_index(index);
+
                         if repeats > 1 {
                             self.selection.expand(
                                 self.text.as_str(),
@@ -323,16 +318,21 @@ mod ScrollTextCore {
                                 repeats >= 3,
                             );
                         }
-                        Used
                     }
                     TextInputAction::PressEnd { .. } => {
                         if self.has_sel_focus {
                             self.set_primary(cx);
                         }
-                        Used
+                        return Used;
                     }
                 },
+            };
+
+            if old_range != self.selection.range() {
+                self.set_view_offset_from_cursor(cx, self.selection.edit_index());
+                cx.redraw();
             }
+            Used
         }
     }
 }

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -10,7 +10,7 @@ use kas::event::components::{ScrollComponent, TextInput, TextInputAction};
 use kas::event::{CursorIcon, FocusSource, Scroll};
 use kas::prelude::*;
 use kas::text::format::{self, FormattableText};
-use kas::text::{SelectionHelper, Text};
+use kas::text::{CursorRange, SelectionHelper, Text};
 use kas::theme::TextClass;
 
 #[impl_self]
@@ -245,9 +245,7 @@ mod ScrollTextCore {
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
             let line_range = |index| self.text.find_line(index).ok().flatten().map(|r| r.1);
-            let old_range = self.selection.range();
-
-            match event {
+            let range = match event {
                 Event::Command(cmd, _) => match cmd {
                     Command::Escape | Command::Deselect if !self.selection.is_empty() => {
                         self.selection.clear_selection();
@@ -289,31 +287,36 @@ mod ScrollTextCore {
                         clear,
                         repeats,
                     } => {
-                        let rel_pos = (coord - self.rect().pos).cast();
-                        let index = self.text.unchecked_display().text_index_nearest(rel_pos);
-                        self.selection.set_edit_index(index);
-                        if clear {
-                            self.selection.clear_selection();
-                        }
-
-                        if repeats > 1 {
-                            self.selection
-                                .expand(self.text.as_str(), &line_range, repeats >= 3);
-                        }
-
                         if !self.has_sel_focus {
                             cx.request_sel_focus(self.id(), FocusSource::Pointer);
+                        }
+
+                        let rel_pos = (coord - self.rect().pos).cast();
+                        let cursor = self.text.unchecked_display().text_index_nearest(rel_pos);
+                        let anchor = if clear { cursor } else { self.selection.sel_index() };
+
+                        let range = CursorRange::from(anchor..cursor);
+                        if repeats > 1 {
+                            TextInput::expand_range(
+                                self.text.as_str(),
+                                range,
+                                (repeats >= 3).then_some(&line_range),
+                            )
+                        } else {
+                            range
                         }
                     }
                     TextInputAction::PressMove { coord, repeats } => {
                         let rel_pos = (coord - self.rect().pos).cast();
                         let index = self.text.unchecked_display().text_index_nearest(rel_pos);
-                        self.selection.set_edit_index(index);
 
-                        if repeats > 1 {
-                            self.selection
-                                .expand(self.text.as_str(), &line_range, repeats >= 3);
-                        }
+                        TextInput::adjust_range(
+                            self.text.as_str(),
+                            *self.selection,
+                            index,
+                            repeats,
+                            Some(&line_range),
+                        )
                     }
                     TextInputAction::PressEnd { .. } => {
                         if self.has_sel_focus {
@@ -324,8 +327,9 @@ mod ScrollTextCore {
                 },
             };
 
-            if old_range != self.selection.range() {
-                self.set_view_offset_from_cursor(cx, self.selection.edit_index());
+            if range != *self.selection {
+                self.selection = range.into();
+                self.set_view_offset_from_cursor(cx, range.edit_index());
                 cx.redraw();
             }
             Used

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -244,7 +244,9 @@ mod ScrollTextCore {
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &Self::Data, event: Event) -> IsUsed {
+            let line_range = |index| self.text.find_line(index).ok().flatten().map(|r| r.1);
             let old_range = self.selection.range();
+
             match event {
                 Event::Command(cmd, _) => match cmd {
                     Command::Escape | Command::Deselect if !self.selection.is_empty() => {
@@ -295,11 +297,8 @@ mod ScrollTextCore {
                         }
 
                         if repeats > 1 {
-                            self.selection.expand(
-                                self.text.as_str(),
-                                &|index| self.text.find_line(index).ok().flatten().map(|r| r.1),
-                                repeats >= 3,
-                            );
+                            self.selection
+                                .expand(self.text.as_str(), &line_range, repeats >= 3);
                         }
 
                         if !self.has_sel_focus {
@@ -312,11 +311,8 @@ mod ScrollTextCore {
                         self.selection.set_edit_index(index);
 
                         if repeats > 1 {
-                            self.selection.expand(
-                                self.text.as_str(),
-                                &|index| self.text.find_line(index).ok().flatten().map(|r| r.1),
-                                repeats >= 3,
-                            );
+                            self.selection
+                                .expand(self.text.as_str(), &line_range, repeats >= 3);
                         }
                     }
                     TextInputAction::PressEnd { .. } => {

--- a/crates/kas-widgets/src/scroll_label.rs
+++ b/crates/kas-widgets/src/scroll_label.rs
@@ -298,7 +298,9 @@ mod ScrollTextCore {
                         repeats,
                     } => {
                         self.set_cursor_from_coord(cx, coord);
-                        self.selection.set_anchor(clear);
+                        if clear {
+                            self.selection.clear_selection();
+                        }
                         if repeats > 1 {
                             self.selection.expand(
                                 self.text.as_str(),


### PR DESCRIPTION
Double-click selection is improved (selection starting from the edge of a word now selects it). This no longer requires a separate selection anchor, hence making `SelectionHelper` redundant.

Renames the `CursorRange` fields to `anchor`, `cursor` and makes these `pub`.