### PR TITLE
MultiPartEditor: add explicit representation of line-breaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,4 +174,4 @@ resolver = "2"
 
 [patch.crates-io.kas-text]
 git = "https://github.com/kas-gui/kas-text.git"
-rev = "575d0ac8bdbb56f8028c15ba1c05f07d2eb66f8d"
+rev = "9db5bad1d3a6c26203f6a2428a67e1cc6835412d"

--- a/crates/kas-core/src/text/mod.rs
+++ b/crates/kas-core/src/text/mod.rs
@@ -11,8 +11,8 @@
 //! [KAS Text]: https://github.com/kas-gui/kas-text/
 
 pub use kas_text::{
-    Align, DPU, Direction, Forme, Line, LineRanges, Lines, MarkerPos, MarkerPosIter, NotReady,
-    Status, Vec2, fonts,
+    Align, DPU, Direction, Forme, Line, LineBreakBytes, LineRanges, Lines, MarkerPos,
+    MarkerPosIter, NotReady, Status, Vec2, fonts,
 };
 
 pub mod format;

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -125,6 +125,15 @@ fn subrange_of(range: &Range<TextIndex>, part: u32) -> Range<usize> {
     range.start.byte()..range.end.byte()
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct StackItem {
+    first_part_num: u32,
+    num_parts: u32,
+    // saved texts from first_part_num
+    texts: Vec<Rc<String>>,
+    cursor: CursorRange<TextIndex>,
+}
+
 /// Editor state common to all parts
 #[derive(Debug)]
 pub struct Common {
@@ -138,10 +147,9 @@ pub struct Common {
     read_only: bool,
     has_key_focus: bool,
     edit_x_coord: Option<f32>,
-    selection: CursorRange<TextIndex>,
+    cursor: CursorRange<TextIndex>,
     last_edit: Option<EditOp>,
-    /// Stack items: (first_part_num, num_parts, Vec of saved texts from first_part_num, selection)
-    undo_stack: UndoStack<(u32, u32, Vec<Rc<String>>, CursorRange<TextIndex>)>,
+    undo_stack: UndoStack<StackItem>,
     current: CurrentAction,
     input_handler: TextInput,
 }
@@ -160,7 +168,7 @@ impl Common {
             read_only: false,
             has_key_focus: false,
             edit_x_coord: None,
-            selection: CursorRange::default(),
+            cursor: CursorRange::default(),
             last_edit: Some(EditOp::Initial),
             undo_stack: UndoStack::new(),
             current: CurrentAction::None,
@@ -241,8 +249,8 @@ impl Common {
     #[inline]
     pub fn cursor_range(&self) -> CursorRange<TextIndex> {
         CursorRange {
-            anchor: self.selection.anchor,
-            cursor: self.selection.cursor,
+            anchor: self.cursor.anchor,
+            cursor: self.cursor.cursor,
         }
     }
 
@@ -252,9 +260,9 @@ impl Common {
     /// guard.
     pub fn set_cursor(&mut self, parts: &impl PartList, range: impl Into<CursorRange<TextIndex>>) {
         let range = range.into();
-        if range != self.selection {
+        if range != self.cursor {
             self.validate_range(parts, range.to_range());
-            self.selection = range;
+            self.cursor = range;
             self.edit_x_coord = None;
         }
     }
@@ -525,7 +533,7 @@ impl<H: Highlighter> Component<H> {
         self.0.part.text = Rc::new(text.to_string());
         let byte = if self.0.common.wrap { 0 } else { self.0.part.text.len() };
         let index = TextIndex::new(0, byte);
-        self.0.common.selection.set_position(index);
+        self.0.common.cursor.set_position(index);
         self
     }
 
@@ -674,7 +682,7 @@ impl Part {
         debug_assert!(range.cursor <= self.as_str().len());
         let anchor = TextIndex::new(p, range.anchor);
         let cursor = TextIndex::new(p, range.cursor);
-        common.selection = CursorRange { anchor, cursor };
+        common.cursor = CursorRange { anchor, cursor };
     }
 
     /// Get text contents as a reference to the internal [`Rc`]
@@ -880,7 +888,7 @@ impl Part {
         }
 
         let pos = self.rect.pos - offset;
-        let range = common.selection.to_range();
+        let range = common.cursor.to_range();
         let range = if p < range.start.part || p > range.end.part {
             0..0
         } else {
@@ -1002,14 +1010,14 @@ impl Part {
         }
 
         if !common.read_only
-            && p == common.selection.cursor.part
+            && p == common.cursor.cursor.part
             && draw.ev_state().has_input_focus(&common.id) == Some(true)
         {
             draw.text_cursor(
                 pos,
                 rect,
                 &self.forme,
-                common.selection.cursor.byte(),
+                common.cursor.cursor.byte(),
                 Some(common.colors.cursor),
             );
         }
@@ -1056,7 +1064,7 @@ impl Part {
     fn ime_surrounding_text(&self, common: &Common, p: u32) -> Option<ImeSurroundingText> {
         const MAX_TEXT_BYTES: usize = ImeSurroundingText::MAX_TEXT_BYTES;
 
-        let sel_range = subrange_of(&common.selection.to_range(), p);
+        let sel_range = subrange_of(&common.cursor.to_range(), p);
         let edit_range = match common.current.clone() {
             CurrentAction::ImePreedit { edit_range, .. } => Some(edit_range.cast()),
             _ => None,
@@ -1097,8 +1105,8 @@ impl Part {
             text = self.as_str()[range].to_string();
         }
 
-        let cursor = common.selection.cursor.byte().saturating_sub(start);
-        let anchor = common.selection.anchor.byte().saturating_sub(start);
+        let cursor = common.cursor.cursor.byte().saturating_sub(start);
+        let anchor = common.cursor.anchor.byte().saturating_sub(start);
         ImeSurroundingText::new(text, cursor, anchor)
             .inspect_err(|err| {
                 // TODO: use Display for err not Debug
@@ -1114,7 +1122,7 @@ impl Part {
         }
 
         let range = match common.current.clone() {
-            CurrentAction::ImeStart(_) => subrange_of(&common.selection.to_range(), p),
+            CurrentAction::ImeStart(_) => subrange_of(&common.cursor.to_range(), p),
             CurrentAction::ImePreedit { edit_range, .. } => edit_range.cast(),
             _ => return,
         };
@@ -1169,7 +1177,7 @@ impl Part {
             Ime::Preedit { text, cursor } => {
                 let (part, mut edit_range) = match common.current.clone() {
                     CurrentAction::ImeStart(part) if cursor.is_some() => {
-                        (part, subrange_of(&common.selection.to_range(), part))
+                        (part, subrange_of(&common.cursor.to_range(), part))
                     }
                     CurrentAction::ImeStart(_) => return EventAction::Used,
                     CurrentAction::ImePreedit { part, edit_range } => (part, edit_range.cast()),
@@ -1198,7 +1206,7 @@ impl Part {
             Ime::Commit { text } => {
                 let (part, edit_range) = match common.current.clone() {
                     CurrentAction::ImeStart(part) => {
-                        (part, subrange_of(&common.selection.to_range(), part))
+                        (part, subrange_of(&common.cursor.to_range(), part))
                     }
                     CurrentAction::ImePreedit { part, edit_range } => (part, edit_range.cast()),
                     _ => return EventAction::Used,
@@ -1221,7 +1229,7 @@ impl Part {
                 after_bytes,
             } => {
                 let (p, edit_range) = match common.current.clone() {
-                    CurrentAction::ImeStart(p) => (p, subrange_of(&common.selection.to_range(), p)),
+                    CurrentAction::ImeStart(p) => (p, subrange_of(&common.cursor.to_range(), p)),
                     CurrentAction::ImePreedit { edit_range, part } => (part, edit_range.cast()),
                     _ => return EventAction::Used,
                 };
@@ -1239,7 +1247,7 @@ impl Part {
                                 *index = start;
                             }
                         };
-                        let mut sel = subrange_of(&common.selection.to_range(), p);
+                        let mut sel = subrange_of(&common.cursor.to_range(), p);
                         adjust(&mut sel.start);
                         adjust(&mut sel.end);
                         self.set_cursor(common, p, sel);
@@ -1381,7 +1389,7 @@ impl Common {
     }
 
     fn copy_selection_to_string(&self, parts: &impl PartList) -> String {
-        let range = self.selection.to_range();
+        let range = self.cursor.to_range();
         if range.start.part == range.end.part {
             return parts.get(range.start.part()).as_str()[range.start.byte()..range.end.byte()]
                 .to_string();
@@ -1410,7 +1418,7 @@ impl Common {
     fn text_index_nearest(&self, parts: &impl PartList, coord: Coord) -> TextIndex {
         let mut l_bound = 0;
         let mut u_bound = parts.len();
-        let mut p = self.selection.cursor.part();
+        let mut p = self.cursor.cursor.part();
         let mut best_dist = i32::MAX;
         let mut best_p = p;
         loop {
@@ -1497,7 +1505,7 @@ impl Common {
                 if self.current.is_none() {
                     let hint = Default::default();
                     let purpose = ImePurpose::Normal;
-                    let p = self.selection.cursor.part();
+                    let p = self.cursor.cursor.part();
                     let part = parts.get_mut(p);
                     let surrounding_text = part.ime_surrounding_text(self, p);
                     cx.replace_ime_focus(self.id.clone(), hint, purpose, surrounding_text);
@@ -1517,9 +1525,9 @@ impl Common {
             }
             Event::LostSelFocus => {
                 // NOTE: we can assume that we will receive Ime::Disabled if IME is active
-                if !self.selection.is_empty() {
+                if !self.cursor.is_empty() {
                     self.save_undo_state(parts, None);
-                    self.selection.clear_selection();
+                    self.cursor.clear_selection();
                 }
                 self.input_handler.stop_selecting();
                 cx.redraw();
@@ -1530,7 +1538,7 @@ impl Common {
                 .unwrap_or(EventAction::Used),
             Event::Key(event, false) if event.state == ElementState::Pressed && !self.read_only => {
                 if let Some(text) = &event.text {
-                    let selection = self.selection.to_range();
+                    let selection = self.cursor.to_range();
                     self.save_undo_state(
                         parts,
                         Some(EditOp::KeyInput(
@@ -1561,7 +1569,7 @@ impl Common {
                 }
             }
             Event::Ime(ime) => {
-                let p = self.selection.cursor.part();
+                let p = self.cursor.cursor.part();
                 match self.current {
                     CurrentAction::None if ime == Ime::Enabled => {
                         self.current = CurrentAction::ImeStart(p.cast());
@@ -1631,7 +1639,7 @@ impl Common {
                     self.current = CurrentAction::Selection;
 
                     let mut cursor = self.text_index_nearest(parts, coord);
-                    let mut anchor = if clear { cursor } else { self.selection.anchor };
+                    let mut anchor = if clear { cursor } else { self.cursor.anchor };
 
                     if repeats > 1 {
                         if anchor.part == cursor.part {
@@ -1656,8 +1664,8 @@ impl Common {
                         return EventAction::Used;
                     }
 
-                    let mut anchor = self.selection.anchor;
-                    let mut cursor = self.selection.cursor;
+                    let mut anchor = self.cursor.anchor;
+                    let mut cursor = self.cursor.cursor;
                     let index = self.text_index_nearest(parts, coord);
                     if index.part == anchor.part && index.part == cursor.part {
                         let part = parts.get(index.part());
@@ -1735,8 +1743,12 @@ impl Common {
                 (start, texts)
             }
         };
-        self.undo_stack
-            .try_push((part, parts.len(), texts, self.selection));
+        self.undo_stack.try_push(StackItem {
+            first_part_num: part,
+            num_parts: parts.len(),
+            texts,
+            cursor: self.cursor,
+        });
     }
 
     /// Request key focus, if we don't have it or IME
@@ -1756,7 +1768,7 @@ impl Common {
         let editable = !self.read_only;
         let mut shift = cx.modifiers().shift_key();
         let mut buf = [0u8; 4];
-        let cursor = self.selection.cursor;
+        let cursor = self.cursor.cursor;
         let c_byte = cursor.byte();
         let c_p = cursor.part();
         let c_part = parts.get(c_p);
@@ -1764,7 +1776,7 @@ impl Common {
         let c_part_len = c_part.as_str().len();
         let num_parts = parts.len();
         let multi_line = self.wrap;
-        let selection = self.selection.to_range();
+        let selection = self.cursor.to_range();
         let have_sel = selection.end > selection.start;
         let string;
 
@@ -1967,7 +1979,7 @@ impl Common {
                 } else {
                     return Ok(EventAction::Used);
                 };
-                Action::Delete(self.selection.cursor..end, true)
+                Action::Delete(self.cursor.cursor..end, true)
             }
             Command::DelBack if editable => {
                 let start = if c_byte > 0
@@ -1982,7 +1994,7 @@ impl Common {
                 } else {
                     return Ok(EventAction::Used);
                 };
-                Action::Delete(start..self.selection.cursor, true)
+                Action::Delete(start..self.cursor.cursor, true)
             }
             Command::DelWord if editable => {
                 let next = c_part.as_str()[c_byte..]
@@ -1997,7 +2009,7 @@ impl Common {
                 } else {
                     return Ok(EventAction::Used);
                 };
-                Action::Delete(self.selection.cursor..end, true)
+                Action::Delete(self.cursor.cursor..end, true)
             }
             Command::DelWordBack if editable => {
                 let start = if c_byte > 0 {
@@ -2014,10 +2026,10 @@ impl Common {
                 } else {
                     return Ok(EventAction::Used);
                 };
-                Action::Delete(start..self.selection.cursor, true)
+                Action::Delete(start..self.cursor.cursor, true)
             }
             Command::SelectAll => {
-                self.selection.anchor = TextIndex::new(0, 0);
+                self.cursor.anchor = TextIndex::new(0, 0);
                 shift = true; // hack
                 let p = parts.len() - 1;
                 let len = parts.get(p).as_str().len();
@@ -2074,13 +2086,13 @@ impl Common {
 
         let action = match action {
             Action::Deselect => {
-                self.selection.clear_selection();
+                self.cursor.clear_selection();
                 cx.redraw();
                 EventAction::Cursor
             }
             Action::Activate => EventAction::Activate(code),
             Action::Insert(s, is_key_input) => {
-                let mut index = self.selection.cursor;
+                let mut index = self.cursor.cursor;
                 let range = if have_sel { selection.clone() } else { index..index };
                 index = self.replace_range(parts, range, s);
                 self.set_cursor(parts, index);
@@ -2094,9 +2106,9 @@ impl Common {
                 EventAction::Edit { is_key_input }
             }
             Action::Move(index, x_coord) => {
-                self.selection.cursor = index;
+                self.cursor.cursor = index;
                 if !shift {
-                    self.selection.clear_selection();
+                    self.cursor.clear_selection();
                 } else {
                     self.set_primary(parts, cx);
                 }
@@ -2105,13 +2117,12 @@ impl Common {
                 EventAction::Cursor
             }
             Action::UndoRedo(redo) => {
-                if let Some((p, old_num_parts, texts, cursor)) = self.undo_stack.undo_or_redo(redo)
-                {
-                    let mut p = *p;
+                if let Some(item) = self.undo_stack.undo_or_redo(redo) {
+                    let mut p = item.first_part_num;
                     let mut n: usize = 0;
-                    if parts.len() < *old_num_parts {
-                        n = (old_num_parts - parts.len()).cast();
-                        for text in &texts[..n] {
+                    if parts.len() < item.num_parts {
+                        n = (item.num_parts - parts.len()).cast();
+                        for text in &item.texts[..n] {
                             let part = Part {
                                 text: Rc::clone(text),
                                 ..Default::default()
@@ -2119,12 +2130,12 @@ impl Common {
                             parts.insert(p, part);
                             p += 1;
                         }
-                    } else if parts.len() > *old_num_parts {
-                        let n_delete = parts.len() - old_num_parts;
+                    } else if parts.len() > item.num_parts {
+                        let n_delete = parts.len() - item.num_parts;
                         parts.delete(p..p + n_delete);
                     }
 
-                    for text in &texts[n..] {
+                    for text in &item.texts[n..] {
                         let part = parts.get_mut(p);
                         if !Rc::ptr_eq(&part.text, text) {
                             part.text = Rc::clone(text);
@@ -2134,7 +2145,7 @@ impl Common {
                     }
 
                     self.edit_x_coord = None;
-                    let range = *cursor;
+                    let range = item.cursor;
                     self.set_cursor(parts, range);
                     EventAction::Edit {
                         is_key_input: false,
@@ -2150,7 +2161,7 @@ impl Common {
 
     /// Set primary clipboard (mouse buffer) contents from selection
     fn set_primary(&self, parts: &impl PartList, cx: &mut EventCx) {
-        if self.has_key_focus && !self.selection.is_empty() && cx.has_primary() {
+        if self.has_key_focus && !self.cursor.is_empty() && cx.has_primary() {
             cx.set_primary(self.copy_selection_to_string(parts));
         }
     }
@@ -2161,7 +2172,7 @@ impl Common {
     ///
     /// This method additionally requests a redraw.
     pub fn set_view_offset_from_cursor(&self, parts: &impl PartList, cx: &mut EventCx) {
-        let cursor = self.selection.cursor;
+        let cursor = self.cursor.cursor;
         let part = parts.get(cursor.part());
         if part.is_ready()
             && let Some(marker) = part.forme.text_glyph_pos(cursor.byte()).next_back()
@@ -2228,7 +2239,7 @@ impl Editor {
         Rc::make_mut(&mut self.part.text).clear();
         self.part.require_reprepare();
 
-        self.common.selection.set_position(TextIndex::new(0, 0));
+        self.common.cursor.set_position(TextIndex::new(0, 0));
         self.common.edit_x_coord = None;
         self.error_state = None;
     }
@@ -2288,7 +2299,7 @@ impl Editor {
         self.part.require_reprepare();
 
         let len = TextIndex::new(0, self.as_str().len());
-        self.common.selection.set_max_len(len);
+        self.common.cursor.set_max_len(len);
         self.common.edit_x_coord = None;
         self.error_state = None;
     }
@@ -2303,7 +2314,7 @@ impl Editor {
 
         self.common.cancel_selection_and_ime(&mut self.part, cx);
 
-        let selection = self.common.selection.to_range();
+        let selection = self.common.cursor.to_range();
         let start = selection.start.byte();
         let end = selection.end.byte();
         self.part.replace_range(start..end, text);
@@ -2316,8 +2327,8 @@ impl Editor {
     #[inline]
     pub fn cursor_range(&self) -> CursorRange<usize> {
         CursorRange {
-            anchor: self.common.selection.anchor.byte(),
-            cursor: self.common.selection.cursor.byte(),
+            anchor: self.common.cursor.anchor.byte(),
+            cursor: self.common.cursor.cursor.byte(),
         }
     }
 

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -686,9 +686,21 @@ impl Part {
     }
 
     /// Get text contents
+    ///
+    /// Note that this excludes the terminating line-break: see
+    /// [`Self::line_ending`].
     #[inline]
     pub fn as_str(&self) -> &str {
         self.text.as_str()
+    }
+
+    /// Get the terminating line break, if any
+    ///
+    /// Note that this may be empty (usually the last `Part` will have no line
+    /// ending).
+    #[inline]
+    pub fn line_ending(&self) -> &LineBreakBytes {
+        &self.line_break
     }
 
     fn set_cursor(&self, common: &mut Common, p: u32, range: impl Into<CursorRange<usize>>) {

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -25,7 +25,7 @@ use kas::geom::{Rect, Vec2};
 use kas::layout::{AlignHints, AxisInfo, SizeRules};
 use kas::prelude::*;
 use kas::text::fonts::FontSelector;
-use kas::text::{CursorRange, Direction, Forme, NotReady, Status, format};
+use kas::text::{CursorRange, Direction, Forme, LineBreakBytes, NotReady, Status, format};
 use kas::theme::{Background, DrawCx, SizeCx, TextClass};
 use kas::util::UndoStack;
 use kas::{Layout, autoimpl};
@@ -130,7 +130,7 @@ struct StackItem {
     first_part_num: u32,
     num_parts: u32,
     // saved texts from first_part_num
-    texts: Vec<Rc<String>>,
+    texts: Vec<(Rc<String>, LineBreakBytes)>,
     cursor: CursorRange<TextIndex>,
 }
 
@@ -142,6 +142,7 @@ pub struct Common {
     colors: SchemeColors,
     font: FontSelector,
     dpem: f32,
+    default_line_break: LineBreakBytes,
     direction: Direction,
     wrap: bool,
     read_only: bool,
@@ -163,6 +164,7 @@ impl Common {
             colors: SchemeColors::default(),
             font: FontSelector::default(),
             dpem: 16.0,
+            default_line_break: LineBreakBytes::LF,
             direction: Direction::Auto,
             wrap,
             read_only: false,
@@ -190,6 +192,12 @@ impl Common {
         } else {
             None
         }
+    }
+
+    /// Set the default line break encoding
+    #[inline]
+    pub fn set_default_line_break(&mut self, lb: LineBreakBytes) {
+        self.default_line_break = lb;
     }
 
     /// Get the base text direction
@@ -290,6 +298,8 @@ pub struct Part {
     forme: Forme,
     highlight: highlight::Cache,
     text: Rc<String>,
+    /// Line break terminating this part.
+    line_break: LineBreakBytes,
 }
 
 /// A list of parts
@@ -475,7 +485,7 @@ impl<H: Highlighter> Component<H> {
     {
         let editor = Editor {
             common: Common::new(wrap),
-            part: Part::default(),
+            part: Part::empty(),
             error_state: None,
         };
         Component(editor, H::default())
@@ -647,29 +657,34 @@ impl<H: Highlighter> Component<H> {
     }
 }
 
-impl Default for Part {
+impl Part {
+    /// Construct an empty part
+    ///
+    /// This part has no text and no terminating line-break.
     #[inline]
-    fn default() -> Self {
+    pub fn empty() -> Self {
         Part {
             rect: Rect::ZERO,
             status: Status::Empty,
             forme: Forme::default(),
             highlight: Default::default(),
             text: Default::default(),
+            line_break: LineBreakBytes::NONE,
         }
     }
-}
 
-impl<S: ToString> From<S> for Part {
-    fn from(text: S) -> Self {
+    /// Construct a part with given text and terminating line-break
+    pub fn new(text: impl ToString, line_break: LineBreakBytes) -> Self {
         Part {
+            rect: Rect::ZERO,
+            status: Status::Empty,
+            forme: Forme::default(),
+            highlight: Default::default(),
             text: Rc::new(text.to_string()),
-            ..Default::default()
+            line_break,
         }
     }
-}
 
-impl Part {
     /// Get text contents
     #[inline]
     pub fn as_str(&self) -> &str {
@@ -1320,8 +1335,8 @@ impl Common {
         }
 
         // Break the input text into lines.
-        let mut lines = kas::text::Lines::new(replacement).map(|(line, _)| line);
-        let mut line = lines.next().unwrap_or("");
+        let mut lines = kas::text::Lines::new(replacement);
+        let (mut line, mut lb) = lines.next().unwrap_or(("", LineBreakBytes::NONE));
 
         // Iterate over all but the last line of the input text:
         for next_line in lines {
@@ -1329,9 +1344,10 @@ impl Common {
                 let part = parts.get_mut(p);
                 let end = part.text.len();
                 part.replace_range(b_start..end, line);
+                part.line_break = lb;
             } else {
                 // p == p_end: we preserve the last part for now
-                let mut part = Part::from(line);
+                let mut part = Part::new(line, lb);
                 if b_start > 0 {
                     let first_part = parts.get(p);
                     debug_assert!(b_start <= first_part.text.len());
@@ -1344,8 +1360,11 @@ impl Common {
 
             p += 1;
             b_start = 0;
-            line = next_line;
+            (line, lb) = next_line;
         }
+
+        // The last line should never have a terminating line-break
+        debug_assert!(lb.is_none());
 
         // Handle the last input line slightly differently to the above loop
         let last_line_end = if b_start > 0 {
@@ -1733,12 +1752,18 @@ impl Common {
         self.last_edit = edit;
         let (part, texts) = match edit {
             None | Some(EditOp::Initial) | Some(EditOp::Cursor) => (0, vec![]),
-            Some(EditOp::Ime(part)) => (part, vec![parts.get(part).clone_text()]),
+            Some(EditOp::Ime(p)) => {
+                let part = parts.get(p);
+                (p, vec![(part.clone_text(), part.line_break)])
+            }
             Some(EditOp::KeyInput(start, last))
             | Some(EditOp::KeyDelete(start, last))
             | Some(EditOp::Replace(start, last)) => {
                 let texts = (start..last + 1)
-                    .map(|part| parts.get(part).clone_text())
+                    .map(|p| {
+                        let part = parts.get(p);
+                        (part.clone_text(), part.line_break)
+                    })
                     .collect();
                 (start, texts)
             }
@@ -1767,7 +1792,7 @@ impl Common {
     ) -> Result<EventAction, NotReady> {
         let editable = !self.read_only;
         let mut shift = cx.modifiers().shift_key();
-        let mut buf = [0u8; 4];
+        let default_line_break = self.default_line_break;
         let cursor = self.cursor.cursor;
         let c_byte = cursor.byte();
         let c_p = cursor.part();
@@ -1805,7 +1830,7 @@ impl Common {
             Command::Activate => Action::Activate,
             Command::Enter if shift || !multi_line => Action::Activate,
             Command::Enter if editable && multi_line => {
-                Action::Insert('\n'.encode_utf8(&mut buf), true)
+                Action::Insert(default_line_break.as_str(), true)
             }
             // NOTE: we might choose to optionally handle Tab in the future,
             // but without some workaround it prevents keyboard navigation.
@@ -2122,11 +2147,8 @@ impl Common {
                     let mut n: usize = 0;
                     if parts.len() < item.num_parts {
                         n = (item.num_parts - parts.len()).cast();
-                        for text in &item.texts[..n] {
-                            let part = Part {
-                                text: Rc::clone(text),
-                                ..Default::default()
-                            };
+                        for (text, lb) in &item.texts[..n] {
+                            let part = Part::new(text, *lb);
                             parts.insert(p, part);
                             p += 1;
                         }
@@ -2135,10 +2157,11 @@ impl Common {
                         parts.delete(p..p + n_delete);
                     }
 
-                    for text in &item.texts[n..] {
+                    for (text, lb) in &item.texts[n..] {
                         let part = parts.get_mut(p);
                         if !Rc::ptr_eq(&part.text, text) {
                             part.text = Rc::clone(text);
+                            part.line_break = *lb;
                             part.status = Status::Empty;
                         }
                         p += 1;

--- a/crates/kas-widgets/src/edit/editor.rs
+++ b/crates/kas-widgets/src/edit/editor.rs
@@ -1286,38 +1286,52 @@ impl Common {
         range: Range<TextIndex>,
         replacement: &str,
     ) -> TextIndex {
-        self.validate_range(parts, range.clone());
-
         if !parts.variable_length() {
+            debug_assert!(range.start.part == 0 && range.end.part == 0);
             let range = subrange_of(&range, 0);
             parts.get_mut(0).replace_range(range.clone(), replacement);
             return TextIndex::new(0, range.start + replacement.len());
         }
 
+        let (mut p_end, b_end) = if range.end.part() < parts.len() {
+            (range.end.part(), range.end.byte())
+        } else {
+            debug_assert!(false);
+            let p_end = parts.len() - 1;
+            let b_end = parts.get(p_end).text.len();
+            (p_end, b_end)
+        };
+
         let mut p = range.start.part();
-        let p_end = range.end.part();
         let mut b_start = range.start.byte();
         debug_assert!(b_start <= parts.get(p).text.len());
+        if p > p_end || p == p_end && b_start > b_end {
+            debug_assert!(false);
+            p = p_end;
+            b_start = b_end;
+        }
 
         // Break the input text into lines.
         let mut lines = kas::text::Lines::new(replacement).map(|(line, _)| line);
         let mut line = lines.next().unwrap_or("");
-        let mut remainder = None;
 
+        // Iterate over all but the last line of the input text:
         for next_line in lines {
-            if p <= p_end {
+            if p < p_end {
                 let part = parts.get_mut(p);
                 let end = part.text.len();
-                if p == p_end {
-                    let b_end = range.end.byte();
-                    debug_assert!(b_end <= end);
-                    if b_end < end {
-                        remainder = Some(part.as_str()[b_end..].to_string());
-                    }
-                }
                 part.replace_range(b_start..end, line);
             } else {
-                parts.insert(p, Part::from(line));
+                // p == p_end: we preserve the last part for now
+                let mut part = Part::from(line);
+                if b_start > 0 {
+                    let first_part = parts.get(p);
+                    debug_assert!(b_start <= first_part.text.len());
+                    let end = first_part.text.len().min(b_start);
+                    part.replace_range(0..0, &first_part.as_str()[..end]);
+                }
+                parts.insert(p, part);
+                p_end += 1;
             }
 
             p += 1;
@@ -1327,42 +1341,40 @@ impl Common {
 
         // Handle the last input line slightly differently to the above loop
         let last_line_end = if b_start > 0 {
-            let part = parts.get_mut(p);
-            let mut end = part.text.len();
+            // Note that b_start > 0 implies p was not advanced yet
+            debug_assert_eq!(p, range.start.part());
+
             if p == p_end {
-                debug_assert!(range.end.byte() <= end);
-                end = end.min(range.end.byte());
+                let part = parts.get_mut(p);
+                debug_assert!(b_end <= part.text.len());
+                let end = b_end.min(part.text.len());
+
+                part.replace_range(b_start..end, line);
+                b_start + line.len()
+            } else {
+                let part = parts.get_mut(p);
+                debug_assert!(b_start <= part.text.len());
+                let p0_text = part.text.clone();
+                let p0_end = part.text.len().min(b_start);
+
+                parts.delete(p..p_end);
+
+                let part = parts.get_mut(p);
+                debug_assert!(b_end <= part.text.len());
+                let end = b_end.min(part.text.len());
+                part.replace_range(0..end, &p0_text[..p0_end]);
+                part.replace_range(p0_end..p0_end, line);
+                p0_end + line.len()
             }
-
-            part.replace_range(b_start..end, line);
-            end = b_start + line.len();
-
-            if p_end > p {
-                parts.delete(p + 1..p_end);
-                let part = parts.remove(p + 1);
-                let rest = &part.as_str()[range.end.byte()..];
-                parts.get_mut(p).replace_range(end..end, rest);
-            }
-
-            end
-        } else if p <= p_end {
-            // Remove excess lines
+        } else {
+            debug_assert!(p <= p_end && b_start == 0);
             parts.delete(p..p_end);
 
             let part = parts.get_mut(p);
-            debug_assert!(range.end.byte() <= part.text.len());
-            let end = range.end.byte().min(part.text.len());
-            part.replace_range(b_start..end, line);
-            b_start + line.len()
-        } else {
-            let mut part = Part::from(line);
-            let len = line.len();
-
-            if let Some(remainder) = remainder.take() {
-                part.replace_range(len..len, &remainder);
-            }
-            parts.insert(p, part);
-            len
+            debug_assert!(b_end <= part.text.len());
+            let end = b_end.min(part.text.len());
+            part.replace_range(0..end, line);
+            line.len()
         };
 
         TextIndex::new(p, last_line_end)

--- a/crates/kas-widgets/src/edit/multi_part.rs
+++ b/crates/kas-widgets/src/edit/multi_part.rs
@@ -256,7 +256,9 @@ mod MultiPartEditor {
 
         /// Read text contents from parts
         ///
-        /// The whole contents equals the concatenation of parts. FIXME
+        /// To reconstruct the whole text, for each `part`, concatenate its
+        /// text (`part.as_str()`) followed by its terminating line break
+        /// (`part.line_ending().as_str()`).
         pub fn text_parts(&self) -> impl Iterator<Item = &Part> {
             self.inner.parts.iter()
         }
@@ -264,13 +266,9 @@ mod MultiPartEditor {
         /// Copy text contents to a `String`
         pub fn text_to_string(&self) -> String {
             let mut s = String::new();
-            let mut iter = self.text_parts();
-            if let Some(first) = iter.next() {
-                s.push_str(first.as_str());
-            }
-            for part in iter {
-                s.push('\n'); // TODO
+            for part in self.text_parts() {
                 s.push_str(part.as_str());
+                s.push_str(part.line_ending().as_str());
             }
             s
         }

--- a/crates/kas-widgets/src/edit/multi_part.rs
+++ b/crates/kas-widgets/src/edit/multi_part.rs
@@ -13,7 +13,7 @@ use kas::cast::Ceil;
 use kas::event::components::ScrollComponent;
 use kas::event::{CursorIcon, Scroll};
 use kas::prelude::*;
-use kas::text::{Direction, Status};
+use kas::text::{Direction, LineBreakBytes, Status};
 use kas::theme::{FrameStyle, TextClass};
 
 #[derive(Debug)]
@@ -290,6 +290,16 @@ mod MultiPartEditor {
             self.vert_bar.set_value(cx, self.scroll.offset().1);
         }
 
+        /// Set the default line break encoding
+        ///
+        /// Where an initial text is provided ([`Self::new`],
+        /// [`Self::with_text`]) the default line-break is inferred from the
+        /// given text if possible. Otherwise [`LineBreakBytes::LF`] is used.
+        #[inline]
+        pub fn set_default_line_break(&mut self, lb: LineBreakBytes) {
+            self.inner.common.set_default_line_break(lb);
+        }
+
         /// Set the base text direction (inline)
         ///
         /// If [`Direction::Auto`] or [`Direction::AutoRtl`] is used, the direction
@@ -352,7 +362,7 @@ mod Inner {
                 content_size: Size::ZERO,
                 common: Common::new(true),
                 highlighter: H::default(),
-                parts: vec![Part::default()],
+                parts: vec![Part::empty()],
             }
         }
     }
@@ -367,8 +377,16 @@ mod Inner {
 
             self.common.set_cursor(&self.parts, TextIndex::new(0, 0));
 
+            let mut have_default_lb = false;
+
             self.parts = kas::text::Lines::new(text)
-                .map(|(line, _)| Part::from(line))
+                .map(|(line, lb)| {
+                    if !have_default_lb && lb.is_default_line_break() {
+                        self.common.set_default_line_break(lb);
+                        have_default_lb = true;
+                    }
+                    Part::new(line, lb)
+                })
                 .collect();
             debug_assert!(!self.parts.is_empty());
 


### PR DESCRIPTION
This should allow byte-identical read and write, even if mixed line endings are used. It should also support opening a document and writing new lines using the first line-break style used by that document.