### PR TITLE
Multi-part text editing

### DIFF
--- a/crates/kas-view/src/list_view.rs
+++ b/crates/kas-view/src/list_view.rs
@@ -602,8 +602,8 @@ mod ListView {
                 } else if a > b {
                     b..a
                 } else {
-                    for i in 0..a {
-                        self.widgets[i].token = None;
+                    for w in &mut self.widgets[0..a] {
+                        w.token = None;
                     }
                     b..alloc_len
                 };

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -194,7 +194,7 @@ mod EditBoxCore {
                     cx.depress_with_key(&self, code);
                     result = self.guard.activate(&mut self.editor.0, cx, data);
                 }
-                EventAction::Edit => {
+                EventAction::Edit { .. } => {
                     self.call_guard_edit(cx, data);
                     return Used;
                 }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -42,9 +42,9 @@ pub struct ActionResetStatus;
 /// Result type of [`Component::handle_event`]
 #[derive(Debug)]
 pub enum EventAction {
-    /// Key not used, no action
+    /// Input event was not used
     Unused,
-    /// Key used, no action
+    /// Input event was consumed without action
     Used,
     /// Focus has been gained
     FocusGained,
@@ -56,14 +56,28 @@ pub enum EventAction {
     Activate(Option<PhysicalKey>),
     /// Transient (uncommitted) edit by IME
     Preedit,
-    /// Text was edited by key command
-    Edit,
+    /// Text was edited
+    Edit {
+        /// This is true on key input (e.g. pressing <kbd>A</kbd> or
+        /// <kbd>Backspace</kbd>), false on edits from other causes (e.g. paste,
+        /// undo, input method editor).
+        is_key_input: bool,
+    },
 }
 
 impl EventAction {
     /// If true, text has been edited and must be re-prepared.
     pub fn requires_repreparation(&self) -> bool {
-        matches!(self, EventAction::Preedit | EventAction::Edit)
+        matches!(self, EventAction::Preedit | EventAction::Edit { .. })
+    }
+
+    /// If true, update the scroll position from the cursor
+    pub fn requires_set_view_offset(&self) -> bool {
+        match self {
+            EventAction::FocusGained | EventAction::Cursor => true,
+            EventAction::Edit { is_key_input } => !is_key_input,
+            _ => false,
+        }
     }
 }
 
@@ -591,6 +605,8 @@ impl<H: Highlighter> Component<H> {
         let action = self.0.common.handle_event(&mut self.0.part, cx, event);
         if action.requires_repreparation() {
             self.prepare_and_scroll(cx);
+        } else if action.requires_set_view_offset() {
+            self.0.common.set_view_offset_from_cursor(&self.0.part, cx);
         }
         action
     }
@@ -1179,7 +1195,9 @@ impl Part {
                     edit_range: edit_range.cast(),
                 };
                 common.edit_x_coord = None;
-                EventAction::Edit
+                EventAction::Edit {
+                    is_key_input: false,
+                }
             }
             Ime::DeleteSurrounding {
                 before_bytes,
@@ -1412,7 +1430,9 @@ impl Common {
     ///
     /// If [`EventAction::requires_repreparation`] then the caller **must**
     /// re-prepare and position each part (see e.g.
-    /// [`Component::prepare_and_scroll`]).
+    /// [`Component::prepare_and_scroll`]). If otherwise
+    /// [`EventAction::requires_set_view_offset`] then the caller should call
+    /// [`Common::set_view_offset_from_cursor`].
     //
     // TODO(opt): should we use dyn PartList to reduce code size?
     pub fn handle_event(
@@ -1421,7 +1441,7 @@ impl Common {
         cx: &mut EventCx,
         event: Event,
     ) -> EventAction {
-        let mut event_action = EventAction::Used;
+        let event_action;
         let range = match event {
             Event::NavFocus(source) if source == FocusSource::Key => {
                 if !self.input_handler.is_selecting() {
@@ -1443,7 +1463,6 @@ impl Common {
             }
             Event::KeyFocus => {
                 self.has_key_focus = true;
-                self.set_view_offset_from_cursor(parts, cx);
 
                 return if self.current.is_none() {
                     let hint = Default::default();
@@ -1478,9 +1497,6 @@ impl Common {
             }
             Event::Command(cmd, code) => match self.cmd_action(parts, cx, cmd, code) {
                 Ok(action) => {
-                    if matches!(action, EventAction::Cursor) {
-                        self.set_view_offset_from_cursor(parts, cx);
-                    }
                     return action;
                 }
                 Err(NotReady) => return EventAction::Used,
@@ -1501,7 +1517,7 @@ impl Common {
                     self.set_cursor(parts, end);
                     self.edit_x_coord = None;
 
-                    EventAction::Edit
+                    EventAction::Edit { is_key_input: true }
                 } else {
                     let opt_cmd = cx
                         .config()
@@ -1509,12 +1525,7 @@ impl Common {
                         .try_match_event(cx.modifiers(), event);
                     if let Some(cmd) = opt_cmd {
                         match self.cmd_action(parts, cx, cmd, Some(event.physical_key)) {
-                            Ok(action) => {
-                                if matches!(action, EventAction::Cursor) {
-                                    self.set_view_offset_from_cursor(parts, cx);
-                                }
-                                action
-                            }
+                            Ok(action) => action,
                             Err(NotReady) => EventAction::Used,
                         }
                     } else {
@@ -1570,7 +1581,11 @@ impl Common {
                     let part = parts.get_mut(p);
                     let range = part.trim_paste(self.wrap, &content);
                     cursor = self.replace_range(parts, cursor..cursor, &content[range.clone()]);
-                    event_action = EventAction::Edit;
+                    event_action = EventAction::Edit {
+                        is_key_input: false,
+                    };
+                } else {
+                    event_action = EventAction::Cursor;
                 }
                 cursor.into()
             }
@@ -1608,6 +1623,7 @@ impl Common {
                             // TODO: anchor and cursor use different parts; expand separately then recombine
                         }
                     }
+                    event_action = EventAction::Cursor;
                     CursorRange::from(anchor..cursor)
                 }
                 TextInputAction::PressMove { coord, repeats } => {
@@ -1633,6 +1649,7 @@ impl Common {
                         // TODO
                         cursor = index;
                     }
+                    event_action = EventAction::Cursor;
                     CursorRange::from(anchor..cursor)
                 }
                 TextInputAction::PressEnd { coord } => {
@@ -1657,7 +1674,6 @@ impl Common {
 
         if range != self.selection {
             self.set_cursor(parts, range);
-            self.set_view_offset_from_cursor(parts, cx);
             self.edit_x_coord = None;
             cx.redraw();
         }
@@ -2045,19 +2061,19 @@ impl Common {
                 EventAction::Cursor
             }
             Action::Activate => EventAction::Activate(code),
-            Action::Insert(s, _) => {
+            Action::Insert(s, is_key_input) => {
                 let mut index = self.selection.cursor;
                 let range = if have_sel { selection.clone() } else { index..index };
                 index = self.replace_range(parts, range, s);
                 self.set_cursor(parts, index);
                 self.edit_x_coord = None;
-                EventAction::Edit
+                EventAction::Edit { is_key_input }
             }
-            Action::Delete(sel, _) => {
+            Action::Delete(sel, is_key_input) => {
                 self.replace_range(parts, sel.clone(), "");
                 self.set_cursor(parts, sel.start);
                 self.edit_x_coord = None;
-                EventAction::Edit
+                EventAction::Edit { is_key_input }
             }
             Action::Move(index, x_coord) => {
                 self.selection.cursor = index;
@@ -2102,7 +2118,9 @@ impl Common {
                     self.edit_x_coord = None;
                     let range = *cursor;
                     self.set_cursor(parts, range);
-                    EventAction::Edit
+                    EventAction::Edit {
+                        is_key_input: false,
+                    }
                 } else {
                     EventAction::Used
                 }

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -1393,7 +1393,10 @@ impl Common {
         let part = parts.get(best_p);
         let rel_pos = (coord - part.rect().pos).cast();
         let byte = part.forme.text_index_nearest(rel_pos);
-        TextIndex::new(p, byte)
+        debug_assert!(byte <= part.as_str().len());
+        let index = TextIndex::new(best_p, byte);
+        self.validate_range(parts, index..index);
+        index
     }
 
     /// Get the part used by IME operations
@@ -1720,11 +1723,12 @@ impl Common {
         let mut shift = cx.modifiers().shift_key();
         let mut buf = [0u8; 4];
         let cursor = self.selection.cursor;
+        let c_byte = cursor.byte();
         let c_p = cursor.part();
-        let cursor = cursor.byte();
         let c_part = parts.get(c_p);
         debug_assert!(c_part.is_ready());
         let c_part_len = c_part.as_str().len();
+        let num_parts = parts.len();
         let multi_line = self.wrap;
         let selection = self.selection.to_range();
         let have_sel = selection.end > selection.start;
@@ -1764,135 +1768,122 @@ impl Common {
                 Action::Move(selection.start, None)
             }
             Command::Left => {
-                let text;
-                let mut p = c_p;
-                let mut cursor = cursor;
-                if cursor > 0 {
-                    text = c_part.as_str();
-                } else if p > 0 {
-                    p -= 1;
-                    text = parts.get(p).as_str();
-                    cursor = text.len();
+                if c_byte > 0 {
+                    let text = c_part.as_str();
+                    let byte = GraphemeCursor::new(c_byte, text.len(), true)
+                        .prev_boundary(text, 0)
+                        .unwrap()
+                        .unwrap_or(0);
+                    Action::Move(TextIndex::new(c_p, byte), None)
+                } else if c_p > 0 {
+                    let byte = parts.get(c_p - 1).as_str().len();
+                    Action::Move(TextIndex::new(c_p - 1, byte), None)
                 } else {
                     return Ok(EventAction::Used);
-                };
-
-                let byte = GraphemeCursor::new(cursor, text.len(), true)
-                    .prev_boundary(text, 0)
-                    .unwrap()
-                    .unwrap_or(0);
-                Action::Move(TextIndex::new(p, byte), None)
+                }
             }
             Command::Right | Command::End if !shift && have_sel => {
                 Action::Move(selection.end, None)
             }
             Command::Right => {
-                if cursor < c_part_len {
-                    let byte = GraphemeCursor::new(cursor, c_part_len, true)
+                if c_byte < c_part_len {
+                    let byte = GraphemeCursor::new(c_byte, c_part_len, true)
                         .next_boundary(c_part.as_str(), 0)
                         .unwrap()
                         .unwrap_or(c_part_len);
                     Action::Move(TextIndex::new(c_p, byte), None)
+                } else if c_p.checked_add(1).map(|p| p < num_parts).unwrap_or(false) {
+                    Action::Move(TextIndex::new(c_p + 1, 0), None)
                 } else {
-                    let p = c_p + 1;
-                    if p < parts.len() {
-                        Action::Move(TextIndex::new(p, 0), None)
-                    } else {
-                        return Ok(EventAction::Used);
-                    }
+                    return Ok(EventAction::Used);
                 }
             }
-            Command::WordLeft if cursor > 0 => {
-                let mut iter = c_part.as_str()[0..cursor].split_word_bound_indices();
-                let mut byte = iter.next_back().map(|(index, _)| index).unwrap_or(0);
-                while c_part.as_str()[byte..]
-                    .chars()
-                    .next()
-                    .map(|c| c.is_whitespace())
-                    .unwrap_or(false)
-                {
-                    if let Some((index, _)) = iter.next_back() {
-                        byte = index;
-                    } else {
-                        break;
+            Command::WordLeft => {
+                if c_byte > 0 {
+                    let mut iter = c_part.as_str()[0..c_byte].split_word_bound_indices();
+                    let mut byte = iter.next_back().map(|(index, _)| index).unwrap_or(0);
+                    while c_part.as_str()[byte..]
+                        .chars()
+                        .next()
+                        .map(|c| c.is_whitespace())
+                        .unwrap_or(false)
+                    {
+                        if let Some((index, _)) = iter.next_back() {
+                            byte = index;
+                        } else {
+                            break;
+                        }
                     }
+                    Action::Move(TextIndex::new(c_p, byte), None)
+                } else if c_p > 0 {
+                    let byte = parts.get(c_p - 1).as_str().len();
+                    Action::Move(TextIndex::new(c_p - 1, byte), None)
+                } else {
+                    return Ok(EventAction::Used);
                 }
-                // TODO: prev
-                Action::Move(TextIndex::new(c_p, byte), None)
             }
-            Command::WordRight if cursor < c_part_len => {
-                let mut iter = c_part.as_str()[cursor..].split_word_bound_indices().skip(1);
-                let mut byte = iter
-                    .next()
-                    .map(|(index, _)| cursor + index)
-                    .unwrap_or(c_part_len);
-                while c_part.as_str()[byte..]
-                    .chars()
-                    .next()
-                    .map(|c| c.is_whitespace())
-                    .unwrap_or(false)
-                {
-                    if let Some((index, _)) = iter.next() {
-                        byte = cursor + index;
-                    } else {
-                        break;
+            Command::WordRight => {
+                if c_byte < c_part_len {
+                    let mut iter = c_part.as_str()[c_byte..].split_word_bound_indices().skip(1);
+                    let mut byte = iter
+                        .next()
+                        .map(|(index, _)| c_byte + index)
+                        .unwrap_or(c_part_len);
+                    while c_part.as_str()[byte..]
+                        .chars()
+                        .next()
+                        .map(|c| c.is_whitespace())
+                        .unwrap_or(false)
+                    {
+                        if let Some((index, _)) = iter.next() {
+                            byte = c_byte + index;
+                        } else {
+                            break;
+                        }
                     }
+                    Action::Move(TextIndex::new(c_p, byte), None)
+                } else if c_p.checked_add(1).map(|p| p < num_parts).unwrap_or(false) {
+                    Action::Move(TextIndex::new(c_p + 1, 0), None)
+                } else {
+                    return Ok(EventAction::Used);
                 }
-                // TODO: next
-                Action::Move(TextIndex::new(c_p, byte), None)
-            }
-            // Avoid use of unused navigation keys (e.g. by ScrollComponent):
-            Command::WordLeft | Command::WordRight => {
-                return Ok(EventAction::Used);
             }
             Command::Up | Command::Down if multi_line => {
                 let x = match self.edit_x_coord {
                     Some(x) => x,
                     None => c_part
                         .forme
-                        .text_glyph_pos(cursor)
+                        .text_glyph_pos(c_byte)
                         .next_back()
                         .map(|r| r.pos.0)
                         .unwrap_or(0.0),
                 };
-                let mut line = c_part.forme.find_line(cursor).map(|r| r.0).unwrap_or(0);
-                // We can tolerate invalid line numbers here!
-                line = match cmd {
-                    Command::Up => line.wrapping_sub(1),
-                    Command::Down => line.wrapping_add(1),
-                    _ => unreachable!(),
+
+                let line = c_part.forme.find_line(c_byte).map(|r| r.0).unwrap_or(0);
+                let (p, line) = match cmd {
+                    Command::Up if line > 0 => (c_p, line - 1),
+                    Command::Up if c_p > 0 => {
+                        let p = c_p - 1;
+                        (p, parts.get(p).forme.num_lines().saturating_sub(1))
+                    }
+                    Command::Down if line + 1 < c_part.forme.num_lines() => (c_p, line + 1),
+                    Command::Down if c_p + 1 < parts.len() => (c_p + 1, 0),
+                    _ => return Ok(EventAction::Used),
                 };
-                const HALF: usize = usize::MAX / 2;
-                let nearest_end = match line {
-                    0..=HALF => c_part_len,
-                    _ => 0,
-                };
-                // TODO: prev/next
-                c_part
-                    .forme
-                    .line_index_nearest(line, x)
-                    .map(|index| Action::Move(TextIndex::new(c_p, index), Some(x)))
-                    .unwrap_or(Action::Move(TextIndex::new(c_p, nearest_end), None))
+
+                if let Some(index) = parts.get(p).forme.line_index_nearest(line, x) {
+                    Action::Move(TextIndex::new(p, index), Some(x))
+                } else {
+                    debug_assert!(false);
+                    return Ok(EventAction::Used);
+                }
             }
-            Command::Home if cursor > 0 => {
-                // TODO: we don't need to use find_line if each part represents a line
-                let index = c_part
-                    .forme
-                    .find_line(cursor)
-                    .map(|r| r.1.start)
-                    .unwrap_or(0);
-                Action::Move(TextIndex::new(c_p, index), None)
+            Command::Home if c_byte > 0 => Action::Move(TextIndex::new(c_p, 0), None),
+            Command::End if c_byte < c_part_len => {
+                Action::Move(TextIndex::new(c_p, c_part_len), None)
             }
-            Command::End if cursor < c_part_len => {
-                let index = c_part
-                    .forme
-                    .find_line(cursor)
-                    .map(|r| r.1.end)
-                    .unwrap_or(c_part_len);
-                Action::Move(TextIndex::new(c_p, index), None)
-            }
-            Command::DocHome if c_p > 0 || cursor > 0 => Action::Move(TextIndex::new(0, 0), None),
-            Command::DocEnd if c_p + 1 < parts.len() || cursor < c_part_len => {
+            Command::DocHome if c_p > 0 || c_byte > 0 => Action::Move(TextIndex::new(0, 0), None),
+            Command::DocEnd if c_p + 1 < parts.len() || c_byte < c_part_len => {
                 let p = parts.len() - 1;
                 let len = parts.get(p).as_str().len();
                 Action::Move(TextIndex::new(p, len), None)
@@ -1904,13 +1895,14 @@ impl Common {
             Command::PageUp | Command::PageDown if multi_line => {
                 let mut v = c_part
                     .forme
-                    .text_glyph_pos(cursor)
+                    .text_glyph_pos(c_byte)
                     .next_back()
                     .map(|r| r.pos.into())
                     .unwrap_or(Vec2::ZERO);
                 if let Some(x) = self.edit_x_coord {
                     v.0 = x;
                 }
+
                 // TODO: page height should be an input?
                 let mut line_height = self.dpem;
                 if let Some(line) = c_part.forme.lines().next() {
@@ -1921,54 +1913,74 @@ impl Common {
                     h_dist *= -1.0;
                 }
                 v.1 += h_dist;
+
+                // v is currently relative to c_part's pos
                 let pos = c_part.rect.pos + Offset::conv_to(Nearest, v);
-                let index = self.text_index_nearest(parts, pos).byte();
-                Action::Move(TextIndex::new(c_p, index), Some(v.0))
+                let index = self.text_index_nearest(parts, pos);
+                Action::Move(index, Some(v.0))
             }
             Command::Delete | Command::DelBack if editable && have_sel => {
                 Action::Delete(selection.clone(), true)
             }
             Command::Delete if editable => {
-                if let Some(action) = GraphemeCursor::new(cursor, c_part_len, true)
-                    .next_boundary(c_part.as_str(), 0)
-                    .unwrap()
-                    .map(|next| {
-                        Action::Delete(self.selection.cursor..TextIndex::new(c_p, next), true)
-                    })
+                let end = if let Ok(Some(next)) =
+                    GraphemeCursor::new(c_byte, c_part_len, true).next_boundary(c_part.as_str(), 0)
+                    && next > c_byte
                 {
-                    action
+                    TextIndex::new(c_p, next)
+                } else if c_p + 1 < parts.len() {
+                    TextIndex::new(c_p + 1, 0)
                 } else {
                     return Ok(EventAction::Used);
-                }
+                };
+                Action::Delete(self.selection.cursor..end, true)
             }
             Command::DelBack if editable => {
-                if let Some(action) = GraphemeCursor::new(cursor, c_part_len, true)
-                    .prev_boundary(c_part.as_str(), 0)
-                    .unwrap()
-                    .map(|prev| {
-                        Action::Delete(TextIndex::new(c_p, prev)..self.selection.cursor, true)
-                    })
+                let start = if c_byte > 0
+                    && let Ok(Some(prev)) = GraphemeCursor::new(c_byte, c_part_len, true)
+                        .prev_boundary(c_part.as_str(), 0)
                 {
-                    action
+                    TextIndex::new(c_p, prev)
+                } else if c_p > 0 {
+                    let p = c_p - 1;
+                    let end = parts.get(p).as_str().len();
+                    TextIndex::new(p, end)
                 } else {
                     return Ok(EventAction::Used);
-                }
+                };
+                Action::Delete(start..self.selection.cursor, true)
             }
             Command::DelWord if editable => {
-                let next = c_part.as_str()[cursor..]
+                let next = c_part.as_str()[c_byte..]
                     .split_word_bound_indices()
                     .nth(1)
-                    .map(|(index, _)| cursor + index)
+                    .map(|(index, _)| c_byte + index)
                     .unwrap_or(c_part_len);
-                Action::Delete(self.selection.cursor..TextIndex::new(c_p, next), true)
+                let end = if next > c_byte {
+                    TextIndex::new(c_p, next)
+                } else if c_p + 1 < parts.len() {
+                    TextIndex::new(c_p + 1, 0)
+                } else {
+                    return Ok(EventAction::Used);
+                };
+                Action::Delete(self.selection.cursor..end, true)
             }
             Command::DelWordBack if editable => {
-                let prev = c_part.as_str()[0..cursor]
-                    .split_word_bound_indices()
-                    .next_back()
-                    .map(|(index, _)| index)
-                    .unwrap_or(0);
-                Action::Delete(TextIndex::new(c_p, prev)..self.selection.cursor, true)
+                let start = if c_byte > 0 {
+                    let prev = c_part.as_str()[0..c_byte]
+                        .split_word_bound_indices()
+                        .next_back()
+                        .map(|(index, _)| index)
+                        .unwrap_or(0);
+                    TextIndex::new(c_p, prev)
+                } else if c_p > 0 {
+                    let p = c_p - 1;
+                    let end = parts.get(p).as_str().len();
+                    TextIndex::new(p, end)
+                } else {
+                    return Ok(EventAction::Used);
+                };
+                Action::Delete(start..self.selection.cursor, true)
             }
             Command::SelectAll => {
                 self.selection.anchor = TextIndex::new(0, 0);

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -222,23 +222,17 @@ impl Common {
         }
     }
 
-    /// Set the cursor index (clearing any selection)
-    ///
-    /// This does not interact with undo history or call action handlers on the
-    /// guard.
-    #[inline]
-    pub fn set_cursor(&mut self, index: TextIndex) {
-        self.set_cursor_range(CursorRange::from(index));
-    }
-
     /// Set the cursor index / range
     ///
     /// This does not interact with undo history or call action handlers on the
     /// guard.
-    #[inline]
-    pub fn set_cursor_range(&mut self, range: CursorRange<TextIndex>) {
-        self.edit_x_coord = None;
-        self.selection = range;
+    pub fn set_cursor(&mut self, parts: &impl PartList, range: impl Into<CursorRange<TextIndex>>) {
+        let range = range.into();
+        if range != self.selection {
+            self.validate_range(parts, range.to_range());
+            self.selection = range;
+            self.edit_x_coord = None;
+        }
     }
 
     /// Checks whether any edits have landed
@@ -625,6 +619,15 @@ impl Part {
         self.text.as_str()
     }
 
+    fn set_cursor(&self, common: &mut Common, p: u32, range: impl Into<CursorRange<usize>>) {
+        let range = range.into();
+        debug_assert!(range.anchor <= self.as_str().len());
+        debug_assert!(range.cursor <= self.as_str().len());
+        let anchor = TextIndex::new(p, range.anchor);
+        let cursor = TextIndex::new(p, range.cursor);
+        common.selection = CursorRange { anchor, cursor };
+    }
+
     /// Get text contents as a reference to the internal [`Rc`]
     #[inline]
     pub fn text(&self) -> &Rc<String> {
@@ -970,6 +973,8 @@ impl Part {
     /// Replace a section of text
     #[inline]
     fn replace_range(&mut self, range: Range<usize>, replace_with: &str) {
+        debug_assert!(range.start <= range.end);
+        debug_assert!(range.end <= self.as_str().len());
         Rc::make_mut(&mut self.text).replace_range(range, replace_with);
         self.require_reprepare();
     }
@@ -998,10 +1003,7 @@ impl Part {
         if common.current.is_ime_enabled() {
             let action = std::mem::replace(&mut common.current, CurrentAction::None);
             if let CurrentAction::ImePreedit { edit_range, .. } = action {
-                common
-                    .selection
-                    .set_position(TextIndex::new(p, edit_range.start));
-                self.replace_range(edit_range.cast(), "");
+                self.set_cursor(common, p, usize::conv(edit_range.start));
             }
         }
     }
@@ -1131,14 +1133,15 @@ impl Part {
 
                 self.replace_range(edit_range.clone(), text);
                 edit_range.end = edit_range.start + text.len();
-                if let Some((start, end)) = cursor {
-                    common.selection.anchor = TextIndex::new(part, edit_range.start + start);
-                    common.selection.cursor = TextIndex::new(part, edit_range.start + end);
+                let sel = if let Some((start, end)) = cursor {
+                    CursorRange {
+                        anchor: edit_range.start + start,
+                        cursor: edit_range.start + end,
+                    }
                 } else {
-                    common
-                        .selection
-                        .set_position(TextIndex::new(part, edit_range.start + text.len()));
-                }
+                    CursorRange::from(edit_range.start + text.len())
+                };
+                self.set_cursor(common, part, sel);
 
                 common.current = CurrentAction::ImePreedit {
                     part,
@@ -1157,9 +1160,7 @@ impl Part {
                 };
 
                 self.replace_range(edit_range.clone(), text);
-                common
-                    .selection
-                    .set_position(TextIndex::new(part, edit_range.start + text.len()));
+                self.set_cursor(common, part, edit_range.start + text.len());
 
                 common.current = CurrentAction::ImePreedit {
                     part,
@@ -1172,11 +1173,9 @@ impl Part {
                 before_bytes,
                 after_bytes,
             } => {
-                let edit_range = match common.current.clone() {
-                    CurrentAction::ImeStart(part) => {
-                        subrange_of(&common.selection.to_range(), part)
-                    }
-                    CurrentAction::ImePreedit { edit_range, .. } => edit_range.cast(),
+                let (p, edit_range) = match common.current.clone() {
+                    CurrentAction::ImeStart(p) => (p, subrange_of(&common.selection.to_range(), p)),
+                    CurrentAction::ImePreedit { edit_range, part } => (part, edit_range.cast()),
                     _ => return EventAction::Used,
                 };
 
@@ -1186,15 +1185,17 @@ impl Part {
                     if self.as_str().is_char_boundary(start) {
                         self.replace_range(start..end, "");
                         let len = end - start;
-                        let adjust = |index: &mut TextIndex| {
-                            if index.byte() >= end {
-                                index.byte -= u32::conv(len);
-                            } else if index.byte() > start {
-                                index.byte = start.cast();
+                        let adjust = |index: &mut usize| {
+                            if *index >= end {
+                                *index -= len;
+                            } else if *index > start {
+                                *index = start;
                             }
                         };
-                        adjust(&mut common.selection.cursor);
-                        adjust(&mut common.selection.anchor);
+                        let mut sel = subrange_of(&common.selection.to_range(), p);
+                        adjust(&mut sel.start);
+                        adjust(&mut sel.end);
+                        self.set_cursor(common, p, sel);
                     } else {
                         log::warn!("buggy IME tried to delete range not at char boundary");
                     }
@@ -1221,6 +1222,13 @@ impl Part {
 }
 
 impl Common {
+    fn validate_range(&self, parts: &impl PartList, range: Range<TextIndex>) {
+        debug_assert!(range.start <= range.end);
+        debug_assert!(range.end.part() < parts.len());
+        debug_assert!(range.start.byte() <= parts.get(range.start.part()).as_str().len());
+        debug_assert!(range.end.byte() <= parts.get(range.end.part()).as_str().len());
+    }
+
     /// Replace a section of text
     ///
     /// Returns the index of the end of the replacement.
@@ -1231,7 +1239,8 @@ impl Common {
         range: Range<TextIndex>,
         replace_with: &str,
     ) -> TextIndex {
-        debug_assert!(range.start <= range.end);
+        self.validate_range(parts, range.clone());
+
         if !parts.variable_length() {
             let range = subrange_of(&range, 0);
             parts.get_mut(0).replace_range(range.clone(), replace_with);
@@ -1431,7 +1440,7 @@ impl Common {
                     self.cancel_selection_and_ime(parts, cx);
 
                     let end = self.replace_range(parts, selection.clone(), text);
-                    self.selection.set_position(end);
+                    self.set_cursor(parts, end);
                     self.edit_x_coord = None;
 
                     EventAction::Edit
@@ -1578,8 +1587,7 @@ impl Common {
                         self.set_primary(parts, cx);
                     } else {
                         let index = self.text_index_nearest(parts, coord);
-                        self.selection.cursor = index;
-                        self.selection.clear_selection();
+                        self.set_cursor(parts, index);
                     }
                     self.current = CurrentAction::None;
 
@@ -1590,7 +1598,7 @@ impl Common {
         };
 
         if range != self.selection {
-            self.selection = range;
+            self.set_cursor(parts, range);
             self.set_view_offset_from_cursor(parts, cx);
             self.edit_x_coord = None;
             cx.redraw();
@@ -1974,13 +1982,13 @@ impl Common {
                 let mut index = self.selection.cursor;
                 let range = if have_sel { selection.clone() } else { index..index };
                 index = self.replace_range(parts, range, s);
-                self.selection.set_position(index);
+                self.set_cursor(parts, index);
                 self.edit_x_coord = None;
                 EventAction::Edit
             }
             Action::Delete(sel, _) => {
                 self.replace_range(parts, sel.clone(), "");
-                self.selection.set_position(sel.start);
+                self.set_cursor(parts, sel.start);
                 self.edit_x_coord = None;
                 EventAction::Edit
             }
@@ -2028,7 +2036,8 @@ impl Common {
                     }
 
                     self.edit_x_coord = None;
-                    self.selection = *cursor;
+                    let range = *cursor;
+                    self.set_cursor(parts, range);
                     EventAction::Edit
                 } else {
                     EventAction::Used
@@ -2118,7 +2127,7 @@ impl Editor {
         Rc::make_mut(&mut self.part.text).clear();
         self.part.require_reprepare();
 
-        self.common.selection.set_max_len(TextIndex::new(0, 0));
+        self.common.selection.set_position(TextIndex::new(0, 0));
         self.common.edit_x_coord = None;
         self.error_state = None;
     }
@@ -2198,7 +2207,7 @@ impl Editor {
         let end = selection.end.byte();
         self.part.replace_range(start..end, text);
         let index = TextIndex::new(0, start + text.len());
-        self.common.selection.set_position(index);
+        self.common.set_cursor(&self.part, index);
         self.error_state = None;
     }
 
@@ -2217,7 +2226,7 @@ impl Editor {
     /// guard.
     #[inline]
     pub fn set_cursor(&mut self, index: usize) {
-        self.common.set_cursor(TextIndex::new(0, index))
+        self.common.set_cursor(&self.part, TextIndex::new(0, index))
     }
 
     /// Set the cursor index / range
@@ -2226,7 +2235,7 @@ impl Editor {
     /// guard.
     #[inline]
     pub fn set_cursor_range(&mut self, range: CursorRange<usize>) {
-        self.common.set_cursor_range(CursorRange {
+        self.common.set_cursor(&self.part, CursorRange {
             anchor: TextIndex::new(0, range.anchor),
             cursor: TextIndex::new(0, range.cursor),
         });

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -328,6 +328,50 @@ impl PartList for Part {
     }
 }
 
+impl PartList for Vec<Part> {
+    #[inline]
+    fn len(&self) -> u32 {
+        Vec::len(self).cast()
+    }
+
+    #[inline]
+    fn get(&self, part: u32) -> &Part {
+        let p: usize = part.cast();
+        <[Part]>::get(self, p).expect("invalid part index")
+    }
+
+    #[inline]
+    fn get_mut(&mut self, part: u32) -> &mut Part {
+        let p: usize = part.cast();
+        <[Part]>::get_mut(self, p).expect("invalid part index")
+    }
+
+    #[inline]
+    fn iter(&self) -> impl Iterator<Item = &Part> {
+        <[Part]>::iter(self)
+    }
+
+    #[inline]
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut Part> {
+        <[Part]>::iter_mut(self)
+    }
+
+    #[inline]
+    fn variable_length(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn insert(&mut self, index: u32, part: Part) {
+        Vec::insert(self, index.cast(), part);
+    }
+
+    #[inline]
+    fn delete(&mut self, index: u32) {
+        Vec::remove(self, index.cast());
+    }
+}
+
 /// Inner editor interface
 ///
 /// This type provides an API usable by [`EditGuard`] and (read-only) via

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -81,6 +81,16 @@ impl EventAction {
     }
 }
 
+impl From<IsUsed> for EventAction {
+    #[inline]
+    fn from(is_used: IsUsed) -> Self {
+        match is_used {
+            IsUsed::Used => Self::Used,
+            IsUsed::Unused => Self::Unused,
+        }
+    }
+}
+
 /// Multi-part text index
 ///
 /// This type may also be used with single-part editors, using `part = 0`.
@@ -1441,16 +1451,15 @@ impl Common {
         cx: &mut EventCx,
         event: Event,
     ) -> EventAction {
-        let event_action;
-        let range = match event {
+        match event {
             Event::NavFocus(source) if source == FocusSource::Key => {
                 if !self.input_handler.is_selecting() {
                     self.request_key_focus(cx, source);
                 }
-                return EventAction::Used;
+                EventAction::Used
             }
-            Event::NavFocus(_) => return EventAction::Used,
-            Event::LostNavFocus => return EventAction::Used,
+            Event::NavFocus(_) => EventAction::Used,
+            Event::LostNavFocus => EventAction::Used,
             Event::SelFocus(source) => {
                 // NOTE: sel focus implies key focus since we only request
                 // the latter. We must set before calling self.set_primary.
@@ -1459,12 +1468,12 @@ impl Common {
                     self.set_primary(parts, cx);
                 }
 
-                return EventAction::Used;
+                EventAction::Used
             }
             Event::KeyFocus => {
                 self.has_key_focus = true;
 
-                return if self.current.is_none() {
+                if self.current.is_none() {
                     let hint = Default::default();
                     let purpose = ImePurpose::Normal;
                     let p = self.selection.cursor.part();
@@ -1474,16 +1483,16 @@ impl Common {
                     EventAction::FocusGained
                 } else {
                     EventAction::Used
-                };
+                }
             }
             Event::LostKeyFocus => {
                 self.has_key_focus = false;
                 cx.redraw();
-                return if self.current.is_ime_enabled() {
+                if self.current.is_ime_enabled() {
                     EventAction::FocusLost
                 } else {
                     EventAction::Used
-                };
+                }
             }
             Event::LostSelFocus => {
                 // NOTE: we can assume that we will receive Ime::Disabled if IME is active
@@ -1493,16 +1502,13 @@ impl Common {
                 }
                 self.input_handler.stop_selecting();
                 cx.redraw();
-                return EventAction::Used;
+                EventAction::Used
             }
-            Event::Command(cmd, code) => match self.cmd_action(parts, cx, cmd, code) {
-                Ok(action) => {
-                    return action;
-                }
-                Err(NotReady) => return EventAction::Used,
-            },
+            Event::Command(cmd, code) => self
+                .cmd_action(parts, cx, cmd, code)
+                .unwrap_or(EventAction::Used),
             Event::Key(event, false) if event.state == ElementState::Pressed && !self.read_only => {
-                return if let Some(text) = &event.text {
+                if let Some(text) = &event.text {
                     let selection = self.selection.to_range();
                     self.save_undo_state(
                         parts,
@@ -1531,7 +1537,7 @@ impl Common {
                     } else {
                         EventAction::Unused
                     }
-                };
+                }
             }
             Event::Ime(ime) => {
                 let p = self.selection.cursor.part();
@@ -1561,16 +1567,13 @@ impl Common {
                     self.save_undo_state(parts, opt_op);
                 }
 
-                return parts.get_mut(p).handle_ime(self, cx, p, ime);
+                parts.get_mut(p).handle_ime(self, cx, p, ime)
             }
             Event::PressStart(press) if press.is_tertiary() => {
-                return match press.grab_click(self.id.clone()).complete(cx) {
-                    Unused => EventAction::Unused,
-                    Used => EventAction::Used,
-                };
+                press.grab_click(self.id.clone()).complete(cx).into()
             }
             Event::PressEnd { press, .. } if press.is_tertiary() => {
-                let mut cursor = self.text_index_nearest(parts, press.coord);
+                let cursor = self.text_index_nearest(parts, press.coord);
                 self.cancel_selection_and_ime(parts, cx);
                 self.request_key_focus(cx, FocusSource::Pointer);
 
@@ -1580,18 +1583,19 @@ impl Common {
 
                     let part = parts.get_mut(p);
                     let range = part.trim_paste(self.wrap, &content);
-                    cursor = self.replace_range(parts, cursor..cursor, &content[range.clone()]);
-                    event_action = EventAction::Edit {
+                    let cursor = self.replace_range(parts, cursor..cursor, &content[range.clone()]);
+                    self.set_cursor(parts, cursor);
+                    EventAction::Edit {
                         is_key_input: false,
-                    };
+                    }
                 } else {
-                    event_action = EventAction::Cursor;
+                    self.set_cursor(parts, cursor);
+                    EventAction::Cursor
                 }
-                cursor.into()
             }
             event => match self.input_handler.handle(cx, self.id.clone(), event) {
-                TextInputAction::Used => return EventAction::Used,
-                TextInputAction::Unused => return EventAction::Unused,
+                TextInputAction::Used => EventAction::Used,
+                TextInputAction::Unused => EventAction::Unused,
                 TextInputAction::PressStart {
                     coord,
                     clear,
@@ -1623,8 +1627,8 @@ impl Common {
                             // TODO: anchor and cursor use different parts; expand separately then recombine
                         }
                     }
-                    event_action = EventAction::Cursor;
-                    CursorRange::from(anchor..cursor)
+                    self.set_cursor(parts, CursorRange::from(anchor..cursor));
+                    EventAction::Cursor
                 }
                 TextInputAction::PressMove { coord, repeats } => {
                     if self.current != CurrentAction::Selection {
@@ -1649,8 +1653,8 @@ impl Common {
                         // TODO
                         cursor = index;
                     }
-                    event_action = EventAction::Cursor;
-                    CursorRange::from(anchor..cursor)
+                    self.set_cursor(parts, CursorRange::from(anchor..cursor));
+                    EventAction::Cursor
                 }
                 TextInputAction::PressEnd { coord } => {
                     if let Some((p, part)) = self.ime_part(parts) {
@@ -1667,17 +1671,10 @@ impl Common {
                     self.current = CurrentAction::None;
 
                     self.request_key_focus(cx, FocusSource::Pointer);
-                    return EventAction::Used;
+                    EventAction::Used
                 }
             },
-        };
-
-        if range != self.selection {
-            self.set_cursor(parts, range);
-            self.edit_x_coord = None;
-            cx.redraw();
         }
-        event_action
     }
 
     /// Cancel on-going selection and IME actions

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -442,6 +442,11 @@ impl<H: Highlighter> Layout for Component<H> {
 
     #[inline]
     fn set_rect(&mut self, cx: &mut SizeCx, rect: Rect, _: AlignHints) {
+        let rewrap = rect.size.0 != self.0.part.rect().size.0;
+        self.0
+            .part
+            .prepare_wrap(&self.0.common, rect.size.0, rewrap);
+
         self.0.part.set_rect(&self.0.common, cx, rect);
     }
 
@@ -565,7 +570,9 @@ impl<H: Highlighter> Component<H> {
         }
 
         self.prepare_runs();
-        self.0.part.prepare_wrap(&self.0.common, self.rect().size.0);
+        self.0
+            .part
+            .prepare_wrap(&self.0.common, self.rect().size.0, false);
     }
 
     /// Fully prepare text for display, ensuring the cursor is within view
@@ -581,7 +588,11 @@ impl<H: Highlighter> Component<H> {
                 self.0.common.update_direction(&self.0.part);
             }
 
-            if self.0.part.prepare_wrap(&self.0.common, self.rect().size.0) {
+            if self
+                .0
+                .part
+                .prepare_wrap(&self.0.common, self.rect().size.0, false)
+            {
                 cx.resize();
                 self.0.common.set_view_offset_from_cursor(&self.0.part, cx);
             }
@@ -774,17 +785,13 @@ impl Part {
     ///
     /// This `rect` is stored and available through [`Self::rect`].
     ///
-    /// Changing the width requires re-wrapping lines; other changes to `rect`
-    /// should be very cheap.
+    /// Note that this method does not perform line-wrapping; it is recommended
+    /// to call [`Self::prepare_wrap`] before this method.
     ///
     /// Note that editors always use default alignment of content.
     pub fn set_rect(&mut self, common: &Common, cx: &mut SizeCx, rect: Rect) {
-        if rect.size.0 != self.rect.size.0 {
-            self.status = self.status.min(Status::Shaped);
-        }
         self.rect = rect;
 
-        self.prepare_wrap(common, rect.size.0);
         if let Some(p) = common.current.ime_part() {
             self.set_ime_cursor_area(common, cx, p);
         }
@@ -807,18 +814,18 @@ impl Part {
     /// `width` is a required input (used for wrapping and alignment). If
     /// `width == 0` or [`Self::status`] is less than [`Status::Shaped`] then
     /// this method aborts (returns `false` without wrapping). Otherwise this
-    /// method performs line-wrapping (if required) and sets the status to
-    /// [`Status::Ready`].
+    /// method performs line-wrapping (if required by the existing status or if
+    /// `rewrap`) and sets the status to [`Status::Ready`].
     ///
     /// Returns `true` when the size of the bounding-box changes.
-    pub fn prepare_wrap(&mut self, common: &Common, width: i32) -> bool {
+    pub fn prepare_wrap(&mut self, common: &Common, width: i32, rewrap: bool) -> bool {
         if self.status < Status::Shaped || width == 0 {
             return false;
         };
 
         let bb = self.forme.bounding_box();
 
-        if self.status == Status::Shaped {
+        if rewrap || self.status == Status::Shaped {
             let align_width = width.cast();
             let wrap_width = if !common.wrap { f32::INFINITY } else { align_width };
             self.forme

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -275,7 +275,8 @@ pub trait PartList {
     /// list has exactly one `Part`.
     fn variable_length(&self) -> bool;
     fn insert(&mut self, index: u32, part: Part);
-    fn delete(&mut self, index: u32);
+    fn remove(&mut self, index: u32) -> Part;
+    fn delete(&mut self, range: Range<u32>);
 }
 
 impl PartList for Part {
@@ -317,7 +318,12 @@ impl PartList for Part {
     }
 
     #[inline]
-    fn delete(&mut self, _: u32) {
+    fn remove(&mut self, _: u32) -> Part {
+        unimplemented!()
+    }
+
+    #[inline]
+    fn delete(&mut self, _: Range<u32>) {
         unimplemented!()
     }
 }
@@ -361,8 +367,14 @@ impl PartList for Vec<Part> {
     }
 
     #[inline]
-    fn delete(&mut self, index: u32) {
-        Vec::remove(self, index.cast());
+    fn remove(&mut self, index: u32) -> Part {
+        Vec::remove(self, index.cast())
+    }
+
+    #[inline]
+    fn delete(&mut self, range: Range<u32>) {
+        let range: Range<usize> = range.cast();
+        Vec::drain(self, range);
     }
 }
 
@@ -1237,45 +1249,88 @@ impl Common {
         &mut self,
         parts: &mut impl PartList,
         range: Range<TextIndex>,
-        replace_with: &str,
+        replacement: &str,
     ) -> TextIndex {
         self.validate_range(parts, range.clone());
 
         if !parts.variable_length() {
             let range = subrange_of(&range, 0);
-            parts.get_mut(0).replace_range(range.clone(), replace_with);
-            return TextIndex::new(0, range.start + replace_with.len());
+            parts.get_mut(0).replace_range(range.clone(), replacement);
+            return TextIndex::new(0, range.start + replacement.len());
         }
 
         let mut p = range.start.part();
         let p_end = range.end.part();
         let mut b_start = range.start.byte();
-        let mut last_line_end = 0;
-        for (line, _) in kas::text::Lines::new(replace_with) {
-            last_line_end = b_start + line.len();
-            if p < p_end {
+        debug_assert!(b_start <= parts.get(p).text.len());
+
+        // Break the input text into lines.
+        let mut lines = kas::text::Lines::new(replacement).map(|(line, _)| line);
+        let mut line = lines.next().unwrap_or("");
+        let mut remainder = None;
+
+        for next_line in lines {
+            if p <= p_end {
                 let part = parts.get_mut(p);
-                let b_end = if p + 1 != p_end {
-                    part.text.len()
-                } else {
-                    range.end.byte()
-                };
-                part.replace_range(b_start..b_end, line);
+                let end = part.text.len();
+                if p == p_end {
+                    let b_end = range.end.byte();
+                    debug_assert!(b_end <= end);
+                    if b_end < end {
+                        remainder = Some(part.as_str()[b_end..].to_string());
+                    }
+                }
+                part.replace_range(b_start..end, line);
             } else {
                 parts.insert(p, Part::from(line));
             }
+
             p += 1;
             b_start = 0;
+            line = next_line;
         }
 
-        let p_repl_end = p;
+        // Handle the last input line slightly differently to the above loop
+        let last_line_end = if b_start > 0 {
+            let part = parts.get_mut(p);
+            let mut end = part.text.len();
+            if p == p_end {
+                debug_assert!(range.end.byte() <= end);
+                end = end.min(range.end.byte());
+            }
 
-        while p < p_end {
-            parts.delete(p);
-            p += 1;
-        }
+            part.replace_range(b_start..end, line);
+            end = b_start + line.len();
 
-        TextIndex::new(p_repl_end, last_line_end)
+            if p_end > p {
+                parts.delete(p + 1..p_end);
+                let part = parts.remove(p + 1);
+                let rest = &part.as_str()[range.end.byte()..];
+                parts.get_mut(p).replace_range(end..end, rest);
+            }
+
+            end
+        } else if p <= p_end {
+            // Remove excess lines
+            parts.delete(p..p_end);
+
+            let part = parts.get_mut(p);
+            debug_assert!(range.end.byte() <= part.text.len());
+            let end = range.end.byte().min(part.text.len());
+            part.replace_range(b_start..end, line);
+            b_start + line.len()
+        } else {
+            let mut part = Part::from(line);
+            let len = line.len();
+
+            if let Some(remainder) = remainder.take() {
+                part.replace_range(len..len, &remainder);
+            }
+            parts.insert(p, part);
+            len
+        };
+
+        TextIndex::new(p, last_line_end)
     }
 
     fn copy_selection_to_string(&self, parts: &impl PartList) -> String {
@@ -2019,11 +2074,8 @@ impl Common {
                             p += 1;
                         }
                     } else if parts.len() > *old_num_parts {
-                        let mut n_delete = parts.len() - old_num_parts;
-                        while n_delete > 0 {
-                            parts.delete(p);
-                            n_delete -= 1;
-                        }
+                        let n_delete = parts.len() - old_num_parts;
+                        parts.delete(p..p + n_delete);
                     }
 
                     for text in &texts[n..] {

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -535,7 +535,7 @@ impl<H: Highlighter> Component<H> {
         }
 
         self.prepare_runs();
-        self.0.part.prepare_wrap(&self.0.common);
+        self.0.part.prepare_wrap(&self.0.common, self.rect().size.0);
     }
 
     /// Fully prepare text for display, ensuring the cursor is within view
@@ -545,9 +545,18 @@ impl<H: Highlighter> Component<H> {
     /// be called after changes to the text, alignment or wrap-width.
     #[inline]
     pub fn prepare_and_scroll(&mut self, cx: &mut EventCx) {
-        self.0
-            .common
-            .prepare_and_scroll(&mut self.0.part, &mut self.1, cx);
+        if !self.0.part.is_ready() {
+            if self.0.part.status < Status::Shaped {
+                self.0.part.prepare_runs(&self.0.common, &mut self.1);
+                self.0.common.update_direction(&self.0.part);
+            }
+
+            if self.0.part.prepare_wrap(&self.0.common, self.rect().size.0) {
+                cx.resize();
+                self.0.common.set_view_offset_from_cursor(&self.0.part, cx);
+            }
+            cx.redraw();
+        }
     }
 
     /// Measure required vertical height, wrapping as configured
@@ -575,9 +584,7 @@ impl<H: Highlighter> Component<H> {
     pub fn handle_event(&mut self, cx: &mut EventCx, event: Event) -> EventAction {
         let action = self.0.common.handle_event(&mut self.0.part, cx, event);
         if action.requires_repreparation() {
-            self.0
-                .common
-                .prepare_and_scroll(&mut self.0.part, &mut self.1, cx);
+            self.prepare_and_scroll(cx);
         }
         action
     }
@@ -736,7 +743,7 @@ impl Part {
         }
         self.rect = rect;
 
-        self.prepare_wrap(common);
+        self.prepare_wrap(common, rect.size.0);
         if let Some(p) = common.current.ime_part() {
             self.set_ime_cursor_area(common, cx, p);
         }
@@ -756,20 +763,22 @@ impl Part {
     /// displaying text: it advances [`Self::status`] from [`Status::Shaped`]
     /// to [`Status::Ready`].
     ///
-    /// If [`Self::status`] is less than [`Status::Shaped`], this method
-    /// returns early, otherwise it performs line-wrapping (if required) and
-    /// sets the status to [`Status::Ready`].
+    /// `width` is a required input (used for wrapping and alignment). If
+    /// `width == 0` or [`Self::status`] is less than [`Status::Shaped`] then
+    /// this method aborts (returns `false` without wrapping). Otherwise this
+    /// method performs line-wrapping (if required) and sets the status to
+    /// [`Status::Ready`].
     ///
     /// Returns `true` when the size of the bounding-box changes.
-    pub fn prepare_wrap(&mut self, common: &Common) -> bool {
-        if self.status < Status::Shaped || self.rect.size.0 == 0 {
+    pub fn prepare_wrap(&mut self, common: &Common, width: i32) -> bool {
+        if self.status < Status::Shaped || width == 0 {
             return false;
         };
 
         let bb = self.forme.bounding_box();
 
         if self.status == Status::Shaped {
-            let align_width = self.rect.size.0.cast();
+            let align_width = width.cast();
             let wrap_width = if !common.wrap { f32::INFINITY } else { align_width };
             self.forme
                 .prepare_lines(wrap_width, align_width, Align::Default);
@@ -798,6 +807,8 @@ impl Part {
     }
 
     /// Implementation of [`Viewport::content_size`]
+    ///
+    /// Returns [`Size::ZERO`] if not prepared.
     pub fn content_size(&self) -> Size {
         if !self.is_ready() {
             return Size::ZERO;
@@ -1258,39 +1269,6 @@ impl Common {
         TextIndex::new(p_repl_end, last_line_end)
     }
 
-    /// Fully prepare text for display, ensuring the cursor is within view
-    ///
-    /// This method performs all required steps of preparation according to the
-    /// [`Status`] (which is advanced to [`Status::Ready`]). This method should
-    /// be called after changes to the text, alignment or wrap-width.
-    #[inline]
-    pub fn prepare_and_scroll<H: Highlighter>(
-        &mut self,
-        parts: &mut impl PartList,
-        highlighter: &mut H,
-        cx: &mut EventCx,
-    ) {
-        let mut any_resized = false;
-
-        for (i, part) in parts.iter_mut().enumerate() {
-            if !part.is_ready() {
-                if part.status < Status::Shaped {
-                    part.prepare_runs(self, highlighter);
-                    if i == 0 {
-                        self.update_direction(part);
-                    }
-                }
-                any_resized |= part.prepare_wrap(self);
-            }
-        }
-
-        if any_resized {
-            cx.resize();
-            self.set_view_offset_from_cursor(parts, cx);
-        }
-        cx.redraw();
-    }
-
     fn copy_selection_to_string(&self, parts: &impl PartList) -> String {
         let range = self.selection.to_range();
         if range.start.part == range.end.part {
@@ -1365,8 +1343,9 @@ impl Common {
 
     /// Handle an event
     ///
-    /// If [`EventAction::requires_repreparation`] then the caller **must** call
-    /// re-prepare the text by calling [`Common::prepare_and_scroll`].
+    /// If [`EventAction::requires_repreparation`] then the caller **must**
+    /// re-prepare and position each part (see e.g.
+    /// [`Component::prepare_and_scroll`]).
     //
     // TODO(opt): should we use dyn PartList to reduce code size?
     pub fn handle_event(
@@ -2072,7 +2051,7 @@ impl Common {
     /// It is assumed that the text has not changed.
     ///
     /// A redraw is assumed since the cursor moved.
-    fn set_view_offset_from_cursor(&self, parts: &impl PartList, cx: &mut EventCx) {
+    pub fn set_view_offset_from_cursor(&self, parts: &impl PartList, cx: &mut EventCx) {
         let cursor = self.selection.cursor;
         let part = parts.get(cursor.part());
         if part.is_ready()

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -1442,7 +1442,9 @@ impl Common {
     /// re-prepare and position each part (see e.g.
     /// [`Component::prepare_and_scroll`]). If otherwise
     /// [`EventAction::requires_set_view_offset`] then the caller should call
-    /// [`Common::set_view_offset_from_cursor`].
+    /// [`Common::set_view_offset_from_cursor`]. (In both cases, a redraw
+    /// should be requested; this may happen as a side-effect of calling one of
+    /// the methods mentioned here.)
     //
     // TODO(opt): should we use dyn PartList to reduce code size?
     pub fn handle_event(
@@ -2138,7 +2140,7 @@ impl Common {
     ///
     /// It is assumed that the text has not changed.
     ///
-    /// A redraw is assumed since the cursor moved.
+    /// This method additionally requests a redraw.
     pub fn set_view_offset_from_cursor(&self, parts: &impl PartList, cx: &mut EventCx) {
         let cursor = self.selection.cursor;
         let part = parts.get(cursor.part());
@@ -2150,6 +2152,7 @@ impl Common {
             let size = Size(0, i32::conv_to(Ceil, marker.pos.1 - marker.descent) - y0);
             cx.set_scroll(Scroll::Rect(Rect { pos, size }));
         }
+        cx.redraw();
     }
 }
 

--- a/crates/kas-widgets/src/edit/multi_part.rs
+++ b/crates/kas-widgets/src/edit/multi_part.rs
@@ -438,7 +438,7 @@ mod Inner {
 
                 content_size.0 = content_size.0.max(part_size.0);
                 content_size.1 += part_size.1;
-                rect.pos.1 = content_size.1;
+                rect.pos.1 += part_size.1;
             }
             self.content_size = content_size;
         }
@@ -509,8 +509,35 @@ mod Inner {
         fn handle_event(&mut self, cx: &mut EventCx, _: &(), event: Event) -> IsUsed {
             let action = self.common.handle_event(&mut self.parts, cx, event);
             if action.requires_repreparation() {
-                self.common
-                    .prepare_and_scroll(&mut self.parts, &mut self.highlighter, cx);
+                // TODO(opt): skip updating unchanged parts
+                let mut any_resized = false;
+                let mut content_size = Size::ZERO;
+                let mut rect = self.rect();
+
+                for part in &mut self.parts {
+                    if !part.is_ready() {
+                        if part.status() < Status::Shaped {
+                            part.prepare_runs(&self.common, &mut self.highlighter);
+                        }
+                        any_resized |= part.prepare_wrap(&self.common, rect.size.0);
+                    }
+
+                    let part_size = part.content_size();
+                    rect.size.1 = part_size.1;
+                    part.set_rect(&self.common, &mut cx.size_cx(), rect);
+
+                    content_size.0 = content_size.0.max(part_size.0);
+                    content_size.1 += part_size.1;
+                    rect.pos.1 += part_size.1;
+                }
+
+                self.content_size = content_size;
+
+                cx.redraw();
+                if any_resized {
+                    cx.resize();
+                    self.common.set_view_offset_from_cursor(&self.parts, cx);
+                }
             }
 
             match action {

--- a/crates/kas-widgets/src/edit/multi_part.rs
+++ b/crates/kas-widgets/src/edit/multi_part.rs
@@ -149,7 +149,7 @@ mod MultiPartEditor {
                 size: self.rect().size - self.frame_size,
             };
             let used = self.scroll.scroll_by_event(cx, event, self.id(), rect);
-            self.update_content_size(cx);
+            self.update_scroll_offset(cx);
             used
         }
 

--- a/crates/kas-widgets/src/edit/multi_part.rs
+++ b/crates/kas-widgets/src/edit/multi_part.rs
@@ -428,10 +428,13 @@ mod Inner {
 
         #[inline]
         fn set_rect(&mut self, cx: &mut SizeCx, mut rect: Rect, _: AlignHints) {
+            let rewrap = rect.size.0 != self.rect().size.0;
             self.core.set_rect(rect);
 
             let mut content_size = Size::ZERO;
             for part in &mut self.parts {
+                part.prepare_wrap(&self.common, rect.size.0, rewrap);
+
                 let part_size = part.content_size();
                 rect.size.1 = part_size.1;
                 part.set_rect(&self.common, cx, rect);
@@ -519,7 +522,7 @@ mod Inner {
                         if part.status() < Status::Shaped {
                             part.prepare_runs(&self.common, &mut self.highlighter);
                         }
-                        any_resized |= part.prepare_wrap(&self.common, rect.size.0);
+                        any_resized |= part.prepare_wrap(&self.common, rect.size.0, false);
                     }
 
                     let part_size = part.content_size();

--- a/crates/kas-widgets/src/edit/multi_part.rs
+++ b/crates/kas-widgets/src/edit/multi_part.rs
@@ -6,7 +6,7 @@
 //! The [`MultiPartEditor`] widget
 
 use super::editor::{Common, EventAction, Part};
-use crate::edit::editor::{ActionResetStatus, TextIndex};
+use crate::edit::editor::{ActionResetStatus, PartList, TextIndex};
 use crate::edit::highlight::{Highlighter, Plain};
 use crate::{ScrollBar, ScrollBarMsg};
 use kas::cast::Ceil;
@@ -15,7 +15,6 @@ use kas::event::{CursorIcon, Scroll};
 use kas::prelude::*;
 use kas::text::{Direction, Status};
 use kas::theme::{FrameStyle, TextClass};
-use std::rc::Rc;
 
 #[derive(Debug)]
 struct CallOnEdit;
@@ -77,7 +76,13 @@ mod MultiPartEditor {
             // Set bar position, dependent on text direction. TODO: move on text-dir-change.
             let bar_width = cx.scroll_bar_width();
             let (x0, x1);
-            if !self.inner.part.text_is_rtl() {
+            if !self
+                .inner
+                .parts
+                .first()
+                .map(|part| part.text_is_rtl())
+                .unwrap_or_default()
+            {
                 x1 = rect.pos.0 + rect.size.0;
                 x0 = x1 - bar_width;
             } else {
@@ -251,16 +256,21 @@ mod MultiPartEditor {
 
         /// Read text contents from parts
         ///
-        /// The whole contents equals the concatenation of parts.
-        pub fn text_parts(&self) -> impl Iterator<Item = &Rc<String>> {
-            std::iter::once(self.inner.part.text())
+        /// The whole contents equals the concatenation of parts. FIXME
+        pub fn text_parts(&self) -> impl Iterator<Item = &Part> {
+            self.inner.parts.iter()
         }
 
         /// Copy text contents to a `String`
         pub fn text_to_string(&self) -> String {
             let mut s = String::new();
-            for part in self.text_parts() {
-                s.push_str(part);
+            let mut iter = self.text_parts();
+            if let Some(first) = iter.next() {
+                s.push_str(first.as_str());
+            }
+            for part in iter {
+                s.push('\n'); // TODO
+                s.push_str(part.as_str());
             }
             s
         }
@@ -325,9 +335,10 @@ mod Inner {
     pub struct Inner<H: Highlighter> {
         core: widget_core!(),
         width: (f32, f32),
+        content_size: Size,
         common: Common,
         highlighter: H,
-        part: Part,
+        parts: Vec<Part>,
     }
 
     impl Default for Self
@@ -338,9 +349,10 @@ mod Inner {
             Inner {
                 core: Default::default(),
                 width: (8.0, 16.0),
+                content_size: Size::ZERO,
                 common: Common::new(true),
                 highlighter: H::default(),
-                part: Part::default(),
+                parts: vec![Part::default()],
             }
         }
     }
@@ -349,12 +361,17 @@ mod Inner {
         /// Set the initial text (inline)
         ///
         /// This method should only be used on a new `Inner`.
-        #[inline]
         #[must_use]
         fn with_text(mut self, text: &str) -> Self {
             debug_assert!(self.common.is_unedited());
+
             self.common.set_cursor(TextIndex::new(0, 0));
-            self.part = Part::from(text);
+
+            self.parts = kas::text::Lines::new(text)
+                .map(|(line, _)| Part::from(line))
+                .collect();
+            debug_assert!(!self.parts.is_empty());
+
             self
         }
 
@@ -366,69 +383,78 @@ mod Inner {
             Inner {
                 core: self.core,
                 width: self.width,
+                content_size: self.content_size,
                 common: self.common,
                 highlighter,
-                part: self.part,
-            }
-        }
-
-        fn prepare_runs(&mut self) {
-            if self.part.status() < Status::Shaped {
-                self.part
-                    .prepare_runs(&mut self.common, &mut self.highlighter);
-                self.common.update_direction(&self.part);
+                parts: self.parts,
             }
         }
     }
 
     impl Layout for Self {
-        #[inline]
-        fn rect(&self) -> Rect {
-            self.part.rect()
-        }
-
         fn size_rules(&mut self, cx: &mut SizeCx, axis: AxisInfo) -> SizeRules {
             let (min, mut ideal): (i32, i32);
             if axis.is_horizontal() {
                 let dpem = cx.dpem(TextClass::Editor);
                 min = (self.width.0 * dpem).cast_to(Ceil);
                 ideal = (self.width.1 * dpem).cast_to(Ceil);
-            } else if let Some(width) = axis.other() {
-                let Ok(h) = self.part.measure_height(width.cast(), None) else {
-                    if cfg!(debug_assertions) {
-                        panic!("Part: expected prepare_runs() to be called");
-                    } else {
-                        return SizeRules::EMPTY;
-                    }
-                };
+            } else if let Some(width) = axis.other()
+                && let Some(first) = self.parts.first()
+                && let Ok(h) = first.measure_height(width.cast(), None)
+            {
                 min = h.cast_to(Ceil);
                 ideal = min;
             } else {
-                unreachable!()
+                debug_assert!(false);
+                return SizeRules::EMPTY;
             };
 
-            let rules = self.part.size_rules(&self.common, cx, axis);
+            let rules = if axis.is_horizontal() {
+                self.parts
+                    .iter_mut()
+                    .map(|part| part.size_rules(&self.common, cx, axis))
+                    .fold(SizeRules::default(), |rules, item| rules.max(item))
+            } else {
+                self.parts
+                    .iter_mut()
+                    .map(|part| part.size_rules(&self.common, cx, axis))
+                    .reduce(|a, b| a.appended(b))
+                    .unwrap_or_default()
+            };
             ideal = ideal.max(rules.ideal_size());
 
             SizeRules::new(min, ideal, Stretch::High).with_margins(cx.text_margins().extract(axis))
         }
 
         #[inline]
-        fn set_rect(&mut self, cx: &mut SizeCx, rect: Rect, _: AlignHints) {
-            self.part.set_rect(&self.common, cx, rect);
+        fn set_rect(&mut self, cx: &mut SizeCx, mut rect: Rect, _: AlignHints) {
+            self.core.set_rect(rect);
+
+            let mut content_size = Size::ZERO;
+            for part in &mut self.parts {
+                let part_size = part.content_size();
+                rect.size.1 = part_size.1;
+                part.set_rect(&self.common, cx, rect);
+
+                content_size.0 = content_size.0.max(part_size.0);
+                content_size.1 += part_size.1;
+                rect.pos.1 = content_size.1;
+            }
+            self.content_size = content_size;
         }
     }
 
     impl Viewport for Self {
         #[inline]
         fn content_size(&self) -> Size {
-            self.part.content_size()
+            self.content_size
         }
 
         #[inline]
         fn draw_with_offset(&self, mut draw: DrawCx, rect: Rect, offset: Offset) {
-            self.part
-                .draw_with_offset(draw, &self.common, 0, rect, offset);
+            for (i, part) in self.parts.iter().enumerate() {
+                part.draw_with_offset(draw.re(), &self.common, i.cast(), rect, offset);
+            }
         }
     }
 
@@ -458,22 +484,33 @@ mod Inner {
         }
 
         fn configure(&mut self, cx: &mut ConfigCx) {
-            if let Some(ActionResetStatus) = self.common.configure(&cx.size_cx(), self.core.id()) {
-                self.part.require_reprepare();
-            }
+            let mut opt_reset = self.common.configure(&cx.size_cx(), self.core.id());
+
             if let Some(_) = self.highlighter.configure(cx) {
                 self.common.set_colors(self.highlighter.scheme_colors());
-                self.part.require_reprepare();
+                opt_reset = Some(ActionResetStatus);
             }
 
-            self.prepare_runs();
+            for (i, part) in self.parts.iter_mut().enumerate() {
+                if opt_reset.is_some() {
+                    part.require_reprepare();
+                } else if part.status() >= Status::Shaped {
+                    continue;
+                }
+
+                part.prepare_runs(&self.common, &mut self.highlighter);
+
+                if i == 0 {
+                    self.common.update_direction(part);
+                }
+            }
         }
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &(), event: Event) -> IsUsed {
-            let action = self.common.handle_event(&mut self.part, cx, event);
+            let action = self.common.handle_event(&mut self.parts, cx, event);
             if action.requires_repreparation() {
                 self.common
-                    .prepare_and_scroll(&mut self.part, &mut self.highlighter, cx);
+                    .prepare_and_scroll(&mut self.parts, &mut self.highlighter, cx);
             }
 
             match action {

--- a/crates/kas-widgets/src/edit/multi_part.rs
+++ b/crates/kas-widgets/src/edit/multi_part.rs
@@ -508,7 +508,7 @@ mod Inner {
 
         fn handle_event(&mut self, cx: &mut EventCx, _: &(), event: Event) -> IsUsed {
             let action = self.common.handle_event(&mut self.parts, cx, event);
-            if action.requires_repreparation() {
+            let set_view_offset = if action.requires_repreparation() {
                 // TODO(opt): skip updating unchanged parts
                 let mut any_resized = false;
                 let mut content_size = Size::ZERO;
@@ -536,8 +536,14 @@ mod Inner {
                 cx.redraw();
                 if any_resized {
                     cx.resize();
-                    self.common.set_view_offset_from_cursor(&self.parts, cx);
                 }
+                any_resized
+            } else {
+                action.requires_set_view_offset()
+            };
+            if set_view_offset {
+                cx.redraw();
+                self.common.set_view_offset_from_cursor(&self.parts, cx);
             }
 
             match action {
@@ -546,7 +552,7 @@ mod Inner {
                 | EventAction::FocusGained
                 | EventAction::FocusLost
                 | EventAction::Preedit => Used,
-                EventAction::Edit => {
+                EventAction::Edit { .. } => {
                     cx.push(CallOnEdit);
                     Used
                 }

--- a/crates/kas-widgets/src/edit/multi_part.rs
+++ b/crates/kas-widgets/src/edit/multi_part.rs
@@ -365,7 +365,7 @@ mod Inner {
         fn with_text(mut self, text: &str) -> Self {
             debug_assert!(self.common.is_unedited());
 
-            self.common.set_cursor(TextIndex::new(0, 0));
+            self.common.set_cursor(&self.parts, TextIndex::new(0, 0));
 
             self.parts = kas::text::Lines::new(text)
                 .map(|(line, _)| Part::from(line))

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -343,15 +343,17 @@ Demonstration of *as-you-type* formatting from **Markdown**.
                 _ => Direction::Up,
             };
         })
-        .on_message(|cx, data, UpdateContents(text)| {
-            match Markdown::new(&text) {
+        .on_message(
+            |cx, data, UpdateContents(text)| match Markdown::new(&text) {
                 Ok(text) => cx.send(data.label_id.clone(), text),
                 Err(err) => {
-                    // TODO: display the error in the GUI
-                    eprintln!("{err}");
+                    let msg = format!("{err}");
+                    if let Ok(text) = Markdown::new(&msg) {
+                        cx.send(data.label_id.clone(), text);
+                    }
                 }
-            }
-        })
+            },
+        )
         .on_message(|_, data, SetLabelId(id)| data.label_id = id);
 
     Page::new(ui)


### PR DESCRIPTION
This follows #710, implementing multi-part editing support. There are some pre-existing issues (e.g. mouse interaction with scrolling), but editing does appear to work (basic testing).

Motivation: make the editor scale to large input documents. Performance is acceptable now but could still be better (e.g. I can paste the 2374-line `editor.rs` file into `examples/text-editor` and type away; under a release build there is no noticeable lag while under a debug build some actions like the paste still have noticeable lag though the typing at least is lag-free).