### PR TITLE
Add trait `AutoEditGuard`

### DIFF
--- a/crates/kas-view/src/filter.rs
+++ b/crates/kas-view/src/filter.rs
@@ -6,7 +6,7 @@
 //! Filters over data
 
 use kas::event::EventCx;
-use kas_widgets::edit::{EditGuard, Editor};
+use kas_widgets::edit::{AutoEditGuard, Editor};
 use std::fmt::Debug;
 
 /// Ability to set filter
@@ -90,27 +90,23 @@ impl Filter<String> for ContainsCaseInsensitive {
 #[derive(Debug, Default)]
 pub struct SetFilter<T: Debug>(pub T);
 
-/// An [`EditGuard`] which sends a [`SetFilter`] message on every change
+/// An [`AutoEditGuard`] which sends a [`SetFilter`] message on every change
 ///
 /// This may be used for search-as-you-type.
 pub struct KeystrokeGuard;
-impl EditGuard for KeystrokeGuard {
-    type Data = ();
-
-    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Self::Data) {
+impl AutoEditGuard for KeystrokeGuard {
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx) {
         cx.push(SetFilter(edit.as_str().to_string()));
     }
 }
 
-/// An [`EditGuard`] which sends a [`SetFilter`] message on activate and focus loss
+/// An [`AutoEditGuard`] which sends a [`SetFilter`] message on activate and focus loss
 ///
 /// This may be used for search-as-you-type.
 pub struct AflGuard;
-impl EditGuard for AflGuard {
-    type Data = ();
-
+impl AutoEditGuard for AflGuard {
     #[inline]
-    fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Self::Data) {
+    fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx) {
         cx.push(SetFilter(edit.as_str().to_string()));
     }
 }

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -395,6 +395,18 @@ impl<A: 'static> EditBox<StringGuard<A>> {
     }
 }
 
+impl<G: AutoEditGuard, H: Highlighter> EditBox<G, H> {
+    /// Set the initial text (inline)
+    ///
+    /// This method should only be used on a new `EditBox`.
+    #[inline]
+    #[must_use]
+    pub fn with_text(mut self, text: impl ToString) -> Self {
+        self.inner = self.inner.with_text(text);
+        self
+    }
+}
+
 impl<G: EditGuard, H: Highlighter> EditBox<G, H> {
     /// Set the base text direction (inline)
     ///
@@ -404,16 +416,6 @@ impl<G: EditGuard, H: Highlighter> EditBox<G, H> {
     #[inline]
     pub fn with_direction(mut self, direction: Direction) -> Self {
         self.inner.set_direction(direction);
-        self
-    }
-
-    /// Set the initial text (inline)
-    ///
-    /// This method should only be used on a new `EditBox`.
-    #[inline]
-    #[must_use]
-    pub fn with_text(mut self, text: impl ToString) -> Self {
-        self.inner = self.inner.with_text(text);
         self
     }
 

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -63,7 +63,7 @@ mod EditBox {
     #[autoimpl(Debug where G: trait, H: trait)]
     #[autoimpl(Deref<Target = Editor> using self.inner)]
     #[widget]
-    pub struct EditBox<G: EditGuard = DefaultGuard<()>, H: Highlighter = Plain> {
+    pub struct EditBox<G: EditGuard = DefaultGuard, H: Highlighter = Plain> {
         core: widget_core!(),
         scroll: ScrollComponent,
         // NOTE: inner is a Viewport which doesn't use update methods, therefore we don't call them.
@@ -319,7 +319,7 @@ mod EditBox {
     }
 }
 
-impl<A: 'static> EditBox<DefaultGuard<A>> {
+impl EditBox<DefaultGuard> {
     /// Construct an `EditBox` with the given initial `text` (no event handling)
     #[inline]
     pub fn text<S: ToString>(text: S) -> Self {
@@ -331,7 +331,7 @@ impl<A: 'static> EditBox<DefaultGuard<A>> {
 
     /// Construct a read-only `EditBox` displaying some `String` value
     #[inline]
-    pub fn string(value_fn: impl Fn(&A) -> String + Send + 'static) -> EditBox<StringGuard<A>> {
+    pub fn string<A>(value_fn: impl Fn(&A) -> String + Send + 'static) -> EditBox<StringGuard<A>> {
         EditBox::new(StringGuard::new(value_fn)).with_read_only(true)
     }
 
@@ -349,7 +349,7 @@ impl<A: 'static> EditBox<DefaultGuard<A>> {
     /// emitted via [`EventCx::push`]. The cached value is then cleared to
     /// avoid sending duplicate messages.
     #[inline]
-    pub fn parser<T: Debug + Display + FromStr, M: Debug + 'static>(
+    pub fn parser<A, T: Debug + Display + FromStr, M: Debug + 'static>(
         value_fn: impl Fn(&A) -> T + Send + 'static,
         msg_fn: impl Fn(T) -> M + Send + 'static,
     ) -> EditBox<ParseGuard<A, T>> {
@@ -365,7 +365,7 @@ impl<A: 'static> EditBox<DefaultGuard<A>> {
     /// On every edit, the guard attempts to parse the field's input as type
     /// `T` via [`FromStr`]. On success, the result is converted to a
     /// message via `on_afl` then emitted via [`EventCx::push`].
-    pub fn instant_parser<T: Debug + Display + FromStr, M: Debug + 'static>(
+    pub fn instant_parser<A, T: Debug + Display + FromStr, M: Debug + 'static>(
         value_fn: impl Fn(&A) -> T + Send + 'static,
         msg_fn: impl Fn(T) -> M + Send + 'static,
     ) -> EditBox<InstantParseGuard<A, T>> {

--- a/crates/kas-widgets/src/edit/edit_box.rs
+++ b/crates/kas-widgets/src/edit/edit_box.rs
@@ -238,7 +238,11 @@ mod EditBox {
     }
 
     impl<G: EditGuard> EditBox<G, Plain> {
-        /// Construct an `EditBox` with an [`EditGuard`]
+        /// Construct an `EditBox`
+        ///
+        /// If the editor is *autonomous* (is not affected by input data) then
+        /// pass a `guard` implementing [`AutoEditGuard`], otherwise the `guard`
+        /// should implement [`EditGuard`].
         #[inline]
         pub fn new(guard: G) -> Self {
             EditBox {

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -168,7 +168,6 @@ mod EditBoxCore {
 
         fn configure(&mut self, cx: &mut ConfigCx) {
             self.editor.configure(cx, self.id());
-            self.guard.configure(&mut self.editor.0, cx);
         }
 
         fn update(&mut self, cx: &mut ConfigCx, data: &G::Data) {
@@ -183,10 +182,10 @@ mod EditBoxCore {
             let mut result = Used;
             match self.editor.handle_event(cx, event) {
                 EventAction::Unused => return Unused,
-                EventAction::Used | EventAction::Cursor | EventAction::Preedit => return Used,
-                EventAction::FocusGained => {
-                    self.guard.focus_gained(&mut self.editor.0, cx, data);
-                }
+                EventAction::Used
+                | EventAction::FocusGained
+                | EventAction::Cursor
+                | EventAction::Preedit => return Used,
                 EventAction::FocusLost => {
                     self.guard.focus_lost(&mut self.editor.0, cx, data);
                 }

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -231,7 +231,11 @@ mod EditBoxCore {
     }
 
     impl<G: EditGuard> EditBoxCore<G, Plain> {
-        /// Construct an `EditBoxCore` with an [`EditGuard`]
+        /// Construct an `EditBoxCore`
+        ///
+        /// If the editor is *autonomous* (is not affected by input data) then
+        /// pass a `guard` implementing [`AutoEditGuard`], otherwise the `guard`
+        /// should implement [`EditGuard`].
         #[inline]
         pub fn new(guard: G) -> EditBoxCore<G> {
             EditBoxCore {

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -65,7 +65,7 @@ mod EditBoxCore {
     #[autoimpl(Debug where G: trait, H: trait)]
     #[widget]
     #[layout(self.editor)]
-    pub struct EditBoxCore<G: EditGuard = DefaultGuard<()>, H: Highlighter = Plain> {
+    pub struct EditBoxCore<G: EditGuard = DefaultGuard, H: Highlighter = Plain> {
         core: widget_core!(),
         width: (f32, f32),
         lines: (f32, f32),
@@ -290,7 +290,7 @@ mod EditBoxCore {
     }
 }
 
-impl<A: 'static> EditBoxCore<DefaultGuard<A>> {
+impl EditBoxCore<DefaultGuard> {
     /// Construct an `EditBoxCore` with the given initial `text` (no event handling)
     #[inline]
     pub fn text<S: ToString>(text: S) -> Self {

--- a/crates/kas-widgets/src/edit/edit_field.rs
+++ b/crates/kas-widgets/src/edit/edit_field.rs
@@ -305,6 +305,18 @@ impl EditBoxCore<DefaultGuard> {
     }
 }
 
+impl<G: AutoEditGuard, H: Highlighter> EditBoxCore<G, H> {
+    /// Set the initial text (inline)
+    ///
+    /// This method should only be used on a new `EditBoxCore`.
+    #[inline]
+    #[must_use]
+    pub fn with_text(mut self, text: impl ToString) -> Self {
+        self.editor = self.editor.with_text(text);
+        self
+    }
+}
+
 impl<G: EditGuard, H: Highlighter> EditBoxCore<G, H> {
     /// Set the base text direction
     ///
@@ -314,16 +326,6 @@ impl<G: EditGuard, H: Highlighter> EditBoxCore<G, H> {
     #[inline]
     pub fn set_direction(&mut self, direction: Direction) {
         self.editor.set_direction(direction);
-    }
-
-    /// Set the initial text (inline)
-    ///
-    /// This method should only be used on a new `EditBoxCore`.
-    #[inline]
-    #[must_use]
-    pub fn with_text(mut self, text: impl ToString) -> Self {
-        self.editor = self.editor.with_text(text);
-        self
     }
 
     /// Set whether this `EditBoxCore` is read-only (inline)

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -75,10 +75,8 @@ pub trait EditGuard: Sized {
 /// This guard should probably not be used for a functional user-interface but
 /// may be useful in mock UIs.
 #[autoimpl(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct DefaultGuard<A>(PhantomData<fn(A)>);
-impl<A: 'static> EditGuard for DefaultGuard<A> {
-    type Data = A;
-}
+pub struct DefaultGuard;
+impl AutoEditGuard for DefaultGuard {}
 
 #[impl_self]
 mod StringGuard {

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -29,9 +29,10 @@ pub trait EditGuard: Sized {
     ///
     /// This method may also be called on loss of input focus (see
     /// [`Self::focus_lost`]).
-    fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &Self::Data) {
-        let _ = (edit, cx, data);
-    }
+    ///
+    /// If this method is not required, consider implementing [`AutoEditGuard`]
+    /// instead.
+    fn update(&mut self, edit: &mut Editor, cx: &mut ConfigCx, data: &Self::Data);
 
     /// Activation guard
     ///
@@ -40,6 +41,7 @@ pub trait EditGuard: Sized {
     /// from `handle_event`.
     ///
     /// The default implementation calls [`Self::focus_lost`] and returns [`Used`].
+    #[inline]
     fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) -> IsUsed {
         self.focus_lost(edit, cx, data);
         Used
@@ -52,6 +54,7 @@ pub trait EditGuard: Sized {
     ///
     /// The default implementation calls [`Self::update`] since updates are
     /// inhibited while the editor has input focus.
+    #[inline]
     fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) {
         self.update(edit, cx, data);
     }
@@ -64,8 +67,78 @@ pub trait EditGuard: Sized {
     ///
     /// The guard may call [`Editor::set_error`] here.
     /// The error state is cleared immediately before calling this method.
+    #[inline]
     fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) {
         let _ = (edit, cx, data);
+    }
+}
+
+/// Event-handling *guard* for an independent [`Editor`]
+///
+/// This trait is for autonomous [`EditBox`]es: those containing their own data
+/// instead of dependant on update from input data.
+///
+/// All methods have a default implementation which does nothing.
+///
+/// [`EditBox`]: super::EditBox
+pub trait AutoEditGuard: Sized {
+    /// Activation guard
+    ///
+    /// This function is called when the widget is "activated", for example by
+    /// the Enter/Return key for single-line edit boxes. Its result is returned
+    /// from `handle_event`.
+    ///
+    /// The default implementation calls [`Self::focus_lost`] and returns [`Used`].
+    #[inline]
+    fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx) -> IsUsed {
+        self.focus_lost(edit, cx);
+        Used
+    }
+
+    /// Focus-lost guard
+    ///
+    /// This function is called after the widget has lost both keyboard and IME
+    /// focus.
+    ///
+    /// The default implementation does nothing.
+    #[inline]
+    fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx) {
+        let _ = (edit, cx);
+    }
+
+    /// Edit guard
+    ///
+    /// This function is called after the text is updated (including by keyboard
+    /// input, an undo action or by a message like
+    /// [`kas::messages::SetValueText`]).
+    ///
+    /// The guard may call [`Editor::set_error`] here.
+    /// The error state is cleared immediately before calling this method.
+    #[inline]
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx) {
+        let _ = (edit, cx);
+    }
+}
+
+impl<G: AutoEditGuard> EditGuard for G {
+    type Data = ();
+
+    #[inline]
+    fn update(&mut self, _: &mut Editor, _: &mut ConfigCx, _: &Self::Data) {}
+
+    #[inline]
+    fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Self::Data) -> IsUsed {
+        self.activate(edit, cx)
+    }
+
+    #[inline]
+    fn focus_lost(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Self::Data) {
+        self.focus_lost(edit, cx);
+    }
+
+    #[inline]
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Self::Data) {
+        self.edit(edit, cx);
     }
 }
 
@@ -75,9 +148,7 @@ pub trait EditGuard: Sized {
 /// may be useful in mock UIs.
 #[autoimpl(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct DefaultGuard;
-impl EditGuard for DefaultGuard {
-    type Data = ();
-}
+impl AutoEditGuard for DefaultGuard {}
 
 #[impl_self]
 mod StringGuard {

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -23,13 +23,6 @@ pub trait EditGuard: Sized {
     /// Data type
     type Data;
 
-    /// Configure guard
-    ///
-    /// This function is called when the attached widget is configured.
-    fn configure(&mut self, edit: &mut Editor, cx: &mut ConfigCx) {
-        let _ = (edit, cx);
-    }
-
     /// Update guard
     ///
     /// This function is called when input data is updated **and** the editor
@@ -51,13 +44,6 @@ pub trait EditGuard: Sized {
     fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) -> IsUsed {
         self.focus_lost(edit, cx, data);
         Used
-    }
-
-    /// Focus-gained guard
-    ///
-    /// This function is called when the widget gains keyboard or IME focus.
-    fn focus_gained(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Self::Data) {
-        let _ = (edit, cx, data);
     }
 
     /// Focus-lost guard

--- a/crates/kas-widgets/src/edit/guard.rs
+++ b/crates/kas-widgets/src/edit/guard.rs
@@ -8,7 +8,6 @@
 use super::Editor;
 use kas::prelude::*;
 use std::fmt::{Debug, Display};
-use std::marker::PhantomData;
 use std::str::FromStr;
 
 /// Event-handling *guard* for an [`Editor`]
@@ -76,7 +75,9 @@ pub trait EditGuard: Sized {
 /// may be useful in mock UIs.
 #[autoimpl(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct DefaultGuard;
-impl AutoEditGuard for DefaultGuard {}
+impl EditGuard for DefaultGuard {
+    type Data = ();
+}
 
 #[impl_self]
 mod StringGuard {

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -34,6 +34,10 @@ enum Control {
     DecrLen,
     IncrLen,
     Reverse,
+}
+
+#[derive(Clone, Debug)]
+enum Update {
     Select(usize, String),
     UpdateCurrent(String),
 }
@@ -56,15 +60,6 @@ impl Data {
                 self.dir = self.dir.reversed();
                 return;
             }
-            Control::Select(index, text) => {
-                self.active = index;
-                self.active_string = text;
-                return;
-            }
-            Control::UpdateCurrent(text) => {
-                self.active_string = text;
-                return;
-            }
         };
 
         self.len = len;
@@ -72,6 +67,18 @@ impl Data {
             self.active = len - 1;
             // NOTE: We should update self.active_string here but we cannot
             // access the newly active widget's data from here.
+        }
+    }
+
+    fn update(&mut self, update: Update) {
+        match update {
+            Update::Select(index, text) => {
+                self.active = index;
+                self.active_string = text;
+            }
+            Update::UpdateCurrent(text) => {
+                self.active_string = text;
+            }
         }
     }
 }
@@ -88,7 +95,7 @@ impl EditGuard for ListEntryGuard {
 
     fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Data) {
         if data.active == self.0 {
-            cx.push(Control::UpdateCurrent(edit.as_str().to_string()));
+            cx.push(Update::UpdateCurrent(edit.as_str().to_string()));
         }
     }
 }
@@ -117,7 +124,7 @@ mod ListEntry {
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Data) {
             if let Some(SelectEntry(n)) = cx.try_pop() {
                 if data.active != n {
-                    cx.push(Control::Select(n, self.edit.as_str().to_string()));
+                    cx.push(Update::Select(n, self.edit.as_str().to_string()));
                 }
             }
         }
@@ -180,7 +187,8 @@ fn main() -> kas::runner::Result<()> {
 
     let ui = tree
         .with_state(data)
-        .on_message(|_, data, control| data.handle(control));
+        .on_message(|_, data, control| data.handle(control))
+        .on_message(|_, data, update| data.update(update));
 
     let window = Window::new(ui, "Dynamic widget demo");
 

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -20,7 +20,7 @@
 //! is still fast.
 
 use kas::prelude::*;
-use kas::widgets::edit::{EditBox, EditGuard, Editor};
+use kas::widgets::edit::{AutoEditGuard, EditBox, Editor};
 use kas::widgets::{Button, Label, List, RadioButton, ScrollRegion, Separator, Text};
 use kas::widgets::{column, row};
 use std::rc::Rc;
@@ -88,15 +88,13 @@ impl Data {
 
 #[derive(Debug)]
 struct ListEntryGuard(usize);
-impl EditGuard for ListEntryGuard {
-    type Data = ();
-
-    fn activate(&mut self, _: &mut Editor, cx: &mut EventCx, _: &()) -> IsUsed {
+impl AutoEditGuard for ListEntryGuard {
+    fn activate(&mut self, _: &mut Editor, cx: &mut EventCx) -> IsUsed {
         cx.push(SelectEntry(self.0));
         Used
     }
 
-    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &()) {
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx) {
         cx.push(Update::Update(self.0, edit.text().clone()));
     }
 }

--- a/examples/data-list.rs
+++ b/examples/data-list.rs
@@ -23,6 +23,7 @@ use kas::prelude::*;
 use kas::widgets::edit::{EditBox, EditGuard, Editor};
 use kas::widgets::{Button, Label, List, RadioButton, ScrollRegion, Separator, Text};
 use kas::widgets::{column, row};
+use std::rc::Rc;
 
 #[derive(Debug)]
 struct SelectEntry(usize);
@@ -38,8 +39,8 @@ enum Control {
 
 #[derive(Clone, Debug)]
 enum Update {
-    Select(usize, String),
-    UpdateCurrent(String),
+    Select(usize, Rc<String>),
+    Update(usize, Rc<String>),
 }
 
 #[derive(Debug)]
@@ -47,7 +48,7 @@ struct Data {
     len: usize,
     active: usize,
     dir: Direction,
-    active_string: String,
+    active_string: Rc<String>,
 }
 impl Data {
     fn handle(&mut self, control: Control) {
@@ -76,8 +77,10 @@ impl Data {
                 self.active = index;
                 self.active_string = text;
             }
-            Update::UpdateCurrent(text) => {
-                self.active_string = text;
+            Update::Update(index, text) => {
+                if self.active == index {
+                    self.active_string = text;
+                }
             }
         }
     }
@@ -86,17 +89,15 @@ impl Data {
 #[derive(Debug)]
 struct ListEntryGuard(usize);
 impl EditGuard for ListEntryGuard {
-    type Data = Data;
+    type Data = ();
 
-    fn activate(&mut self, _: &mut Editor, cx: &mut EventCx, _: &Data) -> IsUsed {
+    fn activate(&mut self, _: &mut Editor, cx: &mut EventCx, _: &()) -> IsUsed {
         cx.push(SelectEntry(self.0));
         Used
     }
 
-    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, data: &Data) {
-        if data.active == self.0 {
-            cx.push(Update::UpdateCurrent(edit.as_str().to_string()));
-        }
+    fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &()) {
+        cx.push(Update::Update(self.0, edit.text().clone()));
     }
 }
 
@@ -114,7 +115,7 @@ mod ListEntry {
         label: Label<String>,
         #[widget(&data.active)]
         radio: RadioButton<usize>,
-        #[widget]
+        #[widget(&())]
         edit: EditBox<ListEntryGuard>,
     }
 
@@ -124,7 +125,7 @@ mod ListEntry {
         fn handle_messages(&mut self, cx: &mut EventCx, data: &Data) {
             if let Some(SelectEntry(n)) = cx.try_pop() {
                 if data.active != n {
-                    cx.push(Update::Select(n, self.edit.as_str().to_string()));
+                    cx.push(Update::Select(n, self.edit.text().clone()));
                 }
             }
         }
@@ -166,7 +167,7 @@ fn main() -> kas::runner::Result<()> {
         len: 5,
         active: 0,
         dir: Direction::Down,
-        active_string: ListEntry::new(0).label.as_str().to_string(),
+        active_string: Rc::new(ListEntry::new(0).label.as_str().to_string()),
     };
 
     let list = List::new(vec![]).on_update(|cx, list, data: &Data| {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -17,7 +17,7 @@ use kas::dir::{Down, Right};
 use kas::image::Svg;
 use kas::prelude::*;
 use kas::theme::{MarginStyle, TextClass};
-use kas::widgets::edit::{EditGuard, Editor, highlight::SyntectHighlighter};
+use kas::widgets::edit::{AutoEditGuard, Editor, highlight::SyntectHighlighter};
 use kas::widgets::{column, *};
 use kas::window::Popup;
 use std::ops::Range;
@@ -88,15 +88,13 @@ fn widgets() -> Page<AppData> {
     };
 
     struct Guard;
-    impl EditGuard for Guard {
-        type Data = ();
-
-        fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &()) -> IsUsed {
+    impl AutoEditGuard for Guard {
+        fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx) -> IsUsed {
             cx.push(Item::Edit(edit.clone_text()));
             Used
         }
 
-        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &()) {
+        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx) {
             // 7a is the colour of *magic*!
             if edit.as_str().len() % (7 + 1) == 0 {
                 edit.set_error(cx, Some("Invalid length: is a multiple of (7 + 1)!".into()));
@@ -463,10 +461,8 @@ fn filter_list() -> Page<AppData> {
 
     #[derive(Debug, Default)]
     struct MonthYearFilterGuard(MonthYearFilter);
-    impl EditGuard for MonthYearFilterGuard {
-        type Data = ();
-
-        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Self::Data) {
+    impl AutoEditGuard for MonthYearFilterGuard {
+        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx) {
             let mut filter = MonthYearFilter {
                 text: edit.as_str().to_uppercase(),
                 month_end: edit.as_str().len(),

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -89,14 +89,14 @@ fn widgets() -> Page<AppData> {
 
     struct Guard;
     impl EditGuard for Guard {
-        type Data = Data;
+        type Data = ();
 
-        fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Data) -> IsUsed {
+        fn activate(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &()) -> IsUsed {
             cx.push(Item::Edit(edit.clone_text()));
             Used
         }
 
-        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &Data) {
+        fn edit(&mut self, edit: &mut Editor, cx: &mut EventCx, _: &()) {
             // 7a is the colour of *magic*!
             if edit.as_str().len() % (7 + 1) == 0 {
                 edit.set_error(cx, Some("Invalid length: is a multiple of (7 + 1)!".into()));
@@ -151,7 +151,7 @@ fn widgets() -> Page<AppData> {
         row!["ScrollLabel", ScrollLabel::new(text).map_any()],
         row![
             "EditBox",
-            EditBox::new(Guard).with_text("length must not be a multiple of 8!"),
+            EditBox::new(Guard).with_text("length must not be a multiple of 8!").map_any(),
         ],
         row![
             "Button",

--- a/examples/splitter.rs
+++ b/examples/splitter.rs
@@ -32,6 +32,7 @@ fn main() -> kas::runner::Result<()> {
             EditBox::text(format!("Pane {}", n + 1))
                 .with_frame_style(kas::theme::FrameStyle::None)
                 .with_multi_line(true)
+                .map_any()
         })),
     ];
 


### PR DESCRIPTION
# Motivation

Reduce confusion about whether an editors contents is derived from input data or is autonomous.

Note: simple widgets like `CheckBox` require a `state_fn: impl Fn(&ConfigCx, &A) -> bool` or similar so that their state is always driven by input data. For complex widgets like editors this is not always the case. While there is an argument for trying to force this, Kas has a long tradition of supporting stateful widgets; forcing all widgets with "real data" (i.e. not a cache or something like the cursor position) to have an external binding for that data would neither be possible to enforce nor easy to do in a performant fashion.

# Additions

`trait AutoEditGuard` is essentially a cut-down version of `EditGuard` without input data or an `update()` handler.

# Removals

Edit handlers for `configure` and `focus_gained` were removed: `configure` should not normally be wanted (and can be done through an external wrapper like `AdaptEvents` if absolutely required) and `focus_gained` should not (in my opinion) ever be able to influence the state of an editor.

# Changes

`DefaultGuard` is no longer parametrised over the input data type.

Fns `EditBox::with_text` and `EditBoxCore::with_text` are now only available when the guard implements `AutoEditGuard`.