### PR TITLE
Move some text editor fields from Part to Common

### DIFF
--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -71,6 +71,7 @@ pub struct Common {
     colors: SchemeColors,
     font: FontSelector,
     dpem: f32,
+    direction: Direction,
 }
 
 impl Common {
@@ -81,6 +82,7 @@ impl Common {
             colors: SchemeColors::default(),
             font: FontSelector::default(),
             dpem: 16.0,
+            direction: Direction::Auto,
         }
     }
 
@@ -128,7 +130,6 @@ impl Common {
 pub struct Part {
     // TODO(opt): id is duplicated here since macros don't let us put the core here
     id: Id,
-    direction: Direction,
     wrap: bool,
     read_only: bool,
     rect: Rect,
@@ -225,7 +226,8 @@ impl<H: Highlighter> Component<H> {
     /// non-directional content.
     #[inline]
     pub fn set_direction(&mut self, direction: Direction) {
-        self.0.part.set_direction(direction);
+        self.0.common.direction = direction;
+        self.0.part.status = Status::New;
     }
 
     /// Replace the highlighter
@@ -279,7 +281,7 @@ impl<H: Highlighter> Component<H> {
         }
 
         self.0.part.configure(id);
-        self.0.part.prepare_runs(&self.0.common, &mut self.1);
+        self.0.part.prepare_runs(&mut self.0.common, &mut self.1);
     }
 
     /// Fully prepare text for display
@@ -295,7 +297,7 @@ impl<H: Highlighter> Component<H> {
             return;
         }
 
-        self.0.part.prepare_runs(&self.0.common, &mut self.1);
+        self.0.part.prepare_runs(&mut self.0.common, &mut self.1);
         self.0.part.prepare_wrap();
     }
 
@@ -308,7 +310,7 @@ impl<H: Highlighter> Component<H> {
     pub fn prepare_and_scroll(&mut self, cx: &mut EventCx) {
         self.0
             .part
-            .prepare_and_scroll(&self.0.common, &mut self.1, cx);
+            .prepare_and_scroll(&mut self.0.common, &mut self.1, cx);
     }
 
     /// Measure required vertical height, wrapping as configured
@@ -319,7 +321,7 @@ impl<H: Highlighter> Component<H> {
     /// modify `self`.
     #[inline]
     pub fn measure_height(&mut self, wrap_width: f32, max_lines: Option<NonZeroUsize>) -> f32 {
-        self.0.part.prepare_runs(&self.0.common, &mut self.1);
+        self.0.part.prepare_runs(&mut self.0.common, &mut self.1);
         self.0.part.display.measure_height(wrap_width, max_lines)
     }
 
@@ -338,7 +340,7 @@ impl<H: Highlighter> Component<H> {
         if action.requires_repreparation() {
             self.0
                 .part
-                .prepare_and_scroll(&self.0.common, &mut self.1, cx);
+                .prepare_and_scroll(&mut self.0.common, &mut self.1, cx);
         }
         action
     }
@@ -356,7 +358,6 @@ impl Part {
     pub fn new(wrap: bool) -> Self {
         Part {
             id: Id::default(),
-            direction: Direction::Auto,
             wrap,
             read_only: false,
             rect: Rect::ZERO,
@@ -372,17 +373,6 @@ impl Part {
             current: CurrentAction::None,
             input_handler: Default::default(),
         }
-    }
-
-    /// Set the base text direction
-    ///
-    /// If [`Direction::Auto`] or [`Direction::AutoRtl`] is used, the direction
-    /// will be updated on edit to persist the last used text direction to
-    /// non-directional content.
-    #[inline]
-    pub fn set_direction(&mut self, direction: Direction) {
-        self.direction = direction;
-        self.status = Status::New;
     }
 
     /// Set the initial text (inline)
@@ -448,8 +438,8 @@ impl Part {
     /// the [`Status`] to [`Status::LevelRuns`].
     /// This method must be called again after any edits to the `Part`'s text.
     #[inline]
-    pub fn prepare_runs<H: Highlighter>(&mut self, common: &Common, highlighter: &mut H) {
-        fn inner<H: Highlighter>(part: &mut Part, common: &Common, highlighter: &mut H) {
+    pub fn prepare_runs<H: Highlighter>(&mut self, common: &mut Common, highlighter: &mut H) {
+        fn inner<H: Highlighter>(part: &mut Part, common: &mut Common, highlighter: &mut H) {
             part.highlight.highlight(&part.text, highlighter);
 
             let text = part.text.as_str();
@@ -457,7 +447,7 @@ impl Part {
             match part.status {
                 Status::New => part
                     .display
-                    .prepare_runs(text, part.direction, font_tokens)
+                    .prepare_runs(text, common.direction, font_tokens)
                     .expect("no suitable font found"),
                 Status::ResizeLevelRuns => part.display.resize_runs(text, font_tokens),
                 _ => return,
@@ -465,8 +455,8 @@ impl Part {
 
             part.status = Status::LevelRuns;
 
-            if part.direction.is_auto() {
-                part.direction = if part.display.text_is_rtl() {
+            if common.direction.is_auto() {
+                common.direction = if part.display.text_is_rtl() {
                     Direction::AutoRtl
                 } else {
                     Direction::Auto
@@ -582,7 +572,7 @@ impl Part {
     #[inline]
     pub fn prepare_and_scroll<H: Highlighter>(
         &mut self,
-        common: &Common,
+        common: &mut Common,
         highlighter: &mut H,
         cx: &mut EventCx,
     ) {

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -69,6 +69,7 @@ impl EventAction {
 #[derive(Debug)]
 pub struct Common {
     colors: SchemeColors,
+    font: FontSelector,
 }
 
 impl Common {
@@ -77,14 +78,21 @@ impl Common {
     pub fn new() -> Self {
         Common {
             colors: SchemeColors::default(),
+            font: FontSelector::default(),
         }
     }
 
     /// Configure `Common` data
     #[inline]
     #[must_use]
-    pub fn configure(&mut self) -> Option<ActionResetStatus> {
-        None
+    pub fn configure(&mut self, cx: &SizeCx) -> Option<ActionResetStatus> {
+        let font = cx.font(TextClass::Editor);
+        if font != self.font {
+            self.font = font;
+            Some(ActionResetStatus)
+        } else {
+            None
+        }
     }
 
     /// Read highlighter colors
@@ -116,7 +124,6 @@ impl Common {
 pub struct Part {
     // TODO(opt): id is duplicated here since macros don't let us put the core here
     id: Id,
-    font: FontSelector,
     dpem: f32,
     direction: Direction,
     wrap: bool,
@@ -260,7 +267,7 @@ impl<H: Highlighter> Component<H> {
     /// Configure component
     #[inline]
     pub fn configure(&mut self, cx: &mut ConfigCx, id: Id) {
-        if let Some(ActionResetStatus) = self.0.common.configure() {
+        if let Some(ActionResetStatus) = self.0.common.configure(&cx.size_cx()) {
             self.0.part.require_reprepare();
         }
 
@@ -270,7 +277,7 @@ impl<H: Highlighter> Component<H> {
         }
 
         self.0.part.configure(cx, id);
-        self.0.part.prepare_runs(&mut self.1);
+        self.0.part.prepare_runs(&self.0.common, &mut self.1);
     }
 
     /// Fully prepare text for display
@@ -286,7 +293,7 @@ impl<H: Highlighter> Component<H> {
             return;
         }
 
-        self.0.part.prepare_runs(&mut self.1);
+        self.0.part.prepare_runs(&self.0.common, &mut self.1);
         self.0.part.prepare_wrap();
     }
 
@@ -297,7 +304,9 @@ impl<H: Highlighter> Component<H> {
     /// be called after changes to the text, alignment or wrap-width.
     #[inline]
     pub fn prepare_and_scroll(&mut self, cx: &mut EventCx) {
-        self.0.part.prepare_and_scroll(&mut self.1, cx);
+        self.0
+            .part
+            .prepare_and_scroll(&self.0.common, &mut self.1, cx);
     }
 
     /// Measure required vertical height, wrapping as configured
@@ -308,7 +317,7 @@ impl<H: Highlighter> Component<H> {
     /// modify `self`.
     #[inline]
     pub fn measure_height(&mut self, wrap_width: f32, max_lines: Option<NonZeroUsize>) -> f32 {
-        self.0.part.prepare_runs(&mut self.1);
+        self.0.part.prepare_runs(&self.0.common, &mut self.1);
         self.0.part.display.measure_height(wrap_width, max_lines)
     }
 
@@ -325,7 +334,9 @@ impl<H: Highlighter> Component<H> {
     pub fn handle_event(&mut self, cx: &mut EventCx, event: Event) -> EventAction {
         let action = self.0.part.handle_event(cx, event);
         if action.requires_repreparation() {
-            self.0.part.prepare_and_scroll(&mut self.1, cx);
+            self.0
+                .part
+                .prepare_and_scroll(&self.0.common, &mut self.1, cx);
         }
         action
     }
@@ -343,7 +354,6 @@ impl Part {
     pub fn new(wrap: bool) -> Self {
         Part {
             id: Id::default(),
-            font: FontSelector::default(),
             dpem: 16.0,
             direction: Direction::Auto,
             wrap,
@@ -428,13 +438,8 @@ impl Part {
     pub fn configure(&mut self, cx: &mut ConfigCx, id: Id) {
         self.id = id;
         let cx = cx.size_cx();
-        let font = cx.font(TextClass::Editor);
         let dpem = cx.dpem(TextClass::Editor);
-        if font != self.font {
-            self.font = font;
-            self.dpem = dpem;
-            self.status = Status::New;
-        } else if dpem != self.dpem {
+        if dpem != self.dpem {
             self.dpem = dpem;
             self.status = self.status.min(Status::ResizeLevelRuns);
         }
@@ -448,12 +453,12 @@ impl Part {
     /// the [`Status`] to [`Status::LevelRuns`].
     /// This method must be called again after any edits to the `Part`'s text.
     #[inline]
-    pub fn prepare_runs<H: Highlighter>(&mut self, highlighter: &mut H) {
-        fn inner<H: Highlighter>(part: &mut Part, highlighter: &mut H) {
+    pub fn prepare_runs<H: Highlighter>(&mut self, common: &Common, highlighter: &mut H) {
+        fn inner<H: Highlighter>(part: &mut Part, common: &Common, highlighter: &mut H) {
             part.highlight.highlight(&part.text, highlighter);
 
             let text = part.text.as_str();
-            let font_tokens = part.highlight.font_tokens(part.dpem, part.font);
+            let font_tokens = part.highlight.font_tokens(part.dpem, common.font);
             match part.status {
                 Status::New => part
                     .display
@@ -475,7 +480,7 @@ impl Part {
         }
 
         if self.status < Status::LevelRuns {
-            inner(self, highlighter);
+            inner(self, common, highlighter);
         }
     }
 
@@ -580,12 +585,17 @@ impl Part {
     /// [`Status`] (which is advanced to [`Status::Ready`]). This method should
     /// be called after changes to the text, alignment or wrap-width.
     #[inline]
-    pub fn prepare_and_scroll<H: Highlighter>(&mut self, highlighter: &mut H, cx: &mut EventCx) {
+    pub fn prepare_and_scroll<H: Highlighter>(
+        &mut self,
+        common: &Common,
+        highlighter: &mut H,
+        cx: &mut EventCx,
+    ) {
         if self.is_prepared() {
             return;
         }
 
-        self.prepare_runs(highlighter);
+        self.prepare_runs(common, highlighter);
         if self.prepare_wrap() {
             cx.resize();
             self.set_view_offset_from_cursor(cx);

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -208,7 +208,7 @@ impl<H: Highlighter> Component<H> {
     {
         let editor = Editor {
             common: Common::new(wrap),
-            part: Part::new(),
+            part: Part::default(),
             error_state: None,
         };
         Component(editor, H::default())
@@ -356,10 +356,9 @@ impl<H: Highlighter> Component<H> {
     }
 }
 
-impl Part {
-    /// Construct a new instance
+impl Default for Part {
     #[inline]
-    pub fn new() -> Self {
+    fn default() -> Self {
         Part {
             id: Id::default(),
             rect: Rect::ZERO,
@@ -376,7 +375,9 @@ impl Part {
             input_handler: Default::default(),
         }
     }
+}
 
+impl Part {
     /// Set the initial text (inline)
     ///
     /// This method should only be used on a new `Part`.

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -67,39 +67,16 @@ impl EventAction {
 
 /// Editor state common to all parts
 #[derive(Debug, Default)]
-pub struct Common<H: Highlighter> {
+pub struct Common {
     colors: SchemeColors,
-    highlighter: H,
 }
 
-impl<H: Highlighter> Common<H> {
-    /// Replace the highlighter
-    #[inline]
-    pub fn with_highlighter<H2: Highlighter>(self, highlighter: H2) -> Common<H2> {
-        Common {
-            colors: SchemeColors::default(),
-            highlighter,
-        }
-    }
-
-    /// Set a new highlighter of the same type
-    ///
-    /// Also call [`Part::require_reprepare`]()
-    /// on each part to ensure the highlighting is updated.
-    pub fn set_highlighter(&mut self, highlighter: H) {
-        self.highlighter = highlighter;
-    }
-
+impl Common {
     /// Configure `Common` data
     #[inline]
     #[must_use]
-    pub fn configure(&mut self, cx: &mut ConfigCx) -> Option<ActionResetStatus> {
-        if let Some(_) = self.highlighter.configure(cx) {
-            self.colors = self.highlighter.scheme_colors();
-            Some(ActionResetStatus)
-        } else {
-            None
-        }
+    pub fn configure(&mut self) -> Option<ActionResetStatus> {
+        None
     }
 
     /// Read highlighter colors
@@ -174,7 +151,7 @@ pub struct Editor {
 ///
 /// See also [`Part`] (accessible through [`Self::part`]).
 #[derive(Debug)]
-pub struct Component<H: Highlighter>(pub Editor, pub Common<H>);
+pub struct Component<H: Highlighter>(pub Editor, pub Common, pub H);
 
 impl<H: Highlighter> Layout for Component<H> {
     #[inline]
@@ -211,7 +188,7 @@ impl<H: Highlighter> Component<H> {
             part: Part::new(wrap),
             error_state: None,
         };
-        Component(editor, Common::default())
+        Component(editor, Common::default(), H::default())
     }
 
     /// Set whether long lines are automatically wrapped
@@ -234,16 +211,12 @@ impl<H: Highlighter> Component<H> {
     /// Replace the highlighter
     #[inline]
     pub fn with_highlighter<H2: Highlighter>(self, highlighter: H2) -> Component<H2> {
-        let common = Common {
-            colors: self.1.colors,
-            highlighter,
-        };
-        Component(self.0, common)
+        Component(self.0, self.1, highlighter)
     }
 
     /// Set a new highlighter of the same type
     pub fn set_highlighter(&mut self, highlighter: H) {
-        self.1.highlighter = highlighter;
+        self.2 = highlighter;
         self.0.part.require_reprepare();
     }
 
@@ -277,10 +250,17 @@ impl<H: Highlighter> Component<H> {
     /// Configure component
     #[inline]
     pub fn configure(&mut self, cx: &mut ConfigCx, id: Id) {
-        if let Some(ActionResetStatus) = self.1.configure(cx) {
+        if let Some(ActionResetStatus) = self.1.configure() {
             self.0.part.require_reprepare();
         }
-        self.0.part.configure(&mut self.1, cx, id);
+
+        if let Some(_) = self.2.configure(cx) {
+            self.1.colors = self.2.scheme_colors();
+            self.0.part.require_reprepare();
+        }
+
+        self.0.part.configure(cx, id);
+        self.0.part.prepare_runs(&mut self.2);
     }
 
     /// Fully prepare text for display
@@ -296,7 +276,7 @@ impl<H: Highlighter> Component<H> {
             return;
         }
 
-        self.0.part.prepare_runs(&mut self.1);
+        self.0.part.prepare_runs(&mut self.2);
         self.0.part.prepare_wrap();
     }
 
@@ -307,7 +287,7 @@ impl<H: Highlighter> Component<H> {
     /// be called after changes to the text, alignment or wrap-width.
     #[inline]
     pub fn prepare_and_scroll(&mut self, cx: &mut EventCx) {
-        self.0.part.prepare_and_scroll(&mut self.1, cx);
+        self.0.part.prepare_and_scroll(&mut self.2, cx);
     }
 
     /// Measure required vertical height, wrapping as configured
@@ -318,7 +298,7 @@ impl<H: Highlighter> Component<H> {
     /// modify `self`.
     #[inline]
     pub fn measure_height(&mut self, wrap_width: f32, max_lines: Option<NonZeroUsize>) -> f32 {
-        self.0.part.prepare_runs(&mut self.1);
+        self.0.part.prepare_runs(&mut self.2);
         self.0.part.display.measure_height(wrap_width, max_lines)
     }
 
@@ -335,7 +315,7 @@ impl<H: Highlighter> Component<H> {
     pub fn handle_event(&mut self, cx: &mut EventCx, event: Event) -> EventAction {
         let action = self.0.part.handle_event(cx, event);
         if action.requires_repreparation() {
-            self.0.part.prepare_and_scroll(&mut self.1, cx);
+            self.0.part.prepare_and_scroll(&mut self.2, cx);
         }
         action
     }
@@ -435,7 +415,7 @@ impl Part {
     /// Configure component
     ///
     /// [`Common::configure`] must be called before this method.
-    pub fn configure<H: Highlighter>(&mut self, common: &mut Common<H>, cx: &mut ConfigCx, id: Id) {
+    pub fn configure(&mut self, cx: &mut ConfigCx, id: Id) {
         self.id = id;
         let cx = cx.size_cx();
         let font = cx.font(TextClass::Editor);
@@ -448,7 +428,6 @@ impl Part {
             self.dpem = dpem;
             self.status = self.status.min(Status::ResizeLevelRuns);
         }
-        self.prepare_runs(common);
     }
 
     /// Perform run-breaking and shaping
@@ -459,10 +438,9 @@ impl Part {
     /// the [`Status`] to [`Status::LevelRuns`].
     /// This method must be called again after any edits to the `Part`'s text.
     #[inline]
-    pub fn prepare_runs<H: Highlighter>(&mut self, common: &mut Common<H>) {
-        fn inner<H: Highlighter>(part: &mut Part, common: &mut Common<H>) {
-            part.highlight
-                .highlight(&part.text, &mut common.highlighter);
+    pub fn prepare_runs<H: Highlighter>(&mut self, highlighter: &mut H) {
+        fn inner<H: Highlighter>(part: &mut Part, highlighter: &mut H) {
+            part.highlight.highlight(&part.text, highlighter);
 
             let text = part.text.as_str();
             let font_tokens = part.highlight.font_tokens(part.dpem, part.font);
@@ -487,7 +465,7 @@ impl Part {
         }
 
         if self.status < Status::LevelRuns {
-            inner(self, common);
+            inner(self, highlighter);
         }
     }
 
@@ -592,12 +570,12 @@ impl Part {
     /// [`Status`] (which is advanced to [`Status::Ready`]). This method should
     /// be called after changes to the text, alignment or wrap-width.
     #[inline]
-    pub fn prepare_and_scroll<H: Highlighter>(&mut self, common: &mut Common<H>, cx: &mut EventCx) {
+    pub fn prepare_and_scroll<H: Highlighter>(&mut self, highlighter: &mut H, cx: &mut EventCx) {
         if self.is_prepared() {
             return;
         }
 
-        self.prepare_runs(common);
+        self.prepare_runs(highlighter);
         if self.prepare_wrap() {
             cx.resize();
             self.set_view_offset_from_cursor(cx);

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -70,6 +70,7 @@ impl EventAction {
 pub struct Common {
     colors: SchemeColors,
     font: FontSelector,
+    dpem: f32,
 }
 
 impl Common {
@@ -79,6 +80,7 @@ impl Common {
         Common {
             colors: SchemeColors::default(),
             font: FontSelector::default(),
+            dpem: 16.0,
         }
     }
 
@@ -87,8 +89,10 @@ impl Common {
     #[must_use]
     pub fn configure(&mut self, cx: &SizeCx) -> Option<ActionResetStatus> {
         let font = cx.font(TextClass::Editor);
-        if font != self.font {
+        let dpem = cx.dpem(TextClass::Editor);
+        if font != self.font || dpem != self.dpem {
             self.font = font;
+            self.dpem = dpem;
             Some(ActionResetStatus)
         } else {
             None
@@ -124,7 +128,6 @@ impl Common {
 pub struct Part {
     // TODO(opt): id is duplicated here since macros don't let us put the core here
     id: Id,
-    dpem: f32,
     direction: Direction,
     wrap: bool,
     read_only: bool,
@@ -177,7 +180,7 @@ impl<H: Highlighter> Layout for Component<H> {
 
     #[inline]
     fn size_rules(&mut self, cx: &mut SizeCx, axis: AxisInfo) -> SizeRules {
-        self.0.part.size_rules(cx, axis)
+        self.0.part.size_rules(&self.0.common, cx, axis)
     }
 
     #[inline]
@@ -270,13 +273,12 @@ impl<H: Highlighter> Component<H> {
         if let Some(ActionResetStatus) = self.0.common.configure(&cx.size_cx()) {
             self.0.part.require_reprepare();
         }
-
         if let Some(_) = self.1.configure(cx) {
             self.0.common.colors = self.1.scheme_colors();
             self.0.part.require_reprepare();
         }
 
-        self.0.part.configure(cx, id);
+        self.0.part.configure(id);
         self.0.part.prepare_runs(&self.0.common, &mut self.1);
     }
 
@@ -332,7 +334,7 @@ impl<H: Highlighter> Component<H> {
     /// Handle an event
     #[inline]
     pub fn handle_event(&mut self, cx: &mut EventCx, event: Event) -> EventAction {
-        let action = self.0.part.handle_event(cx, event);
+        let action = self.0.part.handle_event(&self.0.common, cx, event);
         if action.requires_repreparation() {
             self.0
                 .part
@@ -354,7 +356,6 @@ impl Part {
     pub fn new(wrap: bool) -> Self {
         Part {
             id: Id::default(),
-            dpem: 16.0,
             direction: Direction::Auto,
             wrap,
             read_only: false,
@@ -435,14 +436,8 @@ impl Part {
     /// Configure component
     ///
     /// [`Common::configure`] must be called before this method.
-    pub fn configure(&mut self, cx: &mut ConfigCx, id: Id) {
+    pub fn configure(&mut self, id: Id) {
         self.id = id;
-        let cx = cx.size_cx();
-        let dpem = cx.dpem(TextClass::Editor);
-        if dpem != self.dpem {
-            self.dpem = dpem;
-            self.status = self.status.min(Status::ResizeLevelRuns);
-        }
     }
 
     /// Perform run-breaking and shaping
@@ -458,7 +453,7 @@ impl Part {
             part.highlight.highlight(&part.text, highlighter);
 
             let text = part.text.as_str();
-            let font_tokens = part.highlight.font_tokens(part.dpem, common.font);
+            let font_tokens = part.highlight.font_tokens(common.dpem, common.font);
             match part.status {
                 Status::New => part
                     .display
@@ -491,11 +486,11 @@ impl Part {
     }
 
     /// Solve size rules
-    pub fn size_rules(&mut self, cx: &mut SizeCx, axis: AxisInfo) -> SizeRules {
+    pub fn size_rules(&mut self, common: &Common, cx: &mut SizeCx, axis: AxisInfo) -> SizeRules {
         let rules = if axis.is_horizontal() {
             let mut bound = 0i32;
             if self.wrap {
-                let (min, ideal) = cx.wrapped_line_len(TextClass::Editor, self.dpem);
+                let (min, ideal) = cx.wrapped_line_len(TextClass::Editor, common.dpem);
                 if self.status >= Status::LevelRuns {
                     bound = self.display.measure_width(ideal.cast()).cast_ceil();
                 }
@@ -763,7 +758,7 @@ impl Part {
     /// If [`EventAction::requires_repreparation`] then the caller **must** call
     /// re-prepare the text by calling [`Self::prepare_and_scroll`].
     #[inline]
-    pub fn handle_event(&mut self, cx: &mut EventCx, event: Event) -> EventAction {
+    pub fn handle_event(&mut self, common: &Common, cx: &mut EventCx, event: Event) -> EventAction {
         if !self.is_prepared() {
             debug_assert!(false);
             return EventAction::Unused;
@@ -822,7 +817,7 @@ impl Part {
                 cx.redraw();
                 return EventAction::Used;
             }
-            Event::Command(cmd, code) => match self.cmd_action(cx, cmd, code) {
+            Event::Command(cmd, code) => match self.cmd_action(common, cx, cmd, code) {
                 Ok(action) => {
                     if matches!(action, EventAction::Cursor) {
                         self.set_view_offset_from_cursor(cx);
@@ -848,7 +843,7 @@ impl Part {
                         .shortcuts()
                         .try_match_event(cx.modifiers(), event);
                     if let Some(cmd) = opt_cmd {
-                        match self.cmd_action(cx, cmd, Some(event.physical_key)) {
+                        match self.cmd_action(common, cx, cmd, Some(event.physical_key)) {
                             Ok(action) => {
                                 if matches!(action, EventAction::Cursor) {
                                     self.set_view_offset_from_cursor(cx);
@@ -1252,6 +1247,7 @@ impl Part {
     /// Drive action of a [`Command`]
     fn cmd_action(
         &mut self,
+        common: &Common,
         cx: &mut EventCx,
         mut cmd: Command,
         code: Option<PhysicalKey>,
@@ -1408,7 +1404,7 @@ impl Part {
                     v.0 = x;
                 }
                 // TODO: page height should be an input?
-                let mut line_height = self.dpem;
+                let mut line_height = common.dpem;
                 if let Some(line) = self.display.lines().next() {
                     line_height = line.bottom() - line.top();
                 }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -66,12 +66,20 @@ impl EventAction {
 }
 
 /// Editor state common to all parts
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Common {
     colors: SchemeColors,
 }
 
 impl Common {
+    /// Construct a new instance
+    #[inline]
+    pub fn new() -> Self {
+        Common {
+            colors: SchemeColors::default(),
+        }
+    }
+
     /// Configure `Common` data
     #[inline]
     #[must_use]
@@ -186,7 +194,7 @@ impl<H: Highlighter> Component<H> {
         H: Default,
     {
         let editor = Editor {
-            common: Common::default(),
+            common: Common::new(),
             part: Part::new(wrap),
             error_state: None,
         };

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -193,7 +193,7 @@ impl<H: Highlighter> Layout for Component<H> {
     fn draw(&self, draw: DrawCx) {
         self.0
             .part
-            .draw_with_offset(draw, &self.0.common.colors, self.rect(), Offset::ZERO);
+            .draw_with_offset(draw, &self.0.common, self.rect(), Offset::ZERO);
     }
 }
 
@@ -330,13 +330,13 @@ impl<H: Highlighter> Component<H> {
     pub fn draw_with_offset(&self, draw: DrawCx, rect: Rect, offset: Offset) {
         self.0
             .part
-            .draw_with_offset(draw, &self.0.common.colors, rect, offset);
+            .draw_with_offset(draw, &self.0.common, rect, offset);
     }
 
     /// Handle an event
     #[inline]
     pub fn handle_event(&mut self, cx: &mut EventCx, event: Event) -> EventAction {
-        let action = self.0.part.handle_event(&self.0.common, cx, event);
+        let action = self.0.part.handle_event(&mut self.0.common, cx, event);
         if action.requires_repreparation() {
             self.0
                 .part
@@ -616,13 +616,7 @@ impl Part {
     }
 
     /// Implementation of [`Viewport::draw_with_offset`]
-    pub fn draw_with_offset(
-        &self,
-        mut draw: DrawCx,
-        colors: &SchemeColors,
-        rect: Rect,
-        offset: Offset,
-    ) {
+    pub fn draw_with_offset(&self, mut draw: DrawCx, common: &Common, rect: Rect, offset: Offset) {
         if !self.is_prepared() {
             return;
         }
@@ -632,7 +626,7 @@ impl Part {
 
         let color_tokens = self.highlight.color_tokens();
         let default_colors = format::Colors {
-            foreground: colors.foreground,
+            foreground: common.colors.foreground,
             background: None,
         };
         let mut buf = [(0, default_colors); 3];
@@ -645,17 +639,17 @@ impl Part {
             }
         } else if color_tokens.is_empty() {
             buf[1].0 = range.start;
-            buf[1].1.foreground = colors.selection_foreground;
-            buf[1].1.background = Some(colors.selection_background);
+            buf[1].1.foreground = common.colors.selection_foreground;
+            buf[1].1.background = Some(common.colors.selection_background);
             buf[2].0 = range.end;
             let r0 = if range.start > 0 { 0 } else { 1 };
             &buf[r0..]
         } else {
             let set_selection_colors = |c: &mut format::Colors| {
-                if c.foreground == colors.foreground {
-                    c.foreground = colors.selection_foreground;
+                if c.foreground == common.colors.foreground {
+                    c.foreground = common.colors.selection_foreground;
                 }
-                c.background = Some(colors.selection_background);
+                c.background = Some(common.colors.selection_background);
             };
 
             vec.reserve(color_tokens.len() + 2);
@@ -738,7 +732,7 @@ impl Part {
                 rect,
                 &self.display,
                 self.selection.cursor,
-                Some(colors.cursor),
+                Some(common.colors.cursor),
             );
         }
     }
@@ -748,7 +742,12 @@ impl Part {
     /// If [`EventAction::requires_repreparation`] then the caller **must** call
     /// re-prepare the text by calling [`Self::prepare_and_scroll`].
     #[inline]
-    pub fn handle_event(&mut self, common: &Common, cx: &mut EventCx, event: Event) -> EventAction {
+    pub fn handle_event(
+        &mut self,
+        common: &mut Common,
+        cx: &mut EventCx,
+        event: Event,
+    ) -> EventAction {
         if !self.is_prepared() {
             debug_assert!(false);
             return EventAction::Unused;
@@ -1237,7 +1236,7 @@ impl Part {
     /// Drive action of a [`Command`]
     fn cmd_action(
         &mut self,
-        common: &Common,
+        common: &mut Common,
         cx: &mut EventCx,
         mut cmd: Command,
         code: Option<PhysicalKey>,

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -72,6 +72,7 @@ pub struct Common {
     font: FontSelector,
     dpem: f32,
     direction: Direction,
+    read_only: bool,
 }
 
 impl Common {
@@ -83,6 +84,7 @@ impl Common {
             font: FontSelector::default(),
             dpem: 16.0,
             direction: Direction::Auto,
+            read_only: false,
         }
     }
 
@@ -131,7 +133,6 @@ pub struct Part {
     // TODO(opt): id is duplicated here since macros don't let us put the core here
     id: Id,
     wrap: bool,
-    read_only: bool,
     rect: Rect,
     status: Status,
     display: TextDisplay,
@@ -359,7 +360,6 @@ impl Part {
         Part {
             id: Id::default(),
             wrap,
-            read_only: false,
             rect: Rect::ZERO,
             status: Status::New,
             display: TextDisplay::default(),
@@ -726,7 +726,7 @@ impl Part {
             draw.decorate_text(pos, rect, &self.display, &tokens[r0..]);
         }
 
-        if !self.read_only && draw.ev_state().has_input_focus(&self.id) == Some(true) {
+        if !common.read_only && draw.ev_state().has_input_focus(&self.id) == Some(true) {
             draw.text_cursor(
                 pos,
                 rect,
@@ -815,7 +815,9 @@ impl Part {
                 }
                 Err(NotReady) => return EventAction::Used,
             },
-            Event::Key(event, false) if event.state == ElementState::Pressed && !self.read_only => {
+            Event::Key(event, false)
+                if event.state == ElementState::Pressed && !common.read_only =>
+            {
                 return if let Some(text) = &event.text {
                     self.save_undo_state(Some(EditOp::KeyInput));
                     self.cancel_selection_and_ime(cx);
@@ -1243,7 +1245,7 @@ impl Part {
     ) -> Result<EventAction, NotReady> {
         debug_assert!(self.is_prepared());
 
-        let editable = !self.read_only;
+        let editable = !common.read_only;
         let mut shift = cx.modifiers().shift_key();
         let mut buf = [0u8; 4];
         let cursor = self.selection.cursor;
@@ -1683,13 +1685,13 @@ impl Editor {
     /// Get whether this text-edit widget is read-only
     #[inline]
     pub fn is_read_only(&self) -> bool {
-        self.part.read_only
+        self.common.read_only
     }
 
     /// Set whether this text-edit widget is editable
     #[inline]
     pub fn set_read_only(&mut self, read_only: bool) {
-        self.part.read_only = read_only;
+        self.common.read_only = read_only;
     }
 
     /// True if the editor uses multi-line mode

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -72,18 +72,20 @@ pub struct Common {
     font: FontSelector,
     dpem: f32,
     direction: Direction,
+    wrap: bool,
     read_only: bool,
 }
 
 impl Common {
     /// Construct a new instance
     #[inline]
-    pub fn new() -> Self {
+    pub fn new(wrap: bool) -> Self {
         Common {
             colors: SchemeColors::default(),
             font: FontSelector::default(),
             dpem: 16.0,
             direction: Direction::Auto,
+            wrap,
             read_only: false,
         }
     }
@@ -132,7 +134,6 @@ impl Common {
 pub struct Part {
     // TODO(opt): id is duplicated here since macros don't let us put the core here
     id: Id,
-    wrap: bool,
     rect: Rect,
     status: Status,
     display: TextDisplay,
@@ -187,7 +188,7 @@ impl<H: Highlighter> Layout for Component<H> {
 
     #[inline]
     fn set_rect(&mut self, cx: &mut SizeCx, rect: Rect, _: AlignHints) {
-        self.0.part.set_rect(cx, rect);
+        self.0.part.set_rect(&mut self.0.common, cx, rect);
     }
 
     #[inline]
@@ -206,8 +207,8 @@ impl<H: Highlighter> Component<H> {
         H: Default,
     {
         let editor = Editor {
-            common: Common::new(),
-            part: Part::new(wrap),
+            common: Common::new(wrap),
+            part: Part::new(),
             error_state: None,
         };
         Component(editor, H::default())
@@ -216,8 +217,8 @@ impl<H: Highlighter> Component<H> {
     /// Set whether long lines are automatically wrapped
     #[inline]
     pub fn set_wrap(&mut self, wrap: bool) {
-        self.0.part.wrap = wrap;
-        self.0.part.status = Status::New;
+        self.0.common.wrap = wrap;
+        self.0.part.status = self.0.part.status.min(Status::LevelRuns);
     }
 
     /// Set the base text direction
@@ -261,6 +262,8 @@ impl<H: Highlighter> Component<H> {
     #[must_use]
     pub fn with_text(mut self, text: impl ToString) -> Self {
         self.0.part = self.0.part.with_text(text);
+        let index = if self.0.common.wrap { 0 } else { self.0.part.text.len() };
+        self.0.part.selection.set_position(index);
         self
     }
 
@@ -299,7 +302,7 @@ impl<H: Highlighter> Component<H> {
         }
 
         self.0.part.prepare_runs(&mut self.0.common, &mut self.1);
-        self.0.part.prepare_wrap();
+        self.0.part.prepare_wrap(&mut self.0.common);
     }
 
     /// Fully prepare text for display, ensuring the cursor is within view
@@ -356,10 +359,9 @@ impl<H: Highlighter> Component<H> {
 impl Part {
     /// Construct a new instance
     #[inline]
-    pub fn new(wrap: bool) -> Self {
+    pub fn new() -> Self {
         Part {
             id: Id::default(),
-            wrap,
             rect: Rect::ZERO,
             status: Status::New,
             display: TextDisplay::default(),
@@ -383,10 +385,7 @@ impl Part {
     pub fn with_text(mut self, text: impl ToString) -> Self {
         debug_assert!(self.current == CurrentAction::None && !self.input_handler.is_selecting());
         let text = text.to_string();
-        let len = text.len();
         self.text = text;
-        let index = if self.wrap { 0 } else { len };
-        self.selection.set_position(index);
         self
     }
 
@@ -479,7 +478,7 @@ impl Part {
     pub fn size_rules(&mut self, common: &Common, cx: &mut SizeCx, axis: AxisInfo) -> SizeRules {
         let rules = if axis.is_horizontal() {
             let mut bound = 0i32;
-            if self.wrap {
+            if common.wrap {
                 let (min, ideal) = cx.wrapped_line_len(TextClass::Editor, common.dpem);
                 if self.status >= Status::LevelRuns {
                     bound = self.display.measure_width(ideal.cast()).cast_ceil();
@@ -492,7 +491,7 @@ impl Part {
                 SizeRules::new(bound, bound, Stretch::Filler)
             }
         } else {
-            let wrap_width = self
+            let wrap_width = common
                 .wrap
                 .then(|| axis.other().map(|w| w.cast()))
                 .flatten()
@@ -515,13 +514,13 @@ impl Part {
     /// should be very cheap.
     ///
     /// Note that editors always use default alignment of content.
-    pub fn set_rect(&mut self, cx: &mut SizeCx, rect: Rect) {
+    pub fn set_rect(&mut self, common: &mut Common, cx: &mut SizeCx, rect: Rect) {
         if rect.size.0 != self.rect.size.0 {
             self.status = self.status.min(Status::LevelRuns);
         }
         self.rect = rect;
 
-        self.prepare_wrap();
+        self.prepare_wrap(common);
         if self.current.is_ime_enabled() {
             self.set_ime_cursor_area(cx);
         }
@@ -545,7 +544,7 @@ impl Part {
     /// changes to alignment or the wrap-width.
     ///
     /// Returns `true` when the size of the bounding-box changes.
-    fn prepare_wrap(&mut self) -> bool {
+    fn prepare_wrap(&mut self, common: &mut Common) -> bool {
         if self.status < Status::LevelRuns || self.rect.size.0 == 0 {
             return false;
         };
@@ -554,7 +553,7 @@ impl Part {
 
         if self.status == Status::LevelRuns {
             let align_width = self.rect.size.0.cast();
-            let wrap_width = if !self.wrap { f32::INFINITY } else { align_width };
+            let wrap_width = if !common.wrap { f32::INFINITY } else { align_width };
             self.display
                 .prepare_lines(wrap_width, align_width, Align::Default);
             self.display.ensure_non_negative_alignment();
@@ -581,7 +580,7 @@ impl Part {
         }
 
         self.prepare_runs(common, highlighter);
-        if self.prepare_wrap() {
+        if self.prepare_wrap(common) {
             cx.resize();
             self.set_view_offset_from_cursor(cx);
         }
@@ -972,7 +971,7 @@ impl Part {
                 if let Some(content) = cx.get_primary() {
                     self.save_undo_state(Some(EditOp::Clipboard));
 
-                    let range = self.trim_paste(&content);
+                    let range = self.trim_paste(common.wrap, &content);
                     self.replace_range(index..index, &content[range.clone()]);
                     index += range.len();
                     event_action = EventAction::Edit;
@@ -1219,9 +1218,9 @@ impl Part {
         }
     }
 
-    fn trim_paste(&self, text: &str) -> Range<usize> {
+    fn trim_paste(&self, wrap: bool, text: &str) -> Range<usize> {
         let mut end = text.len();
-        if !self.wrap {
+        if !wrap {
             // We cut the content short on control characters and
             // ignore them (preventing line-breaks and ignoring any
             // actions such as recursive-paste).
@@ -1250,7 +1249,7 @@ impl Part {
         let mut buf = [0u8; 4];
         let cursor = self.selection.cursor;
         let len = self.as_str().len();
-        let multi_line = self.wrap;
+        let multi_line = common.wrap;
         let selection = self.selection.to_range();
         let have_sel = selection.end > selection.start;
         let string;
@@ -1450,7 +1449,7 @@ impl Part {
             }
             Command::Paste if editable => {
                 if let Some(content) = cx.get_clipboard() {
-                    let range = self.trim_paste(&content);
+                    let range = self.trim_paste(common.wrap, &content);
                     string = content;
                     Action::Insert(&string[range], EditOp::Clipboard)
                 } else {
@@ -1697,7 +1696,7 @@ impl Editor {
     /// True if the editor uses multi-line mode
     #[inline]
     pub fn multi_line(&self) -> bool {
-        self.part.wrap
+        self.common.wrap
     }
 
     /// Get whether the widget has input focus

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -133,6 +133,7 @@ pub struct Part {
 /// [`Deref`](std::ops::Deref) from [`EditBoxCore`] and [`EditBox`].
 #[autoimpl(Debug)]
 pub struct Editor {
+    common: Common,
     part: Part,
     error_state: Option<Option<Cow<'static, str>>>,
 }
@@ -151,7 +152,7 @@ pub struct Editor {
 ///
 /// See also [`Part`] (accessible through [`Self::part`]).
 #[derive(Debug)]
-pub struct Component<H: Highlighter>(pub Editor, pub Common, pub H);
+pub struct Component<H: Highlighter>(pub Editor, pub H);
 
 impl<H: Highlighter> Layout for Component<H> {
     #[inline]
@@ -173,7 +174,7 @@ impl<H: Highlighter> Layout for Component<H> {
     fn draw(&self, draw: DrawCx) {
         self.0
             .part
-            .draw_with_offset(draw, &self.1.colors, self.rect(), Offset::ZERO);
+            .draw_with_offset(draw, &self.0.common.colors, self.rect(), Offset::ZERO);
     }
 }
 
@@ -185,10 +186,11 @@ impl<H: Highlighter> Component<H> {
         H: Default,
     {
         let editor = Editor {
+            common: Common::default(),
             part: Part::new(wrap),
             error_state: None,
         };
-        Component(editor, Common::default(), H::default())
+        Component(editor, H::default())
     }
 
     /// Set whether long lines are automatically wrapped
@@ -211,12 +213,12 @@ impl<H: Highlighter> Component<H> {
     /// Replace the highlighter
     #[inline]
     pub fn with_highlighter<H2: Highlighter>(self, highlighter: H2) -> Component<H2> {
-        Component(self.0, self.1, highlighter)
+        Component(self.0, highlighter)
     }
 
     /// Set a new highlighter of the same type
     pub fn set_highlighter(&mut self, highlighter: H) {
-        self.2 = highlighter;
+        self.1 = highlighter;
         self.0.part.require_reprepare();
     }
 
@@ -227,7 +229,7 @@ impl<H: Highlighter> Component<H> {
         if self.0.error_state.is_some() {
             Background::Error
         } else {
-            self.1.background_color()
+            self.0.common.background_color()
         }
     }
 
@@ -250,17 +252,17 @@ impl<H: Highlighter> Component<H> {
     /// Configure component
     #[inline]
     pub fn configure(&mut self, cx: &mut ConfigCx, id: Id) {
-        if let Some(ActionResetStatus) = self.1.configure() {
+        if let Some(ActionResetStatus) = self.0.common.configure() {
             self.0.part.require_reprepare();
         }
 
-        if let Some(_) = self.2.configure(cx) {
-            self.1.colors = self.2.scheme_colors();
+        if let Some(_) = self.1.configure(cx) {
+            self.0.common.colors = self.1.scheme_colors();
             self.0.part.require_reprepare();
         }
 
         self.0.part.configure(cx, id);
-        self.0.part.prepare_runs(&mut self.2);
+        self.0.part.prepare_runs(&mut self.1);
     }
 
     /// Fully prepare text for display
@@ -276,7 +278,7 @@ impl<H: Highlighter> Component<H> {
             return;
         }
 
-        self.0.part.prepare_runs(&mut self.2);
+        self.0.part.prepare_runs(&mut self.1);
         self.0.part.prepare_wrap();
     }
 
@@ -287,7 +289,7 @@ impl<H: Highlighter> Component<H> {
     /// be called after changes to the text, alignment or wrap-width.
     #[inline]
     pub fn prepare_and_scroll(&mut self, cx: &mut EventCx) {
-        self.0.part.prepare_and_scroll(&mut self.2, cx);
+        self.0.part.prepare_and_scroll(&mut self.1, cx);
     }
 
     /// Measure required vertical height, wrapping as configured
@@ -298,7 +300,7 @@ impl<H: Highlighter> Component<H> {
     /// modify `self`.
     #[inline]
     pub fn measure_height(&mut self, wrap_width: f32, max_lines: Option<NonZeroUsize>) -> f32 {
-        self.0.part.prepare_runs(&mut self.2);
+        self.0.part.prepare_runs(&mut self.1);
         self.0.part.display.measure_height(wrap_width, max_lines)
     }
 
@@ -307,7 +309,7 @@ impl<H: Highlighter> Component<H> {
     pub fn draw_with_offset(&self, draw: DrawCx, rect: Rect, offset: Offset) {
         self.0
             .part
-            .draw_with_offset(draw, &self.1.colors, rect, offset);
+            .draw_with_offset(draw, &self.0.common.colors, rect, offset);
     }
 
     /// Handle an event
@@ -315,7 +317,7 @@ impl<H: Highlighter> Component<H> {
     pub fn handle_event(&mut self, cx: &mut EventCx, event: Event) -> EventAction {
         let action = self.0.part.handle_event(cx, event);
         if action.requires_repreparation() {
-            self.0.part.prepare_and_scroll(&mut self.2, cx);
+            self.0.part.prepare_and_scroll(&mut self.1, cx);
         }
         action
     }

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -47,18 +47,10 @@ pub trait EditGuard: Sized {
     /// the Enter/Return key for single-line edit boxes. Its result is returned
     /// from `handle_event`.
     ///
-    /// The default implementation:
-    ///
-    /// -   If the field is editable, calls [`Self::focus_lost`] and returns
-    ///     returns [`Used`].
-    /// -   If the field is not editable, returns [`Unused`].
+    /// The default implementation calls [`Self::focus_lost`] and returns [`Used`].
     fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) -> IsUsed {
-        if !edit.is_read_only() {
-            self.focus_lost(edit, cx, data);
-            Used
-        } else {
-            Unused
-        }
+        self.focus_lost(edit, cx, data);
+        Used
     }
 
     /// Focus-gained guard
@@ -250,10 +242,10 @@ mod InstantParseGuard {
     /// This guard displays a value formatted from input data, updates the error
     /// state according to parse success on each keystroke, and sends a message
     /// immediately (where successful parsing occurred).
-    #[autoimpl(Debug ignore self.value_fn, self.on_afl)]
+    #[autoimpl(Debug ignore self.value_fn, self.on_edit)]
     pub struct InstantParseGuard<A, T: Debug + Display + FromStr> {
         value_fn: Box<dyn Fn(&A) -> T + Send>,
-        on_afl: Box<dyn Fn(&mut EventCx, T) + Send>,
+        on_edit: Box<dyn Fn(&mut EventCx, T) + Send>,
     }
 
     impl Self {
@@ -265,14 +257,14 @@ mod InstantParseGuard {
         ///
         /// On every edit, the guard attempts to parse the field's input as type
         /// `T` via [`FromStr`]. On success, the result is converted to a
-        /// message via `on_afl` then emitted via [`EventCx::push`].
+        /// message via `on_edit` then emitted via [`EventCx::push`].
         pub fn new<M: Debug + 'static>(
             value_fn: impl Fn(&A) -> T + Send + 'static,
-            on_afl: impl Fn(T) -> M + Send + 'static,
+            on_edit: impl Fn(T) -> M + Send + 'static,
         ) -> Self {
             InstantParseGuard {
                 value_fn: Box::new(value_fn),
-                on_afl: Box::new(move |cx, value| cx.push(on_afl(value))),
+                on_edit: Box::new(move |cx, value| cx.push(on_edit(value))),
             }
         }
     }
@@ -296,7 +288,7 @@ mod InstantParseGuard {
                 edit.set_error(cx, Some("parse failure".into()));
             }
             if let Ok(value) = result {
-                (self.on_afl)(cx, value);
+                (self.on_edit)(cx, value);
             }
         }
     }

--- a/crates/kas-widgets/src/edit/highlight.rs
+++ b/crates/kas-widgets/src/edit/highlight.rs
@@ -138,9 +138,7 @@ impl Highlighter for Plain {
     }
 
     #[inline]
-    fn new_state(&self) -> Self::State {
-        ()
-    }
+    fn new_state(&self) -> Self::State {}
 
     #[inline]
     fn highlight_line(


### PR DESCRIPTION
Multi-part text editor support (for scalability) is WIP. This is a small amount of progress towards that aim (a subset of easy steps).

The `highlighter` is moved out of `Common` to allow the latter to be unparametrised. `Common` is then made a field of `Editor`, allowing usage of everything but the `highlighter` from the `Editor` API (which is intended only for single-`Part` usage).

`EditGuard::activate` now calls `focus_lost` regardless of the read-only status of the text (minor simplification).